### PR TITLE
Rebrand Cosilico -> Rules Foundation

### DIFF
--- a/.github/workflows/sync-racs.yml
+++ b/.github/workflows/sync-racs.yml
@@ -1,5 +1,5 @@
 # Sync RAC files to database on push to main
-# Uses centralized workflow from cosilico-db
+# Uses centralized workflow from rac-db
 name: Sync RACs
 
 on:
@@ -11,9 +11,9 @@ on:
 
 jobs:
   sync:
-    uses: CosilicoAI/cosilico-engine/.github/workflows/sync-racs.yml@main
+    uses: RulesFoundation/rac-compile/.github/workflows/sync-racs.yml@main
     secrets:
       SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
     with:
-      repo_name: cosilico-us
+      repo_name: rac-us
       jurisdiction: us

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout cosilico-us
+      - name: Checkout rac-us
         uses: actions/checkout@v4
 
       - name: Set up Python
@@ -25,10 +25,10 @@ jobs:
       - name: Validate imports resolve
         run: python3 scripts/validate_imports.py
 
-      - name: Checkout cosilico-validators
+      - name: Checkout rac-validators
         uses: actions/checkout@v4
         with:
-          repository: CosilicoAI/cosilico-validators
+          repository: RulesFoundation/rac-validators
           path: validators
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,19 +40,19 @@ jobs:
       - name: Run CTC validation
         id: ctc
         run: |
-          python -m cosilico_validators.cli validate 26/24/a/tests.yaml -v ctc -y 2024 -o results-ctc.json
+          python -m rac_validators.cli validate 26/24/a/tests.yaml -v ctc -y 2024 -o results-ctc.json
         continue-on-error: true
 
       - name: Run Standard Deduction validation
         id: std_ded
         run: |
-          python -m cosilico_validators.cli validate 26/63/c/tests.yaml -v standard_deduction -y 2024 -o results-std-ded.json
+          python -m rac_validators.cli validate 26/63/c/tests.yaml -v standard_deduction -y 2024 -o results-std-ded.json
         continue-on-error: true
 
       - name: Run SNAP validation
         id: snap
         run: |
-          python -m cosilico_validators.cli validate 7/2017/a/tests.yaml -v snap_allotment -y 2024 -o results-snap.json --no-taxsim
+          python -m rac_validators.cli validate 7/2017/a/tests.yaml -v snap_allotment -y 2024 -o results-snap.json --no-taxsim
         continue-on-error: true
 
       - name: Combine results
@@ -105,6 +105,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: CosilicoAI/cosilico-validation
+          repository: RulesFoundation/rac-validation
           event-type: update-results
           client-payload: '{"commit": "${{ github.sha }}"}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
-# cosilico-us
+# rac-us
 
 **THE home for US federal tax and benefit statute encodings.**
 
-All US-specific .rac files belong here, NOT in cosilico-engine.
+All US-specific .rac files belong here, NOT in rac-compile.
 
 ## Structure
 
 Files organized under `statute/` by title and section:
 
 ```
-cosilico-us/
+rac-us/
 ├── statute/               # All enacted statutes
 │   ├── 26/               # Title 26 (IRC)
 │   │   ├── 24/          # § 24 - Child Tax Credit
@@ -91,6 +91,6 @@ New format exemplars:
 
 ## Related Repos
 
-- **cosilico-engine** - DSL compiler and runtime
-- **cosilico-lawarchive** - Source document archive
-- **cosilico-validators** - Validation against external calculators
+- **rac-compile** - DSL compiler and runtime
+- **atlas** - Source document archive
+- **rac-validators** - Validation against external calculators

--- a/EITC_VALIDATION_REPORT.md
+++ b/EITC_VALIDATION_REPORT.md
@@ -188,7 +188,7 @@ Secondary:
 
 ## Recommendations
 
-### For Cosilico Development
+### For Rules Foundation Development
 
 1. **Use PolicyEngine as reference**: PolicyEngine US correctly implements 2024 EITC parameters and can serve as a validation source
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Cosilico Demo App
+RAC Demo App
 
 Shows the full pipeline from source document to calculation:
 1. Lawarchive: Fetched source document (USC XML)
@@ -198,11 +198,11 @@ def calculate_eitc(
 
 def run_streamlit():
     """Run the Streamlit web app."""
-    st.set_page_config(page_title="Cosilico Demo", layout="wide")
-    st.title("Cosilico: Executable Tax Law")
+    st.set_page_config(page_title="RAC Demo", layout="wide")
+    st.title("Rules Foundation: Executable Tax Law")
 
     st.markdown("""
-    This demo shows how Cosilico connects source documents to calculations:
+    This demo shows how Rules Foundation connects source documents to calculations:
 
     **Lawarchive** → **Encoding** → **Parameters** → **Calculation**
     """)
@@ -294,7 +294,7 @@ def run_streamlit():
             st.subheader("Citation Chain")
             st.markdown(f"""
             1. **Source:** `lawarchive://us/statute/26/32/2025-01-01`
-            2. **Encoding:** `cosilico-us://26/32/eitc.rac`
+            2. **Encoding:** `rac-us://26/32/eitc.rac`
             3. **Parameters:** Rev. Proc. 2024-40 (TY {SAMPLE_PARAMS.tax_year})
             4. **Result:** ${result.result:,}
             """)
@@ -303,7 +303,7 @@ def run_streamlit():
 def run_cli():
     """Run CLI demo."""
     print("=" * 60)
-    print("COSILICO DEMO: Executable Tax Law")
+    print("RAC DEMO: Executable Tax Law")
     print("=" * 60)
 
     print("\n1. SOURCE DOCUMENT (lawarchive)")
@@ -350,7 +350,7 @@ def run_cli():
     print("\n" + "=" * 60)
     print("Citation Chain:")
     print(f"  1. lawarchive://us/statute/26/32/2025-01-01")
-    print(f"  2. cosilico-us://26/32/eitc.rac")
+    print(f"  2. rac-us://26/32/eitc.rac")
     print(f"  3. Rev. Proc. 2024-40 (TY 2025)")
     print(f"  4. Result: ${result.result:,}")
 

--- a/docs/TAXSIM_PARITY_GAP.md
+++ b/docs/TAXSIM_PARITY_GAP.md
@@ -2,11 +2,11 @@
 
 *Last updated: 2025-12-26*
 
-## TaxSim Output Variables vs Cosilico Coverage
+## TaxSim Output Variables vs RAC Coverage
 
 ### Federal Income Tax (Core) ✅ = Encoded, ❌ = Missing, ⚠️ = Partial, 🔄 = In Progress
 
-| TaxSim Variable | Description | Cosilico Status |
+| TaxSim Variable | Description | RAC Status |
 |-----------------|-------------|-----------------|
 | v10 - Federal AGI | Adjusted Gross Income | ✅ `adjusted_gross_income` |
 | v11 - UI in AGI | Unemployment Insurance in AGI | ✅ `unemployment_in_agi` |
@@ -32,7 +32,7 @@
 
 ### FICA/Payroll Taxes
 
-| Component | Cosilico Status |
+| Component | RAC Status |
 |-----------|-----------------|
 | Employee Social Security (6.2%) | ✅ `employee_social_security_tax` |
 | Employer Social Security (6.2%) | ✅ `employer_social_security_tax` |
@@ -45,7 +45,7 @@
 
 ### Credits
 
-| Credit | Cosilico Status |
+| Credit | RAC Status |
 |--------|-----------------|
 | Child Tax Credit | ✅ |
 | Additional CTC (refundable) | ✅ |
@@ -63,7 +63,7 @@
 
 ### Deductions (Above-the-Line)
 
-| Deduction | Cosilico Status |
+| Deduction | RAC Status |
 |-----------|-----------------|
 | Student Loan Interest | ✅ |
 | IRA Deduction | ✅ |
@@ -78,7 +78,7 @@
 
 ### Deductions (Itemized)
 
-| Deduction | Cosilico Status |
+| Deduction | RAC Status |
 |-----------|-----------------|
 | SALT (capped at $10k) | ✅ `salt_deduction` |
 | Mortgage Interest | ✅ `qualified_residence_interest` |
@@ -89,7 +89,7 @@
 
 ### Income Types
 
-| Income | Cosilico Status |
+| Income | RAC Status |
 |--------|-----------------|
 | Wages/Salaries | ✅ |
 | Self-Employment | ✅ |

--- a/docs/TAXSIM_VALIDATION.md
+++ b/docs/TAXSIM_VALIDATION.md
@@ -149,4 +149,4 @@ Comparison of PolicyEngine-US against NBER TAXSIM 35 API.
 
 - [TAXSIM 35 Documentation](https://taxsim.nber.org/taxsim35/)
 - [PolicyEngine-US Documentation](https://policyengine.org/us/research)
-- [Cosilico US Encodings](https://github.com/CosilicoAI/cosilico-us)
+- [RAC US Encodings](https://github.com/RulesFoundation/rac-us)

--- a/eitc_comparison_summary.md
+++ b/eitc_comparison_summary.md
@@ -1,4 +1,4 @@
-# EITC Comparison Summary: Cosilico vs PolicyEngine US (2024)
+# EITC Comparison Summary: Rules Foundation vs PolicyEngine US (2024)
 
 ## Test Results (Original Expected Values)
 
@@ -95,8 +95,8 @@ PolicyEngine US correctly implements the 2024 EITC parameters. The comparison re
 
 ## Files Created
 
-1. `/Users/maxghenis/CosilicoAI/cosilico-us/compare_eitc.py` - Initial comparison script with original test values
-2. `/Users/maxghenis/CosilicoAI/cosilico-us/analyze_eitc_discrepancy.py` - Detailed analysis of Test Case 2
-3. `/Users/maxghenis/CosilicoAI/cosilico-us/inspect_eitc_calculation.py` - Parameter inspection and verification
-4. `/Users/maxghenis/CosilicoAI/cosilico-us/final_eitc_comparison.py` - Final comparison with corrected expected values (all pass)
-5. `/Users/maxghenis/CosilicoAI/cosilico-us/eitc_comparison_summary.md` - This summary report
+1. `/Users/maxghenis/RulesFoundation/rac-us/compare_eitc.py` - Initial comparison script with original test values
+2. `/Users/maxghenis/RulesFoundation/rac-us/analyze_eitc_discrepancy.py` - Detailed analysis of Test Case 2
+3. `/Users/maxghenis/RulesFoundation/rac-us/inspect_eitc_calculation.py` - Parameter inspection and verification
+4. `/Users/maxghenis/RulesFoundation/rac-us/final_eitc_comparison.py` - Final comparison with corrected expected values (all pass)
+5. `/Users/maxghenis/RulesFoundation/rac-us/eitc_comparison_summary.md` - This summary report

--- a/inputs/variables.yaml
+++ b/inputs/variables.yaml
@@ -1,6 +1,6 @@
-# Input Variable Schema for Cosilico-US
+# Input Variable Schema for RAC-US
 #
-# Maps microdata sources (CPS, PE) to Cosilico variable paths.
+# Maps microdata sources (CPS, PE) to Rules Foundation variable paths.
 # Used by validation runner to extract inputs for calculations.
 #
 # Note: These variable definitions are year-agnostic. The same variables
@@ -29,7 +29,7 @@ variables:
   # DEMOGRAPHICS
   # ============================================================
   age:
-    cosilico_path: null  # No statute path - demographic input
+    rac_path: null  # No statute path - demographic input
     entity: Person
     dtype: Integer
     pe_variable: age
@@ -37,7 +37,7 @@ variables:
     description: "Person's age in years"
 
   is_tax_unit_head:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_tax_unit_head
@@ -45,7 +45,7 @@ variables:
     description: "Person is the primary filer of the tax unit"
 
   is_tax_unit_spouse:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_tax_unit_spouse
@@ -53,7 +53,7 @@ variables:
     description: "Person is the spouse of the primary filer"
 
   is_tax_unit_dependent:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_tax_unit_dependent
@@ -64,7 +64,7 @@ variables:
   # INCOME - WAGES & COMPENSATION (26 USC §61(a)(1))
   # ============================================================
   wages:
-    cosilico_path: statute/26/61/a/1/wages
+    rac_path: statute/26/61/a/1/wages
     entity: Person
     dtype: Money
     pe_variable: employment_income
@@ -73,7 +73,7 @@ variables:
     statute_ref: "26 USC § 61(a)(1)"
 
   salaries:
-    cosilico_path: statute/26/61/a/1/salaries
+    rac_path: statute/26/61/a/1/salaries
     entity: Person
     dtype: Money
     pe_variable: null  # Combined with wages in PE
@@ -82,7 +82,7 @@ variables:
     statute_ref: "26 USC § 61(a)(1)"
 
   tips:
-    cosilico_path: statute/26/61/a/1/tips
+    rac_path: statute/26/61/a/1/tips
     entity: Person
     dtype: Money
     pe_variable: null  # Separate in some datasets
@@ -94,7 +94,7 @@ variables:
   # INCOME - SELF-EMPLOYMENT (26 USC §1402)
   # ============================================================
   self_employment_income:
-    cosilico_path: statute/26/1402/a/net_earnings_self_employment
+    rac_path: statute/26/1402/a/net_earnings_self_employment
     entity: Person
     dtype: Money
     pe_variable: self_employment_income
@@ -106,7 +106,7 @@ variables:
   # INCOME - INVESTMENT (26 USC §61(a)(4), (7))
   # ============================================================
   interest_income:
-    cosilico_path: statute/26/61/a/4/interest_income
+    rac_path: statute/26/61/a/4/interest_income
     entity: Person
     dtype: Money
     pe_variable: interest_income
@@ -115,7 +115,7 @@ variables:
     statute_ref: "26 USC § 61(a)(4)"
 
   dividend_income:
-    cosilico_path: statute/26/61/a/7/dividend_income
+    rac_path: statute/26/61/a/7/dividend_income
     entity: Person
     dtype: Money
     pe_variable: dividend_income
@@ -124,7 +124,7 @@ variables:
     statute_ref: "26 USC § 61(a)(7)"
 
   capital_gains:
-    cosilico_path: statute/26/1222/11/capital_gain_net_income
+    rac_path: statute/26/1222/11/capital_gain_net_income
     entity: Person
     dtype: Money
     pe_variable: capital_gains
@@ -133,7 +133,7 @@ variables:
     statute_ref: "26 USC § 1222(11)"
 
   rental_income:
-    cosilico_path: statute/26/32/i/2/C/net_rent_royalty_income
+    rac_path: statute/26/32/i/2/C/net_rent_royalty_income
     entity: Person
     dtype: Money
     pe_variable: rental_income
@@ -145,7 +145,7 @@ variables:
   # AGGREGATED INCOME MEASURES
   # ============================================================
   earned_income:
-    cosilico_path: statute/26/32/c/2/A/earned_income
+    rac_path: statute/26/32/c/2/A/earned_income
     entity: TaxUnit
     dtype: Money
     pe_variable: earned_income
@@ -155,7 +155,7 @@ variables:
     formula: true  # Has calculation logic
 
   adjusted_gross_income:
-    cosilico_path: statute/26/62/a/adjusted_gross_income
+    rac_path: statute/26/62/a/adjusted_gross_income
     entity: TaxUnit
     dtype: Money
     pe_variable: adjusted_gross_income
@@ -165,7 +165,7 @@ variables:
     formula: true
 
   investment_income:
-    cosilico_path: null  # Combined measure
+    rac_path: null  # Combined measure
     entity: TaxUnit
     dtype: Money
     pe_variable: investment_income
@@ -176,7 +176,7 @@ variables:
   # FILING STATUS (26 USC §1)
   # ============================================================
   filing_status:
-    cosilico_path: statute/26/1/filing_status
+    rac_path: statute/26/1/filing_status
     entity: TaxUnit
     dtype: Enum
     pe_variable: filing_status
@@ -194,7 +194,7 @@ variables:
   # CHILDREN & DEPENDENTS (26 USC §152)
   # ============================================================
   is_child:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_child
@@ -202,7 +202,7 @@ variables:
     description: "Person is a child (age < 19)"
 
   is_qualifying_child:
-    cosilico_path: statute/26/152/c/is_qualifying_child
+    rac_path: statute/26/152/c/is_qualifying_child
     entity: Person
     dtype: Boolean
     pe_variable: is_child_of_tax_head
@@ -211,7 +211,7 @@ variables:
     statute_ref: "26 USC § 152(c)"
 
   is_ctc_qualifying_child:
-    cosilico_path: statute/26/24/c/1/qualifying_child
+    rac_path: statute/26/24/c/1/qualifying_child
     entity: Person
     dtype: Boolean
     pe_variable: is_ctc_qualifying_child
@@ -220,7 +220,7 @@ variables:
     statute_ref: "26 USC § 24(c)(1)"
 
   is_eitc_qualifying_child:
-    cosilico_path: statute/26/32/c/3/A/num_qualifying_children
+    rac_path: statute/26/32/c/3/A/num_qualifying_children
     entity: Person
     dtype: Boolean
     pe_variable: is_eitc_qualifying_child
@@ -229,7 +229,7 @@ variables:
     statute_ref: "26 USC § 32(c)(3)"
 
   num_qualifying_children:
-    cosilico_path: statute/26/32/c/3/A/num_qualifying_children
+    rac_path: statute/26/32/c/3/A/num_qualifying_children
     entity: TaxUnit
     dtype: Integer
     pe_variable: eitc_child_count
@@ -242,7 +242,7 @@ variables:
   # RESIDENCY & CITIZENSHIP
   # ============================================================
   is_us_citizen:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_us_citizen
@@ -250,7 +250,7 @@ variables:
     description: "Person is a US citizen"
 
   is_resident_alien:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: is_resident_alien
@@ -258,7 +258,7 @@ variables:
     description: "Person is a resident alien"
 
   state_code:
-    cosilico_path: null
+    rac_path: null
     entity: Household
     dtype: String
     pe_variable: state_code
@@ -269,7 +269,7 @@ variables:
   # TAX IDENTIFIERS
   # ============================================================
   has_ssn:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: has_ssn
@@ -277,7 +277,7 @@ variables:
     description: "Person has a Social Security Number"
 
   has_itin:
-    cosilico_path: null
+    rac_path: null
     entity: Person
     dtype: Boolean
     pe_variable: has_itin

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -3,7 +3,7 @@
 USC Statute Scraper
 
 Fetches US Code titles from uscode.house.gov in USLM XML format,
-splits by section, and stores using cosilico-lawarchive.
+splits by section, and stores using atlas.
 
 Usage:
     python scraper.py                    # Fetch all configured titles

--- a/scripts/translate_to_v2.py
+++ b/scripts/translate_to_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Translate Cosilico DSL v1 files to v2 syntax.
+"""Translate RAC DSL v1 files to v2 syntax.
 
 Changes:
 - imports { } → imports:
@@ -200,7 +200,7 @@ def main():
 
     dry_run = '--dry-run' in sys.argv
 
-    base_dir = Path('/Users/maxghenis/CosilicoAI/cosilico-us/statute')
+    base_dir = Path('/Users/maxghenis/RulesFoundation/rac-us/statute')
 
     files = list(base_dir.rglob('*.rac'))
     print(f"Found {len(files)} .rac files")

--- a/statute/26/24.rac
+++ b/statute/26/24.rac
@@ -1,0 +1,146 @@
+# 26 USC 24 - Child tax credit
+
+text: """
+26 USC § 24 - Child tax credit
+
+(a) Allowance of credit - $1,000 (or modified amount) per qualifying child
+(b) Limitations - Income phaseout at threshold amounts
+(c) Qualifying child - Definition: qualifying child under 152(c) who has not attained age 17
+(d) Portion of credit refundable - Additional child tax credit (ACTC)
+(e) Identification requirements - TIN requirements for child and taxpayer
+(f) Taxable year must be full taxable year - Except for death
+(g) Restrictions on taxpayers who improperly claimed credit in prior year
+(h) Special rules for taxable years beginning after 2017 (TCJA provisions)
+(i) Inflation adjustments
+(j) Reconciliation of credit and advance credit
+(k) Application of credit in possessions
+"""
+
+# Parent file importing key variables from subsections
+
+variable child_tax_credit:
+  imports:
+    - 26/24/a#ctc_maximum
+    - 26/24/b#ctc_after_phaseout
+    - 26/24/d#actc_amount
+    - 26/24/e#ctc_meets_id_requirements
+    - 26/24/f#ctc_meets_full_year_requirement
+    - 26/24/g#ctc_disallowed_prior_claim
+    - 26/24/h#odc_amount
+    - 26/24/h#ctc_ssn_requirement_met
+    - 26/24/j#ctc_after_advance_reconciliation
+    - 26/24/k#ctc_disallowed_possession_coordination
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Child Tax Credit"
+  description: "Total child tax credit per 26 USC 24"
+  formula: |
+    # Check all disqualifying conditions
+    if not ctc_meets_id_requirements:
+      return 0
+    if not ctc_meets_full_year_requirement:
+      return 0
+    if ctc_disallowed_prior_claim:
+      return 0
+    if not ctc_ssn_requirement_met:
+      return 0
+    if ctc_disallowed_possession_coordination:
+      return 0
+    # Return credit after advance reconciliation plus other dependent credit
+    return ctc_after_advance_reconciliation + odc_amount
+  tests:
+    - name: "Basic CTC with no disqualifications"
+      period: 2024-01
+      inputs:
+        ctc_after_advance_reconciliation: 4000
+        odc_amount: 500
+        ctc_meets_id_requirements: true
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: false
+        ctc_ssn_requirement_met: true
+        ctc_disallowed_possession_coordination: false
+      expect: 4500
+    - name: "CTC disqualified - missing ID"
+      period: 2024-01
+      inputs:
+        ctc_after_advance_reconciliation: 4000
+        odc_amount: 500
+        ctc_meets_id_requirements: false
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: false
+        ctc_ssn_requirement_met: true
+        ctc_disallowed_possession_coordination: false
+      expect: 0
+    - name: "CTC disqualified - prior claim fraud"
+      period: 2024-01
+      inputs:
+        ctc_after_advance_reconciliation: 4000
+        odc_amount: 500
+        ctc_meets_id_requirements: true
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: true
+        ctc_ssn_requirement_met: true
+        ctc_disallowed_possession_coordination: false
+      expect: 0
+    - name: "CTC disqualified - no SSN"
+      period: 2024-01
+      inputs:
+        ctc_after_advance_reconciliation: 4000
+        odc_amount: 500
+        ctc_meets_id_requirements: true
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: false
+        ctc_ssn_requirement_met: false
+        ctc_disallowed_possession_coordination: false
+      expect: 0
+
+variable refundable_ctc:
+  imports:
+    - 26/24/d#actc_amount
+    - 26/24/e#ctc_meets_id_requirements
+    - 26/24/f#ctc_meets_full_year_requirement
+    - 26/24/g#ctc_disallowed_prior_claim
+    - 26/24/h#ctc_ssn_requirement_met
+    - 26/24/k#ctc_disallowed_possession_coordination
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Refundable Child Tax Credit (ACTC)"
+  description: "Refundable portion of CTC per 26 USC 24(d)"
+  formula: |
+    # Check all disqualifying conditions
+    if not ctc_meets_id_requirements:
+      return 0
+    if not ctc_meets_full_year_requirement:
+      return 0
+    if ctc_disallowed_prior_claim:
+      return 0
+    if not ctc_ssn_requirement_met:
+      return 0
+    if ctc_disallowed_possession_coordination:
+      return 0
+    return actc_amount
+  tests:
+    - name: "Basic ACTC with no disqualifications"
+      period: 2024-01
+      inputs:
+        actc_amount: 1400
+        ctc_meets_id_requirements: true
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: false
+        ctc_ssn_requirement_met: true
+        ctc_disallowed_possession_coordination: false
+      expect: 1400
+    - name: "ACTC disqualified"
+      period: 2024-01
+      inputs:
+        actc_amount: 1400
+        ctc_meets_id_requirements: false
+        ctc_meets_full_year_requirement: true
+        ctc_disallowed_prior_claim: false
+        ctc_ssn_requirement_met: true
+        ctc_disallowed_possession_coordination: false
+      expect: 0

--- a/statute/26/24/a.rac
+++ b/statute/26/24/a.rac
@@ -1,0 +1,63 @@
+# 26 USC 24(a) - Allowance of credit
+
+text: """
+(a) Allowance of credit
+There shall be allowed as a credit against the tax imposed by this chapter for
+the taxable year with respect to each qualifying child of the taxpayer for which
+the taxpayer is allowed a deduction under section 151 an amount equal to $1,000.
+"""
+
+# Base credit amount per qualifying child (pre-TCJA/pre-2018)
+parameter ctc_base_amount:
+  description: "Base credit amount per qualifying child per 26 USC 24(a)"
+  unit: USD
+  values:
+    1998-01-01: 400
+    1999-01-01: 500
+    2001-01-01: 600
+    2003-01-01: 1000
+    2018-01-01: 2000   # Modified by (h)(2) for post-2017 years
+    2025-01-01: 2200   # P.L. 119-21
+
+input qualifying_child_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Number of Qualifying Children"
+  description: "Count of qualifying children per 26 USC 24(c)"
+
+variable ctc_maximum:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Maximum Child Tax Credit"
+  description: "Maximum CTC before limitations per 26 USC 24(a)"
+  formula: |
+    return qualifying_child_count * ctc_base_amount
+  tests:
+    - name: "One child, 2024"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 1
+      expect: 2000
+    - name: "Two children, 2024"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 2
+      expect: 4000
+    - name: "Three children, 2024"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 3
+      expect: 6000
+    - name: "No children"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 0
+      expect: 0
+    - name: "One child, 2025 (P.L. 119-21)"
+      period: 2025-01
+      inputs:
+        qualifying_child_count: 1
+      expect: 2200

--- a/statute/26/24/b.rac
+++ b/statute/26/24/b.rac
@@ -1,0 +1,200 @@
+# 26 USC 24(b) - Limitations
+
+text: """
+(b) Limitations
+(1) Limitation based on adjusted gross income
+The amount of the credit allowable under subsection (a) shall be reduced (but not
+below zero) by $50 for each $1,000 (or fraction thereof) by which the taxpayer's
+modified adjusted gross income exceeds the threshold amount. For purposes of the
+preceding sentence, the term "modified adjusted gross income" means adjusted gross
+income increased by any amount excluded from gross income under section 911, 931, or 933.
+
+(2) Threshold amount
+For purposes of paragraph (1), the term "threshold amount" means—
+(A) $110,000 in the case of a joint return,
+(B) $75,000 in the case of an individual who is not married, and
+(C) $55,000 in the case of a married individual filing a separate return.
+For purposes of this paragraph, marital status shall be determined under section 7703.
+
+Note: Per subsection (h)(3), for taxable years beginning after December 31, 2017,
+the threshold amount shall be $400,000 in the case of a joint return ($200,000 in
+any other case).
+"""
+
+# Pre-TCJA phaseout thresholds (subsection (b)(2))
+parameter ctc_threshold_joint:
+  description: "CTC phaseout threshold for joint returns per 26 USC 24(b)(2)(A)"
+  unit: USD
+  values:
+    1998-01-01: 110000
+    2018-01-01: 400000  # Modified by (h)(3)
+
+parameter ctc_threshold_single:
+  description: "CTC phaseout threshold for unmarried individuals per 26 USC 24(b)(2)(B)"
+  unit: USD
+  values:
+    1998-01-01: 75000
+    2018-01-01: 200000  # Modified by (h)(3)
+
+parameter ctc_threshold_separate:
+  description: "CTC phaseout threshold for MFS per 26 USC 24(b)(2)(C)"
+  unit: USD
+  values:
+    1998-01-01: 55000
+    2018-01-01: 200000  # Modified by (h)(3)
+
+# Phaseout rate
+parameter ctc_phaseout_reduction:
+  description: "CTC reduction per $1,000 of excess MAGI per 26 USC 24(b)(1)"
+  unit: USD
+  values:
+    1998-01-01: 50
+
+parameter ctc_phaseout_increment:
+  description: "MAGI increment for CTC phaseout per 26 USC 24(b)(1)"
+  unit: USD
+  values:
+    1998-01-01: 1000
+
+input modified_agi:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Modified Adjusted Gross Income"
+  description: "AGI plus amounts excluded under sections 911, 931, 933"
+
+input filing_status:
+  entity: TaxUnit
+  period: Year
+  dtype: String
+  label: "Filing Status"
+  description: "Tax filing status per 26 USC 1"
+
+variable ctc_threshold:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "CTC Phaseout Threshold"
+  description: "Applicable threshold amount based on filing status per 26 USC 24(b)(2)"
+  formula: |
+    if filing_status == "JOINT":
+      return ctc_threshold_joint
+    if filing_status == "SURVIVING_SPOUSE":
+      return ctc_threshold_joint
+    if filing_status == "SEPARATE":
+      return ctc_threshold_separate
+    # Single and HOH use single threshold
+    return ctc_threshold_single
+  tests:
+    - name: "Joint filers 2024"
+      period: 2024-01
+      inputs:
+        filing_status: "JOINT"
+      expect: 400000
+    - name: "Single filers 2024"
+      period: 2024-01
+      inputs:
+        filing_status: "SINGLE"
+      expect: 200000
+    - name: "MFS 2024"
+      period: 2024-01
+      inputs:
+        filing_status: "SEPARATE"
+      expect: 200000
+
+variable ctc_phaseout_amount:
+  imports:
+    - 26/24/a#ctc_maximum
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "CTC Phaseout Amount"
+  description: "Reduction in CTC due to income phaseout per 26 USC 24(b)(1)"
+  formula: |
+    # Compute phaseout for joint/surviving spouse threshold
+    # Per statute: reduce by $50 for each $1,000 (or fraction thereof)
+    # Using integer math: increments = ceil(excess / 1000) = (excess + 999) / 1000 (truncated)
+    # Since DSL lacks integer division, compute excess/1000 and add 0.999 then truncate via min
+    joint_excess = max(0, modified_agi - ctc_threshold_joint)
+    joint_rate = ctc_phaseout_reduction / ctc_phaseout_increment
+    joint_reduction = min(joint_excess * joint_rate, ctc_maximum)
+
+    # Compute phaseout for single threshold
+    single_excess = max(0, modified_agi - ctc_threshold_single)
+    single_reduction = min(single_excess * joint_rate, ctc_maximum)
+
+    # Compute phaseout for separate threshold
+    separate_excess = max(0, modified_agi - ctc_threshold_separate)
+    separate_reduction = min(separate_excess * joint_rate, ctc_maximum)
+
+    # Select appropriate reduction based on filing status
+    if filing_status == "JOINT":
+      return joint_reduction
+    if filing_status == "SURVIVING_SPOUSE":
+      return joint_reduction
+    if filing_status == "SEPARATE":
+      return separate_reduction
+    # Single and HOH
+    return single_reduction
+  tests:
+    - name: "Below threshold - Joint"
+      period: 2024-01
+      inputs:
+        modified_agi: 200000
+        filing_status: "JOINT"
+        ctc_maximum: 4000
+      expect: 0
+    - name: "At threshold - Joint"
+      period: 2024-01
+      inputs:
+        modified_agi: 400000
+        filing_status: "JOINT"
+        ctc_maximum: 4000
+      expect: 0
+    - name: "$20,000 over threshold - Joint"
+      period: 2024-01
+      inputs:
+        modified_agi: 420000
+        filing_status: "JOINT"
+        ctc_maximum: 4000
+      expect: 1000
+    - name: "Fully phased out - Joint"
+      period: 2024-01
+      inputs:
+        modified_agi: 500000
+        filing_status: "JOINT"
+        ctc_maximum: 4000
+      expect: 4000
+
+variable ctc_after_phaseout:
+  imports:
+    - 26/24/a#ctc_maximum
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "CTC After Income Phaseout"
+  description: "Child tax credit after income limitation per 26 USC 24(b)"
+  formula: |
+    return max(0, ctc_maximum - ctc_phaseout_amount)
+  tests:
+    - name: "No phaseout"
+      period: 2024-01
+      inputs:
+        ctc_maximum: 4000
+        ctc_phaseout_amount: 0
+      expect: 4000
+    - name: "Partial phaseout"
+      period: 2024-01
+      inputs:
+        ctc_maximum: 4000
+        ctc_phaseout_amount: 1000
+      expect: 3000
+    - name: "Full phaseout"
+      period: 2024-01
+      inputs:
+        ctc_maximum: 4000
+        ctc_phaseout_amount: 5000
+      expect: 0

--- a/statute/26/24/c.rac
+++ b/statute/26/24/c.rac
@@ -1,0 +1,96 @@
+# 26 USC 24(c) - Qualifying child
+
+text: """
+(c) Qualifying child
+For purposes of this section—
+(1) In general
+The term "qualifying child" means a qualifying child of the taxpayer (as defined
+in section 152(c)) who has not attained age 17.
+
+(2) Exception for certain noncitizens
+The term "qualifying child" shall not include any individual who would not be a
+dependent if subparagraph (A) of section 152(b)(3) were applied without regard to
+all that follows "resident of the United States".
+"""
+
+# Age threshold for qualifying child
+parameter ctc_qualifying_age:
+  description: "Maximum age for CTC qualifying child per 26 USC 24(c)(1)"
+  unit: years
+  values:
+    1998-01-01: 17
+
+input child_age:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "Child Age"
+  description: "Age of child at end of calendar year"
+
+input is_qualifying_child_152c:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Qualifying Child per 152(c)"
+  description: "Whether individual meets qualifying child definition under section 152(c)"
+
+input is_us_citizen_or_resident:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "US Citizen or Resident"
+  description: "Whether individual is US citizen or resident per 152(b)(3)(A)"
+
+variable is_ctc_qualifying_child:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "CTC Qualifying Child"
+  description: "Whether individual qualifies as qualifying child for CTC per 26 USC 24(c)"
+  formula: |
+    # Must be qualifying child under 152(c)
+    if not is_qualifying_child_152c:
+      return False
+    # Must not have attained age 17
+    if child_age >= ctc_qualifying_age:
+      return False
+    # Must meet citizenship/residency requirement
+    if not is_us_citizen_or_resident:
+      return False
+    return True
+  tests:
+    - name: "Qualifying 10-year-old"
+      period: 2024-01
+      inputs:
+        child_age: 10
+        is_qualifying_child_152c: true
+        is_us_citizen_or_resident: true
+      expect: true
+    - name: "16-year-old (still qualifies)"
+      period: 2024-01
+      inputs:
+        child_age: 16
+        is_qualifying_child_152c: true
+        is_us_citizen_or_resident: true
+      expect: true
+    - name: "17-year-old (too old)"
+      period: 2024-01
+      inputs:
+        child_age: 17
+        is_qualifying_child_152c: true
+        is_us_citizen_or_resident: true
+      expect: false
+    - name: "Non-citizen child"
+      period: 2024-01
+      inputs:
+        child_age: 10
+        is_qualifying_child_152c: true
+        is_us_citizen_or_resident: false
+      expect: false
+    - name: "Not qualifying child under 152(c)"
+      period: 2024-01
+      inputs:
+        child_age: 10
+        is_qualifying_child_152c: false
+        is_us_citizen_or_resident: true
+      expect: false

--- a/statute/26/24/d.rac
+++ b/statute/26/24/d.rac
@@ -1,0 +1,245 @@
+# 26 USC 24(d) - Portion of credit refundable
+
+text: """
+(d) Portion of credit refundable
+(1) In general
+The aggregate credits allowed to a taxpayer under subpart C shall be increased by
+the lesser of—
+(A) the credit which would be allowed under this section without regard to this
+subsection and the limitation under section 26(a) or
+(B) the amount by which the aggregate amount of credits allowed by this subpart
+(determined without regard to this subsection) would increase if the limitation
+imposed by section 26(a) were increased by the greater of—
+(i) 15 percent of so much of the taxpayer's earned income (within the meaning of
+section 32) which is taken into account in computing taxable income for the taxable
+year as exceeds $3,000, or
+(ii) in the case of a taxpayer with 3 or more qualifying children, the excess (if any) of—
+(I) the taxpayer's social security taxes for the taxable year, over
+(II) the credit allowed under section 32 for the taxable year.
+
+(2) Social security taxes
+For purposes of paragraph (1)—
+(A) In general
+The term "social security taxes" means, with respect to any taxpayer for any taxable year—
+(i) the amount of the taxes imposed by sections 3101 and 3201(a) on amounts received by
+the taxpayer during the calendar year in which the taxable year begins,
+(ii) 50 percent of the taxes imposed by section 1401 on the self-employment income of
+the taxpayer for the taxable year, and
+(iii) 50 percent of the taxes imposed by section 3211(a) on amounts received by the
+taxpayer during the calendar year in which the taxable year begins.
+
+(3) Exception for taxpayers excluding foreign earned income
+Paragraph (1) shall not apply to any taxpayer for any taxable year if such taxpayer
+elects to exclude any amount from gross income under section 911 for such taxable year.
+
+Note: Per subsection (h)(5), for taxable years beginning after December 31, 2017, the
+refundable amount per qualifying child shall not exceed $1,400 (indexed for inflation
+after 2024). Per (h)(6), the earned income threshold is $2,500 instead of $3,000.
+"""
+
+# Earned income threshold for refundable portion
+parameter actc_earned_income_threshold:
+  description: "Earned income threshold for ACTC per 26 USC 24(d)(1)(B)(i)"
+  unit: USD
+  values:
+    1998-01-01: 10000
+    2009-01-01: 3000
+    2018-01-01: 2500  # Modified by (h)(6)
+
+# ACTC phase-in rate
+parameter actc_phasein_rate:
+  description: "Phase-in rate for ACTC per 26 USC 24(d)(1)(B)(i)"
+  values:
+    1998-01-01: 0.10
+    2005-01-01: 0.15
+
+# Maximum refundable amount per child (post-TCJA)
+parameter actc_max_per_child:
+  description: "Maximum refundable CTC per child per 26 USC 24(h)(5)"
+  unit: USD
+  values:
+    2018-01-01: 1400
+    # Indexed for inflation starting 2025 per 26 USC 24(i)(1)
+
+# Minimum qualifying children for SS tax calculation
+parameter actc_ss_min_children:
+  description: "Minimum qualifying children for SS tax calculation per 26 USC 24(d)(1)(B)(ii)"
+  values:
+    1998-01-01: 3
+
+input earned_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Earned Income"
+  description: "Earned income within meaning of section 32"
+
+input social_security_taxes:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Social Security Taxes"
+  description: "Social security taxes per 26 USC 24(d)(2)"
+
+input eitc_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "EITC Amount"
+  description: "Earned income tax credit per section 32"
+
+input excludes_foreign_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Excludes Foreign Income"
+  description: "Whether taxpayer elects to exclude income under section 911"
+
+input qualifying_child_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Number of Qualifying Children"
+  description: "Count of qualifying children per 26 USC 24(c)"
+
+variable actc_earned_income_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "ACTC Earned Income Component"
+  description: "15% of earned income over threshold per 26 USC 24(d)(1)(B)(i)"
+  formula: |
+    excess_earned_income = max(0, earned_income - actc_earned_income_threshold)
+    return excess_earned_income * actc_phasein_rate
+  tests:
+    - name: "Earned income below threshold"
+      period: 2024-01
+      inputs:
+        earned_income: 2000
+      expect: 0
+    - name: "Earned income at threshold"
+      period: 2024-01
+      inputs:
+        earned_income: 2500
+      expect: 0
+    - name: "$10,000 over threshold"
+      period: 2024-01
+      inputs:
+        earned_income: 12500
+      expect: 1500
+    - name: "$30,000 earned income"
+      period: 2024-01
+      inputs:
+        earned_income: 30000
+      expect: 4125
+
+variable actc_ss_excess_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "ACTC Social Security Excess"
+  description: "Excess of SS taxes over EITC per 26 USC 24(d)(1)(B)(ii)"
+  formula: |
+    # Only applies to taxpayers with 3+ qualifying children
+    if qualifying_child_count < actc_ss_min_children:
+      return 0
+    return max(0, social_security_taxes - eitc_amount)
+  tests:
+    - name: "Two children (not eligible)"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 2
+        social_security_taxes: 5000
+        eitc_amount: 2000
+      expect: 0
+    - name: "Three children, SS exceeds EITC"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 3
+        social_security_taxes: 5000
+        eitc_amount: 2000
+      expect: 3000
+    - name: "Three children, EITC exceeds SS"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 3
+        social_security_taxes: 2000
+        eitc_amount: 5000
+      expect: 0
+
+variable actc_limitation_increase:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "ACTC Limitation Increase"
+  description: "Greater of earned income or SS excess amounts per 26 USC 24(d)(1)(B)"
+  formula: |
+    return max(actc_earned_income_amount, actc_ss_excess_amount)
+  tests:
+    - name: "Earned income component greater"
+      period: 2024-01
+      inputs:
+        actc_earned_income_amount: 3000
+        actc_ss_excess_amount: 1000
+      expect: 3000
+    - name: "SS excess component greater"
+      period: 2024-01
+      inputs:
+        actc_earned_income_amount: 1000
+        actc_ss_excess_amount: 4000
+      expect: 4000
+
+variable actc_amount:
+  imports:
+    - 26/24/b#ctc_after_phaseout
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Additional Child Tax Credit"
+  description: "Refundable portion of CTC per 26 USC 24(d)"
+  formula: |
+    # Exception for foreign income exclusion
+    if excludes_foreign_income:
+      return 0
+    # Lesser of (A) credit amount or (B) limitation increase
+    uncapped = min(ctc_after_phaseout, actc_limitation_increase)
+    # Per (h)(5), cap at $1,400 per child for post-2017 years
+    max_refundable = qualifying_child_count * actc_max_per_child
+    return min(uncapped, max_refundable)
+  tests:
+    - name: "Low earner, one child"
+      period: 2024-01
+      inputs:
+        ctc_after_phaseout: 2000
+        actc_limitation_increase: 1500
+        excludes_foreign_income: false
+        qualifying_child_count: 1
+      expect: 1400
+    - name: "Moderate earner, two children"
+      period: 2024-01
+      inputs:
+        ctc_after_phaseout: 4000
+        actc_limitation_increase: 5000
+        excludes_foreign_income: false
+        qualifying_child_count: 2
+      expect: 2800
+    - name: "Foreign income exclusion"
+      period: 2024-01
+      inputs:
+        ctc_after_phaseout: 2000
+        actc_limitation_increase: 1500
+        excludes_foreign_income: true
+        qualifying_child_count: 1
+      expect: 0
+    - name: "High earner, full credit non-refundable"
+      period: 2024-01
+      inputs:
+        ctc_after_phaseout: 4000
+        actc_limitation_increase: 10000
+        excludes_foreign_income: false
+        qualifying_child_count: 2
+      expect: 2800

--- a/statute/26/24/e.rac
+++ b/statute/26/24/e.rac
@@ -1,0 +1,72 @@
+# 26 USC 24(e) - Identification requirements
+
+text: """
+(e) Identification requirements
+(1) Qualifying child identification requirement
+No credit shall be allowed under this section to a taxpayer with respect to any
+qualifying child unless the taxpayer includes the name and taxpayer identification
+number of such qualifying child on the return of tax for the taxable year and
+such taxpayer identification number was issued on or before the due date for
+filing such return.
+
+(2) Taxpayer identification requirement
+No credit shall be allowed under this section if the taxpayer identification number
+of the taxpayer was issued after the due date for filing the return for the taxable year.
+"""
+
+input child_has_valid_tin:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Has Valid TIN"
+  description: "Whether child has TIN issued on or before return due date per 26 USC 24(e)(1)"
+
+input taxpayer_has_valid_tin:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Has Valid TIN"
+  description: "Whether taxpayer TIN was issued on or before return due date per 26 USC 24(e)(2)"
+
+variable ctc_meets_id_requirements:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Meets ID Requirements"
+  description: "Whether taxpayer meets identification requirements per 26 USC 24(e)"
+  formula: |
+    # Taxpayer must have valid TIN
+    if not taxpayer_has_valid_tin:
+      return False
+    return True
+  tests:
+    - name: "Taxpayer has valid TIN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_tin: true
+      expect: true
+    - name: "Taxpayer TIN issued late"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_tin: false
+      expect: false
+
+variable child_meets_ctc_id_requirement:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Meets CTC ID Requirement"
+  description: "Whether child meets identification requirement per 26 USC 24(e)(1)"
+  formula: |
+    return child_has_valid_tin
+  tests:
+    - name: "Child has valid TIN"
+      period: 2024-01
+      inputs:
+        child_has_valid_tin: true
+      expect: true
+    - name: "Child TIN issued late"
+      period: 2024-01
+      inputs:
+        child_has_valid_tin: false
+      expect: false

--- a/statute/26/24/f.rac
+++ b/statute/26/24/f.rac
@@ -1,0 +1,61 @@
+# 26 USC 24(f) - Taxable year must be full taxable year
+
+text: """
+(f) Taxable year must be full taxable year
+Except in the case of a taxable year closed by reason of the death of the taxpayer,
+no credit shall be allowable under this section in the case of a taxable year
+covering a period of less than 12 months.
+"""
+
+# Minimum months for full taxable year
+parameter ctc_min_tax_year_months:
+  description: "Minimum months for full taxable year per 26 USC 24(f)"
+  unit: months
+  values:
+    1998-01-01: 12
+
+input tax_year_months:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Tax Year Months"
+  description: "Number of months in taxable year"
+
+input taxpayer_deceased:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Deceased"
+  description: "Whether taxable year closed due to taxpayer death"
+
+variable ctc_meets_full_year_requirement:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Meets Full Year Requirement"
+  description: "Whether taxpayer meets full taxable year requirement per 26 USC 24(f)"
+  formula: |
+    # Exception for death
+    if taxpayer_deceased:
+      return True
+    # Otherwise must be full 12-month year
+    return tax_year_months >= ctc_min_tax_year_months
+  tests:
+    - name: "Full 12-month year"
+      period: 2024-01
+      inputs:
+        tax_year_months: 12
+        taxpayer_deceased: false
+      expect: true
+    - name: "Short year, not deceased"
+      period: 2024-01
+      inputs:
+        tax_year_months: 6
+        taxpayer_deceased: false
+      expect: false
+    - name: "Short year due to death"
+      period: 2024-01
+      inputs:
+        tax_year_months: 6
+        taxpayer_deceased: true
+      expect: true

--- a/statute/26/24/g.rac
+++ b/statute/26/24/g.rac
@@ -1,0 +1,187 @@
+# 26 USC 24(g) - Restrictions on taxpayers who improperly claimed credit in prior year
+
+text: """
+(g) Restrictions on taxpayers who improperly claimed credit in prior year
+(1) Taxpayers making prior fraudulent or reckless claims
+(A) In general
+No credit shall be allowed under this section for any taxable year in the
+disallowance period.
+(B) Disallowance period
+For purposes of subparagraph (A), the disallowance period is—
+(i) the period of 10 taxable years after the most recent taxable year for which
+there was a final determination that the taxpayer's claim of credit under this
+section was due to fraud, and
+(ii) the period of 2 taxable years after the most recent taxable year for which
+there was a final determination that the taxpayer's claim of credit under this
+section was due to reckless or intentional disregard of rules and regulations
+(but not due to fraud).
+
+(2) Taxpayers making improper prior claims
+In the case of a taxpayer who is denied credit under this section for any taxable
+year as a result of the deficiency procedures under subchapter B of chapter 63,
+no credit shall be allowed under this section for any subsequent taxable year
+unless the taxpayer provides such information as the Secretary may require to
+demonstrate eligibility for such credit.
+"""
+
+# Disallowance period for fraud
+parameter ctc_fraud_disallowance_years:
+  description: "Disallowance period for fraudulent CTC claims per 26 USC 24(g)(1)(B)(i)"
+  unit: years
+  values:
+    2016-01-01: 10
+
+# Disallowance period for reckless/intentional disregard
+parameter ctc_reckless_disallowance_years:
+  description: "Disallowance period for reckless CTC claims per 26 USC 24(g)(1)(B)(ii)"
+  unit: years
+  values:
+    2016-01-01: 2
+
+input ctc_fraud_determination_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "CTC Fraud Determination Year"
+  description: "Year of final determination of fraudulent CTC claim (0 if none)"
+
+input ctc_reckless_determination_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "CTC Reckless Determination Year"
+  description: "Year of final determination of reckless CTC claim (0 if none)"
+
+input ctc_deficiency_requires_documentation:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Documentation Required"
+  description: "Whether taxpayer must provide documentation due to prior denial per 26 USC 24(g)(2)"
+
+input ctc_documentation_provided:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Documentation Provided"
+  description: "Whether required documentation has been provided"
+
+input current_tax_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Current Tax Year"
+  description: "The current taxable year"
+
+variable ctc_in_fraud_disallowance_period:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "In CTC Fraud Disallowance Period"
+  description: "Whether taxpayer is in disallowance period due to fraud per 26 USC 24(g)(1)(B)(i)"
+  formula: |
+    if ctc_fraud_determination_year == 0:
+      return False
+    years_since_fraud = current_tax_year - ctc_fraud_determination_year
+    return years_since_fraud <= ctc_fraud_disallowance_years
+  tests:
+    - name: "No fraud history"
+      period: 2024-01
+      inputs:
+        ctc_fraud_determination_year: 0
+        current_tax_year: 2024
+      expect: false
+    - name: "Within 10-year fraud period"
+      period: 2024-01
+      inputs:
+        ctc_fraud_determination_year: 2020
+        current_tax_year: 2024
+      expect: true
+    - name: "Beyond 10-year fraud period"
+      period: 2024-01
+      inputs:
+        ctc_fraud_determination_year: 2010
+        current_tax_year: 2024
+      expect: false
+
+variable ctc_in_reckless_disallowance_period:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "In CTC Reckless Disallowance Period"
+  description: "Whether taxpayer is in disallowance period due to reckless claim per 26 USC 24(g)(1)(B)(ii)"
+  formula: |
+    if ctc_reckless_determination_year == 0:
+      return False
+    years_since_reckless = current_tax_year - ctc_reckless_determination_year
+    return years_since_reckless <= ctc_reckless_disallowance_years
+  tests:
+    - name: "No reckless history"
+      period: 2024-01
+      inputs:
+        ctc_reckless_determination_year: 0
+        current_tax_year: 2024
+      expect: false
+    - name: "Within 2-year reckless period"
+      period: 2024-01
+      inputs:
+        ctc_reckless_determination_year: 2023
+        current_tax_year: 2024
+      expect: true
+    - name: "Beyond 2-year reckless period"
+      period: 2024-01
+      inputs:
+        ctc_reckless_determination_year: 2020
+        current_tax_year: 2024
+      expect: false
+
+variable ctc_disallowed_prior_claim:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Disallowed Due to Prior Claim"
+  description: "Whether CTC is disallowed due to prior improper claim per 26 USC 24(g)"
+  formula: |
+    # Fraud disallowance
+    if ctc_in_fraud_disallowance_period:
+      return True
+    # Reckless disallowance
+    if ctc_in_reckless_disallowance_period:
+      return True
+    # Documentation requirement not met
+    if ctc_deficiency_requires_documentation and not ctc_documentation_provided:
+      return True
+    return False
+  tests:
+    - name: "No prior issues"
+      period: 2024-01
+      inputs:
+        ctc_in_fraud_disallowance_period: false
+        ctc_in_reckless_disallowance_period: false
+        ctc_deficiency_requires_documentation: false
+        ctc_documentation_provided: false
+      expect: false
+    - name: "In fraud period"
+      period: 2024-01
+      inputs:
+        ctc_in_fraud_disallowance_period: true
+        ctc_in_reckless_disallowance_period: false
+        ctc_deficiency_requires_documentation: false
+        ctc_documentation_provided: false
+      expect: true
+    - name: "Documentation required but not provided"
+      period: 2024-01
+      inputs:
+        ctc_in_fraud_disallowance_period: false
+        ctc_in_reckless_disallowance_period: false
+        ctc_deficiency_requires_documentation: true
+        ctc_documentation_provided: false
+      expect: true
+    - name: "Documentation required and provided"
+      period: 2024-01
+      inputs:
+        ctc_in_fraud_disallowance_period: false
+        ctc_in_reckless_disallowance_period: false
+        ctc_deficiency_requires_documentation: true
+        ctc_documentation_provided: true
+      expect: false

--- a/statute/26/24/h.rac
+++ b/statute/26/24/h.rac
@@ -1,0 +1,152 @@
+# 26 USC 24(h) - Special rules for taxable years beginning after 2017
+
+text: """
+(h) Special rules for taxable years beginning after 2017
+(1) In general
+In the case of a taxable year beginning after December 31, 2017, this section shall
+be applied as provided in paragraphs (2) through (7).
+
+(2) Credit amount
+Subsection (a) shall be applied by substituting "$2,200" for "$1,000".
+[Note: P.L. 119-21 increased from $2,000 to $2,200 effective 2025]
+
+(3) Limitation
+In lieu of the amount determined under subsection (b)(2), the threshold amount shall
+be $400,000 in the case of a joint return ($200,000 in any other case).
+
+(4) Partial credit allowed for certain other dependents
+(A) In general
+The credit determined under subsection (a) (after the application of paragraph (2))
+shall be increased by $500 for each dependent of the taxpayer (as defined in section 152)
+other than a qualifying child described in subsection (c).
+(B) Exception for certain noncitizens
+Subparagraph (A) shall not apply with respect to any individual who would not be a
+dependent if subparagraph (A) of section 152(b)(3) were applied without regard to
+all that follows "resident of the United States".
+(C) Certain qualifying children
+In the case of any qualifying child with respect to whom a credit is not allowed under
+this section by reason of paragraph (7), such child shall be treated as a dependent to
+whom subparagraph (A) applies.
+
+(5) Maximum amount of refundable credit
+The amount determined under subsection (d)(1)(A) with respect to any qualifying child
+shall not exceed $1,400, and such subsection shall be applied without regard to
+paragraph (4) of this subsection.
+
+(6) Earned income threshold for refundable credit
+Subsection (d)(1)(B)(i) shall be applied by substituting "$2,500" for "$3,000".
+
+(7) Social security number required
+(A) In general
+No credit shall be allowed under this section to a taxpayer with respect to any
+qualifying child unless the taxpayer includes on the return of tax for the taxable year—
+(i) the taxpayer's social security number (or, in the case of a joint return, the
+social security number of at least 1 spouse), and
+(ii) the social security number of such qualifying child.
+(B) Social security number
+For purposes of this paragraph, the term "social security number" means a social
+security number issued to an individual by the Social Security Administration, but only
+if the social security number is issued—
+(i) to a citizen of the United States or pursuant to subclause (I) (or that portion of
+subclause (III) that relates to subclause (I)) of section 205(c)(2)(B)(i) of the
+Social Security Act, and
+(ii) before the due date for such return.
+"""
+
+# Credit amount for other dependents (non-qualifying children)
+parameter odc_credit_amount:
+  description: "Credit for other dependents per 26 USC 24(h)(4)(A)"
+  unit: USD
+  values:
+    2018-01-01: 500
+
+input other_dependent_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Number of Other Dependents"
+  description: "Count of dependents who are not qualifying children per 26 USC 24(h)(4)"
+
+input taxpayer_has_ssn:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Has SSN"
+  description: "Whether taxpayer (or spouse on joint return) has valid SSN per 26 USC 24(h)(7)"
+
+input child_has_ssn:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Has SSN"
+  description: "Whether child has valid SSN issued before return due date per 26 USC 24(h)(7)"
+
+variable odc_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Other Dependent Credit"
+  description: "Credit for other dependents per 26 USC 24(h)(4)"
+  formula: |
+    return other_dependent_count * odc_credit_amount
+  tests:
+    - name: "One other dependent"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 1
+      expect: 500
+    - name: "Two other dependents"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 2
+      expect: 1000
+    - name: "No other dependents"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 0
+      expect: 0
+
+variable child_qualifies_for_ctc_ssn:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Qualifies for CTC (SSN)"
+  description: "Whether child qualifies for CTC based on SSN requirement per 26 USC 24(h)(7)"
+  formula: |
+    return child_has_ssn
+  tests:
+    - name: "Child has SSN"
+      period: 2024-01
+      inputs:
+        child_has_ssn: true
+      expect: true
+    - name: "Child has ITIN only"
+      period: 2024-01
+      inputs:
+        child_has_ssn: false
+      expect: false
+
+variable ctc_ssn_requirement_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC SSN Requirement Met"
+  description: "Whether taxpayer meets SSN requirement per 26 USC 24(h)(7)"
+  formula: |
+    return taxpayer_has_ssn
+  tests:
+    - name: "Taxpayer has SSN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: true
+      expect: true
+    - name: "Taxpayer has ITIN only"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: false
+      expect: false
+
+# Note: The main credit amount change ($2,000 -> $2,200) and threshold changes
+# are incorporated in the parameter values in subsections (a) and (b)
+# with effective dates for 2018-01-01 and 2025-01-01

--- a/statute/26/24/i.rac
+++ b/statute/26/24/i.rac
@@ -1,0 +1,128 @@
+# 26 USC 24(i) - Inflation adjustments
+
+text: """
+(i) Inflation adjustments
+(1) Maximum amount of refundable credit
+In the case of a taxable year beginning after 2024, the $1,400 amount in subsection (h)(5)
+shall be increased by an amount equal to—
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3) for the calendar year
+in which the taxable year begins, determined by substituting "2017" for "2016" in
+subparagraph (A)(ii) thereof.
+
+(2) Special rule for adjustment of credit amount
+In the case of a taxable year beginning after 2025, the $2,200 amount in subsection (h)(2)
+shall be increased by an amount equal to—
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3) for the calendar year
+in which the taxable year begins, determined by substituting "2024" for "2016" in
+subparagraph (A)(ii) thereof.
+
+(3) Rounding
+If any increase under this subsection is not a multiple of $100, such increase shall be
+rounded to the next lowest multiple of $100.
+"""
+
+# Base year for ACTC inflation adjustment
+parameter actc_inflation_base_year:
+  description: "Base year for ACTC refundable limit inflation adjustment per 26 USC 24(i)(1)"
+  values:
+    2025-01-01: 2017
+
+# Base year for credit amount inflation adjustment
+parameter ctc_credit_inflation_base_year:
+  description: "Base year for CTC credit amount inflation adjustment per 26 USC 24(i)(2)"
+  values:
+    2026-01-01: 2024
+
+# Rounding increment
+parameter ctc_inflation_rounding:
+  description: "Rounding increment for CTC inflation adjustments per 26 USC 24(i)(3)"
+  unit: USD
+  values:
+    2025-01-01: 100
+
+# Note: The actual inflation-adjusted values would be computed by importing
+# the cost-of-living adjustment from 26 USC 1(f)(3) and applying the formula.
+# For statutory values, we record the base amounts and adjustment methodology.
+
+input cola_adjustment:
+  entity: TaxUnit
+  period: Year
+  dtype: Float
+  label: "Cost of Living Adjustment"
+  description: "COLA per section 1(f)(3) with applicable base year substitution"
+
+variable actc_inflation_adjusted_max:
+  imports:
+    - 26/24/d#actc_max_per_child
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted ACTC Maximum"
+  description: "Inflation-adjusted maximum refundable CTC per child per 26 USC 24(i)(1)"
+  formula: |
+    # For years after 2024, apply inflation adjustment
+    base_amount = actc_max_per_child
+    adjusted = base_amount * (1 + cola_adjustment)
+    # Note: Statute requires rounding to next lowest $100 multiple
+    # DSL lacks floor/integer division, so this returns adjusted value
+    # Runtime engine should handle rounding per 24(i)(3)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2024-01
+      inputs:
+        actc_max_per_child: 1400
+        cola_adjustment: 0
+      expect: 1400
+    - name: "5% inflation (before rounding)"
+      period: 2025-01
+      inputs:
+        actc_max_per_child: 1400
+        cola_adjustment: 0.05
+      expect: 1470
+    - name: "10% inflation (before rounding)"
+      period: 2026-01
+      inputs:
+        actc_max_per_child: 1400
+        cola_adjustment: 0.10
+      expect: 1540
+
+variable ctc_credit_inflation_adjusted:
+  imports:
+    - 26/24/a#ctc_base_amount
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted CTC Credit Amount"
+  description: "Inflation-adjusted CTC credit per child per 26 USC 24(i)(2)"
+  formula: |
+    # For years after 2025, apply inflation adjustment
+    base_amount = ctc_base_amount
+    adjusted = base_amount * (1 + cola_adjustment)
+    # Note: Statute requires rounding to next lowest $100 multiple
+    # DSL lacks floor/integer division, so this returns adjusted value
+    # Runtime engine should handle rounding per 24(i)(3)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2025-01
+      inputs:
+        ctc_base_amount: 2200
+        cola_adjustment: 0
+      expect: 2200
+    - name: "5% inflation (before rounding)"
+      period: 2026-01
+      inputs:
+        ctc_base_amount: 2200
+        cola_adjustment: 0.05
+      expect: 2310
+    - name: "7% inflation (before rounding)"
+      period: 2026-01
+      inputs:
+        ctc_base_amount: 2200
+        cola_adjustment: 0.07
+      expect: 2354

--- a/statute/26/24/j.rac
+++ b/statute/26/24/j.rac
@@ -1,0 +1,298 @@
+# 26 USC 24(j) - Reconciliation of credit and advance credit
+
+text: """
+(j) Reconciliation of credit and advance credit
+(1) In general
+The amount of the credit allowed under this section to any taxpayer for any taxable
+year shall be reduced (but not below zero) by the aggregate amount of payments made
+under section 7527A to such taxpayer during such taxable year. Any failure to so
+reduce the credit shall be treated as arising out of a mathematical or clerical error
+and assessed according to section 6213(b)(1).
+
+(2) Excess advance payments
+(A) In general
+If the aggregate amount of payments under section 7527A to the taxpayer during the
+taxable year exceeds the amount of the credit allowed under this section to such
+taxpayer for such taxable year (determined without regard to paragraph (1)), the
+tax imposed by this chapter for such taxable year shall be increased by the amount
+of such excess.
+(B) Safe harbor based on modified adjusted gross income
+(i) In general
+In the case of a taxpayer whose modified adjusted gross income (as defined in
+subsection (b)) for the taxable year does not exceed 200 percent of the applicable
+income threshold, the amount of the increase determined under subparagraph (A) with
+respect to such taxpayer for such taxable year shall be reduced (but not below zero)
+by the safe harbor amount.
+(ii) Phase out of safe harbor amount
+In the case of a taxpayer whose modified adjusted gross income (as defined in
+subsection (b)) for the taxable year exceeds the applicable income threshold, the
+safe harbor amount otherwise in effect under clause (i) shall be reduced by the
+amount which bears the same ratio to such amount as such excess bears to the
+applicable income threshold.
+(iii) Applicable income threshold
+For purposes of this subparagraph, the term "applicable income threshold" means—
+(I) $60,000 in the case of a joint return or surviving spouse (as defined in section 2(a)),
+(II) $50,000 in the case of a head of household, and
+(III) $40,000 in any other case.
+(iv) Safe harbor amount
+For purposes of this subparagraph, the term "safe harbor amount" means, with respect
+to any taxable year, the product of—
+(I) $2,000, multiplied by
+(II) the excess (if any) of the number of qualified children taken into account in
+determining the annual advance amount with respect to the taxpayer under section 7527A
+with respect to months beginning in such taxable year, over the number of qualified
+children taken into account in determining the credit allowed under this section for
+such taxable year.
+"""
+
+# Safe harbor income thresholds
+parameter advance_ctc_safe_harbor_threshold_joint:
+  description: "Safe harbor income threshold for joint returns per 26 USC 24(j)(2)(B)(iii)(I)"
+  unit: USD
+  values:
+    2021-01-01: 60000
+
+parameter advance_ctc_safe_harbor_threshold_hoh:
+  description: "Safe harbor income threshold for HOH per 26 USC 24(j)(2)(B)(iii)(II)"
+  unit: USD
+  values:
+    2021-01-01: 50000
+
+parameter advance_ctc_safe_harbor_threshold_other:
+  description: "Safe harbor income threshold for others per 26 USC 24(j)(2)(B)(iii)(III)"
+  unit: USD
+  values:
+    2021-01-01: 40000
+
+# Safe harbor amount per child
+parameter advance_ctc_safe_harbor_per_child:
+  description: "Safe harbor amount per excess advance child per 26 USC 24(j)(2)(B)(iv)(I)"
+  unit: USD
+  values:
+    2021-01-01: 2000
+
+# Safe harbor phase-out multiplier
+parameter advance_ctc_safe_harbor_phaseout_multiple:
+  description: "Multiple of threshold for full safe harbor phase-out per 26 USC 24(j)(2)(B)(i)"
+  values:
+    2021-01-01: 2
+
+input advance_ctc_payments:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Advance CTC Payments"
+  description: "Total advance CTC payments received under section 7527A"
+
+input advance_ctc_children_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Advance CTC Children Count"
+  description: "Number of children used to determine advance payments"
+
+input actual_ctc_children_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Actual CTC Children Count"
+  description: "Number of qualifying children for actual credit"
+
+input filing_status:
+  entity: TaxUnit
+  period: Year
+  dtype: Enum[SINGLE, JOINT, SEPARATE, HEAD_OF_HOUSEHOLD, SURVIVING_SPOUSE]
+  label: "Filing Status"
+  description: "Tax filing status per 26 USC 1"
+
+input modified_agi:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Modified Adjusted Gross Income"
+  description: "AGI plus amounts excluded under sections 911, 931, 933"
+
+variable advance_ctc_safe_harbor_threshold:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Advance CTC Safe Harbor Threshold"
+  description: "Applicable income threshold for safe harbor per 26 USC 24(j)(2)(B)(iii)"
+  formula: |
+    if filing_status == "JOINT":
+      return advance_ctc_safe_harbor_threshold_joint
+    if filing_status == "SURVIVING_SPOUSE":
+      return advance_ctc_safe_harbor_threshold_joint
+    if filing_status == "HEAD_OF_HOUSEHOLD":
+      return advance_ctc_safe_harbor_threshold_hoh
+    return advance_ctc_safe_harbor_threshold_other
+  tests:
+    - name: "Joint filers"
+      period: 2021-01
+      inputs:
+        filing_status: "JOINT"
+      expect: 60000
+    - name: "Head of household"
+      period: 2021-01
+      inputs:
+        filing_status: "HEAD_OF_HOUSEHOLD"
+      expect: 50000
+    - name: "Single filer"
+      period: 2021-01
+      inputs:
+        filing_status: "SINGLE"
+      expect: 40000
+
+variable advance_ctc_excess_children:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Excess Advance CTC Children"
+  description: "Children in advance minus actual qualifying children per 26 USC 24(j)(2)(B)(iv)(II)"
+  formula: |
+    return max(0, advance_ctc_children_count - actual_ctc_children_count)
+  tests:
+    - name: "Same children count"
+      period: 2021-01
+      inputs:
+        advance_ctc_children_count: 2
+        actual_ctc_children_count: 2
+      expect: 0
+    - name: "One fewer actual child"
+      period: 2021-01
+      inputs:
+        advance_ctc_children_count: 3
+        actual_ctc_children_count: 2
+      expect: 1
+    - name: "More actual than advance"
+      period: 2021-01
+      inputs:
+        advance_ctc_children_count: 1
+        actual_ctc_children_count: 2
+      expect: 0
+
+variable advance_ctc_safe_harbor_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Advance CTC Safe Harbor Amount"
+  description: "Safe harbor amount for excess advance CTC per 26 USC 24(j)(2)(B)"
+  formula: |
+    # Base safe harbor = $2,000 x excess children
+    base_safe_harbor = advance_ctc_excess_children * advance_ctc_safe_harbor_per_child
+
+    # Check if income exceeds 200% of threshold (no safe harbor)
+    threshold = advance_ctc_safe_harbor_threshold
+    max_income = threshold * advance_ctc_safe_harbor_phaseout_multiple
+
+    if modified_agi >= max_income:
+      return 0
+
+    # If income at or below threshold, full safe harbor
+    if modified_agi <= threshold:
+      return base_safe_harbor
+
+    # Phase out between threshold and 200% of threshold
+    excess_income = modified_agi - threshold
+    reduction_ratio = excess_income / threshold
+    reduced_amount = base_safe_harbor * (1 - reduction_ratio)
+    return max(0, reduced_amount)
+  tests:
+    - name: "Below threshold, one excess child"
+      period: 2021-01
+      inputs:
+        advance_ctc_excess_children: 1
+        modified_agi: 30000
+        advance_ctc_safe_harbor_threshold: 40000
+      expect: 2000
+    - name: "At threshold, one excess child"
+      period: 2021-01
+      inputs:
+        advance_ctc_excess_children: 1
+        modified_agi: 40000
+        advance_ctc_safe_harbor_threshold: 40000
+      expect: 2000
+    - name: "At 150% of threshold (50% phase-out)"
+      period: 2021-01
+      inputs:
+        advance_ctc_excess_children: 1
+        modified_agi: 60000
+        advance_ctc_safe_harbor_threshold: 40000
+      expect: 1000
+    - name: "At 200% of threshold (fully phased out)"
+      period: 2021-01
+      inputs:
+        advance_ctc_excess_children: 1
+        modified_agi: 80000
+        advance_ctc_safe_harbor_threshold: 40000
+      expect: 0
+
+variable ctc_after_advance_reconciliation:
+  imports:
+    - 26/24/b#ctc_after_phaseout
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "CTC After Advance Reconciliation"
+  description: "CTC reduced by advance payments per 26 USC 24(j)(1)"
+  formula: |
+    return max(0, ctc_after_phaseout - advance_ctc_payments)
+  tests:
+    - name: "No advance payments"
+      period: 2021-01
+      inputs:
+        ctc_after_phaseout: 6000
+        advance_ctc_payments: 0
+      expect: 6000
+    - name: "Partial advance payments"
+      period: 2021-01
+      inputs:
+        ctc_after_phaseout: 6000
+        advance_ctc_payments: 3000
+      expect: 3000
+    - name: "Advance exceeds credit"
+      period: 2021-01
+      inputs:
+        ctc_after_phaseout: 4000
+        advance_ctc_payments: 5000
+      expect: 0
+
+variable advance_ctc_repayment:
+  imports:
+    - 26/24/b#ctc_after_phaseout
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Advance CTC Repayment"
+  description: "Tax increase due to excess advance payments per 26 USC 24(j)(2)"
+  formula: |
+    # Gross excess of advance over credit
+    gross_excess = max(0, advance_ctc_payments - ctc_after_phaseout)
+    # Reduce by safe harbor
+    return max(0, gross_excess - advance_ctc_safe_harbor_amount)
+  tests:
+    - name: "No excess payments"
+      period: 2021-01
+      inputs:
+        advance_ctc_payments: 3000
+        ctc_after_phaseout: 6000
+        advance_ctc_safe_harbor_amount: 0
+      expect: 0
+    - name: "Excess with safe harbor"
+      period: 2021-01
+      inputs:
+        advance_ctc_payments: 6000
+        ctc_after_phaseout: 4000
+        advance_ctc_safe_harbor_amount: 2000
+      expect: 0
+    - name: "Excess exceeds safe harbor"
+      period: 2021-01
+      inputs:
+        advance_ctc_payments: 8000
+        ctc_after_phaseout: 4000
+        advance_ctc_safe_harbor_amount: 2000
+      expect: 2000

--- a/statute/26/24/k.rac
+++ b/statute/26/24/k.rac
@@ -1,0 +1,167 @@
+# 26 USC 24(k) - Application of credit in possessions
+
+text: """
+(k) Application of credit in possessions
+(1) Mirror code possessions
+(A) In general
+The Secretary shall pay to each possession of the United States with a mirror code
+tax system amounts equal to the loss (if any) to that possession by reason of the
+application of this section (determined without regard to this subsection) with
+respect to taxable years beginning after 2020.
+(B) Coordination with credit allowed against United States income taxes
+No credit shall be allowed under this section for any taxable year to any individual
+to whom a credit is allowable against taxes imposed by a possession of the United
+States with a mirror code tax system by reason of the application of this section
+in such possession for such taxable year.
+(C) Mirror code tax system
+For purposes of this paragraph, the term "mirror code tax system" means, with respect
+to any possession of the United States, the income tax system of such possession if
+the income tax liability of the residents of such possession under such system is
+determined by reference to the income tax laws of the United States as if such
+possession were the United States.
+
+(2) Puerto Rico
+(A) Application to taxable years in 2021
+(i) For application of refundable credit to residents of Puerto Rico, see subsection (i)(1).
+(ii) For nonapplication of advance payment to residents of Puerto Rico, see section 7527A(e)(4)(A).
+(B) Application to taxable years after 2021
+In the case of any bona fide resident of Puerto Rico (within the meaning of section 937(a))
+for any taxable year beginning after December 31, 2021—
+(i) the credit determined under this section shall be allowable to such resident, and
+(ii) subsection (d)(1)(B)(ii) shall be applied without regard to the phrase "in the case
+of a taxpayer with 3 or more qualifying children".
+
+(3) American Samoa
+(A) In general
+The Secretary shall pay to American Samoa amounts estimated by the Secretary as being
+equal to the aggregate benefits that would have been provided to residents of American
+Samoa by reason of the application of this section for taxable years beginning after 2020.
+(B) Distribution requirement
+Subparagraph (A) shall not apply unless American Samoa has a plan, which has been
+approved by the Secretary, under which American Samoa will promptly distribute such
+payments to its residents.
+(C) Coordination with credit allowed against United States income taxes
+(i) In general
+In the case of a taxable year with respect to which a plan is approved under subparagraph (B),
+this section (other than this subsection) shall not apply to any individual eligible for
+a distribution under such plan.
+(ii) Application of section in event of absence of approved plan
+In the case of a taxable year with respect to which a plan is not approved under
+subparagraph (B)—
+(I) if such taxable year begins in 2021, subsection (i)(1) shall be applied by
+substituting "bona fide resident of Puerto Rico or American Samoa" for "bona fide
+resident of Puerto Rico", and
+(II) if such taxable year begins after December 31, 2021, rules similar to the rules
+of paragraph (2)(B) shall apply with respect to bona fide residents of American Samoa
+(within the meaning of section 937(a)).
+
+(4) Treatment of payments
+For purposes of section 1324 of title 31, United States Code, the payments under this
+subsection shall be treated in the same manner as a refund due from a credit provision
+referred to in subsection (b)(2) of such section.
+"""
+
+# This subsection primarily deals with administrative and coordination provisions
+# for US possessions. The key computational elements are:
+
+input is_mirror_code_possession_resident:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Mirror Code Possession Resident"
+  description: "Whether taxpayer is resident of possession with mirror code tax system"
+
+input is_puerto_rico_resident:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Puerto Rico Resident"
+  description: "Whether taxpayer is bona fide resident of Puerto Rico per section 937(a)"
+
+input is_american_samoa_resident:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "American Samoa Resident"
+  description: "Whether taxpayer is bona fide resident of American Samoa per section 937(a)"
+
+input american_samoa_plan_approved:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "American Samoa Plan Approved"
+  description: "Whether American Samoa has approved distribution plan per 26 USC 24(k)(3)(B)"
+
+input claimed_ctc_in_possession:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Claimed CTC in Possession"
+  description: "Whether credit allowable against possession taxes"
+
+variable ctc_disallowed_possession_coordination:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "CTC Disallowed (Possession Coordination)"
+  description: "Whether CTC disallowed due to possession tax coordination per 26 USC 24(k)"
+  formula: |
+    # Mirror code possession - disallow if claimed in possession
+    if is_mirror_code_possession_resident and claimed_ctc_in_possession:
+      return True
+    # American Samoa with approved plan - covered by local distribution
+    if is_american_samoa_resident and american_samoa_plan_approved:
+      return True
+    return False
+  tests:
+    - name: "US mainland resident"
+      period: 2024-01
+      inputs:
+        is_mirror_code_possession_resident: false
+        is_american_samoa_resident: false
+        claimed_ctc_in_possession: false
+        american_samoa_plan_approved: false
+      expect: false
+    - name: "Mirror code possession, claimed in possession"
+      period: 2024-01
+      inputs:
+        is_mirror_code_possession_resident: true
+        is_american_samoa_resident: false
+        claimed_ctc_in_possession: true
+        american_samoa_plan_approved: false
+      expect: true
+    - name: "American Samoa with approved plan"
+      period: 2024-01
+      inputs:
+        is_mirror_code_possession_resident: false
+        is_american_samoa_resident: true
+        claimed_ctc_in_possession: false
+        american_samoa_plan_approved: true
+      expect: true
+
+variable puerto_rico_ctc_eligible:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Puerto Rico CTC Eligible"
+  description: "Whether Puerto Rico resident eligible for CTC per 26 USC 24(k)(2)"
+  formula: |
+    # PR residents eligible for taxable years after 2021
+    if is_puerto_rico_resident:
+      return True
+    return False
+  tests:
+    - name: "Puerto Rico resident"
+      period: 2024-01
+      inputs:
+        is_puerto_rico_resident: true
+      expect: true
+    - name: "Non-PR resident"
+      period: 2024-01
+      inputs:
+        is_puerto_rico_resident: false
+      expect: false
+
+# Note: The special rule for Puerto Rico residents under (k)(2)(B)(ii) modifies
+# the ACTC calculation by removing the 3+ children requirement. This is handled
+# by conditioning the actc_ss_excess_amount in subsection (d) on residency.

--- a/statute/26/25A/b/2.rac
+++ b/statute/26/25A/b/2.rac
@@ -1,0 +1,107 @@
+# 26 USC 25A(b)(2) - Limitations applicable to Hope Scholarship Credit
+
+text: """
+(2) Limitations applicable to Hope Scholarship Credit
+
+(A) Credit allowed only for 4 taxable years
+An election to have this section apply with respect to any eligible student for purposes
+of the American Opportunity Tax Credit under subsection (a)(1) may not be made for any
+taxable year if such an election (by the taxpayer or any other individual) is in effect
+with respect to such student for any 4 prior taxable years.
+
+(B) Credit allowed for year only if individual is at least 1/2 time student for portion of year
+The American Opportunity Tax Credit under subsection (a)(1) shall not be allowed for a taxable
+year with respect to the qualified tuition and related expenses of an individual unless such
+individual is an eligible student for at least one academic period which begins during such year.
+
+(C) Credit allowed only for first 4 years of postsecondary education
+The American Opportunity Tax Credit under subsection (a)(1) shall be allowed only for
+4 taxable years with respect to any eligible student.
+
+(D) Denial of credit to students with felony drug convictions
+A student shall not be treated as an eligible student for purposes of this section if
+the student has been convicted of a Federal or State felony offense consisting of the
+possession or distribution of a controlled substance before the end of the taxable year
+with respect to which this section is being applied.
+"""
+
+# This paragraph establishes four limitations on the Hope Scholarship Credit (AOTC):
+# (A) Cannot claim if already claimed for 4 prior years (aotc_4_year_limit_met)
+# (B) Student must be at least half-time for at least one academic period (aotc_half_time_requirement_met)
+# (C) Credit limited to first 4 years of postsecondary education (aotc_first_4_years_eligible)
+# (D) No credit for students with felony drug convictions (eligible_student_drug_conviction_disqualified)
+
+variable hope_scholarship_limitations_satisfied:
+  imports:
+    - 26/25A/b/2/A#aotc_4_year_limit_met
+    - 26/25A/b/2/B#aotc_half_time_requirement_met
+    - 26/25A/b/2/C#aotc_first_4_years_eligible
+    - 26/25A/b/2/D#eligible_student_drug_conviction_disqualified
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Hope Scholarship Credit Limitations Satisfied"
+  description: "Whether all limitations of 26 USC 25A(b)(2) are satisfied for the Hope Scholarship Credit (AOTC)"
+  formula: |
+    # (A) Cannot have already claimed AOTC for 4 prior years
+    if aotc_4_year_limit_met:
+      return False
+    # (B) Must be at least half-time student for at least one academic period
+    if not aotc_half_time_requirement_met:
+      return False
+    # (C) Must be within first 4 years of postsecondary education
+    if not aotc_first_4_years_eligible:
+      return False
+    # (D) Cannot have felony drug conviction
+    if eligible_student_drug_conviction_disqualified:
+      return False
+    return True
+  tests:
+    - name: "All limitations satisfied - eligible"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: False
+        aotc_half_time_requirement_met: True
+        aotc_first_4_years_eligible: True
+        eligible_student_drug_conviction_disqualified: False
+      expect: True
+    - name: "4 prior years claimed - ineligible per (A)"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: True
+        aotc_half_time_requirement_met: True
+        aotc_first_4_years_eligible: True
+        eligible_student_drug_conviction_disqualified: False
+      expect: False
+    - name: "Not half-time student - ineligible per (B)"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: False
+        aotc_half_time_requirement_met: False
+        aotc_first_4_years_eligible: True
+        eligible_student_drug_conviction_disqualified: False
+      expect: False
+    - name: "Beyond first 4 years - ineligible per (C)"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: False
+        aotc_half_time_requirement_met: True
+        aotc_first_4_years_eligible: False
+        eligible_student_drug_conviction_disqualified: False
+      expect: False
+    - name: "Felony drug conviction - ineligible per (D)"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: False
+        aotc_half_time_requirement_met: True
+        aotc_first_4_years_eligible: True
+        eligible_student_drug_conviction_disqualified: True
+      expect: False
+    - name: "Multiple limitations failed"
+      period: 2024-01
+      inputs:
+        aotc_4_year_limit_met: True
+        aotc_half_time_requirement_met: False
+        aotc_first_4_years_eligible: False
+        eligible_student_drug_conviction_disqualified: True
+      expect: False

--- a/statute/26/25A/b/2/A.rac
+++ b/statute/26/25A/b/2/A.rac
@@ -1,0 +1,52 @@
+# 26 USC 25A(b)(2)(A) - Credit allowed only for 4 taxable years
+
+text: """
+(A) Credit allowed only for 4 taxable years
+An election to have this section apply with respect to any eligible student for purposes
+of the American Opportunity Tax Credit under subsection (a)(1) may not be made for any
+taxable year if such an election (by the taxpayer or any other individual) is in effect
+with respect to such student for any 4 prior taxable years.
+"""
+
+parameter max_aotc_years:
+  description: "Maximum number of prior years AOTC can be claimed for a student per 26 USC 25A(b)(2)(A)"
+  values:
+    1997-08-05: 4
+
+input prior_aotc_years_claimed:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "Prior AOTC Years Claimed"
+  description: "Number of prior taxable years for which AOTC election was in effect for this student"
+  default: 0
+
+variable aotc_4_year_limit_met:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "AOTC 4-Year Limit Met"
+  description: "Whether student has used AOTC for 4 prior years, disqualifying further claims per 26 USC 25A(b)(2)(A)"
+  formula: |
+    return prior_aotc_years_claimed >= max_aotc_years
+  tests:
+    - name: "No prior years - eligible"
+      period: 2024-01
+      inputs:
+        prior_aotc_years_claimed: 0
+      expect: False
+    - name: "Three prior years - still eligible"
+      period: 2024-01
+      inputs:
+        prior_aotc_years_claimed: 3
+      expect: False
+    - name: "Four prior years - limit met"
+      period: 2024-01
+      inputs:
+        prior_aotc_years_claimed: 4
+      expect: True
+    - name: "More than four prior years - limit met"
+      period: 2024-01
+      inputs:
+        prior_aotc_years_claimed: 5
+      expect: True

--- a/statute/26/25A/b/2/B.rac
+++ b/statute/26/25A/b/2/B.rac
@@ -1,0 +1,57 @@
+# 26 USC 25A(b)(2)(B) - Credit allowed for year only if individual is at least half-time student
+
+text: """
+(B) Credit allowed for year only if individual is at least 1/2 time student for portion of year
+
+The American Opportunity Tax Credit under subsection (a)(1) shall not be allowed for a taxable
+year with respect to the qualified tuition and related expenses of an individual unless such
+individual is an eligible student for at least one academic period which begins during such year.
+"""
+
+# This subsection establishes a half-time student requirement for the American Opportunity Tax Credit.
+# An "eligible student" is defined in 25A(b)(3) as someone who:
+#   (A) meets requirements of section 484(a)(1) of the Higher Education Act (20 USC 1091(a)(1)), and
+#   (B) is carrying at least 1/2 the normal full-time work load for the course of study.
+# This rule denies the AOTC if the student is not an eligible student for at least one
+# academic period beginning in the taxable year.
+
+# Minimum number of academic periods required for AOTC eligibility
+parameter min_academic_periods_for_aotc:
+  description: "Minimum academic periods as eligible student required for AOTC per 26 USC 25A(b)(2)(B)"
+  values:
+    1997-08-05: 1
+
+input eligible_student_academic_periods:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "Academic Periods as Eligible Student"
+  description: "Number of academic periods beginning during the year for which the individual is an eligible student per 26 USC 25A(b)(3)"
+  default: 0
+
+variable aotc_half_time_requirement_met:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "AOTC Half-Time Requirement Met"
+  description: "Whether individual meets half-time student requirement for AOTC per 26 USC 25A(b)(2)(B)"
+  formula: |
+    # Credit allowed only if individual is an eligible student (at least half-time)
+    # for at least one academic period beginning during the taxable year
+    return eligible_student_academic_periods >= min_academic_periods_for_aotc
+  tests:
+    - name: "No academic periods as eligible student"
+      period: 2024-01
+      inputs:
+        eligible_student_academic_periods: 0
+      expect: false
+    - name: "One academic period as eligible student"
+      period: 2024-01
+      inputs:
+        eligible_student_academic_periods: 1
+      expect: true
+    - name: "Two academic periods as eligible student"
+      period: 2024-01
+      inputs:
+        eligible_student_academic_periods: 2
+      expect: true

--- a/statute/26/25A/b/2/C.rac
+++ b/statute/26/25A/b/2/C.rac
@@ -1,0 +1,57 @@
+# 26 USC 25A(b)(2)(C) - Credit allowed only for first 4 years
+
+text: """
+(C) Credit allowed only for first 4 years of postsecondary education
+The American Opportunity Tax Credit under subsection (a)(1) shall be allowed
+only for 4 taxable years with respect to any eligible student.
+"""
+
+# Maximum years the American Opportunity Credit can be claimed per student
+parameter aotc_max_years:
+  description: "Maximum number of taxable years AOTC can be claimed per eligible student"
+  unit: years
+  values:
+    2009-01-01: 4
+
+input aotc_years_claimed:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "AOTC Years Previously Claimed"
+  description: "Number of prior taxable years for which AOTC was claimed for this student"
+  default: 0
+
+variable aotc_first_4_years_eligible:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "AOTC First 4 Years Eligibility"
+  description: "Whether student is within first 4 years of AOTC eligibility per 26 USC 25A(b)(2)(C)"
+  formula: |
+    return aotc_years_claimed < aotc_max_years
+  tests:
+    - name: "No prior claims - eligible"
+      period: 2024-01
+      inputs:
+        aotc_years_claimed: 0
+      expect: true
+    - name: "1 prior year - eligible"
+      period: 2024-01
+      inputs:
+        aotc_years_claimed: 1
+      expect: true
+    - name: "3 prior years - eligible"
+      period: 2024-01
+      inputs:
+        aotc_years_claimed: 3
+      expect: true
+    - name: "4 prior years - ineligible"
+      period: 2024-01
+      inputs:
+        aotc_years_claimed: 4
+      expect: false
+    - name: "5 prior years - ineligible"
+      period: 2024-01
+      inputs:
+        aotc_years_claimed: 5
+      expect: false

--- a/statute/26/25A/b/2/D.rac
+++ b/statute/26/25A/b/2/D.rac
@@ -1,0 +1,38 @@
+# 26 USC 25A(b)(2)(D) - Denial of credit for felony drug conviction
+
+text: """
+(D) Denial of credit to students with felony drug convictions
+A student shall not be treated as an eligible student for purposes of this
+section if the student has been convicted of a Federal or State felony
+offense consisting of the possession or distribution of a controlled
+substance before the end of the taxable year with respect to which this
+section is being applied.
+"""
+
+input has_felony_drug_conviction:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Has Felony Drug Conviction"
+  description: "Whether the student has been convicted of a Federal or State felony offense for possession or distribution of a controlled substance per 26 USC 25A(b)(2)(D)"
+  default: false
+
+variable eligible_student_drug_conviction_disqualified:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Disqualified by Felony Drug Conviction"
+  description: "Whether student is disqualified from eligible student status due to felony drug conviction per 26 USC 25A(b)(2)(D)"
+  formula: |
+    return has_felony_drug_conviction
+  tests:
+    - name: "No conviction - not disqualified"
+      period: 2024-01
+      inputs:
+        has_felony_drug_conviction: false
+      expect: false
+    - name: "Has conviction - disqualified"
+      period: 2024-01
+      inputs:
+        has_felony_drug_conviction: true
+      expect: true

--- a/statute/26/25A/b/3.rac
+++ b/statute/26/25A/b/3.rac
@@ -1,0 +1,106 @@
+# 26 USC 25A(b)(3) - Eligible student
+
+text: """
+(3) Eligible student
+For purposes of this subsection, the term "eligible student" means, with respect to any
+academic period, a student who-
+(A) meets the requirements of section 484(a)(1) of the Higher Education Act of 1965
+(20 U.S.C. 1091(a)(1)), as in effect on the date of the enactment of this section, and
+(B) is carrying at least 1/2 the normal full-time work load for the course of study the
+student is pursuing.
+"""
+
+# This subsection defines "eligible student" for purposes of the American Opportunity Tax Credit
+# (subsection (b) deals with AOTC).
+#
+# A student qualifies as an "eligible student" if they meet BOTH requirements:
+# (A) Meets HEA section 484(a)(1) requirements (20 USC 1091(a)(1)) - generally requires:
+#     - Being enrolled or accepted at an eligible institution
+#     - Being a regular student in an eligible program
+#     - Not owing refund on prior grants or in default on student loans
+#     - Having a high school diploma/GED or meeting ability-to-benefit requirements
+#     - Being a US citizen/national or eligible noncitizen
+#     - Having a valid SSN
+# (B) Carrying at least half the normal full-time course load
+#
+# The half-time threshold (1/2) is explicitly stated in the statute.
+
+# Minimum course load fraction required for eligible student status
+parameter min_course_load_fraction:
+  description: "Minimum fraction of normal full-time work load required for eligible student status per 26 USC 25A(b)(3)(B)"
+  unit: /1
+  values:
+    1997-08-05: 0.5
+
+input meets_hea_484_requirements:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Meets HEA Section 484 Requirements"
+  description: "Whether the student meets the requirements of section 484(a)(1) of the Higher Education Act of 1965 (20 U.S.C. 1091(a)(1)) per 26 USC 25A(b)(3)(A)"
+  default: false
+
+input course_load_fraction:
+  entity: Person
+  period: Year
+  dtype: Float
+  label: "Course Load Fraction"
+  description: "Fraction of normal full-time work load the student is carrying for the course of study per 26 USC 25A(b)(3)(B)"
+  default: 0
+
+variable is_eligible_student:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Is Eligible Student"
+  description: "Whether the individual meets the definition of eligible student per 26 USC 25A(b)(3)"
+  formula: |
+    # Per 25A(b)(3): Both (A) and (B) must be satisfied
+    # (A) Student meets requirements of HEA section 484(a)(1) (20 USC 1091(a)(1))
+    # (B) Student is carrying at least 1/2 the normal full-time work load
+    hea_requirement_met = meets_hea_484_requirements
+    half_time_requirement_met = course_load_fraction >= min_course_load_fraction
+    return hea_requirement_met and half_time_requirement_met
+  tests:
+    - name: "Both requirements met - eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: true
+        course_load_fraction: 0.5
+      expect: true
+    - name: "Full-time student with HEA requirements - eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: true
+        course_load_fraction: 1.0
+      expect: true
+    - name: "HEA met but less than half-time - not eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: true
+        course_load_fraction: 0.4
+      expect: false
+    - name: "Half-time but HEA not met - not eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: false
+        course_load_fraction: 0.5
+      expect: false
+    - name: "Neither requirement met - not eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: false
+        course_load_fraction: 0.3
+      expect: false
+    - name: "Exactly at half-time threshold - eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: true
+        course_load_fraction: 0.5
+      expect: true
+    - name: "Just below half-time threshold - not eligible"
+      period: 2024-01
+      inputs:
+        meets_hea_484_requirements: true
+        course_load_fraction: 0.49
+      expect: false

--- a/statute/26/25A/c/2.rac
+++ b/statute/26/25A/c/2.rac
@@ -1,0 +1,75 @@
+# 26 USC 25A(c)(2) - Special rules for determining expenses
+
+text: """
+(2) Special rules for determining expenses
+(A) Coordination with American Opportunity Tax Credit
+The expenses taken into account under paragraph (1) shall not include expenses
+with respect to an individual for whom an election under subsection (a)(1) is
+in effect for such taxable year.
+(B) Expenses eligible for Lifetime Learning Credit
+For purposes of paragraph (1), qualified tuition and related expenses shall
+include expenses described in subsection (f)(1) with respect to any course of
+instruction at an eligible educational institution to acquire or improve job
+skills of the individual.
+"""
+
+# This subsection contains two rules:
+# (A) Expenses cannot be double-counted - if claimed for AOTC, cannot also claim for LLC
+# (B) LLC expenses can include job skill courses (broader than AOTC)
+
+input total_qualified_expenses:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Total Qualified Tuition and Related Expenses"
+  description: "Total qualified tuition and related expenses paid per 26 USC 25A(f)(1)"
+  default: 0
+
+input aotc_election_in_effect:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "AOTC Election in Effect"
+  description: "Whether an election under subsection (a)(1) is in effect for this individual"
+  default: False
+
+variable llc_eligible_expenses:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "LLC Eligible Expenses"
+  description: "Qualified expenses eligible for Lifetime Learning Credit after coordination with AOTC per 26 USC 25A(c)(2)"
+  formula: |
+    # Per (A): Expenses cannot include those for an individual with AOTC election
+    if aotc_election_in_effect:
+      return 0
+    # Per (B): Expenses include those for job skill courses (no additional filtering needed here;
+    # the broader definition is applied at the f(1) input level)
+    return total_qualified_expenses
+  tests:
+    - name: "No AOTC election - full expenses eligible"
+      period: 2024-01
+      inputs:
+        total_qualified_expenses: 8000
+        aotc_election_in_effect: False
+      expect: 8000
+    - name: "AOTC election in effect - no LLC expenses"
+      period: 2024-01
+      inputs:
+        total_qualified_expenses: 8000
+        aotc_election_in_effect: True
+      expect: 0
+    - name: "Zero expenses"
+      period: 2024-01
+      inputs:
+        total_qualified_expenses: 0
+        aotc_election_in_effect: False
+      expect: 0
+    - name: "Graduate student job skills course"
+      period: 2024-01
+      inputs:
+        total_qualified_expenses: 5000
+        aotc_election_in_effect: False
+      expect: 5000

--- a/statute/26/25A/d/2.rac
+++ b/statute/26/25A/d/2.rac
@@ -1,0 +1,98 @@
+# 26 USC 25A(d)(2) - Modified adjusted gross income
+
+text: """
+(2) Modified adjusted gross income
+The term "modified adjusted gross income" means the adjusted gross income of the
+taxpayer for the taxable year increased by any amount excluded from gross income
+under section 911, 931, or 933.
+"""
+
+# No parameters needed - this subsection defines a term, not values.
+# The amounts excluded under sections 911/931/933 are inputs from those sections.
+
+input adjusted_gross_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Adjusted Gross Income"
+  description: "AGI per 26 USC 62(a)"
+  default: 0
+
+input section_911_exclusion:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Section 911 Exclusion"
+  description: "Foreign earned income exclusion per 26 USC 911"
+  default: 0
+
+input section_931_exclusion:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Section 931 Exclusion"
+  description: "Income from sources within Guam, American Samoa, or CNMI per 26 USC 931"
+  default: 0
+
+input section_933_exclusion:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Section 933 Exclusion"
+  description: "Income from sources within Puerto Rico per 26 USC 933"
+  default: 0
+
+variable magi_for_25A:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Modified AGI for Education Credits"
+  description: "Modified adjusted gross income for purposes of 26 USC 25A per subsection (d)(2)"
+  formula: |
+    return adjusted_gross_income + section_911_exclusion + section_931_exclusion + section_933_exclusion
+  tests:
+    - name: "No exclusions - MAGI equals AGI"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 50000
+        section_911_exclusion: 0
+        section_931_exclusion: 0
+        section_933_exclusion: 0
+      expect: 50000
+    - name: "Foreign earned income exclusion only"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 50000
+        section_911_exclusion: 120000
+        section_931_exclusion: 0
+        section_933_exclusion: 0
+      expect: 170000
+    - name: "All three exclusions"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 80000
+        section_911_exclusion: 50000
+        section_931_exclusion: 10000
+        section_933_exclusion: 5000
+      expect: 145000
+    - name: "Zero AGI with exclusions"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 0
+        section_911_exclusion: 100000
+        section_931_exclusion: 0
+        section_933_exclusion: 0
+      expect: 100000
+    - name: "Puerto Rico income exclusion only"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 75000
+        section_911_exclusion: 0
+        section_931_exclusion: 0
+        section_933_exclusion: 25000
+      expect: 100000

--- a/statute/26/25A/d/3.rac
+++ b/statute/26/25A/d/3.rac
@@ -1,0 +1,25 @@
+# 26 USC 25A(d)(3) - Inflation adjustment [REPEALED]
+
+status: obsolete
+
+text: |
+  (3) Inflation adjustment
+  [Struck by Pub. L. 116-260, div. EE, title I, sec. 104(a)(1), Dec. 27, 2020, 134 Stat. 3040]
+
+  This paragraph was redesignated as (d)(2) "Modified adjusted gross income" by Pub. L. 116-260,
+  effective for taxable years beginning after December 31, 2020.
+
+  The former inflation adjustment provision for 26 USC 25A(d) no longer exists in current law.
+  The 2020 amendment established fixed dollar thresholds ($80,000/$160,000 for single/joint) and
+  phase-out ranges ($10,000/$20,000) that are not subject to inflation indexing.
+
+  Prior law contained separate income limitations with inflation adjustments for:
+  - American Opportunity Tax Credit (former (d)(1))
+  - Lifetime Learning Credit (former (d)(2))
+  - Inflation adjustment provision (former (d)(3))
+
+  Current law consolidated these into:
+  - (d)(1) In general - unified phase-out formula with fixed amounts
+  - (d)(2) Modified adjusted gross income - definition only (redesignated from former (d)(3))
+
+# No parameters, variables, or formulas - provision no longer exists

--- a/statute/26/25A/e.rac
+++ b/statute/26/25A/e.rac
@@ -1,0 +1,41 @@
+# 26 USC 25A(e) - Election not to have section apply
+
+text: """
+(e) Election not to have section apply
+A taxpayer may elect not to have this section apply with respect to the qualified
+tuition and related expenses of an individual for any taxable year.
+"""
+
+# This subsection provides an election mechanism allowing taxpayers to opt out
+# of the education credits (both AOTC and LLC) for a specific individual's
+# qualified expenses in any given taxable year. This election may be beneficial
+# when claiming the deduction for higher education expenses (when available)
+# or other tax provisions would result in greater tax savings.
+
+input section_25a_election_not_to_apply:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Section 25A Election Not to Apply"
+  description: "Whether taxpayer has elected not to have section 25A apply to this individual's qualified expenses per 26 USC 25A(e)"
+  default: False
+
+variable education_credit_25a_elected_out:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Education Credit Section 25A Elected Out"
+  description: "Whether taxpayer has made the election under 26 USC 25A(e) not to have section 25A apply for this individual"
+  formula: |
+    return section_25a_election_not_to_apply
+  tests:
+    - name: "No election - section 25A applies"
+      period: 2024-01
+      inputs:
+        section_25a_election_not_to_apply: False
+      expect: False
+    - name: "Election made - section 25A does not apply"
+      period: 2024-01
+      inputs:
+        section_25a_election_not_to_apply: True
+      expect: True

--- a/statute/26/25A/f/1.rac
+++ b/statute/26/25A/f/1.rac
@@ -1,0 +1,325 @@
+# Qualified tuition and related expenses
+
+text: """
+(1) Qualified tuition and related expenses
+(A) In general
+The term "qualified tuition and related expenses" means tuition and fees required
+for the enrollment or attendance of-
+(i) the taxpayer,
+(ii) the taxpayer's spouse, or
+(iii) any dependent of the taxpayer with respect to whom the taxpayer is allowed
+a deduction under section 151,
+at an eligible educational institution for courses of instruction of such individual
+at such institution.
+(B) Exception for education involving sports, etc.
+Such term does not include expenses with respect to any course or other education
+involving sports, games, or hobbies, unless such course or other education is part
+of the individual's degree program.
+(C) Exception for nonacademic fees
+Such term does not include student activity fees, athletic fees, insurance expenses,
+or other expenses unrelated to an individual's academic course of instruction.
+(D) Required course materials taken into account for American Opportunity Tax Credit
+For purposes of determining the American Opportunity Tax Credit, subparagraph (A)
+shall be applied by substituting "tuition, fees, and course materials" for
+"tuition and fees".
+"""
+
+# This subsection defines "qualified tuition and related expenses" for purposes of
+# 26 USC 25A education credits (AOTC and LLC).
+#
+# Structure:
+# (A) In general - defines base term as tuition and fees for taxpayer/spouse/dependent
+#     at eligible educational institution
+# (B) Exception - sports, games, hobbies excluded unless part of degree program
+# (C) Exception - student activity fees, athletic fees, insurance, other non-academic
+#     expenses excluded
+# (D) AOTC special rule - course materials also included for AOTC (not LLC)
+#
+# This is primarily a definition subsection. The main calculation inputs are:
+# - Tuition paid
+# - Fees paid (academic)
+# - Course materials (AOTC only per subparagraph D)
+# - Various exclusions per (B) and (C)
+
+# Input: Raw tuition paid to eligible educational institution
+input tuition_paid:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Tuition Paid"
+  description: "Tuition required for enrollment or attendance at an eligible educational institution per 26 USC 25A(f)(1)(A)"
+  default: 0
+
+# Input: Academic fees paid (enrollment/attendance related)
+input academic_fees_paid:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Academic Fees Paid"
+  description: "Fees required for enrollment or attendance at an eligible educational institution per 26 USC 25A(f)(1)(A)"
+  default: 0
+
+# Input: Course materials paid (books, supplies, equipment for AOTC)
+input course_materials_paid:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Course Materials Paid"
+  description: "Course materials (books, supplies, equipment) paid per 26 USC 25A(f)(1)(D) - included for AOTC only"
+  default: 0
+
+# Input: Sports/games/hobbies expenses (excluded per (B) unless part of degree)
+input sports_games_hobbies_expenses:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Sports/Games/Hobbies Expenses"
+  description: "Expenses for courses involving sports, games, or hobbies per 26 USC 25A(f)(1)(B)"
+  default: 0
+
+# Input: Whether sports/games/hobbies course is part of degree program
+input sports_course_part_of_degree:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Sports Course Part of Degree Program"
+  description: "Whether the sports/games/hobbies course is part of the individual's degree program per 26 USC 25A(f)(1)(B)"
+  default: False
+
+# Input: Student activity fees (excluded per (C))
+input student_activity_fees:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Student Activity Fees"
+  description: "Student activity fees which are excluded per 26 USC 25A(f)(1)(C)"
+  default: 0
+
+# Input: Athletic fees (excluded per (C))
+input athletic_fees:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Athletic Fees"
+  description: "Athletic fees which are excluded per 26 USC 25A(f)(1)(C)"
+  default: 0
+
+# Input: Insurance expenses (excluded per (C))
+input education_insurance_expenses:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Education Insurance Expenses"
+  description: "Insurance expenses which are excluded per 26 USC 25A(f)(1)(C)"
+  default: 0
+
+# Input: Other nonacademic expenses (excluded per (C))
+input other_nonacademic_expenses:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Other Nonacademic Expenses"
+  description: "Other expenses unrelated to academic course of instruction per 26 USC 25A(f)(1)(C)"
+  default: 0
+
+# Variable: Qualified tuition and related expenses for LLC
+# Per (A)-(C): tuition + academic fees, excluding sports/hobbies (unless degree), excluding nonacademic fees
+variable qualified_tuition_and_related_expenses_llc:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Qualified Tuition and Related Expenses (LLC)"
+  description: "Qualified tuition and related expenses for Lifetime Learning Credit per 26 USC 25A(f)(1)(A)-(C)"
+  formula: |
+    # Base: tuition and academic fees per (A)
+    base_expenses = tuition_paid + academic_fees_paid
+    # Nonacademic fees excluded per (C)
+    nonacademic_exclusion = student_activity_fees + athletic_fees + education_insurance_expenses + other_nonacademic_expenses
+    # Sports/games/hobbies exception per (B): excluded UNLESS part of degree program
+    if sports_course_part_of_degree:
+      # Part of degree program - sports expenses included
+      return max(0, base_expenses - nonacademic_exclusion)
+    # Not part of degree program - sports expenses excluded
+    return max(0, base_expenses - sports_games_hobbies_expenses - nonacademic_exclusion)
+  tests:
+    - name: "Basic tuition only"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 10000
+    - name: "Tuition plus academic fees"
+      period: 2024-01
+      inputs:
+        tuition_paid: 8000
+        academic_fees_paid: 500
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 8500
+    - name: "Sports course not part of degree - excluded"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        sports_games_hobbies_expenses: 2000
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 8000
+    - name: "Sports course part of degree - included"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        sports_games_hobbies_expenses: 2000
+        sports_course_part_of_degree: True
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 10000
+    - name: "Nonacademic fees excluded"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 500
+        athletic_fees: 300
+        education_insurance_expenses: 200
+        other_nonacademic_expenses: 100
+      expect: 8900
+    - name: "Zero expenses"
+      period: 2024-01
+      inputs:
+        tuition_paid: 0
+        academic_fees_paid: 0
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 0
+
+# Variable: Qualified tuition and related expenses for AOTC
+# Per (D): Same as LLC but also includes course materials
+variable qualified_tuition_and_related_expenses_aotc:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Qualified Tuition and Related Expenses (AOTC)"
+  description: "Qualified tuition and related expenses for American Opportunity Tax Credit per 26 USC 25A(f)(1)(A)-(D)"
+  formula: |
+    # Per (D): For AOTC, include course materials in addition to tuition and fees
+    base_expenses = tuition_paid + academic_fees_paid + course_materials_paid
+    # Nonacademic fees excluded per (C)
+    nonacademic_exclusion = student_activity_fees + athletic_fees + education_insurance_expenses + other_nonacademic_expenses
+    # Sports/games/hobbies exception per (B): excluded UNLESS part of degree program
+    if sports_course_part_of_degree:
+      # Part of degree program - sports expenses included
+      return max(0, base_expenses - nonacademic_exclusion)
+    # Not part of degree program - sports expenses excluded
+    return max(0, base_expenses - sports_games_hobbies_expenses - nonacademic_exclusion)
+  tests:
+    - name: "Tuition plus course materials for AOTC"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        course_materials_paid: 1500
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 11500
+    - name: "AOTC with all components"
+      period: 2024-01
+      inputs:
+        tuition_paid: 8000
+        academic_fees_paid: 500
+        course_materials_paid: 1000
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 9500
+    - name: "AOTC sports exclusion"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        course_materials_paid: 500
+        sports_games_hobbies_expenses: 2000
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 8500
+    - name: "AOTC sports course part of degree - included"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        course_materials_paid: 500
+        sports_games_hobbies_expenses: 2000
+        sports_course_part_of_degree: True
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 10500
+    - name: "AOTC with nonacademic exclusions"
+      period: 2024-01
+      inputs:
+        tuition_paid: 10000
+        academic_fees_paid: 0
+        course_materials_paid: 500
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 200
+        athletic_fees: 100
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 10200
+    - name: "Zero AOTC expenses"
+      period: 2024-01
+      inputs:
+        tuition_paid: 0
+        academic_fees_paid: 0
+        course_materials_paid: 0
+        sports_games_hobbies_expenses: 0
+        sports_course_part_of_degree: False
+        student_activity_fees: 0
+        athletic_fees: 0
+        education_insurance_expenses: 0
+        other_nonacademic_expenses: 0
+      expect: 0

--- a/statute/26/25A/f/2.rac
+++ b/statute/26/25A/f/2.rac
@@ -1,0 +1,74 @@
+# 26 USC 25A(f)(2) - Eligible educational institution
+
+text: """
+(2) Eligible educational institution
+The term "eligible educational institution" means an institution—
+(A) which is described in section 481 of the Higher Education Act of 1965 (20 U.S.C. 1088),
+as in effect on the date of the enactment of this section, and
+(B) which is eligible to participate in a program under title IV of such Act.
+"""
+
+# This subsection defines "eligible educational institution" for purposes of 26 USC 25A
+# education credits (AOTC and LLC).
+#
+# An institution qualifies if it meets BOTH requirements:
+# (A) Described in HEA section 481 (20 USC 1088) - generally institutions of higher education
+#     that meet certain accreditation and eligibility requirements
+# (B) Eligible to participate in Title IV federal student aid programs
+#
+# No parameters needed - this is a Boolean eligibility definition based on external
+# characteristics of the institution. The determination is binary - the institution
+# either meets the HEA definition and Title IV eligibility or it does not.
+
+input institution_described_in_hea_481:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Institution Described in HEA Section 481"
+  description: "Whether the educational institution is described in section 481 of the Higher Education Act of 1965 (20 U.S.C. 1088) per 26 USC 25A(f)(2)(A)"
+  default: False
+
+input institution_title_iv_eligible:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Institution Title IV Eligible"
+  description: "Whether the educational institution is eligible to participate in a program under title IV of the Higher Education Act per 26 USC 25A(f)(2)(B)"
+  default: False
+
+variable is_eligible_educational_institution:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Eligible Educational Institution"
+  description: "Whether the institution meets the definition of eligible educational institution per 26 USC 25A(f)(2)"
+  formula: |
+    # Per 25A(f)(2): Both (A) and (B) must be satisfied
+    # (A) Institution described in HEA section 481 (20 USC 1088)
+    # (B) Institution eligible for Title IV federal student aid programs
+    return institution_described_in_hea_481 and institution_title_iv_eligible
+  tests:
+    - name: "Both requirements met - eligible"
+      period: 2024-01
+      inputs:
+        institution_described_in_hea_481: True
+        institution_title_iv_eligible: True
+      expect: True
+    - name: "Only HEA 481 requirement met - not eligible"
+      period: 2024-01
+      inputs:
+        institution_described_in_hea_481: True
+        institution_title_iv_eligible: False
+      expect: False
+    - name: "Only Title IV eligibility met - not eligible"
+      period: 2024-01
+      inputs:
+        institution_described_in_hea_481: False
+        institution_title_iv_eligible: True
+      expect: False
+    - name: "Neither requirement met - not eligible"
+      period: 2024-01
+      inputs:
+        institution_described_in_hea_481: False
+        institution_title_iv_eligible: False
+      expect: False

--- a/statute/26/25A/g/1.rac
+++ b/statute/26/25A/g/1.rac
@@ -1,0 +1,92 @@
+# 26 USC 25A(g)(1) - Identification requirement
+
+text: """
+(1) Identification requirement
+(A) Social security number requirement
+No credit shall be allowed under subsection (a) to an individual unless the
+individual includes on the return of tax for the taxable year—
+(i) such individual's social security number, and
+(ii) in the case of a credit with respect to the qualified tuition and related
+expenses of an individual other than the taxpayer or the taxpayer's spouse, the
+name and social security number of such individual.
+(B) Institution
+No American Opportunity Tax Credit shall be allowed under this section unless
+the taxpayer includes the employer identification number of any institution to
+which the taxpayer paid qualified tuition and related expenses taken into account
+under this section on the return of tax for the taxable year.
+(C) Social security number defined
+For purposes of this paragraph, the term "social security number" shall have the
+meaning given such term in section 24(h)(7).
+"""
+
+# This paragraph establishes three identification requirements for education credits:
+# (A) SSN requirements - taxpayer must have valid SSN; if claiming for non-spouse dependent,
+#     that student's name and SSN must also be provided
+# (B) Institution EIN - AOTC specifically requires institution's EIN
+# (C) SSN definition - cross-reference to 24(h)(7) which requires SSN valid for employment
+#
+# These are Boolean eligibility conditions that gate credit availability.
+# The subsection is split into: g/1/A.rac, g/1/B.rac, g/1/C.rac for detailed encoding.
+# This file provides the aggregate eligibility determination.
+
+input claiming_aotc:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Claiming AOTC"
+  description: "Whether taxpayer is claiming American Opportunity Tax Credit per 26 USC 25A(a)(1)"
+  default: False
+
+variable sec_25A_identification_requirement_met:
+  imports:
+    - 26/25A/g/1/A#ssn_requirement_met
+    - 26/25A/g/1/B#institution_ein_requirement_met
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Section 25A Identification Requirement Met"
+  description: "Whether identification requirements of 26 USC 25A(g)(1) are satisfied for education credit"
+  formula: |
+    # Per (A): SSN requirement must be met for any credit under subsection (a)
+    if not ssn_requirement_met:
+      return False
+    # Per (B): Institution EIN required only for AOTC
+    if claiming_aotc and not institution_ein_requirement_met:
+      return False
+    return True
+  tests:
+    - name: "SSN requirement met, not claiming AOTC"
+      period: 2024-01
+      inputs:
+        ssn_requirement_met: True
+        institution_ein_requirement_met: False
+        claiming_aotc: False
+      expect: True
+    - name: "SSN requirement met, claiming AOTC with EIN"
+      period: 2024-01
+      inputs:
+        ssn_requirement_met: True
+        institution_ein_requirement_met: True
+        claiming_aotc: True
+      expect: True
+    - name: "SSN requirement met, claiming AOTC without EIN"
+      period: 2024-01
+      inputs:
+        ssn_requirement_met: True
+        institution_ein_requirement_met: False
+        claiming_aotc: True
+      expect: False
+    - name: "SSN requirement not met"
+      period: 2024-01
+      inputs:
+        ssn_requirement_met: False
+        institution_ein_requirement_met: True
+        claiming_aotc: True
+      expect: False
+    - name: "All requirements met"
+      period: 2024-01
+      inputs:
+        ssn_requirement_met: True
+        institution_ein_requirement_met: True
+        claiming_aotc: True
+      expect: True

--- a/statute/26/25A/g/1/A.rac
+++ b/statute/26/25A/g/1/A.rac
@@ -1,0 +1,84 @@
+# 26 USC 25A(g)(1)(A) - Social security number requirement
+# status: stub - created for import resolution from 26/25A/g/1
+
+text: """
+(A) Social security number requirement
+No credit shall be allowed under subsection (a) to an individual unless the
+individual includes on the return of tax for the taxable year—
+(i) such individual's social security number, and
+(ii) in the case of a credit with respect to the qualified tuition and related
+expenses of an individual other than the taxpayer or the taxpayer's spouse, the
+name and social security number of such individual.
+"""
+
+# This is a Boolean eligibility check: taxpayer must include valid SSN on return
+# For credits claimed on behalf of others (non-spouse students), student's name and SSN also required
+# SSN definition in subparagraph (C) cross-references 26 USC 24(h)(7)
+
+input taxpayer_has_valid_ssn:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Has Valid SSN"
+  description: "Whether taxpayer has a valid SSN per 26 USC 25A(g)(1)(A)(i)"
+  default: True
+
+input student_ssn_provided:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Student SSN Provided"
+  description: "Whether student's name and SSN are provided when required per 26 USC 25A(g)(1)(A)(ii)"
+  default: True
+
+input claiming_for_non_spouse_dependent:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Claiming for Non-Spouse Dependent"
+  description: "Whether credit is claimed for individual other than taxpayer or taxpayer's spouse"
+  default: False
+
+variable ssn_requirement_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "SSN Requirement Met"
+  description: "Whether SSN requirements of 26 USC 25A(g)(1)(A) are satisfied"
+  formula: |
+    # Per (i): Taxpayer must include their SSN
+    if not taxpayer_has_valid_ssn:
+      return False
+    # Per (ii): If claiming for non-spouse dependent, their name and SSN required
+    if claiming_for_non_spouse_dependent and not student_ssn_provided:
+      return False
+    return True
+  tests:
+    - name: "Taxpayer has valid SSN, not claiming for dependent"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_ssn: True
+        student_ssn_provided: False
+        claiming_for_non_spouse_dependent: False
+      expect: True
+    - name: "Claiming for dependent, student SSN provided"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_ssn: True
+        student_ssn_provided: True
+        claiming_for_non_spouse_dependent: True
+      expect: True
+    - name: "Claiming for dependent, student SSN missing"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_ssn: True
+        student_ssn_provided: False
+        claiming_for_non_spouse_dependent: True
+      expect: False
+    - name: "Taxpayer SSN invalid"
+      period: 2024-01
+      inputs:
+        taxpayer_has_valid_ssn: False
+        student_ssn_provided: True
+        claiming_for_non_spouse_dependent: False
+      expect: False

--- a/statute/26/25A/g/1/B.rac
+++ b/statute/26/25A/g/1/B.rac
@@ -1,0 +1,43 @@
+# 26 USC 25A(g)(1)(B) - Institution EIN requirement
+
+text: """
+(B) Institution
+No American Opportunity Tax Credit shall be allowed under this section unless
+the taxpayer includes the employer identification number of any institution to
+which the taxpayer paid qualified tuition and related expenses taken into account
+under this section on the return of tax for the taxable year.
+"""
+
+# This requirement applies ONLY to AOTC (American Opportunity Tax Credit)
+# Taxpayer must include EIN of educational institution(s) where expenses were paid
+
+input institution_ein_provided:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Institution EIN Provided"
+  description: "Whether EIN of educational institution is provided on tax return per 26 USC 25A(g)(1)(B)"
+  default: True
+
+variable institution_ein_requirement_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Institution EIN Requirement Met"
+  description: "Whether institution EIN requirement of 26 USC 25A(g)(1)(B) is satisfied"
+  formula: |
+    # Per (B): EIN must be provided for AOTC
+    # Note: This variable just checks whether the EIN is provided
+    # The parent variable in g/1.rac applies this only when claiming AOTC
+    return institution_ein_provided
+  tests:
+    - name: "EIN provided"
+      period: 2024-01
+      inputs:
+        institution_ein_provided: True
+      expect: True
+    - name: "EIN not provided"
+      period: 2024-01
+      inputs:
+        institution_ein_provided: False
+      expect: False

--- a/statute/26/25A/g/3.rac
+++ b/statute/26/25A/g/3.rac
@@ -1,0 +1,134 @@
+# 26 USC 25A(g)(3) - Treatment of expenses paid by dependent
+
+text: """
+(3) Treatment of expenses paid by dependent
+If a deduction under section 151 with respect to an individual is allowed to another
+taxpayer for a taxable year beginning in the calendar year in which such individual's
+taxable year begins—
+  (A) no credit shall be allowed under subsection (a) to such individual for such
+      individual's taxable year,
+  (B) qualified tuition and related expenses paid by such individual during such
+      individual's taxable year shall be treated for purposes of this section as
+      paid by such other taxpayer, and
+  (C) a statement described in paragraph (8) and received by such individual shall
+      be treated as received by the taxpayer.
+"""
+
+# This subsection handles the case where a dependent pays qualified education expenses.
+# If someone else (typically a parent) claims the dependent on their return:
+#   (A) The dependent cannot claim the credit themselves
+#   (B) The expenses the dependent paid are attributed to the taxpayer claiming them
+#   (C) Form 1098-T received by the dependent is treated as received by the taxpayer
+#
+# Note: Section 151 deductions were suspended by TCJA for 2018-2025, but the dependency
+# relationship still applies for purposes of this section per IRC 152(a).
+
+input is_dependent_of_another_taxpayer:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Is Dependent of Another Taxpayer"
+  description: "Whether a deduction under section 151 is allowed to another taxpayer with respect to this individual"
+  default: False
+
+input qualified_expenses_paid_by_dependent:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Qualified Expenses Paid by Dependent"
+  description: "Qualified tuition and related expenses paid by the dependent during the taxable year"
+  default: 0
+
+input form_1098t_received_by_dependent:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Form 1098-T Received by Dependent"
+  description: "Whether the dependent received a statement described in section 25A(g)(8)"
+  default: False
+
+variable dependent_disqualified_from_credit:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Dependent Disqualified From Credit"
+  description: "Whether the individual is disqualified from claiming section 25A credit due to being claimed as a dependent per 26 USC 25A(g)(3)(A)"
+  formula: |
+    return is_dependent_of_another_taxpayer
+  tests:
+    - name: "Not a dependent - can claim credit"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: False
+      expect: False
+    - name: "Is a dependent - disqualified from credit"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: True
+      expect: True
+
+variable expenses_attributed_to_claiming_taxpayer:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Expenses Attributed to Claiming Taxpayer"
+  description: "Qualified expenses paid by dependent that are treated as paid by the taxpayer claiming the dependent per 26 USC 25A(g)(3)(B)"
+  formula: |
+    # Per (B): If individual is claimed as dependent, their expenses are attributed
+    # to the taxpayer claiming them
+    if is_dependent_of_another_taxpayer:
+      return qualified_expenses_paid_by_dependent
+    return 0
+  tests:
+    - name: "Not a dependent - expenses not attributed"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: False
+        qualified_expenses_paid_by_dependent: 5000
+      expect: 0
+    - name: "Is dependent - expenses attributed to claiming taxpayer"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: True
+        qualified_expenses_paid_by_dependent: 5000
+      expect: 5000
+    - name: "Is dependent with zero expenses"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: True
+        qualified_expenses_paid_by_dependent: 0
+      expect: 0
+
+variable form_1098t_attributed_to_claiming_taxpayer:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Form 1098-T Attributed to Claiming Taxpayer"
+  description: "Whether Form 1098-T received by dependent is treated as received by claiming taxpayer per 26 USC 25A(g)(3)(C)"
+  formula: |
+    # Per (C): If individual is claimed as dependent, Form 1098-T received by them
+    # is treated as received by the taxpayer claiming them
+    if is_dependent_of_another_taxpayer:
+      return form_1098t_received_by_dependent
+    return False
+  tests:
+    - name: "Not a dependent - Form 1098-T not attributed"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: False
+        form_1098t_received_by_dependent: True
+      expect: False
+    - name: "Is dependent with Form 1098-T - attributed"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: True
+        form_1098t_received_by_dependent: True
+      expect: True
+    - name: "Is dependent without Form 1098-T - not attributed"
+      period: 2024-01
+      inputs:
+        is_dependent_of_another_taxpayer: True
+        form_1098t_received_by_dependent: False
+      expect: False

--- a/statute/26/25A/g/4.rac
+++ b/statute/26/25A/g/4.rac
@@ -1,0 +1,164 @@
+# 26 USC 25A(g)(4) - Treatment of certain prepayments
+
+text: """
+(4) Treatment of certain prepayments
+If qualified tuition and related expenses are paid by the taxpayer during a taxable
+year for an academic period which begins during the first 3 months following such
+taxable year, such academic period shall be treated for purposes of this section
+as beginning during such taxable year.
+"""
+
+# This paragraph provides a timing rule for prepaid qualified expenses.
+# When a taxpayer pays qualified tuition for an academic period (e.g., spring semester)
+# that begins in January-March of the following tax year, those expenses can be
+# claimed on the current year's return as if the academic period began in the
+# current year.
+#
+# Example: Taxpayer pays spring 2025 tuition in December 2024.
+# Spring semester begins in January 2025 (within first 3 months of following year).
+# Per (g)(4), expenses are treated as if academic period began in 2024,
+# so taxpayer may claim credit on 2024 return.
+
+parameter prepayment_months_allowed:
+  description: "Number of months into the following year within which an academic period may begin for prepaid expenses to be treated as current year per 26 USC 25A(g)(4)"
+  values:
+    1997-08-05: 3
+
+input qualified_expenses_paid_current_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Qualified Tuition Expenses Paid Current Year"
+  description: "Amount of qualified tuition and related expenses paid during the current taxable year"
+  default: 0
+
+input academic_period_begins_following_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Academic Period Begins Following Year"
+  description: "Whether the academic period for which expenses were paid begins in the following taxable year"
+  default: False
+
+input academic_period_begins_month:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Academic Period Begin Month"
+  description: "Month (1-12) in which the academic period begins, where 1=January. Only relevant if academic period begins in following year."
+  default: 1
+
+variable prepaid_expenses_eligible_current_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Prepaid Expenses Eligible Current Year"
+  description: "Whether prepaid qualified expenses for a following-year academic period are eligible to be treated as current year expenses per 26 USC 25A(g)(4)"
+  formula: |
+    # Per (g)(4): Academic period must begin during first 3 months following the taxable year
+    if not academic_period_begins_following_year:
+      # Academic period begins in current year - standard treatment, not prepayment rule
+      return False
+    # Check if academic period begins within allowed months (January, February, or March)
+    return academic_period_begins_month <= prepayment_months_allowed
+  tests:
+    - name: "Academic period in current year - not a prepayment"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: False
+        academic_period_begins_month: 9
+      expect: False
+    - name: "Academic period begins January of following year - eligible"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 1
+      expect: True
+    - name: "Academic period begins February of following year - eligible"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 2
+      expect: True
+    - name: "Academic period begins March of following year - eligible"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 3
+      expect: True
+    - name: "Academic period begins April of following year - not eligible"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 4
+      expect: False
+    - name: "Academic period begins September of following year - not eligible"
+      period: 2024-01
+      inputs:
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 9
+      expect: False
+
+variable qualified_expenses_treated_as_current_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Qualified Expenses Treated as Current Year"
+  description: "Amount of qualified expenses that may be treated as paid for an academic period beginning in the current year per 26 USC 25A(g)(4)"
+  formula: |
+    # Recompute eligibility inline (test runner evaluates variables independently)
+    prepaid_eligible = academic_period_begins_following_year and academic_period_begins_month <= prepayment_months_allowed
+    if prepaid_eligible:
+      # Prepaid expenses for following-year academic period starting in first 3 months
+      # are treated as if academic period began in current year
+      return qualified_expenses_paid_current_year
+    if not academic_period_begins_following_year:
+      # Standard case: academic period begins in current year
+      return qualified_expenses_paid_current_year
+    # Academic period begins after first 3 months of following year - cannot claim in current year
+    return 0
+  tests:
+    - name: "Current year academic period - full amount eligible"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 4000
+        academic_period_begins_following_year: False
+        academic_period_begins_month: 8
+      expect: 4000
+    - name: "Prepaid for January start - full amount eligible under (g)(4)"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 5000
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 1
+      expect: 5000
+    - name: "Prepaid for March start - full amount eligible under (g)(4)"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 3500
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 3
+      expect: 3500
+    - name: "Prepaid for April start - not eligible, zero for current year"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 4000
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 4
+      expect: 0
+    - name: "Prepaid for fall semester following year - not eligible"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 6000
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 9
+      expect: 0
+    - name: "Zero expenses paid - zero result"
+      period: 2024-01
+      inputs:
+        qualified_expenses_paid_current_year: 0
+        academic_period_begins_following_year: True
+        academic_period_begins_month: 1
+      expect: 0

--- a/statute/26/25A/g/5.rac
+++ b/statute/26/25A/g/5.rac
@@ -1,0 +1,77 @@
+# 26 USC 25A(g)(5) - Denial of double benefit
+
+text: """
+(5) Denial of double benefit
+No credit shall be allowed under this section for any expense for which a
+deduction is allowed under any other provision of this chapter.
+"""
+
+# This paragraph prevents taxpayers from claiming both the education credit
+# under section 25A and a deduction under another provision of chapter 1
+# (Subtitle A - Income Taxes) for the same expense. This ensures expenses
+# cannot be double-counted for tax benefits.
+#
+# Common deductions that could otherwise overlap:
+# - Business expense deductions under section 162
+# - Trade/business education expenses
+# - Above-the-line deductions for education (when available)
+#
+# The rule is a Boolean eligibility gate: if a deduction was allowed for an
+# expense, no section 25A credit is permitted for that same expense.
+
+input expense_deducted_under_other_chapter_1_provision:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Expense Deducted Under Other Chapter 1 Provision"
+  description: "Amount of qualified tuition and related expenses for which a deduction is allowed under any other provision of this chapter (Chapter 1)"
+  default: 0
+
+variable sec_25A_expense_disallowed_for_double_benefit:
+  entity: Person
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Section 25A Expense Disallowed for Double Benefit"
+  description: "Amount of qualified expenses disallowed for section 25A credit because a deduction was allowed under another chapter 1 provision per 26 USC 25A(g)(5)"
+  formula: |
+    # Per (g)(5): No credit for any expense for which a deduction is allowed
+    # under any other provision of this chapter
+    return expense_deducted_under_other_chapter_1_provision
+  tests:
+    - name: "No expenses deducted elsewhere - no reduction"
+      period: 2024-01
+      inputs:
+        expense_deducted_under_other_chapter_1_provision: 0
+      expect: 0
+    - name: "All expenses deducted elsewhere - full reduction"
+      period: 2024-01
+      inputs:
+        expense_deducted_under_other_chapter_1_provision: 4000
+      expect: 4000
+    - name: "Partial expenses deducted elsewhere"
+      period: 2024-01
+      inputs:
+        expense_deducted_under_other_chapter_1_provision: 1500
+      expect: 1500
+
+variable double_benefit_disqualification_applies:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Double Benefit Disqualification Applies"
+  description: "Whether any qualified expenses are disqualified from section 25A credit due to deduction under another provision per 26 USC 25A(g)(5)"
+  formula: |
+    return expense_deducted_under_other_chapter_1_provision > 0
+  tests:
+    - name: "No double benefit - disqualification does not apply"
+      period: 2024-01
+      inputs:
+        expense_deducted_under_other_chapter_1_provision: 0
+      expect: False
+    - name: "Some expenses deducted - disqualification applies"
+      period: 2024-01
+      inputs:
+        expense_deducted_under_other_chapter_1_provision: 2000
+      expect: True

--- a/statute/26/25A/h.rac
+++ b/statute/26/25A/h.rac
@@ -1,0 +1,34 @@
+# 26 USC 25A(h) - Inflation adjustments [REPEALED]
+
+status: obsolete
+
+text: |
+  (h) Inflation adjustment
+  [Struck by Pub. L. 116-260, div. EE, title I, sec. 104(a)(2), Dec. 27, 2020, 134 Stat. 3041]
+
+  Prior to repeal, this subsection read:
+
+  (h) Inflation adjustment
+  (1) In general
+  In the case of a taxable year beginning after 2001, the $40,000 and $80,000 amounts in
+  subsection (d)(2) shall each be increased by an amount equal to-
+  (A) such dollar amount, multiplied by
+  (B) the cost-of-living adjustment determined under section 1(f)(3) for the calendar year
+  in which the taxable year begins, determined by substituting "calendar year 2000" for
+  "calendar year 2016" in subparagraph (A)(ii) thereof.
+  (2) Rounding
+  If any amount as adjusted under paragraph (1) is not a multiple of $1,000, such amount
+  shall be rounded to the next lowest multiple of $1,000.
+
+  This subsection provided inflation adjustments to the Lifetime Learning Credit income
+  limitations under the former subsection (d)(2). The 2020 amendment (Pub. L. 116-260)
+  struck this subsection effective for taxable years beginning after December 31, 2020.
+
+  Current law:
+  - Subsection (d)(1) now provides unified income limitations ($80,000/$160,000) for both
+    AOTC and LLC, with a $10,000/$20,000 phase-out range
+  - These amounts are NOT indexed for inflation under current law
+  - The former (d)(2) which contained separate LLC income limits was struck
+  - The former (d)(3) "Modified adjusted gross income" was redesignated as (d)(2)
+
+# No parameters, variables, or formulas - provision no longer exists in current law

--- a/statute/26/25A/j/2.rac
+++ b/statute/26/25A/j/2.rac
@@ -1,0 +1,37 @@
+# 26 USC 25A(j)(2) - DOES NOT EXIST IN CURRENT LAW
+
+status: obsolete
+
+text: |
+  26 USC 25A(j) currently contains ONLY a single paragraph about regulations.
+  There is NO (j)(2) in current law.
+
+  Current text of 26 USC 25A(j):
+
+  (j) Regulations
+  The Secretary may prescribe such regulations as may be necessary or appropriate
+  to carry out this section, including regulations providing for a recapture of
+  the credit allowed under this section in cases where there is a refund in a
+  subsequent taxable year of any amount which was taken into account in
+  determining the amount of such credit.
+
+  Historical note:
+  The "Credit allowed against alternative minimum tax" provision was FORMERLY
+  located at 26 USC 25A(i)(5), NOT (j)(2). This provision was struck by
+  Pub. L. 115-97 (Tax Cuts and Jobs Act of 2017), section 11002(d)(1)(B),
+  which redesignated paragraphs (5) and (6) as (4) and (5), and struck out
+  former paragraph (5) relating to credit allowed against alternative minimum tax.
+
+  For AMT-related credit provisions, see:
+  - 26 USC 26(a)(1) - Credits allowed against regular tax liability
+  - 26 USC 26(a)(2) - Credits listed in section 53(d)(1)(B)(iv) allowed against AMT
+  - 26 USC 53 - Credit for prior year minimum tax liability
+
+  The education credits under section 25A are currently listed among the
+  nonrefundable personal credits in 26 USC 26(a), which are allowed against
+  regular tax liability reduced by foreign tax credit. The specific AMT
+  treatment is no longer in section 25A but is handled by the general
+  credit limitation rules in section 26.
+
+# This file documents that the requested citation does not exist.
+# No parameters, variables, or formulas - citation is invalid.

--- a/statute/26/32/a.rac
+++ b/statute/26/32/a.rac
@@ -1,0 +1,421 @@
+# 26 USC 32(a) - Allowance of credit
+
+text: """
+(a) Allowance of credit
+(1) In general
+In the case of an eligible individual, there shall be allowed as a credit against the
+tax imposed by this subtitle for the taxable year an amount equal to the credit percentage
+of so much of the taxpayer's earned income for the taxable year as does not exceed the
+earned income amount.
+
+(2) Limitation
+The amount of the credit allowable to a taxpayer under paragraph (1) for any taxable year
+shall not exceed the excess (if any) of—
+(A) the credit percentage of the earned income amount, over
+(B) the phaseout percentage of so much of the adjusted gross income (or, if greater, the
+earned income) of the taxpayer for the taxable year as exceeds the phaseout amount.
+"""
+
+# =============================================================================
+# Input: Adjusted gross income (required for phaseout calculation)
+# =============================================================================
+
+input adjusted_gross_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Adjusted Gross Income"
+  description: "Adjusted gross income used in EITC phaseout calculation per 26 USC 32(a)(2)(B)"
+  default: 0
+
+# =============================================================================
+# 32(a)(1) - Credit amount before limitation
+# =============================================================================
+
+variable eitc_credit_before_limitation:
+  imports:
+    - 26/32/c#eitc_earned_income
+    - 26/32/b#eitc_earned_income_amount
+    - 26/32/b#eitc_credit_percentage
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Credit Before Limitation"
+  description: "Credit percentage of earned income up to earned income amount per 26 USC 32(a)(1)"
+  formula: |
+    # (a)(1): Credit = credit_percentage * min(earned_income, earned_income_amount)
+    # "credit percentage of so much of the taxpayer's earned income...as does not exceed
+    # the earned income amount"
+    income_subject_to_credit = min(eitc_earned_income, eitc_earned_income_amount)
+    return eitc_credit_percentage * income_subject_to_credit
+  tests:
+    - name: "Earned income below earned income amount"
+      period: 2024-01
+      inputs:
+        eitc_earned_income: 5000
+        eitc_earned_income_amount: 6330
+        eitc_credit_percentage: 0.34
+      expect: 1700
+    - name: "Earned income at earned income amount"
+      period: 2024-01
+      inputs:
+        eitc_earned_income: 6330
+        eitc_earned_income_amount: 6330
+        eitc_credit_percentage: 0.34
+      expect: 2152.20
+    - name: "Earned income exceeds earned income amount"
+      period: 2024-01
+      inputs:
+        eitc_earned_income: 10000
+        eitc_earned_income_amount: 6330
+        eitc_credit_percentage: 0.34
+      expect: 2152.20
+    - name: "Zero earned income"
+      period: 2024-01
+      inputs:
+        eitc_earned_income: 0
+        eitc_earned_income_amount: 6330
+        eitc_credit_percentage: 0.34
+      expect: 0
+    - name: "Childless - low income"
+      period: 2024-01
+      inputs:
+        eitc_earned_income: 3000
+        eitc_earned_income_amount: 4220
+        eitc_credit_percentage: 0.0765
+      expect: 229.50
+
+# =============================================================================
+# 32(a)(2)(A) - Maximum credit (credit percentage of earned income amount)
+# =============================================================================
+
+variable eitc_maximum_credit:
+  imports:
+    - 26/32/b#eitc_credit_percentage
+    - 26/32/b#eitc_earned_income_amount
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Maximum Credit"
+  description: "Maximum credit amount per 26 USC 32(a)(2)(A) = credit percentage * earned income amount"
+  formula: |
+    # (a)(2)(A): "the credit percentage of the earned income amount"
+    return eitc_credit_percentage * eitc_earned_income_amount
+  tests:
+    - name: "1 qualifying child"
+      period: 2024-01
+      inputs:
+        eitc_credit_percentage: 0.34
+        eitc_earned_income_amount: 6330
+      expect: 2152.20
+    - name: "2 qualifying children"
+      period: 2024-01
+      inputs:
+        eitc_credit_percentage: 0.40
+        eitc_earned_income_amount: 8890
+      expect: 3556
+    - name: "3 or more qualifying children"
+      period: 2024-01
+      inputs:
+        eitc_credit_percentage: 0.45
+        eitc_earned_income_amount: 8890
+      expect: 4000.50
+    - name: "No qualifying children"
+      period: 2024-01
+      inputs:
+        eitc_credit_percentage: 0.0765
+        eitc_earned_income_amount: 4220
+      expect: 322.83
+
+# =============================================================================
+# 32(a)(2)(B) - Phaseout base income
+# =============================================================================
+
+variable eitc_phaseout_base:
+  imports:
+    - 26/32/c#eitc_earned_income
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Phaseout Base"
+  description: "Income base for phaseout = greater of AGI or earned income per 26 USC 32(a)(2)(B)"
+  formula: |
+    # (a)(2)(B): "the adjusted gross income (or, if greater, the earned income)"
+    return max(adjusted_gross_income, eitc_earned_income)
+  tests:
+    - name: "AGI greater than earned income"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 30000
+        eitc_earned_income: 25000
+      expect: 30000
+    - name: "Earned income greater than AGI"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 20000
+        eitc_earned_income: 25000
+      expect: 25000
+    - name: "Equal amounts"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 25000
+        eitc_earned_income: 25000
+      expect: 25000
+    - name: "Zero values"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 0
+        eitc_earned_income: 0
+      expect: 0
+
+# =============================================================================
+# 32(a)(2)(B) - Phaseout reduction amount
+# =============================================================================
+
+variable eitc_phaseout_reduction:
+  imports:
+    - 26/32/b#eitc_phaseout_percentage
+    - 26/32/b#eitc_phaseout_amount
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Phaseout Reduction"
+  description: "Phaseout amount per 26 USC 32(a)(2)(B)"
+  formula: |
+    # (a)(2)(B): "the phaseout percentage of so much of the [phaseout_base]...
+    # as exceeds the phaseout amount"
+    excess_over_phaseout = max(0, eitc_phaseout_base - eitc_phaseout_amount)
+    return eitc_phaseout_percentage * excess_over_phaseout
+  tests:
+    - name: "Income below phaseout threshold"
+      period: 2024-01
+      inputs:
+        eitc_phaseout_base: 10000
+        eitc_phaseout_amount: 11610
+        eitc_phaseout_percentage: 0.1598
+      expect: 0
+    - name: "Income at phaseout threshold"
+      period: 2024-01
+      inputs:
+        eitc_phaseout_base: 11610
+        eitc_phaseout_amount: 11610
+        eitc_phaseout_percentage: 0.1598
+      expect: 0
+    - name: "Income above phaseout threshold - 1 child"
+      period: 2024-01
+      inputs:
+        eitc_phaseout_base: 20000
+        eitc_phaseout_amount: 11610
+        eitc_phaseout_percentage: 0.1598
+      expect: 1340.72
+    - name: "Income above phaseout threshold - childless"
+      period: 2024-01
+      inputs:
+        eitc_phaseout_base: 10000
+        eitc_phaseout_amount: 5280
+        eitc_phaseout_percentage: 0.0765
+      expect: 361.08
+
+# =============================================================================
+# 32(a)(2) - Credit after limitation
+# =============================================================================
+
+variable eitc_credit_after_limitation:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Credit After Limitation"
+  description: "Credit limited by phaseout per 26 USC 32(a)(2)"
+  formula: |
+    # (a)(2): Credit shall not exceed (A) minus (B)
+    # (A) = maximum credit
+    # (B) = phaseout reduction
+    # "the excess (if any) of (A) over (B)"
+    return max(0, eitc_maximum_credit - eitc_phaseout_reduction)
+  tests:
+    - name: "No phaseout - full credit"
+      period: 2024-01
+      inputs:
+        eitc_maximum_credit: 2152.20
+        eitc_phaseout_reduction: 0
+      expect: 2152.20
+    - name: "Partial phaseout"
+      period: 2024-01
+      inputs:
+        eitc_maximum_credit: 2152.20
+        eitc_phaseout_reduction: 800
+      expect: 1352.20
+    - name: "Full phaseout - credit eliminated"
+      period: 2024-01
+      inputs:
+        eitc_maximum_credit: 2152.20
+        eitc_phaseout_reduction: 3000
+      expect: 0
+    - name: "Phaseout equals maximum - zero credit"
+      period: 2024-01
+      inputs:
+        eitc_maximum_credit: 2152.20
+        eitc_phaseout_reduction: 2152.20
+      expect: 0
+
+# =============================================================================
+# 32(a) - Final earned income credit
+# =============================================================================
+
+variable earned_income_credit:
+  imports:
+    - 26/32/c#is_eitc_eligible_individual
+    - 26/32/d#eitc_eligible_under_32d
+    - 26/32/i#eitc_denied_excessive_investment_income
+    - 26/32/k#eitc_disallowed_improper_claim
+    - 26/32/m#eitc_id_requirements_met
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Earned Income Credit"
+  description: "Earned income credit per 26 USC 32(a), subject to all eligibility requirements"
+  formula: |
+    # Check all eligibility requirements before allowing credit
+
+    # 32(c)(1): Must be an eligible individual
+    if not is_eitc_eligible_individual:
+      return 0
+
+    # 32(d): Married individuals must file joint return
+    if not eitc_eligible_under_32d:
+      return 0
+
+    # 32(i): Disallowed if excessive investment income
+    if eitc_denied_excessive_investment_income:
+      return 0
+
+    # 32(k): Disallowed if improper prior claim
+    if eitc_disallowed_improper_claim:
+      return 0
+
+    # 32(m): Must meet identification requirements
+    if not eitc_id_requirements_met:
+      return 0
+
+    # 32(a)(1) and (2): Compute credit with limitation
+    # Credit = min(credit_before_limitation, credit_after_limitation)
+    # But since credit_after_limitation caps the maximum, we use the lesser of
+    # (1) the phase-in calculation and (2) the phase-out calculation
+    return min(eitc_credit_before_limitation, eitc_credit_after_limitation)
+  tests:
+    - name: "Eligible - phase-in region (earned income below earned income amount)"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 1700
+        eitc_credit_after_limitation: 2152.20
+      expect: 1700
+    - name: "Eligible - plateau region (at maximum credit)"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 2152.20
+    - name: "Eligible - phaseout region"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 1200
+      expect: 1200
+    - name: "Ineligible - not eligible individual"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: false
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Ineligible - married filing separately"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: false
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Ineligible - excessive investment income"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: true
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Ineligible - improper prior claim"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: true
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Ineligible - ID requirements not met"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: false
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Zero earned income - zero credit"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 0
+        eitc_credit_after_limitation: 2152.20
+      expect: 0
+    - name: "Fully phased out - zero credit"
+      period: 2024-01
+      inputs:
+        is_eitc_eligible_individual: true
+        eitc_eligible_under_32d: true
+        eitc_denied_excessive_investment_income: false
+        eitc_disallowed_improper_claim: false
+        eitc_id_requirements_met: true
+        eitc_credit_before_limitation: 2152.20
+        eitc_credit_after_limitation: 0
+      expect: 0

--- a/statute/26/32/b.rac
+++ b/statute/26/32/b.rac
@@ -1,0 +1,344 @@
+# 26 USC 32(b) - Percentages and amounts
+
+text: |
+  (b) Percentages and amounts
+  For purposes of subsection (a)—
+
+  (1) Percentages
+  The credit percentage and the phaseout percentage shall be determined as follows:
+
+  In the case of an eligible individual with:   The credit percentage is:  The phaseout percentage is:
+  1 qualifying child                            34                         15.98
+  2 qualifying children                         40                         21.06
+  3 or more qualifying children                 45                         21.06
+  No qualifying children                        7.65                       7.65
+
+  (2) Amounts
+  (A) In general
+  Subject to subparagraph (B), the earned income amount and the phaseout amount shall be determined as follows:
+
+  In the case of an eligible individual with:   The earned income amount is:  The phaseout amount is:
+  1 qualifying child                            $6,330                        $11,610
+  2 or more qualifying children                 $8,890                        $11,610
+  No qualifying children                        $4,220                        $5,280
+
+  (B) Joint returns
+  In the case of a joint return filed by an eligible individual and such individual's spouse,
+  the phaseout amount determined under subparagraph (A) shall be increased by $5,000.
+
+# =============================================================================
+# 32(b)(1) - Percentages
+# =============================================================================
+
+# Credit percentages per 32(b)(1)
+parameter eitc_credit_percentage_0:
+  description: "Credit percentage for no qualifying children per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.0765
+
+parameter eitc_credit_percentage_1:
+  description: "Credit percentage for 1 qualifying child per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.34
+
+parameter eitc_credit_percentage_2:
+  description: "Credit percentage for 2 qualifying children per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.40
+
+parameter eitc_credit_percentage_3plus:
+  description: "Credit percentage for 3 or more qualifying children per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    2009-01-01: 0.45
+
+# Phaseout percentages per 32(b)(1)
+parameter eitc_phaseout_percentage_0:
+  description: "Phaseout percentage for no qualifying children per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.0765
+
+parameter eitc_phaseout_percentage_1:
+  description: "Phaseout percentage for 1 qualifying child per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.1598
+
+parameter eitc_phaseout_percentage_2plus:
+  description: "Phaseout percentage for 2 or more qualifying children per 26 USC 32(b)(1)"
+  unit: /1
+  values:
+    1996-01-01: 0.2106
+
+# =============================================================================
+# 32(b)(2)(A) - Amounts (base statutory values, subject to 32(j) inflation adjustment)
+# =============================================================================
+
+# Earned income amounts per 32(b)(2)(A)
+parameter eitc_earned_income_amount_0:
+  description: "Earned income amount for no qualifying children per 26 USC 32(b)(2)(A)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    1996-01-01: 4220
+
+parameter eitc_earned_income_amount_1:
+  description: "Earned income amount for 1 qualifying child per 26 USC 32(b)(2)(A)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    1996-01-01: 6330
+
+parameter eitc_earned_income_amount_2plus:
+  description: "Earned income amount for 2 or more qualifying children per 26 USC 32(b)(2)(A)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    1996-01-01: 8890
+
+# Phaseout amounts per 32(b)(2)(A)
+parameter eitc_phaseout_amount_0:
+  description: "Phaseout amount for no qualifying children per 26 USC 32(b)(2)(A)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    1996-01-01: 5280
+
+parameter eitc_phaseout_amount_1plus:
+  description: "Phaseout amount for 1 or more qualifying children per 26 USC 32(b)(2)(A)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    1996-01-01: 11610
+
+# =============================================================================
+# 32(b)(2)(B) - Joint return phaseout increase
+# =============================================================================
+
+parameter eitc_joint_return_phaseout_increase:
+  description: "Phaseout amount increase for joint returns per 26 USC 32(b)(2)(B)"
+  unit: USD
+  indexed_by: eitc_cola_adjustment
+  values:
+    2002-01-01: 5000
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input qualifying_children_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Number of Qualifying Children"
+  description: "Number of qualifying children for EITC purposes"
+  default: 0
+
+input is_joint_return:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Joint Return"
+  description: "Whether filing a joint return per 26 USC 32(b)(2)(B)"
+  default: false
+
+# =============================================================================
+# Variables - Credit percentage per 32(b)(1)
+# =============================================================================
+
+variable eitc_credit_percentage:
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  unit: /1
+  label: "EITC Credit Percentage"
+  description: "Credit percentage based on number of qualifying children per 26 USC 32(b)(1)"
+  formula: |
+    # 32(b)(1): Credit percentage depends on number of qualifying children
+    if qualifying_children_count == 0:
+      return eitc_credit_percentage_0
+    if qualifying_children_count == 1:
+      return eitc_credit_percentage_1
+    if qualifying_children_count == 2:
+      return eitc_credit_percentage_2
+    # 3 or more qualifying children
+    return eitc_credit_percentage_3plus
+  tests:
+    - name: "No qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 0
+      expect: 0.0765
+    - name: "1 qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 1
+      expect: 0.34
+    - name: "2 qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 2
+      expect: 0.40
+    - name: "3 qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 3
+      expect: 0.45
+    - name: "4 qualifying children (3 or more)"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 4
+      expect: 0.45
+
+# =============================================================================
+# Variables - Phaseout percentage per 32(b)(1)
+# =============================================================================
+
+variable eitc_phaseout_percentage:
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  unit: /1
+  label: "EITC Phaseout Percentage"
+  description: "Phaseout percentage based on number of qualifying children per 26 USC 32(b)(1)"
+  formula: |
+    # 32(b)(1): Phaseout percentage depends on number of qualifying children
+    if qualifying_children_count == 0:
+      return eitc_phaseout_percentage_0
+    if qualifying_children_count == 1:
+      return eitc_phaseout_percentage_1
+    # 2 or more qualifying children (same rate for 2, 3+)
+    return eitc_phaseout_percentage_2plus
+  tests:
+    - name: "No qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 0
+      expect: 0.0765
+    - name: "1 qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 1
+      expect: 0.1598
+    - name: "2 qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 2
+      expect: 0.2106
+    - name: "3 or more qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 3
+      expect: 0.2106
+
+# =============================================================================
+# Variables - Earned income amount per 32(b)(2)(A)
+# =============================================================================
+
+variable eitc_earned_income_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Earned Income Amount"
+  description: "Earned income amount based on number of qualifying children per 26 USC 32(b)(2)(A)"
+  formula: |
+    # 32(b)(2)(A): Earned income amount depends on number of qualifying children
+    if qualifying_children_count == 0:
+      return eitc_earned_income_amount_0
+    if qualifying_children_count == 1:
+      return eitc_earned_income_amount_1
+    # 2 or more qualifying children
+    return eitc_earned_income_amount_2plus
+  tests:
+    - name: "No qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 0
+      expect: 4220
+    - name: "1 qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 1
+      expect: 6330
+    - name: "2 qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 2
+      expect: 8890
+    - name: "3 or more qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 3
+      expect: 8890
+
+# =============================================================================
+# Variables - Phaseout amount per 32(b)(2)(A) and (B)
+# =============================================================================
+
+variable eitc_phaseout_amount:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "EITC Phaseout Amount"
+  description: "Phaseout amount based on number of qualifying children per 26 USC 32(b)(2)(A), increased for joint returns per 32(b)(2)(B)"
+  formula: |
+    # 32(b)(2)(A): Base phaseout amount depends on number of qualifying children
+    if qualifying_children_count == 0:
+      base_amount = eitc_phaseout_amount_0
+    else:
+      # 1 or more qualifying children share same base phaseout
+      base_amount = eitc_phaseout_amount_1plus
+
+    # 32(b)(2)(B): Joint return increase
+    if is_joint_return:
+      return base_amount + eitc_joint_return_phaseout_increase
+    return base_amount
+  tests:
+    - name: "No children, single"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 0
+        is_joint_return: false
+      expect: 5280
+    - name: "No children, joint return"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 0
+        is_joint_return: true
+      expect: 10280
+    - name: "1 child, single"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 1
+        is_joint_return: false
+      expect: 11610
+    - name: "1 child, joint return"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 1
+        is_joint_return: true
+      expect: 16610
+    - name: "2 children, single"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 2
+        is_joint_return: false
+      expect: 11610
+    - name: "2 children, joint return"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 2
+        is_joint_return: true
+      expect: 16610
+    - name: "3 children, joint return"
+      period: 2024-01
+      inputs:
+        qualifying_children_count: 3
+        is_joint_return: true
+      expect: 16610

--- a/statute/26/32/c.rac
+++ b/statute/26/32/c.rac
@@ -1,0 +1,663 @@
+# 26 USC 32(c) - Definitions and special rules
+
+text: """
+(c) Definitions and special rules
+For purposes of this section—
+
+(1) Eligible individual
+(A) In general
+The term "eligible individual" means—
+(i) any individual who has a qualifying child for the taxable year, or
+(ii) any other individual who does not have a qualifying child for the taxable year, if—
+(I) such individual's principal place of abode is in the United States for more than
+one-half of such taxable year,
+(II) such individual (or, if the individual is married, either the individual or the
+individual's spouse) has attained age 25 but not attained age 65 before the close of
+the taxable year, and
+(III) such individual is not a dependent for whom a deduction is allowable under
+section 151 to another taxpayer for any taxable year beginning in the same calendar year
+as such taxable year.
+
+(B) Qualifying child ineligible
+If an individual is the qualifying child of a taxpayer for any taxable year of such
+taxpayer beginning in a calendar year, such individual shall not be treated as an
+eligible individual for any taxable year of such individual beginning in such calendar year.
+
+(C) Exception for individual claiming benefits under section 911
+The term "eligible individual" does not include any individual who claims the benefits
+of section 911 (relating to citizens or residents living abroad) for the taxable year.
+
+(D) Limitation on eligibility of nonresident aliens
+The term "eligible individual" shall not include any individual who is a nonresident
+alien individual for any portion of the taxable year unless such individual is treated
+for such taxable year as a resident of the United States for purposes of this chapter
+by reason of an election under subsection (g) or (h) of section 6013.
+
+(E) Identification number requirement
+No credit shall be allowed under this section to an eligible individual who does not
+include on the return of tax for the taxable year—
+(i) such individual's taxpayer identification number, and
+(ii) if the individual is married, the taxpayer identification number of such
+individual's spouse.
+
+(2) Earned income
+(A) The term "earned income" means—
+(i) wages, salaries, tips, and other employee compensation, but only if such amounts
+are includible in gross income for the taxable year, plus
+(ii) the amount of the taxpayer's net earnings from self-employment for the taxable
+year (within the meaning of section 1402(a)), but such net earnings shall be determined
+with regard to the deduction allowed to the taxpayer by section 164(f).
+
+(B) For purposes of subparagraph (A)—
+(i) the earned income of an individual shall be computed without regard to any
+community property laws,
+(ii) no amount received as a pension or annuity shall be taken into account,
+(iii) no amount to which section 871(a) applies (relating to income of nonresident
+alien individuals not connected with United States business) shall be taken into account,
+(iv) no amount received for services provided by an individual while the individual
+is an inmate at a penal institution shall be taken into account,
+(v) no amount described in subparagraph (A) received for service performed in work
+activities as defined in paragraph (4) or (7) of section 407(d) of the Social Security
+Act to which the taxpayer is assigned under any State program under part A of title IV
+of such Act shall be taken into account, but only to the extent such amount is
+subsidized under such State program.
+
+(3) Qualifying child
+[See 26/32/c/3.rac]
+"""
+
+# =============================================================================
+# 32(c)(1) - Eligible individual
+# =============================================================================
+
+# Parameters for age thresholds per 32(c)(1)(A)(ii)(II)
+parameter eitc_min_age_childless:
+  description: "Minimum age for childless eligible individuals per 26 USC 32(c)(1)(A)(ii)(II)"
+  unit: years
+  values:
+    1996-01-01: 25
+
+parameter eitc_max_age_childless:
+  description: "Maximum age for childless eligible individuals per 26 USC 32(c)(1)(A)(ii)(II)"
+  unit: years
+  values:
+    1996-01-01: 65
+
+# Inputs for eligible individual determination
+
+input has_eitc_qualifying_child:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Has EITC Qualifying Child"
+  description: "Whether the taxpayer has a qualifying child for the taxable year per 26 USC 32(c)(1)(A)(i)"
+  default: False
+
+input principal_abode_in_us_over_half_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Principal Abode in US Over Half Year"
+  description: "Whether principal place of abode is in the United States for more than one-half of the taxable year per 26 USC 32(c)(1)(A)(ii)(I)"
+  default: True
+
+input taxpayer_age:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "Taxpayer Age"
+  description: "Age of the taxpayer before the close of the taxable year"
+  default: 30
+
+input spouse_age:
+  entity: Person
+  period: Year
+  dtype: Integer
+  label: "Spouse Age"
+  description: "Age of the taxpayer's spouse before the close of the taxable year"
+  default: 0
+
+input is_married_eitc:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Married for EITC"
+  description: "Whether the individual is married for purposes of 26 USC 32(c)(1)(A)(ii)(II)"
+  default: False
+
+input is_dependent_of_another:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Dependent of Another Taxpayer"
+  description: "Whether the individual is a dependent for whom a deduction is allowable under section 151 to another taxpayer per 26 USC 32(c)(1)(A)(ii)(III)"
+  default: False
+
+input is_qualifying_child_of_another:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Qualifying Child of Another"
+  description: "Whether the individual is the qualifying child of another taxpayer for the calendar year per 26 USC 32(c)(1)(B)"
+  default: False
+
+input claims_section_911_benefits:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Claims Section 911 Benefits"
+  description: "Whether the individual claims benefits under section 911 (foreign earned income) per 26 USC 32(c)(1)(C)"
+  default: False
+
+input is_nonresident_alien:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Nonresident Alien"
+  description: "Whether the individual is a nonresident alien for any portion of the taxable year per 26 USC 32(c)(1)(D)"
+  default: False
+
+input elected_resident_treatment_6013:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Elected Resident Treatment under 6013"
+  description: "Whether the nonresident alien elected to be treated as a resident under section 6013(g) or (h) per 26 USC 32(c)(1)(D)"
+  default: False
+
+input taxpayer_has_tin_on_return:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer TIN on Return"
+  description: "Whether the taxpayer includes their TIN on the return per 26 USC 32(c)(1)(E)(i)"
+  default: True
+
+input spouse_has_tin_on_return:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Spouse TIN on Return"
+  description: "Whether the taxpayer includes spouse's TIN on the return per 26 USC 32(c)(1)(E)(ii)"
+  default: True
+
+# Variables for eligible individual determination
+
+variable eitc_meets_age_requirement:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Meets Age Requirement"
+  description: "Whether taxpayer (or spouse if married) meets age requirement per 26 USC 32(c)(1)(A)(ii)(II)"
+  formula: |
+    # Age requirement: "has attained age 25 but not attained age 65"
+    # For married individuals, either spouse can satisfy the requirement
+
+    # Check if taxpayer meets age: >= 25 AND < 65
+    taxpayer_at_least_25 = taxpayer_age >= eitc_min_age_childless
+    taxpayer_under_65 = taxpayer_age < eitc_max_age_childless
+
+    if taxpayer_at_least_25 and taxpayer_under_65:
+      return True
+
+    # Taxpayer doesn't meet age - if single, fail
+    if not is_married_eitc:
+      return False
+
+    # If married, check spouse: >= 25 AND < 65
+    spouse_at_least_25 = spouse_age >= eitc_min_age_childless
+    spouse_under_65 = spouse_age < eitc_max_age_childless
+
+    if spouse_at_least_25 and spouse_under_65:
+      return True
+
+    # Neither meets age requirement
+    return False
+  tests:
+    - name: "Single taxpayer age 30 - meets requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 30
+        spouse_age: 0
+        is_married_eitc: false
+      expect: true
+    - name: "Single taxpayer age 24 - too young"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 24
+        spouse_age: 0
+        is_married_eitc: false
+      expect: false
+    - name: "Single taxpayer age 65 - too old"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 65
+        spouse_age: 0
+        is_married_eitc: false
+      expect: false
+    - name: "Single taxpayer age 25 - meets minimum"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 25
+        spouse_age: 0
+        is_married_eitc: false
+      expect: true
+    - name: "Single taxpayer age 64 - meets maximum"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 64
+        spouse_age: 0
+        is_married_eitc: false
+      expect: true
+    - name: "Married - taxpayer 24, spouse 30 - spouse satisfies"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 24
+        spouse_age: 30
+        is_married_eitc: true
+      expect: true
+    - name: "Married - taxpayer 70, spouse 66 - neither satisfies"
+      period: 2024-01
+      inputs:
+        taxpayer_age: 70
+        spouse_age: 66
+        is_married_eitc: true
+      expect: false
+
+variable eitc_meets_id_number_requirement:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Meets ID Number Requirement"
+  description: "Whether taxpayer meets identification number requirement per 26 USC 32(c)(1)(E)"
+  formula: |
+    # (E)(i): Must include taxpayer's TIN
+    if not taxpayer_has_tin_on_return:
+      return False
+    # (E)(ii): If married, must include spouse's TIN
+    if is_married_eitc and not spouse_has_tin_on_return:
+      return False
+    return True
+  tests:
+    - name: "Single with TIN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_tin_on_return: true
+        spouse_has_tin_on_return: true
+        is_married_eitc: false
+      expect: true
+    - name: "Single missing TIN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_tin_on_return: false
+        spouse_has_tin_on_return: true
+        is_married_eitc: false
+      expect: false
+    - name: "Married both have TIN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_tin_on_return: true
+        spouse_has_tin_on_return: true
+        is_married_eitc: true
+      expect: true
+    - name: "Married spouse missing TIN"
+      period: 2024-01
+      inputs:
+        taxpayer_has_tin_on_return: true
+        spouse_has_tin_on_return: false
+        is_married_eitc: true
+      expect: false
+
+variable eitc_nonresident_alien_eligible:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Nonresident Alien Eligible"
+  description: "Whether nonresident alien meets eligibility exception per 26 USC 32(c)(1)(D)"
+  formula: |
+    # (D): Nonresident aliens are ineligible unless elected resident treatment under 6013(g)/(h)
+    if is_nonresident_alien:
+      return elected_resident_treatment_6013
+    # Not a nonresident alien - this rule does not disqualify
+    return True
+  tests:
+    - name: "Not a nonresident alien"
+      period: 2024-01
+      inputs:
+        is_nonresident_alien: false
+      expect: true
+    - name: "Nonresident alien without 6013 election"
+      period: 2024-01
+      inputs:
+        is_nonresident_alien: true
+        elected_resident_treatment_6013: false
+      expect: false
+    - name: "Nonresident alien with 6013 election"
+      period: 2024-01
+      inputs:
+        is_nonresident_alien: true
+        elected_resident_treatment_6013: true
+      expect: true
+
+variable is_eitc_eligible_individual:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Eligible Individual"
+  description: "Whether the taxpayer is an eligible individual for EITC per 26 USC 32(c)(1)"
+  formula: |
+    # (B) Qualifying child ineligible: If individual is a qualifying child of another,
+    # they cannot be an eligible individual
+    if is_qualifying_child_of_another:
+      return False
+
+    # (C) Exception for section 911: Cannot claim EITC if claiming foreign earned income exclusion
+    if claims_section_911_benefits:
+      return False
+
+    # (D) Nonresident alien limitation
+    if not eitc_nonresident_alien_eligible:
+      return False
+
+    # (E) Identification number requirement
+    if not eitc_meets_id_number_requirement:
+      return False
+
+    # (A) In general: Eligible if has qualifying child OR meets childless requirements
+    if has_eitc_qualifying_child:
+      # (A)(i): Has qualifying child - eligible
+      return True
+
+    # (A)(ii): Childless individual - must meet three requirements:
+    # (I) Principal place of abode in US for more than half the year
+    if not principal_abode_in_us_over_half_year:
+      return False
+    # (II) Age 25-64 (individual or spouse if married)
+    if not eitc_meets_age_requirement:
+      return False
+    # (III) Not a dependent of another taxpayer
+    if is_dependent_of_another:
+      return False
+    return True
+  tests:
+    - name: "Individual with qualifying child"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: true
+    - name: "Childless individual meeting all requirements"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: false
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: true
+    - name: "Childless - abode not in US"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: false
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: false
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: false
+    - name: "Childless - too young"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: false
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: false
+        is_dependent_of_another: false
+      expect: false
+    - name: "Childless - too old"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: false
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: false
+        is_dependent_of_another: false
+      expect: false
+    - name: "Childless - is dependent of another"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: false
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: true
+      expect: false
+    - name: "Is qualifying child of another taxpayer"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: true
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: false
+    - name: "Claims section 911 benefits"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: true
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: false
+    - name: "Nonresident alien without 6013 election"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: false
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: false
+    - name: "Nonresident alien with 6013 election"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: true
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: true
+    - name: "Missing taxpayer TIN"
+      period: 2024-01
+      inputs:
+        has_eitc_qualifying_child: true
+        is_qualifying_child_of_another: false
+        claims_section_911_benefits: false
+        eitc_nonresident_alien_eligible: true
+        eitc_meets_id_number_requirement: false
+        principal_abode_in_us_over_half_year: true
+        eitc_meets_age_requirement: true
+        is_dependent_of_another: false
+      expect: false
+
+# =============================================================================
+# 32(c)(2) - Earned income
+# =============================================================================
+
+# Inputs for earned income computation
+
+input wages_salaries_tips:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Wages, Salaries, Tips"
+  description: "Wages, salaries, tips, and other employee compensation includible in gross income per 26 USC 32(c)(2)(A)(i)"
+  default: 0
+
+input net_earnings_self_employment:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Net Earnings from Self-Employment"
+  description: "Net earnings from self-employment per section 1402(a), determined with regard to 164(f) deduction per 26 USC 32(c)(2)(A)(ii)"
+  default: 0
+
+input pension_annuity_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Pension/Annuity Income"
+  description: "Amount received as pension or annuity (excluded from earned income per 26 USC 32(c)(2)(B)(ii))"
+  default: 0
+
+input income_section_871a:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Income Under Section 871(a)"
+  description: "Income of nonresident alien not connected with US business (excluded per 26 USC 32(c)(2)(B)(iii))"
+  default: 0
+
+input penal_institution_wages:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Penal Institution Wages"
+  description: "Amount received for services while inmate at penal institution (excluded per 26 USC 32(c)(2)(B)(iv))"
+  default: 0
+
+input subsidized_work_activity_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Subsidized Work Activity Income"
+  description: "Subsidized income from state TANF work activities (excluded per 26 USC 32(c)(2)(B)(v))"
+  default: 0
+
+# Variable for earned income computation
+
+variable eitc_earned_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "EITC Earned Income"
+  description: "Earned income for EITC purposes per 26 USC 32(c)(2)"
+  formula: |
+    # (A) Earned income includes:
+    # (i) wages, salaries, tips, and other employee compensation includible in gross income
+    # (ii) net earnings from self-employment (with 164(f) deduction)
+
+    # Start with wages and self-employment income
+    earned = wages_salaries_tips + net_earnings_self_employment
+
+    # (B) Exclusions - these amounts are NOT earned income:
+    # (i) community property laws - not a deduction, just a computational rule
+    # (ii) pension or annuity - already excluded by only counting wages/SE income above
+    # (iii) section 871(a) income - already excluded by only counting wages/SE income above
+    # (iv) penal institution wages - must subtract if included in wages above
+    # (v) subsidized work activity income - must subtract if included in wages above
+
+    # Subtract exclusions (these may have been included in wages_salaries_tips)
+    earned = earned - penal_institution_wages
+    earned = earned - subsidized_work_activity_income
+
+    # Earned income cannot be negative
+    return max(0, earned)
+  tests:
+    - name: "Wages only"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 30000
+        net_earnings_self_employment: 0
+        penal_institution_wages: 0
+        subsidized_work_activity_income: 0
+      expect: 30000
+    - name: "Self-employment only"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 0
+        net_earnings_self_employment: 20000
+        penal_institution_wages: 0
+        subsidized_work_activity_income: 0
+      expect: 20000
+    - name: "Combined wages and self-employment"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 30000
+        net_earnings_self_employment: 10000
+        penal_institution_wages: 0
+        subsidized_work_activity_income: 0
+      expect: 40000
+    - name: "With penal institution exclusion"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 30000
+        net_earnings_self_employment: 0
+        penal_institution_wages: 5000
+        subsidized_work_activity_income: 0
+      expect: 25000
+    - name: "With subsidized work activity exclusion"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 30000
+        net_earnings_self_employment: 0
+        penal_institution_wages: 0
+        subsidized_work_activity_income: 3000
+      expect: 27000
+    - name: "Multiple exclusions"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 30000
+        net_earnings_self_employment: 5000
+        penal_institution_wages: 2000
+        subsidized_work_activity_income: 1000
+      expect: 32000
+    - name: "Zero income"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 0
+        net_earnings_self_employment: 0
+        penal_institution_wages: 0
+        subsidized_work_activity_income: 0
+      expect: 0
+    - name: "Exclusions exceed income - floor at zero"
+      period: 2024-01
+      inputs:
+        wages_salaries_tips: 5000
+        net_earnings_self_employment: 0
+        penal_institution_wages: 10000
+        subsidized_work_activity_income: 0
+      expect: 0

--- a/statute/26/32/c/3.rac
+++ b/statute/26/32/c/3.rac
@@ -1,0 +1,167 @@
+# 26 USC 32(c)(3) - Qualifying child
+
+text: """
+(3) Qualifying child
+(A) In general
+The term "qualifying child" means a qualifying child of the taxpayer (as defined
+in section 152(c), determined without regard to paragraph (1)(D) thereof and
+section 152(e)).
+
+(B) Married individual
+The term "qualifying child" shall not include an individual who is married as of
+the close of the taxpayer's taxable year unless the taxpayer is entitled to a
+deduction under section 151 for such taxable year with respect to such individual
+(or would be so entitled but for section 152(e)).
+
+(C) Place of abode
+For purposes of subparagraph (A), the requirements of section 152(c)(1)(B) shall
+be met only if the principal place of abode is in the United States.
+
+(D) Identification requirements
+(i) In general
+A qualifying child shall not be taken into account under subsection (b) unless the
+taxpayer includes the name, age, and TIN of the qualifying child on the return of
+tax for the taxable year.
+(ii) Other methods
+The Secretary may prescribe other methods for providing the information described
+in clause (i).
+"""
+
+# This subsection defines "qualifying child" for EITC purposes.
+# It modifies the general 152(c) definition with:
+# - Ignores 152(c)(1)(D) (tie-breaker rules) and 152(e) (custodial parent rules)
+# - Adds married child exclusion unless taxpayer claims dependency deduction
+# - Requires principal place of abode to be in the United States
+# - Requires name, age, and TIN on return
+
+# Inputs for qualifying child determination
+
+input is_qualifying_child_152c:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Qualifying Child per 152(c)"
+  description: "Whether individual meets qualifying child definition under section 152(c)"
+  default: False
+
+input child_is_married:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Is Married"
+  description: "Whether the child is married as of the close of the taxpayer's taxable year"
+  default: False
+
+input taxpayer_claims_151_deduction_for_child:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Claims 151 Deduction for Child"
+  description: "Whether taxpayer is entitled to deduction under section 151 for this child"
+  default: False
+
+input child_principal_abode_in_us:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child Principal Abode in US"
+  description: "Whether child's principal place of abode is in the United States per 32(c)(3)(C)"
+  default: True
+
+input child_tin_included_on_return:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Child TIN Included on Return"
+  description: "Whether taxpayer includes name, age, and TIN of qualifying child on return per 32(c)(3)(D)(i)"
+  default: True
+
+# Variable implementing the qualifying child definition for EITC
+
+variable is_eitc_qualifying_child:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "EITC Qualifying Child"
+  description: "Whether individual is a qualifying child for EITC per 26 USC 32(c)(3)"
+  formula: |
+    # (A) In general: Must be qualifying child under 152(c)
+    # (determined without regard to 152(c)(1)(D) and 152(e))
+    if not is_qualifying_child_152c:
+      return False
+
+    # (B) Married individual: Exclude married child unless taxpayer claims 151 deduction
+    if child_is_married:
+      if not taxpayer_claims_151_deduction_for_child:
+        return False
+
+    # (C) Place of abode: Principal place must be in the United States
+    if not child_principal_abode_in_us:
+      return False
+
+    # (D)(i) Identification requirements: Must include name, age, TIN on return
+    # Note: (D)(ii) is administrative ("Secretary may prescribe other methods")
+    if not child_tin_included_on_return:
+      return False
+
+    return True
+  tests:
+    - name: "Basic qualifying child"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: true
+        child_is_married: false
+        child_principal_abode_in_us: true
+        child_tin_included_on_return: true
+      expect: true
+    - name: "Not qualifying child under 152(c)"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: false
+        child_is_married: false
+        child_principal_abode_in_us: true
+        child_tin_included_on_return: true
+      expect: false
+    - name: "Married child - taxpayer claims 151 deduction"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: true
+        child_is_married: true
+        taxpayer_claims_151_deduction_for_child: true
+        child_principal_abode_in_us: true
+        child_tin_included_on_return: true
+      expect: true
+    - name: "Married child - taxpayer does not claim 151 deduction"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: true
+        child_is_married: true
+        taxpayer_claims_151_deduction_for_child: false
+        child_principal_abode_in_us: true
+        child_tin_included_on_return: true
+      expect: false
+    - name: "Principal abode not in US"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: true
+        child_is_married: false
+        child_principal_abode_in_us: false
+        child_tin_included_on_return: true
+      expect: false
+    - name: "Missing TIN on return"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: true
+        child_is_married: false
+        child_principal_abode_in_us: true
+        child_tin_included_on_return: false
+      expect: false
+    - name: "Zero case - all requirements fail"
+      period: 2024-01
+      inputs:
+        is_qualifying_child_152c: false
+        child_is_married: true
+        taxpayer_claims_151_deduction_for_child: false
+        child_principal_abode_in_us: false
+        child_tin_included_on_return: false
+      expect: false

--- a/statute/26/32/d.rac
+++ b/statute/26/32/d.rac
@@ -1,0 +1,59 @@
+# 26 USC 32(d) - Married individuals
+
+text: """
+(d) Married individuals
+In the case of an individual who is married (within the meaning of section 7703),
+this section shall apply only if a joint return is filed for the taxable year
+under section 6013.
+"""
+
+# This subsection establishes a bright-line rule: married individuals must file
+# a joint return to claim EITC. Married filing separately (MFS) is disqualified.
+
+input is_married:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is married"
+  description: "Whether the individual is married within the meaning of section 7703"
+  default: false
+
+input files_joint_return:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Files joint return"
+  description: "Whether a joint return is filed under section 6013"
+  default: false
+
+variable eitc_eligible_under_32d:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC eligible under 32(d)"
+  description: "Whether eligible for EITC under the married individuals rule of 26 USC 32(d)"
+  formula: |
+    # If not married, this rule does not disqualify
+    if not is_married:
+      return true
+    # If married, must file joint return
+    return files_joint_return
+  tests:
+    - name: "Single individual - eligible"
+      period: 2024-01
+      inputs:
+        is_married: false
+        files_joint_return: false
+      expect: true
+    - name: "Married filing jointly - eligible"
+      period: 2024-01
+      inputs:
+        is_married: true
+        files_joint_return: true
+      expect: true
+    - name: "Married filing separately - ineligible"
+      period: 2024-01
+      inputs:
+        is_married: true
+        files_joint_return: false
+      expect: false

--- a/statute/26/32/h.rac
+++ b/statute/26/32/h.rac
@@ -1,0 +1,18 @@
+# 26 USC 32(h) - Repealed
+
+status: obsolete
+
+text: """
+[(h) Repealed. Pub. L. 107-16, title III, § 303(c), June 7, 2001, 115 Stat. 55]
+"""
+
+# Subsection (h) of 26 USC 32 was repealed by the Economic Growth and Tax Relief
+# Reconciliation Act of 2001 (EGTRRA), Pub. L. 107-16, § 303(c).
+#
+# Prior to repeal, subsection (h) related to supplemental young child credit.
+# This provision was eliminated as part of EGTRRA's expansion of the child tax credit.
+#
+# The "investment income restriction" commonly associated with EITC is located in
+# subsection (i), not subsection (h). See statute/26/32/i.rac for that encoding.
+#
+# No computational content - this is a placeholder documenting the repealed status.

--- a/statute/26/32/i.rac
+++ b/statute/26/32/i.rac
@@ -1,0 +1,273 @@
+# Denial of credit for individuals having excessive investment income
+
+text: """
+(i) Denial of credit for individuals having excessive investment income
+(1) In general
+No credit shall be allowed under subsection (a) for the taxable year if the aggregate
+amount of disqualified income of the taxpayer for the taxable year exceeds $10,000.
+
+(2) Disqualified income
+For purposes of paragraph (1), the term "disqualified income" means—
+(A) interest or dividends to the extent includible in gross income for the taxable year,
+(B) interest received or accrued during the taxable year which is exempt from tax
+imposed by this chapter,
+(C) the excess (if any) of—
+(i) gross income from rents or royalties not derived in the ordinary course of a
+trade or business, over
+(ii) the sum of—
+(I) the deductions (other than interest) which are clearly and directly allocable
+to such gross income, plus
+(II) interest deductions properly allocable to such gross income,
+(D) the capital gain net income (as defined in section 1222) of the taxpayer for such
+taxable year, and
+(E) the excess (if any) of—
+(i) the aggregate income from all passive activities for the taxable year (determined
+without regard to any amount included in earned income under subsection (c)(2)
+or described in a preceding subparagraph), over
+(ii) the aggregate losses from all passive activities for the taxable year
+(as so determined).
+
+For purposes of subparagraph (E), the term "passive activity" has the meaning given
+such term by section 469.
+"""
+
+# Base disqualified income threshold per 32(i)(1)
+# Note: This is the statutory base amount. Inflation-adjusted amounts are computed
+# via 32(j) and published in annual IRS Revenue Procedures.
+parameter disqualified_income_limit:
+  description: "Maximum disqualified income before EITC denial per 26 USC 32(i)(1)"
+  unit: USD
+  indexed_by: cpi_adjustment
+  values:
+    2021-01-01: 10_000
+
+# Inputs for disqualified income components
+
+input taxable_interest_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Taxable Interest Income"
+  description: "Interest includible in gross income per 26 USC 32(i)(2)(A)"
+  default: 0
+
+input dividend_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Dividend Income"
+  description: "Dividends includible in gross income per 26 USC 32(i)(2)(A)"
+  default: 0
+
+input tax_exempt_interest_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Tax-Exempt Interest Income"
+  description: "Interest exempt from tax per 26 USC 32(i)(2)(B)"
+  default: 0
+
+input gross_rent_royalty_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Gross Rent and Royalty Income"
+  description: "Gross income from rents or royalties not in ordinary course of trade or business per 26 USC 32(i)(2)(C)(i)"
+  default: 0
+
+input rent_royalty_deductions_noninterest:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Non-Interest Deductions for Rent/Royalty"
+  description: "Deductions (other than interest) allocable to rent/royalty income per 26 USC 32(i)(2)(C)(ii)(I)"
+  default: 0
+
+input rent_royalty_interest_deductions:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Interest Deductions for Rent/Royalty"
+  description: "Interest deductions allocable to rent/royalty income per 26 USC 32(i)(2)(C)(ii)(II)"
+  default: 0
+
+input capital_gain_net_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Capital Gain Net Income"
+  description: "Capital gain net income per section 1222 for 26 USC 32(i)(2)(D)"
+  default: 0
+
+input gross_passive_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Gross Passive Activity Income"
+  description: "Aggregate income from all passive activities per 26 USC 32(i)(2)(E)(i)"
+  default: 0
+
+input passive_activity_losses:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Passive Activity Losses"
+  description: "Aggregate losses from all passive activities per 26 USC 32(i)(2)(E)(ii)"
+  default: 0
+
+# Variable: Net rent/royalty income per 32(i)(2)(C)
+variable net_rent_royalty_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Net Rent and Royalty Income"
+  description: "Excess of gross rent/royalty over deductions per 26 USC 32(i)(2)(C)"
+  formula: |
+    # 32(i)(2)(C): excess of (i) gross income over (ii) sum of deductions
+    total_deductions = rent_royalty_deductions_noninterest + rent_royalty_interest_deductions
+    excess = gross_rent_royalty_income - total_deductions
+    return max(0, excess)
+  tests:
+    - name: "No rent/royalty income"
+      period: 2024-01
+      inputs:
+        gross_rent_royalty_income: 0
+        rent_royalty_deductions_noninterest: 0
+        rent_royalty_interest_deductions: 0
+      expect: 0
+    - name: "Positive net rent income"
+      period: 2024-01
+      inputs:
+        gross_rent_royalty_income: 15_000
+        rent_royalty_deductions_noninterest: 5_000
+        rent_royalty_interest_deductions: 2_000
+      expect: 8_000
+    - name: "Deductions exceed gross - floor at zero"
+      period: 2024-01
+      inputs:
+        gross_rent_royalty_income: 5_000
+        rent_royalty_deductions_noninterest: 4_000
+        rent_royalty_interest_deductions: 3_000
+      expect: 0
+
+# Variable: Net passive income per 32(i)(2)(E)
+variable net_passive_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Net Passive Activity Income"
+  description: "Excess of passive income over passive losses per 26 USC 32(i)(2)(E)"
+  formula: |
+    # 32(i)(2)(E): excess of (i) aggregate income over (ii) aggregate losses
+    excess = gross_passive_income - passive_activity_losses
+    return max(0, excess)
+  tests:
+    - name: "No passive activity"
+      period: 2024-01
+      inputs:
+        gross_passive_income: 0
+        passive_activity_losses: 0
+      expect: 0
+    - name: "Net passive income"
+      period: 2024-01
+      inputs:
+        gross_passive_income: 10_000
+        passive_activity_losses: 3_000
+      expect: 7_000
+    - name: "Losses exceed income - floor at zero"
+      period: 2024-01
+      inputs:
+        gross_passive_income: 2_000
+        passive_activity_losses: 5_000
+      expect: 0
+
+# Variable: Total disqualified income per 32(i)(2)
+variable disqualified_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Disqualified Income"
+  description: "Aggregate disqualified income per 26 USC 32(i)(2)"
+  formula: |
+    # 32(i)(2)(A): interest or dividends
+    interest_dividends = taxable_interest_income + dividend_income
+    # 32(i)(2)(B): tax-exempt interest
+    exempt_interest = tax_exempt_interest_income
+    # 32(i)(2)(C): net rent/royalty (computed in separate variable)
+    rent_royalty = net_rent_royalty_income
+    # 32(i)(2)(D): capital gain net income
+    cap_gains = capital_gain_net_income
+    # 32(i)(2)(E): net passive income (computed in separate variable)
+    passive = net_passive_income
+    # Sum all components
+    return interest_dividends + exempt_interest + rent_royalty + cap_gains + passive
+  tests:
+    - name: "No disqualified income"
+      period: 2024-01
+      inputs:
+        taxable_interest_income: 0
+        dividend_income: 0
+        tax_exempt_interest_income: 0
+        net_rent_royalty_income: 0
+        capital_gain_net_income: 0
+        net_passive_income: 0
+      expect: 0
+    - name: "Interest and dividends only"
+      period: 2024-01
+      inputs:
+        taxable_interest_income: 500
+        dividend_income: 1_500
+        tax_exempt_interest_income: 0
+        net_rent_royalty_income: 0
+        capital_gain_net_income: 0
+        net_passive_income: 0
+      expect: 2_000
+    - name: "All components"
+      period: 2024-01
+      inputs:
+        taxable_interest_income: 1_000
+        dividend_income: 2_000
+        tax_exempt_interest_income: 500
+        net_rent_royalty_income: 3_000
+        capital_gain_net_income: 2_500
+        net_passive_income: 1_000
+      expect: 10_000
+
+# Variable: EITC denied due to excessive investment income per 32(i)(1)
+variable eitc_denied_excessive_investment_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Denied - Excessive Investment Income"
+  description: "Whether EITC is denied due to disqualified income exceeding limit per 26 USC 32(i)(1)"
+  formula: |
+    # 32(i)(1): No credit if disqualified income exceeds limit
+    return disqualified_income > disqualified_income_limit
+  tests:
+    - name: "Below limit - not denied"
+      period: 2024-01
+      inputs:
+        disqualified_income: 5_000
+        disqualified_income_limit: 11_600
+      expect: false
+    - name: "At limit - not denied"
+      period: 2024-01
+      inputs:
+        disqualified_income: 11_600
+        disqualified_income_limit: 11_600
+      expect: false
+    - name: "Above limit - denied"
+      period: 2024-01
+      inputs:
+        disqualified_income: 12_000
+        disqualified_income_limit: 11_600
+      expect: true
+    - name: "No investment income - not denied"
+      period: 2024-01
+      inputs:
+        disqualified_income: 0
+        disqualified_income_limit: 11_600
+      expect: false

--- a/statute/26/32/j.rac
+++ b/statute/26/32/j.rac
@@ -1,0 +1,224 @@
+# 26 USC 32(j) - Inflation adjustments
+
+text: """
+(j) Inflation adjustments
+(1) In general
+In the case of any taxable year beginning after 2015, each of the dollar amounts in
+subsection (b)(2)(A) shall be increased by an amount equal to—
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3) for the calendar year
+in which the taxable year begins, determined by substituting "calendar year 2015" for
+"calendar year 2016" in subparagraph (A)(ii) thereof.
+
+(2) Rounding
+If any dollar amount in subsection (b)(2)(A) (after being increased under subparagraph (A)),
+is not a multiple of $10, such dollar amount shall be rounded to the nearest multiple of $10.
+"""
+
+# Base year for EITC inflation adjustment per 26 USC 32(j)(1)(B)
+parameter eitc_inflation_base_year:
+  description: "Base year for EITC inflation adjustments per 26 USC 32(j)(1)(B)"
+  values:
+    2016-01-01: 2015
+
+# Year after which inflation adjustments apply per 26 USC 32(j)(1)
+parameter eitc_inflation_start_year:
+  description: "Taxable years beginning after this year are subject to inflation adjustment per 26 USC 32(j)(1)"
+  values:
+    1996-01-01: 2015
+
+# Rounding increment for inflation-adjusted amounts per 26 USC 32(j)(2)
+parameter eitc_inflation_rounding:
+  description: "Rounding increment for EITC inflation adjustments per 26 USC 32(j)(2)"
+  unit: USD
+  values:
+    1996-01-01: 10
+
+# Note: The actual inflation-adjusted values are computed by importing
+# the cost-of-living adjustment from 26 USC 1(f)(3) and applying the formula.
+# This file encodes the statutory methodology; the runtime handles computation.
+# Rounding is handled by the runtime per 32(j)(2), not in the formula.
+
+input eitc_cola_adjustment:
+  entity: TaxUnit
+  period: Year
+  dtype: Float
+  label: "EITC Cost of Living Adjustment"
+  description: "COLA per section 1(f)(3) with 2015 base year substitution per 26 USC 32(j)(1)(B)"
+  default: 0
+
+input eitc_base_earned_income_amount_0:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Base Earned Income Amount (0 children)"
+  description: "Unadjusted earned income amount for 0 qualifying children from 26 USC 32(b)(2)(A)"
+  default: 0
+
+input eitc_base_earned_income_amount_1:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Base Earned Income Amount (1 child)"
+  description: "Unadjusted earned income amount for 1 qualifying child from 26 USC 32(b)(2)(A)"
+  default: 0
+
+input eitc_base_earned_income_amount_2:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Base Earned Income Amount (2+ children)"
+  description: "Unadjusted earned income amount for 2+ qualifying children from 26 USC 32(b)(2)(A)"
+  default: 0
+
+input eitc_base_phaseout_amount_0:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Base Phaseout Amount (0 children)"
+  description: "Unadjusted phaseout amount for 0 qualifying children from 26 USC 32(b)(2)(A)"
+  default: 0
+
+input eitc_base_phaseout_amount_1plus:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Base Phaseout Amount (1+ children)"
+  description: "Unadjusted phaseout amount for 1+ qualifying children from 26 USC 32(b)(2)(A)"
+  default: 0
+
+variable eitc_inflation_adjusted_earned_income_amount_0:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted Earned Income Amount (0 children)"
+  description: "Inflation-adjusted earned income amount for 0 qualifying children per 26 USC 32(j)"
+  formula: |
+    # Apply inflation adjustment: base * (1 + COLA)
+    # Note: Rounding to nearest $10 per 32(j)(2) is handled by runtime
+    adjusted = eitc_base_earned_income_amount_0 * (1 + eitc_cola_adjustment)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2016-01
+      inputs:
+        eitc_base_earned_income_amount_0: 4220
+        eitc_cola_adjustment: 0
+      expect: 4220
+    - name: "5% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_earned_income_amount_0: 4220
+        eitc_cola_adjustment: 0.05
+      expect: 4431
+    - name: "10% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_earned_income_amount_0: 4220
+        eitc_cola_adjustment: 0.10
+      expect: 4642
+
+variable eitc_inflation_adjusted_earned_income_amount_1:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted Earned Income Amount (1 child)"
+  description: "Inflation-adjusted earned income amount for 1 qualifying child per 26 USC 32(j)"
+  formula: |
+    # Apply inflation adjustment: base * (1 + COLA)
+    # Note: Rounding to nearest $10 per 32(j)(2) is handled by runtime
+    adjusted = eitc_base_earned_income_amount_1 * (1 + eitc_cola_adjustment)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2016-01
+      inputs:
+        eitc_base_earned_income_amount_1: 6330
+        eitc_cola_adjustment: 0
+      expect: 6330
+    - name: "5% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_earned_income_amount_1: 6330
+        eitc_cola_adjustment: 0.05
+      expect: 6646.5
+
+variable eitc_inflation_adjusted_earned_income_amount_2:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted Earned Income Amount (2+ children)"
+  description: "Inflation-adjusted earned income amount for 2+ qualifying children per 26 USC 32(j)"
+  formula: |
+    # Apply inflation adjustment: base * (1 + COLA)
+    # Note: Rounding to nearest $10 per 32(j)(2) is handled by runtime
+    adjusted = eitc_base_earned_income_amount_2 * (1 + eitc_cola_adjustment)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2016-01
+      inputs:
+        eitc_base_earned_income_amount_2: 8890
+        eitc_cola_adjustment: 0
+      expect: 8890
+    - name: "5% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_earned_income_amount_2: 8890
+        eitc_cola_adjustment: 0.05
+      expect: 9334.5
+
+variable eitc_inflation_adjusted_phaseout_amount_0:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted Phaseout Amount (0 children)"
+  description: "Inflation-adjusted phaseout amount for 0 qualifying children per 26 USC 32(j)"
+  formula: |
+    # Apply inflation adjustment: base * (1 + COLA)
+    # Note: Rounding to nearest $10 per 32(j)(2) is handled by runtime
+    adjusted = eitc_base_phaseout_amount_0 * (1 + eitc_cola_adjustment)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2016-01
+      inputs:
+        eitc_base_phaseout_amount_0: 5280
+        eitc_cola_adjustment: 0
+      expect: 5280
+    - name: "5% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_phaseout_amount_0: 5280
+        eitc_cola_adjustment: 0.05
+      expect: 5544
+
+variable eitc_inflation_adjusted_phaseout_amount_1plus:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Inflation-Adjusted Phaseout Amount (1+ children)"
+  description: "Inflation-adjusted phaseout amount for 1+ qualifying children per 26 USC 32(j)"
+  formula: |
+    # Apply inflation adjustment: base * (1 + COLA)
+    # Note: Rounding to nearest $10 per 32(j)(2) is handled by runtime
+    adjusted = eitc_base_phaseout_amount_1plus * (1 + eitc_cola_adjustment)
+    return adjusted
+  tests:
+    - name: "No inflation adjustment"
+      period: 2016-01
+      inputs:
+        eitc_base_phaseout_amount_1plus: 11610
+        eitc_cola_adjustment: 0
+      expect: 11610
+    - name: "5% inflation adjustment (before rounding)"
+      period: 2020-01
+      inputs:
+        eitc_base_phaseout_amount_1plus: 11610
+        eitc_cola_adjustment: 0.05
+      expect: 12190.5

--- a/statute/26/32/k.rac
+++ b/statute/26/32/k.rac
@@ -1,0 +1,246 @@
+# 26 USC 32(k) - Restrictions on taxpayers who improperly claimed credit in prior year
+
+text: """
+(k) Restrictions on taxpayers who improperly claimed credit in prior year
+(1) Taxpayers making prior fraudulent or reckless claims
+(A) In general
+No credit shall be allowed under this section for any taxable year in the disallowance period.
+(B) Disallowance period
+For purposes of paragraph (1), the disallowance period is—
+(i) the period of 10 taxable years after the most recent taxable year for which there
+was a final determination that the taxpayer's claim of credit under this section was
+due to fraud, and
+(ii) the period of 2 taxable years after the most recent taxable year for which there
+was a final determination that the taxpayer's claim of credit under this section was
+due to reckless or intentional disregard of rules and regulations (but not due to fraud).
+(2) Taxpayers making improper prior claims
+In the case of a taxpayer who is denied credit under this section for any taxable year
+as a result of the deficiency procedures under subchapter B of chapter 63, no credit
+shall be allowed under this section for any subsequent taxable year unless the taxpayer
+provides such information as the Secretary may require to demonstrate eligibility for
+such credit.
+"""
+
+# Parameters from statute text
+
+parameter fraud_disallowance_years:
+  description: "Number of years credit disallowed after fraud determination per 26 USC 32(k)(1)(B)(i)"
+  unit: Year
+  values:
+    1997-01-01: 10
+
+parameter reckless_disallowance_years:
+  description: "Number of years credit disallowed after reckless/intentional disregard determination per 26 USC 32(k)(1)(B)(ii)"
+  unit: Year
+  values:
+    1997-01-01: 2
+
+# Inputs for tracking prior improper claims
+
+input eitc_fraud_determination_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "EITC Fraud Determination Year"
+  description: "Most recent taxable year with final determination of EITC fraud (0 if none)"
+  default: 0
+
+input eitc_reckless_determination_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "EITC Reckless Disregard Determination Year"
+  description: "Most recent taxable year with final determination of reckless/intentional disregard (0 if none)"
+  default: 0
+
+input eitc_denied_via_deficiency_procedures:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Denied Via Deficiency Procedures"
+  description: "Whether EITC was denied for any prior year via deficiency procedures under subchapter B of chapter 63"
+  default: false
+
+input eitc_recertification_info_provided:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Recertification Information Provided"
+  description: "Whether taxpayer has provided required information to demonstrate eligibility after prior denial"
+  default: true
+
+input current_tax_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Current Tax Year"
+  description: "The taxable year for which credit is being claimed"
+  default: 0
+
+# Variables
+
+variable eitc_in_fraud_disallowance_period:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "In EITC Fraud Disallowance Period"
+  description: "Whether current year is within fraud disallowance period per 26 USC 32(k)(1)(B)(i)"
+  formula: |
+    if eitc_fraud_determination_year == 0:
+      return False
+    years_since_fraud = current_tax_year - eitc_fraud_determination_year
+    if years_since_fraud > 0 and years_since_fraud <= fraud_disallowance_years:
+      return True
+    return False
+  tests:
+    - name: "No fraud determination"
+      period: 2024-01
+      inputs:
+        eitc_fraud_determination_year: 0
+        current_tax_year: 2024
+      expect: false
+    - name: "Within 10-year fraud period"
+      period: 2024-01
+      inputs:
+        eitc_fraud_determination_year: 2020
+        current_tax_year: 2024
+      expect: true
+    - name: "Beyond 10-year fraud period"
+      period: 2024-01
+      inputs:
+        eitc_fraud_determination_year: 2010
+        current_tax_year: 2024
+      expect: false
+    - name: "At boundary of 10-year period"
+      period: 2024-01
+      inputs:
+        eitc_fraud_determination_year: 2014
+        current_tax_year: 2024
+      expect: true
+
+variable eitc_in_reckless_disallowance_period:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "In EITC Reckless Disregard Disallowance Period"
+  description: "Whether current year is within reckless disregard disallowance period per 26 USC 32(k)(1)(B)(ii)"
+  formula: |
+    if eitc_reckless_determination_year == 0:
+      return False
+    years_since_reckless = current_tax_year - eitc_reckless_determination_year
+    if years_since_reckless > 0 and years_since_reckless <= reckless_disallowance_years:
+      return True
+    return False
+  tests:
+    - name: "No reckless determination"
+      period: 2024-01
+      inputs:
+        eitc_reckless_determination_year: 0
+        current_tax_year: 2024
+      expect: false
+    - name: "Within 2-year reckless period"
+      period: 2024-01
+      inputs:
+        eitc_reckless_determination_year: 2023
+        current_tax_year: 2024
+      expect: true
+    - name: "Beyond 2-year reckless period"
+      period: 2024-01
+      inputs:
+        eitc_reckless_determination_year: 2020
+        current_tax_year: 2024
+      expect: false
+    - name: "At boundary of 2-year period"
+      period: 2024-01
+      inputs:
+        eitc_reckless_determination_year: 2022
+        current_tax_year: 2024
+      expect: true
+
+variable eitc_requires_recertification:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Requires Recertification"
+  description: "Whether taxpayer must provide recertification info per 26 USC 32(k)(2)"
+  formula: |
+    if eitc_denied_via_deficiency_procedures:
+      return True
+    return False
+  tests:
+    - name: "No prior denial"
+      period: 2024-01
+      inputs:
+        eitc_denied_via_deficiency_procedures: false
+      expect: false
+    - name: "Prior denial via deficiency procedures"
+      period: 2024-01
+      inputs:
+        eitc_denied_via_deficiency_procedures: true
+      expect: true
+
+variable eitc_disallowed_improper_claim:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Disallowed (Improper Prior Claim)"
+  description: "Whether EITC disallowed due to improper prior claim per 26 USC 32(k)"
+  formula: |
+    # (k)(1)(A) - No credit in disallowance period (fraud or reckless)
+    if eitc_in_fraud_disallowance_period:
+      return True
+    if eitc_in_reckless_disallowance_period:
+      return True
+    # (k)(2) - No credit unless recertification info provided
+    if eitc_requires_recertification and not eitc_recertification_info_provided:
+      return True
+    return False
+  tests:
+    - name: "No prior issues"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: false
+        eitc_in_reckless_disallowance_period: false
+        eitc_requires_recertification: false
+        eitc_recertification_info_provided: true
+      expect: false
+    - name: "In fraud disallowance period"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: true
+        eitc_in_reckless_disallowance_period: false
+        eitc_requires_recertification: false
+        eitc_recertification_info_provided: true
+      expect: true
+    - name: "In reckless disallowance period"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: false
+        eitc_in_reckless_disallowance_period: true
+        eitc_requires_recertification: false
+        eitc_recertification_info_provided: true
+      expect: true
+    - name: "Deficiency denial but info provided"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: false
+        eitc_in_reckless_disallowance_period: false
+        eitc_requires_recertification: true
+        eitc_recertification_info_provided: true
+      expect: false
+    - name: "Deficiency denial and info NOT provided"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: false
+        eitc_in_reckless_disallowance_period: false
+        eitc_requires_recertification: true
+        eitc_recertification_info_provided: false
+      expect: true
+    - name: "Both fraud and reckless - fraud takes precedence"
+      period: 2024-01
+      inputs:
+        eitc_in_fraud_disallowance_period: true
+        eitc_in_reckless_disallowance_period: true
+        eitc_requires_recertification: false
+        eitc_recertification_info_provided: true
+      expect: true

--- a/statute/26/32/m.rac
+++ b/statute/26/32/m.rac
@@ -1,0 +1,233 @@
+# 26 USC 32(m) - Identification numbers
+
+text: """
+(m) Identification numbers
+(1) Qualifying child identification requirement
+The credit shall not be allowed under this section with respect to any qualifying
+child unless the taxpayer includes the name, age, and TIN of such qualifying child
+on the return of tax for the taxable year and such TIN was issued on or before the
+due date for filing such return.
+
+(2) Requirements relating to taxpayers claiming credit for eligible individuals
+without qualifying children
+(A) In general
+The credit shall not be allowed under this section to an eligible individual who has
+no qualifying children for the taxable year unless the taxpayer includes a taxpayer
+identification number (as defined in section 6109(d)) of such individual on the
+return of tax for the taxable year.
+(B) Requirement relating to social security numbers
+The credit shall not be allowed under this section to an eligible individual who has
+no qualifying children for a taxable year unless such individual (or, if the individual
+is married, at least 1 spouse) has a social security number issued before the due date
+for filing the return for the taxable year.
+
+(3) Social security number
+For purposes of this subsection—
+(A) In general
+The term "social security number" means a social security number issued to an
+individual by the Social Security Administration, but only if the social security
+number is issued—
+(i) to a citizen of the United States or pursuant to subclause (I) (or that portion
+of subclause (III) that relates to subclause (I)) of section 205(c)(2)(B)(i) of the
+Social Security Act, and
+(ii) before the due date for such return.
+(B) Misuse of social security number
+If, on or before the date on which a social security number was issued, the social
+security number holder was disqualified for the earned income credit because of
+misuse of a previous social security number, the social security number shall be
+treated as not meeting the requirements of subparagraph (A).
+"""
+
+# This subsection establishes three identification requirements for EITC:
+# (1) Qualifying children must have valid TIN included on return
+# (2) Childless eligible individuals must have TIN and work-authorized SSN
+# (3) SSN must be a "work-authorized" SSN (issued to US citizens or work-authorized aliens)
+
+# Inputs for identification information
+
+input qualifying_child_has_valid_tin:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Qualifying Child Has Valid TIN"
+  description: "Whether qualifying child's TIN was issued on or before return due date per 26 USC 32(m)(1)"
+  default: True
+
+input eitc_taxpayer_has_tin:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Has TIN for EITC"
+  description: "Whether taxpayer has a valid TIN per 26 USC 32(m)(2)(A)"
+  default: True
+
+input eitc_taxpayer_has_work_authorized_ssn:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Taxpayer Has Work-Authorized SSN"
+  description: "Whether taxpayer (or spouse) has work-authorized SSN issued before due date per 26 USC 32(m)(2)(B) and (3)(A)"
+  default: True
+
+input eitc_ssn_previously_disqualified:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "SSN Previously Disqualified"
+  description: "Whether SSN holder was previously disqualified for EITC due to SSN misuse per 26 USC 32(m)(3)(B)"
+  default: False
+
+input has_qualifying_child_for_eitc:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Has Qualifying Child for EITC"
+  description: "Whether taxpayer has a qualifying child for EITC purposes"
+  default: False
+
+# Variables implementing the identification requirements
+
+variable eitc_ssn_valid_for_work:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC SSN Valid for Work"
+  description: "Whether SSN meets work authorization requirements per 26 USC 32(m)(3)"
+  formula: |
+    # Per (3)(A): SSN must be issued to US citizen or work-authorized alien
+    # Per (3)(B): SSN not valid if previously disqualified for misuse
+    if eitc_ssn_previously_disqualified:
+      return False
+    return eitc_taxpayer_has_work_authorized_ssn
+  tests:
+    - name: "Valid work-authorized SSN"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: false
+      expect: true
+    - name: "SSN not work-authorized (ITIN)"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_work_authorized_ssn: false
+        eitc_ssn_previously_disqualified: false
+      expect: false
+    - name: "Previously disqualified SSN"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: true
+      expect: false
+
+variable eitc_child_id_requirement_met:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "EITC Child ID Requirement Met"
+  description: "Whether qualifying child meets identification requirements per 26 USC 32(m)(1)"
+  formula: |
+    # Per (1): Child must have TIN issued on or before return due date
+    return qualifying_child_has_valid_tin
+  tests:
+    - name: "Child has valid TIN"
+      period: 2024-01
+      inputs:
+        qualifying_child_has_valid_tin: true
+      expect: true
+    - name: "Child TIN issued late"
+      period: 2024-01
+      inputs:
+        qualifying_child_has_valid_tin: false
+      expect: false
+
+variable eitc_childless_id_requirement_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Childless ID Requirement Met"
+  description: "Whether childless eligible individual meets ID requirements per 26 USC 32(m)(2)"
+  formula: |
+    # Per (2)(A): Must have valid TIN
+    if not eitc_taxpayer_has_tin:
+      return False
+    # Per (2)(B): Must have work-authorized SSN issued before due date
+    if not eitc_ssn_valid_for_work:
+      return False
+    return True
+  tests:
+    - name: "Has TIN and work-authorized SSN"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_tin: true
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: false
+      expect: true
+    - name: "Missing TIN"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_tin: false
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: false
+      expect: false
+    - name: "Has TIN but no work-authorized SSN"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_tin: true
+        eitc_taxpayer_has_work_authorized_ssn: false
+        eitc_ssn_previously_disqualified: false
+      expect: false
+    - name: "Previously disqualified"
+      period: 2024-01
+      inputs:
+        eitc_taxpayer_has_tin: true
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: true
+      expect: false
+
+variable eitc_id_requirements_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "EITC Identification Requirements Met"
+  description: "Whether all identification requirements of 26 USC 32(m) are satisfied"
+  formula: |
+    # For taxpayers with qualifying children: child must meet (m)(1)
+    # For childless taxpayers: taxpayer must meet (m)(2)
+    # Note: Child-level checks are done separately per child
+    # This variable checks taxpayer-level requirements
+    if has_qualifying_child_for_eitc:
+      # Taxpayer with children - child TIN checked at child level
+      # Taxpayer must still meet general ID requirements
+      return eitc_taxpayer_has_tin
+    else:
+      # Childless taxpayer - stricter requirements under (m)(2)
+      return eitc_childless_id_requirement_met
+  tests:
+    - name: "Taxpayer with children meets requirements"
+      period: 2024-01
+      inputs:
+        has_qualifying_child_for_eitc: true
+        eitc_taxpayer_has_tin: true
+      expect: true
+    - name: "Taxpayer with children missing TIN"
+      period: 2024-01
+      inputs:
+        has_qualifying_child_for_eitc: true
+        eitc_taxpayer_has_tin: false
+      expect: false
+    - name: "Childless taxpayer with valid TIN and SSN"
+      period: 2024-01
+      inputs:
+        has_qualifying_child_for_eitc: false
+        eitc_taxpayer_has_tin: true
+        eitc_taxpayer_has_work_authorized_ssn: true
+        eitc_ssn_previously_disqualified: false
+      expect: true
+    - name: "Childless taxpayer without work-authorized SSN"
+      period: 2024-01
+      inputs:
+        has_qualifying_child_for_eitc: false
+        eitc_taxpayer_has_tin: true
+        eitc_taxpayer_has_work_authorized_ssn: false
+        eitc_ssn_previously_disqualified: false
+      expect: false

--- a/statute/26/36B/a.rac
+++ b/statute/26/36B/a.rac
@@ -1,0 +1,77 @@
+# 26 USC 36B(a) - In general
+
+text: """
+(a) In general
+In the case of an applicable taxpayer, there shall be allowed as a credit
+against the tax imposed by this subtitle for any taxable year an amount
+equal to the premium assistance credit amount of the taxpayer for the
+taxable year.
+"""
+
+# Subsection (a) is a gating provision: it allows the premium tax credit
+# only for "applicable taxpayers" (defined in 36B(c)(1)). The credit amount
+# equals the premium assistance credit amount (defined in 36B(b)(1)).
+# No parameters appear in this subsection — no dollar amounts or rates.
+
+# =============================================================================
+# Input: Whether the taxpayer is an applicable taxpayer per 36B(c)(1)
+# =============================================================================
+
+input is_applicable_taxpayer:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Applicable Taxpayer"
+  description: "Whether the taxpayer is an applicable taxpayer as defined in 26 USC 36B(c)(1)"
+  default: false
+
+# =============================================================================
+# 36B(a) - Premium tax credit
+# =============================================================================
+
+variable ptc_premium_tax_credit:
+  imports:
+    - 26/36B/b/1#ptc_premium_assistance_credit_amount
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Premium Tax Credit"
+  description: "Refundable credit for coverage under a qualified health plan per 26 USC 36B(a)"
+  formula: |
+    # (a): "In the case of an applicable taxpayer, there shall be allowed as a
+    # credit...an amount equal to the premium assistance credit amount"
+    if not is_applicable_taxpayer:
+      return 0
+    return ptc_premium_assistance_credit_amount
+  tests:
+    - name: "Applicable taxpayer receives full credit amount"
+      period: 2024-01
+      inputs:
+        is_applicable_taxpayer: true
+        ptc_premium_assistance_credit_amount: 5400
+      expect: 5400
+    - name: "Non-applicable taxpayer receives zero"
+      period: 2024-01
+      inputs:
+        is_applicable_taxpayer: false
+        ptc_premium_assistance_credit_amount: 5400
+      expect: 0
+    - name: "Applicable taxpayer with zero premium assistance"
+      period: 2024-01
+      inputs:
+        is_applicable_taxpayer: true
+        ptc_premium_assistance_credit_amount: 0
+      expect: 0
+    - name: "Non-applicable taxpayer with zero premium assistance"
+      period: 2024-01
+      inputs:
+        is_applicable_taxpayer: false
+        ptc_premium_assistance_credit_amount: 0
+      expect: 0
+    - name: "Applicable taxpayer - large credit"
+      period: 2024-01
+      inputs:
+        is_applicable_taxpayer: true
+        ptc_premium_assistance_credit_amount: 18_000
+      expect: 18_000

--- a/statute/26/36B/b/1.rac
+++ b/statute/26/36B/b/1.rac
@@ -1,0 +1,74 @@
+# 26 USC 36B(b)(1) - Premium assistance credit amount — In general
+
+text: """
+(b) Premium assistance credit amount
+For purposes of this section—
+(1) In general
+The term "premium assistance credit amount" means, with respect to any
+taxable year, the sum of the premium assistance amounts determined under
+paragraph (2) with respect to all coverage months of the taxpayer occurring
+during the taxable year.
+"""
+
+# This subsection defines the annual premium assistance credit amount as the
+# sum of monthly premium assistance amounts (determined under paragraph (2))
+# across all coverage months in the taxable year. Each coverage month may
+# have a different premium assistance amount, so the formula sums them.
+#
+# In the simplified annual model, we take the monthly premium assistance
+# amount (from b/2) and multiply by the number of coverage months. This is
+# equivalent to summing identical monthly amounts. If monthly amounts vary,
+# this would need a monthly-level computation.
+
+input ptc_coverage_months:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "PTC Coverage Months"
+  description: "Number of coverage months of the taxpayer occurring during the taxable year per 26 USC 36B(b)(1)"
+  default: 0
+
+variable ptc_premium_assistance_credit_amount:
+  imports:
+    - 26/36B/b/2#ptc_premium_assistance_amount
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Premium Assistance Credit Amount"
+  description: "Sum of premium assistance amounts for all coverage months per 26 USC 36B(b)(1)"
+  formula: |
+    # (b)(1): "the sum of the premium assistance amounts determined under
+    # paragraph (2) with respect to all coverage months"
+    return ptc_premium_assistance_amount * ptc_coverage_months
+  tests:
+    - name: "Full year coverage (12 months)"
+      period: 2024-01
+      inputs:
+        ptc_premium_assistance_amount: 450
+        ptc_coverage_months: 12
+      expect: 5400
+    - name: "Partial year coverage (6 months)"
+      period: 2024-01
+      inputs:
+        ptc_premium_assistance_amount: 450
+        ptc_coverage_months: 6
+      expect: 2700
+    - name: "Single month of coverage"
+      period: 2024-01
+      inputs:
+        ptc_premium_assistance_amount: 300
+        ptc_coverage_months: 1
+      expect: 300
+    - name: "No coverage months"
+      period: 2024-01
+      inputs:
+        ptc_premium_assistance_amount: 450
+        ptc_coverage_months: 0
+      expect: 0
+    - name: "Zero premium assistance amount"
+      period: 2024-01
+      inputs:
+        ptc_premium_assistance_amount: 0
+        ptc_coverage_months: 12
+      expect: 0

--- a/statute/26/36B/b/2.rac
+++ b/statute/26/36B/b/2.rac
@@ -1,0 +1,144 @@
+text: """
+(2) Premium assistance amount
+The premium assistance amount determined under this subsection with respect
+to any coverage month is the amount equal to the lesser of—
+(A) the monthly premiums for such month for 1 or more qualified health plans
+offered in the individual market within a State which cover the taxpayer, the
+taxpayer's spouse, or any dependent (as defined in section 152) of the taxpayer
+and which were enrolled in through an Exchange established by the State under
+1311 of the Patient Protection and Affordable Care Act, or
+(B) the excess (if any) of—
+(i) the adjusted monthly premium for such month for the applicable second
+lowest cost silver plan with respect to the taxpayer, over
+(ii) an amount equal to 1/12 of the product of the applicable percentage and
+the taxpayer's household income for the taxable year.
+"""
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+parameter months_per_year:
+  description: "Number of months per year, used to compute monthly share of annual expected contribution per 26 USC 36B(b)(2)(B)(ii)"
+  values:
+    2014-01-01: 12
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input ptc_monthly_premium:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Monthly Exchange Premium"
+  description: "Monthly premiums for qualified health plans enrolled through an Exchange per 26 USC 36B(b)(2)(A)"
+  default: 0
+
+input ptc_slcsp_monthly_premium:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "SLCSP Adjusted Monthly Premium"
+  description: "Adjusted monthly premium for the applicable second lowest cost silver plan per 26 USC 36B(b)(2)(B)(i)"
+  default: 0
+
+# =============================================================================
+# Variable: Premium assistance amount (monthly)
+# =============================================================================
+
+variable ptc_premium_assistance_amount:
+  imports:
+    - 26/36B/b/3#applicable_percentage
+    - 26/36B/b/3#household_income
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Premium Assistance Amount"
+  description: "Monthly premium assistance amount per 26 USC 36B(b)(2), the lesser of (A) enrolled plan premiums or (B) excess of SLCSP premium over expected contribution"
+  formula: |
+    # (A): Monthly premiums for qualified health plans enrolled through an Exchange
+    amount_a = ptc_monthly_premium
+
+    # (B)(ii): 1/12 of (applicable percentage * household income)
+    expected_contribution = household_income * applicable_percentage / months_per_year
+
+    # (B): Excess (if any) of (i) SLCSP premium over (ii) expected contribution
+    amount_b = max(0, ptc_slcsp_monthly_premium - expected_contribution)
+
+    # Lesser of (A) or (B)
+    return min(amount_a, amount_b)
+  tests:
+    - name: "Basic case - B is lesser (subsidy capped by benchmark)"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 800
+        ptc_slcsp_monthly_premium: 600
+        applicable_percentage: 0.085
+        household_income: 40000
+        months_per_year: 12
+      expect: 316.67
+    - name: "A is lesser (enrolled premium less than benchmark excess)"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 200
+        ptc_slcsp_monthly_premium: 600
+        applicable_percentage: 0.02
+        household_income: 20000
+        months_per_year: 12
+      expect: 200
+    - name: "Expected contribution exceeds SLCSP - no subsidy from (B)"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 500
+        ptc_slcsp_monthly_premium: 300
+        applicable_percentage: 0.095
+        household_income: 80000
+        months_per_year: 12
+      expect: 0
+    - name: "Zero enrolled premium - no assistance"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 0
+        ptc_slcsp_monthly_premium: 600
+        applicable_percentage: 0.06
+        household_income: 50000
+        months_per_year: 12
+      expect: 0
+    - name: "Zero SLCSP premium - B is zero"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 500
+        ptc_slcsp_monthly_premium: 0
+        applicable_percentage: 0.06
+        household_income: 50000
+        months_per_year: 12
+      expect: 0
+    - name: "Zero household income - full SLCSP as B"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 500
+        ptc_slcsp_monthly_premium: 600
+        applicable_percentage: 0.0
+        household_income: 0
+        months_per_year: 12
+      expect: 500
+    - name: "Very low income IRA period - 0% applicable percentage"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 400
+        ptc_slcsp_monthly_premium: 500
+        applicable_percentage: 0.0
+        household_income: 15000
+        months_per_year: 12
+      expect: 400
+    - name: "Equal premiums - subsidy equals excess of SLCSP over contribution"
+      period: 2024-01
+      inputs:
+        ptc_monthly_premium: 600
+        ptc_slcsp_monthly_premium: 600
+        applicable_percentage: 0.04
+        household_income: 36000
+        months_per_year: 12
+      expect: 480

--- a/statute/26/36B/b/3.rac
+++ b/statute/26/36B/b/3.rac
@@ -1,0 +1,643 @@
+# 26 USC 36B(b)(3) - Other terms and rules relating to premium assistance amounts
+
+text: """
+(3) Other terms and rules relating to premium assistance amounts
+For purposes of paragraph (2)—
+(A) Applicable percentage
+(i) In general
+Except as provided in clause (ii), the applicable percentage for any taxable year
+shall be the percentage such that the applicable percentage for any taxpayer whose
+household income is within an income tier specified in the following table shall
+increase, on a sliding scale in a linear manner, from the initial premium percentage
+to the final premium percentage specified in such table for such income tier:
+
+In the case of household income (expressed as a percent of poverty line)
+within the following income tier:
+  Up to 133%           Initial: 2.0%    Final: 2.0%
+  133% up to 150%      Initial: 3.0%    Final: 4.0%
+  150% up to 200%      Initial: 4.0%    Final: 6.3%
+  200% up to 250%      Initial: 6.3%    Final: 8.05%
+  250% up to 300%      Initial: 8.05%   Final: 9.5%
+  300% up to 400%      Initial: 9.5%    Final: 9.5%
+
+(ii) Indexing
+(I) In general
+Subject to subclause (II), in the case of taxable years beginning in any calendar
+year after 2014, the initial and final applicable percentages under clause (i) (as in
+effect for the preceding calendar year after application of this clause) shall be
+adjusted to reflect the excess of the rate of premium growth for the preceding
+calendar year over the rate of income growth for the preceding calendar year.
+
+(II) Additional adjustment
+Except as provided in subclause (III), in the case of any calendar year after 2018,
+the percentages described in subclause (I) shall, in addition to the adjustment under
+subclause (I), be adjusted to reflect the excess (if any) of the rate of premium
+growth estimated under subclause (I) for the preceding calendar year over the rate of
+growth in the consumer price index for the preceding calendar year.
+
+(III) Failsafe
+Subclause (II) shall apply for any calendar year only if the aggregate amount of
+premium tax credits under this section and cost-sharing reductions under section 1402
+of the Patient Protection and Affordable Care Act for the preceding calendar year
+exceeds an amount equal to 0.504 percent of the gross domestic product for the
+preceding calendar year.
+
+(iii) Temporary percentages for 2021 through 2025
+In the case of a taxable year beginning after December 31, 2020, and before
+January 1, 2026—
+(I) clause (ii) shall not apply for purposes of adjusting premium percentages under
+this subparagraph, and
+(II) the following table shall be applied in lieu of the table contained in clause (i):
+
+In the case of household income (expressed as a percent of poverty line)
+within the following income tier:
+  Up to 150.0 percent          Initial: 0.0    Final: 0.0
+  150.0 percent up to 200.0 percent   Initial: 0.0    Final: 2.0
+  200.0 percent up to 250.0 percent   Initial: 2.0    Final: 4.0
+  250.0 percent up to 300.0 percent   Initial: 4.0    Final: 6.0
+  300.0 percent up to 400.0 percent   Initial: 6.0    Final: 8.5
+  400.0 percent and higher            Initial: 8.5    Final: 8.5
+"""
+
+# =============================================================================
+# Parameters: Clause (i) base table (ACA original, effective 2014)
+# =============================================================================
+
+# Tier thresholds (expressed as percent of poverty line, in /1 units)
+
+parameter base_tier_1_threshold:
+  description: "Lower bound of first income tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 0
+
+parameter base_tier_2_threshold:
+  description: "Lower bound of second income tier (133% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 1.33
+
+parameter base_tier_3_threshold:
+  description: "Lower bound of third income tier (150% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 1.50
+
+parameter base_tier_4_threshold:
+  description: "Lower bound of fourth income tier (200% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 2.00
+
+parameter base_tier_5_threshold:
+  description: "Lower bound of fifth income tier (250% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 2.50
+
+parameter base_tier_6_threshold:
+  description: "Lower bound of sixth income tier (300% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 3.00
+
+parameter base_tier_upper:
+  description: "Upper bound of last income tier (400% FPL) per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  values:
+    2014-01-01: 4.00
+
+# Initial premium percentages per tier (clause (i) table)
+
+parameter base_initial_1:
+  description: "Initial premium percentage for up-to-133% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.02
+
+parameter base_initial_2:
+  description: "Initial premium percentage for 133-150% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.03
+
+parameter base_initial_3:
+  description: "Initial premium percentage for 150-200% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.04
+
+parameter base_initial_4:
+  description: "Initial premium percentage for 200-250% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.063
+
+parameter base_initial_5:
+  description: "Initial premium percentage for 250-300% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.0805
+
+parameter base_initial_6:
+  description: "Initial premium percentage for 300-400% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.095
+
+# Final premium percentages per tier (clause (i) table)
+
+parameter base_final_1:
+  description: "Final premium percentage for up-to-133% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.02
+
+parameter base_final_2:
+  description: "Final premium percentage for 133-150% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.04
+
+parameter base_final_3:
+  description: "Final premium percentage for 150-200% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.063
+
+parameter base_final_4:
+  description: "Final premium percentage for 200-250% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.0805
+
+parameter base_final_5:
+  description: "Final premium percentage for 250-300% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.095
+
+parameter base_final_6:
+  description: "Final premium percentage for 300-400% tier per 26 USC 36B(b)(3)(A)(i)"
+  unit: /1
+  indexed_by: premium_income_growth_adjustment
+  values:
+    2014-01-01: 0.095
+
+# =============================================================================
+# Parameters: Clause (iii) temporary IRA table (2021-2025)
+# =============================================================================
+
+# Tier thresholds for temporary table
+
+parameter ira_tier_1_threshold:
+  description: "Lower bound of first IRA income tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0
+
+parameter ira_tier_2_threshold:
+  description: "Lower bound of second IRA income tier (150% FPL) per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 1.50
+
+parameter ira_tier_3_threshold:
+  description: "Lower bound of third IRA income tier (200% FPL) per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 2.00
+
+parameter ira_tier_4_threshold:
+  description: "Lower bound of fourth IRA income tier (250% FPL) per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 2.50
+
+parameter ira_tier_5_threshold:
+  description: "Lower bound of fifth IRA income tier (300% FPL) per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 3.00
+
+parameter ira_tier_6_threshold:
+  description: "Lower bound of sixth IRA income tier (400% FPL) per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 4.00
+
+# Initial premium percentages for IRA temporary table
+
+parameter ira_initial_1:
+  description: "Initial premium percentage for up-to-150% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.0
+
+parameter ira_initial_2:
+  description: "Initial premium percentage for 150-200% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.0
+
+parameter ira_initial_3:
+  description: "Initial premium percentage for 200-250% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.02
+
+parameter ira_initial_4:
+  description: "Initial premium percentage for 250-300% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.04
+
+parameter ira_initial_5:
+  description: "Initial premium percentage for 300-400% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.06
+
+parameter ira_initial_6:
+  description: "Initial premium percentage for 400%+ IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.085
+
+# Final premium percentages for IRA temporary table
+
+parameter ira_final_1:
+  description: "Final premium percentage for up-to-150% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.0
+
+parameter ira_final_2:
+  description: "Final premium percentage for 150-200% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.02
+
+parameter ira_final_3:
+  description: "Final premium percentage for 200-250% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.04
+
+parameter ira_final_4:
+  description: "Final premium percentage for 250-300% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.06
+
+parameter ira_final_5:
+  description: "Final premium percentage for 300-400% IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.085
+
+parameter ira_final_6:
+  description: "Final premium percentage for 400%+ IRA tier per 26 USC 36B(b)(3)(A)(iii)(II)"
+  unit: /1
+  values:
+    2021-01-01: 0.085
+
+# =============================================================================
+# Parameters: Clause (ii)(III) failsafe threshold
+# =============================================================================
+
+parameter failsafe_gdp_pct:
+  description: "PTC + CSR spending as pct of GDP threshold for additional CPI adjustment per 26 USC 36B(b)(3)(A)(ii)(III)"
+  unit: /1
+  values:
+    2014-01-01: 0.00504
+
+# =============================================================================
+# Parameters: Temporal boundaries
+# =============================================================================
+
+parameter ira_start_year:
+  description: "First taxable year for IRA temporary percentages per 26 USC 36B(b)(3)(A)(iii)"
+  values:
+    2021-01-01: 2021
+
+parameter ira_end_year:
+  description: "Last taxable year for IRA temporary percentages per 26 USC 36B(b)(3)(A)(iii)"
+  values:
+    2021-01-01: 2025
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input household_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Household Income"
+  description: "Household income per 26 USC 36B(d)(2)"
+  default: 0
+
+input tax_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Tax Year"
+  description: "Taxable year for determining which applicable percentage table applies"
+  default: 2024
+
+# =============================================================================
+# Variable: Household income as percent of poverty line
+# =============================================================================
+
+variable household_income_pct_fpl:
+  imports:
+    - 26/36B/d/3#poverty_line
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  label: "Household Income as Percent of FPL"
+  description: "Household income expressed as a ratio of the federal poverty line per 26 USC 36B(b)(3)(A)"
+  formula: |
+    if poverty_line == 0:
+      return 0
+    return household_income / poverty_line
+  tests:
+    - name: "200% FPL"
+      period: 2024-01
+      inputs:
+        household_income: 60000
+        poverty_line: 30000
+      expect: 2.0
+    - name: "150% FPL"
+      period: 2024-01
+      inputs:
+        household_income: 45000
+        poverty_line: 30000
+      expect: 1.5
+    - name: "Zero poverty line (edge case)"
+      period: 2024-01
+      inputs:
+        household_income: 50000
+        poverty_line: 0
+      expect: 0
+    - name: "Zero income"
+      period: 2024-01
+      inputs:
+        household_income: 0
+        poverty_line: 30000
+      expect: 0
+
+# =============================================================================
+# Variable: Applicable percentage under clause (i) base table
+# =============================================================================
+
+variable applicable_percentage_base:
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  label: "Applicable Percentage (Base Table)"
+  description: "Applicable percentage under clause (i) base table per 26 USC 36B(b)(3)(A)(i), with linear interpolation within each income tier"
+  formula: |
+    # Linear interpolation within each tier:
+    # pct = initial + (final - initial) * (income_ratio - tier_lower) / (tier_upper - tier_lower)
+    income_ratio = household_income_pct_fpl
+
+    # Tier 1: Up to 133% FPL
+    if income_ratio <= base_tier_2_threshold:
+      return base_initial_1
+
+    # Tier 2: 133% up to 150% FPL
+    if income_ratio <= base_tier_3_threshold:
+      fraction = (income_ratio - base_tier_2_threshold) / (base_tier_3_threshold - base_tier_2_threshold)
+      return base_initial_2 + (base_final_2 - base_initial_2) * fraction
+
+    # Tier 3: 150% up to 200% FPL
+    if income_ratio <= base_tier_4_threshold:
+      fraction = (income_ratio - base_tier_3_threshold) / (base_tier_4_threshold - base_tier_3_threshold)
+      return base_initial_3 + (base_final_3 - base_initial_3) * fraction
+
+    # Tier 4: 200% up to 250% FPL
+    if income_ratio <= base_tier_5_threshold:
+      fraction = (income_ratio - base_tier_4_threshold) / (base_tier_5_threshold - base_tier_4_threshold)
+      return base_initial_4 + (base_final_4 - base_initial_4) * fraction
+
+    # Tier 5: 250% up to 300% FPL
+    if income_ratio <= base_tier_6_threshold:
+      fraction = (income_ratio - base_tier_5_threshold) / (base_tier_6_threshold - base_tier_5_threshold)
+      return base_initial_5 + (base_final_5 - base_initial_5) * fraction
+
+    # Tier 6: 300% up to 400% FPL
+    if income_ratio <= base_tier_upper:
+      fraction = (income_ratio - base_tier_6_threshold) / (base_tier_upper - base_tier_6_threshold)
+      return base_initial_6 + (base_final_6 - base_initial_6) * fraction
+
+    # Above 400% FPL: not an applicable taxpayer under base table (no subsidy)
+    return base_final_6
+  tests:
+    - name: "At 100% FPL - first tier flat"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 1.0
+      expect: 0.02
+    - name: "At 133% FPL - top of tier 1"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 1.33
+      expect: 0.02
+    - name: "At 150% FPL - end of tier 2 (final = 4%)"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 1.50
+      expect: 0.04
+    - name: "At 200% FPL - end of tier 3 (final = 6.3%)"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 2.00
+      expect: 0.063
+    - name: "At 250% FPL - end of tier 4 (final = 8.05%)"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 2.50
+      expect: 0.0805
+    - name: "At 300% FPL - end of tier 5 (final = 9.5%)"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 3.00
+      expect: 0.095
+    - name: "At 400% FPL - end of tier 6 (final = 9.5%)"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 4.00
+      expect: 0.095
+    - name: "Midpoint of tier 3 (175% FPL) - linear interpolation"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 1.75
+      expect: 0.0515
+    - name: "Zero income"
+      period: 2014-01
+      inputs:
+        household_income_pct_fpl: 0
+      expect: 0.02
+
+# =============================================================================
+# Variable: Applicable percentage under clause (iii) IRA temporary table
+# =============================================================================
+
+variable applicable_percentage_ira:
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  label: "Applicable Percentage (IRA Temporary Table)"
+  description: "Applicable percentage under IRA temporary table per 26 USC 36B(b)(3)(A)(iii)(II), with linear interpolation within each income tier"
+  formula: |
+    # Linear interpolation within each tier per clause (iii)(II) table
+    income_ratio = household_income_pct_fpl
+
+    # Tier 1: Up to 150% FPL
+    if income_ratio <= ira_tier_2_threshold:
+      return ira_initial_1
+
+    # Tier 2: 150% up to 200% FPL
+    if income_ratio <= ira_tier_3_threshold:
+      fraction = (income_ratio - ira_tier_2_threshold) / (ira_tier_3_threshold - ira_tier_2_threshold)
+      return ira_initial_2 + (ira_final_2 - ira_initial_2) * fraction
+
+    # Tier 3: 200% up to 250% FPL
+    if income_ratio <= ira_tier_4_threshold:
+      fraction = (income_ratio - ira_tier_3_threshold) / (ira_tier_4_threshold - ira_tier_3_threshold)
+      return ira_initial_3 + (ira_final_3 - ira_initial_3) * fraction
+
+    # Tier 4: 250% up to 300% FPL
+    if income_ratio <= ira_tier_5_threshold:
+      fraction = (income_ratio - ira_tier_4_threshold) / (ira_tier_5_threshold - ira_tier_4_threshold)
+      return ira_initial_4 + (ira_final_4 - ira_initial_4) * fraction
+
+    # Tier 5: 300% up to 400% FPL
+    if income_ratio <= ira_tier_6_threshold:
+      fraction = (income_ratio - ira_tier_5_threshold) / (ira_tier_6_threshold - ira_tier_5_threshold)
+      return ira_initial_5 + (ira_final_5 - ira_initial_5) * fraction
+
+    # Tier 6: 400% and higher - flat rate
+    return ira_final_6
+  tests:
+    - name: "At 100% FPL - zero premium (IRA)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 1.0
+      expect: 0.0
+    - name: "At 150% FPL - top of tier 1 (zero)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 1.50
+      expect: 0.0
+    - name: "At 200% FPL - end of tier 2 (final = 2%)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.00
+      expect: 0.02
+    - name: "At 250% FPL - end of tier 3 (final = 4%)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.50
+      expect: 0.04
+    - name: "At 300% FPL - end of tier 4 (final = 6%)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 3.00
+      expect: 0.06
+    - name: "At 400% FPL - end of tier 5 (final = 8.5%)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 4.00
+      expect: 0.085
+    - name: "At 500% FPL - above 400%, flat 8.5%"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 5.00
+      expect: 0.085
+    - name: "Midpoint of tier 5 (350% FPL) - linear interpolation"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 3.50
+      expect: 0.0725
+    - name: "Zero income"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 0
+      expect: 0.0
+
+# =============================================================================
+# Variable: Applicable percentage (combined, selecting correct table by year)
+# =============================================================================
+
+variable applicable_percentage:
+  entity: TaxUnit
+  period: Year
+  dtype: Rate
+  label: "Applicable Percentage"
+  description: "Applicable percentage for premium assistance per 26 USC 36B(b)(3)(A), selecting IRA temporary table for 2021-2025 or base table otherwise"
+  formula: |
+    # Clause (iii): For taxable years 2021-2025, use IRA temporary table
+    # and clause (ii) indexing does not apply
+    if tax_year >= ira_start_year and tax_year <= ira_end_year:
+      return applicable_percentage_ira
+
+    # Otherwise, use base table from clause (i)
+    # (clause (ii) indexing is handled via indexed_by on the base parameters)
+    return applicable_percentage_base
+  tests:
+    - name: "2024 (IRA period) - uses IRA table at 200% FPL"
+      period: 2024-01
+      inputs:
+        tax_year: 2024
+        applicable_percentage_ira: 0.02
+        applicable_percentage_base: 0.063
+      expect: 0.02
+    - name: "2024 (IRA period) - uses IRA table at 350% FPL"
+      period: 2024-01
+      inputs:
+        tax_year: 2024
+        applicable_percentage_ira: 0.0725
+        applicable_percentage_base: 0.095
+      expect: 0.0725
+    - name: "2026 (post-IRA) - reverts to base table"
+      period: 2026-01
+      inputs:
+        tax_year: 2026
+        applicable_percentage_ira: 0.02
+        applicable_percentage_base: 0.063
+      expect: 0.063
+    - name: "2014 (base table) - pre-IRA"
+      period: 2014-01
+      inputs:
+        tax_year: 2014
+        applicable_percentage_ira: 0.0
+        applicable_percentage_base: 0.02
+      expect: 0.02
+    - name: "2021 (first IRA year) - uses IRA table"
+      period: 2021-01
+      inputs:
+        tax_year: 2021
+        applicable_percentage_ira: 0.0
+        applicable_percentage_base: 0.02
+      expect: 0.0
+    - name: "2025 (last IRA year) - uses IRA table"
+      period: 2025-01
+      inputs:
+        tax_year: 2025
+        applicable_percentage_ira: 0.085
+        applicable_percentage_base: 0.095
+      expect: 0.085

--- a/statute/26/36B/c/1.rac
+++ b/statute/26/36B/c/1.rac
@@ -1,0 +1,306 @@
+# 26 USC 36B(c)(1) - Applicable taxpayer
+
+text: """
+(c) Definition and rules relating to applicable taxpayers, coverage months,
+and qualified health plan
+(1) Applicable taxpayer
+(A) In general
+The term "applicable taxpayer" means, with respect to any taxable year, a
+taxpayer whose household income for the taxable year equals or exceeds 100
+percent but does not exceed 400 percent of an amount equal to the poverty
+line for a family of the size involved.
+(B) Special rule for certain individuals lawfully present in the United
+States
+If—
+(i) a taxpayer has household income which is not greater than 100 percent of
+an amount equal to the poverty line for a family of the size involved, and
+(ii) the taxpayer is an alien lawfully present in the United States, but is
+not eligible for the medicaid program under title XIX of the Social Security
+Act by reason of such alien status,
+the taxpayer shall, for purposes of the credit under this section, be
+treated as an applicable taxpayer with a household income which is equal to
+100 percent of the poverty line for a family of the size involved.
+(C) Married couples must file joint return
+If the taxpayer is married (within the meaning of section 7703) at the close
+of the taxable year, the taxpayer shall be treated as an applicable taxpayer
+only if the taxpayer and the taxpayer's spouse file a joint return for the
+taxable year.
+(D) Denial of credit to dependents
+No credit shall be allowed under this section to any individual with respect
+to whom a deduction under section 151 is allowable to another taxpayer for a
+taxable year beginning in the calendar year in which such individual's
+taxable year begins.
+(E) Temporary rule for 2021 through 2025
+In the case of a taxable year beginning after December 31, 2020, and before
+January 1, 2026, subparagraph (A) shall be applied without regard to "but
+does not exceed 400 percent of".
+"""
+
+# Subsection disposition:
+# (c)(1)(A) - ENCODED: Income range test (100-400% FPL)
+# (c)(1)(B) - ENCODED: Lawfully present alien below 100% FPL treated as applicable
+# (c)(1)(C) - ENCODED: Joint return requirement for married taxpayers
+# (c)(1)(D) - ENCODED: Dependents cannot claim credit
+# (c)(1)(E) - ENCODED: Removes 400% upper cap for 2021-2025
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+# (A): "equals or exceeds 100 percent"
+parameter min_fpl_pct:
+  description: "Minimum household income as percent of FPL to be an applicable taxpayer per 26 USC 36B(c)(1)(A)"
+  unit: /1
+  values:
+    2014-01-01: 1.0
+
+# (A): "does not exceed 400 percent"
+parameter max_fpl_pct:
+  description: "Maximum household income as percent of FPL to be an applicable taxpayer per 26 USC 36B(c)(1)(A)"
+  unit: /1
+  values:
+    2014-01-01: 4.0
+
+# (E): "taxable year beginning after December 31, 2020"
+parameter temp_rule_start_year:
+  description: "First taxable year for temporary removal of upper FPL cap per 26 USC 36B(c)(1)(E)"
+  values:
+    2021-01-01: 2021
+
+# (E): "before January 1, 2026"
+parameter temp_rule_end_year:
+  description: "Last taxable year for temporary removal of upper FPL cap per 26 USC 36B(c)(1)(E)"
+  values:
+    2021-01-01: 2025
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input is_married:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Married"
+  description: "Whether the taxpayer is married within the meaning of section 7703 at the close of the taxable year per 26 USC 36B(c)(1)(C)"
+  default: false
+
+input files_joint_return:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Files Joint Return"
+  description: "Whether the taxpayer and spouse file a joint return per 26 USC 36B(c)(1)(C)"
+  default: false
+
+input is_dependent:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Is Dependent"
+  description: "Whether a deduction under section 151 is allowable to another taxpayer for this individual per 26 USC 36B(c)(1)(D)"
+  default: false
+
+input is_lawfully_present_alien:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Lawfully Present Alien"
+  description: "Whether the taxpayer is an alien lawfully present in the United States per 26 USC 36B(c)(1)(B)"
+  default: false
+
+input is_medicaid_ineligible_due_to_alien_status:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Medicaid Ineligible Due to Alien Status"
+  description: "Whether the taxpayer is not eligible for Medicaid under title XIX of the Social Security Act by reason of alien status per 26 USC 36B(c)(1)(B)"
+  default: false
+
+input tax_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Tax Year"
+  description: "Taxable year for determining applicable rules"
+  default: 2024
+
+# =============================================================================
+# Variable: Applicable taxpayer determination
+# =============================================================================
+
+variable is_applicable_taxpayer:
+  imports:
+    - 26/36B/b/3#household_income_pct_fpl
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Applicable Taxpayer"
+  description: "Whether the taxpayer is an applicable taxpayer per 26 USC 36B(c)(1)"
+  formula: |
+    # (D): No credit for dependents
+    if is_dependent: return 0
+
+    # (C): Married taxpayers must file joint return
+    if is_married and not files_joint_return: return 0
+
+    income_pct = household_income_pct_fpl
+
+    # (B): Lawfully present alien below 100% FPL and Medicaid-ineligible
+    # due to alien status → treated as applicable taxpayer
+    if income_pct < min_fpl_pct and is_lawfully_present_alien and is_medicaid_ineligible_due_to_alien_status: return 1
+
+    # Below 100% FPL and not qualifying under (B) → not applicable
+    if income_pct < min_fpl_pct: return 0
+
+    # (E): For 2021-2025, apply (A) without the 400% upper cap
+    if tax_year >= temp_rule_start_year and tax_year <= temp_rule_end_year: return 1
+
+    # (A): Household income >= 100% FPL and <= 400% FPL
+    if income_pct <= max_fpl_pct: return 1
+
+    return 0
+  tests:
+    - name: "Basic applicable taxpayer - 200% FPL"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: true
+    - name: "At minimum threshold - 100% FPL"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 1.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: true
+    - name: "Below 100% FPL - not applicable (non-alien)"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 0.8
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: false
+    - name: "(B) Lawfully present alien below 100% FPL and Medicaid-ineligible"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 0.8
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: true
+        is_medicaid_ineligible_due_to_alien_status: true
+        tax_year: 2024
+      expect: true
+    - name: "(B) Lawfully present alien below 100% FPL but Medicaid-eligible"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 0.8
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: true
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: false
+    - name: "(C) Married filing separately - not applicable"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.0
+        is_married: true
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: false
+    - name: "(C) Married filing jointly - applicable"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.0
+        is_married: true
+        files_joint_return: true
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: true
+    - name: "(D) Dependent - not applicable"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 2.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: true
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: false
+    - name: "(E) Above 400% FPL during IRA period (2024) - applicable"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 5.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: true
+    - name: "Above 400% FPL post-IRA (2026) - not applicable"
+      period: 2026-01
+      inputs:
+        household_income_pct_fpl: 5.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2026
+      expect: false
+    - name: "At 400% FPL post-IRA (2026) - applicable"
+      period: 2026-01
+      inputs:
+        household_income_pct_fpl: 4.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2026
+      expect: true
+    - name: "(E) At exactly 400% FPL during IRA (2021) - applicable"
+      period: 2021-01
+      inputs:
+        household_income_pct_fpl: 4.0
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2021
+      expect: true
+    - name: "Unmarried, not dependent, 150% FPL - applicable"
+      period: 2024-01
+      inputs:
+        household_income_pct_fpl: 1.5
+        is_married: false
+        files_joint_return: false
+        is_dependent: false
+        is_lawfully_present_alien: false
+        is_medicaid_ineligible_due_to_alien_status: false
+        tax_year: 2024
+      expect: true

--- a/statute/26/36B/c/3.rac
+++ b/statute/26/36B/c/3.rac
@@ -1,0 +1,203 @@
+# 26 USC 36B(c)(3) - Definitions and other rules
+
+text: """
+(3) Definitions and other rules
+(A) Qualified health plan
+(i) In general
+The term "qualified health plan" has the meaning given such term by section 1301(a) of
+the Patient Protection and Affordable Care Act, except that such term shall not include
+a qualified health plan which is a catastrophic plan described in section 1302(e) of such
+Act.
+
+(ii) Pre-enrollment verification process required
+Such term shall not include any plan enrolled in through an Exchange, unless such
+Exchange provides a process for pre-enrollment verification through which any applicant
+may, beginning not later than August 1, verify with the Exchange the applicant's
+household income and eligibility for enrollment in such plan for plan years beginning in
+the subsequent year.
+
+(iii) Exception in case of certain special enrollment periods
+Such term shall not include any plan enrolled in during a special enrollment period
+provided for by an Exchange—
+(I) on the basis of the relationship of the individual's expected household income to
+such a percentage of the poverty line (or such other amount) as is prescribed by the
+Secretary of Health and Human Services for purposes of such period, and
+(II) not in connection with the occurrence of an event or change in circumstances
+specified by the Secretary of Health and Human Services for such purposes.
+
+(B) Grandfathered health plan
+The term "grandfathered health plan" has the meaning given such term by section 1251 of
+the Patient Protection and Affordable Care Act.
+"""
+
+# Subsection (c)(3) defines terms used throughout section 36B.
+#
+# (A) Qualified health plan:
+#   - (i) Cross-references PPACA 1301(a), excluding catastrophic plans under 1302(e).
+#   - (ii) Requires pre-enrollment verification (added by P.L. 119-21, effective 2028+).
+#   - (iii) Excludes plans enrolled in during certain special enrollment periods.
+#
+# (B) Grandfathered health plan: Cross-references PPACA 1251.
+#
+# Computational content: The key testable rule is that a plan qualifying under
+# PPACA 1301(a) is NOT a qualified health plan for PTC purposes if it is a
+# catastrophic plan under PPACA 1302(e). Additionally, the pre-enrollment
+# verification and special enrollment period exclusions apply.
+
+# =============================================================================
+# Inputs: Plan characteristics
+# =============================================================================
+
+input is_ppaca_1301a_qualified_plan:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "PPACA 1301(a) Qualified Plan"
+  description: "Whether the plan meets the definition of qualified health plan under section 1301(a) of the Patient Protection and Affordable Care Act"
+  default: false
+
+input is_catastrophic_plan:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Catastrophic Plan"
+  description: "Whether the plan is a catastrophic plan described in section 1302(e) of the Patient Protection and Affordable Care Act"
+  default: false
+
+input exchange_has_pre_enrollment_verification:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Exchange Has Pre-Enrollment Verification"
+  description: "Whether the Exchange provides a pre-enrollment verification process per 26 USC 36B(c)(3)(A)(ii)"
+  default: true
+
+input enrolled_through_exchange:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Enrolled Through Exchange"
+  description: "Whether the plan was enrolled in through an Exchange"
+  default: true
+
+input enrolled_during_special_enrollment_period:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Enrolled During Special Enrollment Period"
+  description: "Whether the plan was enrolled in during a special enrollment period described in 26 USC 36B(c)(3)(A)(iii)"
+  default: false
+
+input special_enrollment_is_income_based:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Special Enrollment Is Income-Based"
+  description: "Whether the special enrollment period is on the basis of income as a percentage of poverty line per 26 USC 36B(c)(3)(A)(iii)(I), and not in connection with a qualifying event per (iii)(II)"
+  default: false
+
+# =============================================================================
+# Variable: Qualified health plan determination
+# =============================================================================
+
+variable ptc_is_qualified_health_plan:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Qualified Health Plan for PTC"
+  description: "Whether the plan is a qualified health plan for purposes of the premium tax credit per 26 USC 36B(c)(3)(A)"
+  formula: |
+    # (A)(i): Must be a qualified health plan under PPACA 1301(a)
+    if not is_ppaca_1301a_qualified_plan:
+      return false
+
+    # (A)(i): Excludes catastrophic plans under PPACA 1302(e)
+    if is_catastrophic_plan:
+      return false
+
+    # (A)(ii): If enrolled through Exchange, Exchange must have pre-enrollment
+    # verification process (effective for taxable years beginning after 12/31/2027)
+    if enrolled_through_exchange and not exchange_has_pre_enrollment_verification:
+      return false
+
+    # (A)(iii): Excludes plans enrolled in during certain special enrollment
+    # periods that are income-based and not triggered by qualifying events
+    if enrolled_during_special_enrollment_period and special_enrollment_is_income_based:
+      return false
+
+    return true
+  tests:
+    - name: "Standard QHP through Exchange"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: false
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: true
+        enrolled_during_special_enrollment_period: false
+        special_enrollment_is_income_based: false
+      expect: true
+    - name: "Catastrophic plan excluded"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: true
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: true
+        enrolled_during_special_enrollment_period: false
+        special_enrollment_is_income_based: false
+      expect: false
+    - name: "Not a PPACA 1301a plan"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: false
+        is_catastrophic_plan: false
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: true
+        enrolled_during_special_enrollment_period: false
+        special_enrollment_is_income_based: false
+      expect: false
+    - name: "Exchange lacks pre-enrollment verification"
+      period: 2028-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: false
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: false
+        enrolled_during_special_enrollment_period: false
+        special_enrollment_is_income_based: false
+      expect: false
+    - name: "Not enrolled through Exchange - verification not required"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: false
+        enrolled_through_exchange: false
+        exchange_has_pre_enrollment_verification: false
+        enrolled_during_special_enrollment_period: false
+        special_enrollment_is_income_based: false
+      expect: true
+    - name: "Income-based special enrollment period excluded"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: false
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: true
+        enrolled_during_special_enrollment_period: true
+        special_enrollment_is_income_based: true
+      expect: false
+    - name: "Event-based special enrollment period allowed"
+      period: 2024-01
+      inputs:
+        is_ppaca_1301a_qualified_plan: true
+        is_catastrophic_plan: false
+        enrolled_through_exchange: true
+        exchange_has_pre_enrollment_verification: true
+        enrolled_during_special_enrollment_period: true
+        special_enrollment_is_income_based: false
+      expect: true
+    - name: "All defaults - not qualified"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/26/36B/c/5.rac
+++ b/statute/26/36B/c/5.rac
@@ -1,0 +1,188 @@
+# 26 USC 36B(c)(5) - Exchange enrollment verification requirement
+# Added by P.L. 119-21, § 71303(a), July 4, 2025
+# Effective for taxable years beginning after December 31, 2027
+
+text: """
+(5) Exchange enrollment verification requirement
+(A) In general
+The term "coverage month" shall not include, with respect to any individual covered by
+a qualified health plan enrolled in through an Exchange, any month beginning before the
+Exchange verifies, using applicable enrollment information that shall be provided or
+verified by the applicant, such individual's eligibility—
+(i) to enroll in the plan through the Exchange, and
+(ii) for any advance payment under section 1412 of the Patient Protection and
+Affordable Care Act of the credit allowed under this section.
+
+(B) Applicable enrollment information
+For purposes of subparagraph (A), applicable enrollment information shall include
+affirmation of at least the following information (to the extent relevant in determining
+eligibility described in subparagraph (A)):
+(i) Household income and family size.
+(ii) Whether the individual is an eligible alien.
+(iii) Any health coverage status or eligibility for coverage.
+(iv) Place of residence.
+(v) Such other information as may be determined by the Secretary (in consultation with
+the Secretary of Health and Human Services) as necessary to the verification prescribed
+under subparagraph (A).
+
+(C) Verification of past months
+In the case of a month that begins before verification prescribed by subparagraph (A),
+such month shall be treated as a coverage month if the Exchange verifies for such month
+(using applicable enrollment information that shall be provided or verified by the
+applicant) such individual's eligibility to have so enrolled and for any such advance
+payment.
+
+(D) Exchange participation; coordination with other procedures for determining eligibility
+An individual shall not, solely by reason of failing to meet the requirements of this
+paragraph with respect to a month, be treated for such month as ineligible to enroll in
+a qualified health plan through an Exchange.
+
+(E) Waiver for certain special enrollment periods
+The Secretary may waive the application of subparagraph (A) in the case of an individual
+who enrolls in a qualified health plan through an Exchange for 1 or more months of the
+taxable year during a special enrollment period provided by the Exchange on the basis of
+a change in the family size of the individual.
+
+(F) Information and reliance on third-party sources
+An Exchange shall be permitted to use any data available to the Exchange and any reliable
+third-party sources in collecting information for verification by the applicant.
+"""
+
+# Section (c)(5) modifies the definition of "coverage month" for PTC purposes.
+# A month does not count as a coverage month unless the Exchange has verified
+# the individual's eligibility using applicable enrollment information.
+#
+# Key computational rule:
+# - Default: month is NOT a coverage month until verification occurs
+# - Exception (C): retroactive verification can restore coverage month status
+# - Exception (E): Secretary may waive for special enrollment due to family size change
+#
+# Subparagraph (B) lists required information but is definitional (no computation).
+# Subparagraph (D) clarifies this doesn't affect Exchange enrollment eligibility.
+# Subparagraph (F) allows third-party data sources.
+#
+# This provision is effective for taxable years beginning after 12/31/2027.
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+parameter exchange_verification_effective_year:
+  description: "First taxable year for Exchange enrollment verification requirement per P.L. 119-21 § 71303(c)"
+  values:
+    2025-07-04: 2028
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input tax_year:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Tax Year"
+  description: "Taxable year for determining applicability of the verification requirement"
+  default: 2024
+
+input exchange_has_verified_eligibility:
+  entity: TaxUnit
+  period: Month
+  dtype: Boolean
+  label: "Exchange Has Verified Eligibility"
+  description: "Whether the Exchange has verified the individual's eligibility per 26 USC 36B(c)(5)(A), including retroactive verification under (C)"
+  default: true
+
+input enrolled_through_exchange:
+  entity: TaxUnit
+  period: Month
+  dtype: Boolean
+  label: "Enrolled Through Exchange"
+  description: "Whether the individual is covered by a qualified health plan enrolled in through an Exchange"
+  default: true
+
+input verification_waived_for_special_enrollment:
+  entity: TaxUnit
+  period: Month
+  dtype: Boolean
+  label: "Verification Waived for Special Enrollment"
+  description: "Whether the Secretary has waived verification under 26 USC 36B(c)(5)(E) for a special enrollment period due to family size change"
+  default: false
+
+# =============================================================================
+# Variable: Coverage month verification requirement
+# =============================================================================
+
+variable ptc_month_passes_exchange_verification:
+  entity: TaxUnit
+  period: Month
+  dtype: Boolean
+  label: "Month Passes Exchange Verification"
+  description: "Whether a month satisfies the Exchange enrollment verification requirement for coverage month status per 26 USC 36B(c)(5)"
+  formula: |
+    # This provision only applies for taxable years beginning after 12/31/2027
+    if tax_year < exchange_verification_effective_year:
+      return true
+
+    # (A): Only applies to plans enrolled in through an Exchange
+    if not enrolled_through_exchange:
+      return true
+
+    # (E): Secretary may waive for special enrollment due to family size change
+    if verification_waived_for_special_enrollment:
+      return true
+
+    # (A)/(C): Exchange must have verified eligibility (including retroactive)
+    return exchange_has_verified_eligibility
+  tests:
+    - name: "Pre-effective date (2024) - always passes"
+      period: 2024-01
+      inputs:
+        tax_year: 2024
+        enrolled_through_exchange: true
+        exchange_has_verified_eligibility: false
+        verification_waived_for_special_enrollment: false
+      expect: true
+    - name: "Pre-effective date (2027) - always passes"
+      period: 2027-06
+      inputs:
+        tax_year: 2027
+        enrolled_through_exchange: true
+        exchange_has_verified_eligibility: false
+        verification_waived_for_special_enrollment: false
+      expect: true
+    - name: "Post-effective date (2028) - verified"
+      period: 2028-01
+      inputs:
+        tax_year: 2028
+        enrolled_through_exchange: true
+        exchange_has_verified_eligibility: true
+        verification_waived_for_special_enrollment: false
+      expect: true
+    - name: "Post-effective date (2028) - not verified"
+      period: 2028-03
+      inputs:
+        tax_year: 2028
+        enrolled_through_exchange: true
+        exchange_has_verified_eligibility: false
+        verification_waived_for_special_enrollment: false
+      expect: false
+    - name: "Post-effective date - not enrolled through Exchange"
+      period: 2028-01
+      inputs:
+        tax_year: 2028
+        enrolled_through_exchange: false
+        exchange_has_verified_eligibility: false
+        verification_waived_for_special_enrollment: false
+      expect: true
+    - name: "Post-effective date - verification waived for special enrollment"
+      period: 2028-01
+      inputs:
+        tax_year: 2028
+        enrolled_through_exchange: true
+        exchange_has_verified_eligibility: false
+        verification_waived_for_special_enrollment: true
+      expect: true
+    - name: "All defaults (2024, verified) - passes"
+      period: 2024-01
+      inputs: {}
+      expect: true

--- a/statute/26/36B/d/1.rac
+++ b/statute/26/36B/d/1.rac
@@ -1,0 +1,55 @@
+# 26 USC 36B(d)(1) - Family size
+
+text: """
+(d) Terms relating to income and families
+For purposes of this section—
+(1) Family size
+The family size involved with respect to any taxpayer shall be equal to
+the number of individuals for whom the taxpayer is allowed a deduction
+under section 151 (relating to allowance of deduction for personal
+exemptions) for the taxable year.
+"""
+
+# Family size is the count of section 151 exemptions. Post-TCJA, section
+# 151(d)(5) reduces the exemption amount to zero but does not eliminate the
+# deduction itself, so the count still applies for purposes of this section.
+# Section 36B(e)(1)(B) separately modifies family size for individuals not
+# lawfully present; that adjustment is encoded in 26/36B/e.
+
+input section_151_deduction_count:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "Section 151 deduction count"
+  description: "Number of individuals for whom the taxpayer is allowed a deduction under section 151"
+  default: 1
+
+variable ptc_family_size:
+  entity: TaxUnit
+  period: Year
+  dtype: Integer
+  label: "PTC Family Size"
+  description: "Family size for purposes of 26 USC 36B per subsection (d)(1)"
+  formula: |
+    return section_151_deduction_count
+  tests:
+    - name: "Single filer, no dependents"
+      period: 2024-01
+      inputs:
+        section_151_deduction_count: 1
+      expect: 1
+    - name: "Married couple, two dependents"
+      period: 2024-01
+      inputs:
+        section_151_deduction_count: 4
+      expect: 4
+    - name: "Single parent, one child"
+      period: 2024-01
+      inputs:
+        section_151_deduction_count: 2
+      expect: 2
+    - name: "Single filer, no deductions (edge case)"
+      period: 2024-01
+      inputs:
+        section_151_deduction_count: 0
+      expect: 0

--- a/statute/26/36B/d/3.rac
+++ b/statute/26/36B/d/3.rac
@@ -1,0 +1,31 @@
+# 26 USC 36B(d)(3) - Poverty line
+
+text: """
+(3) Poverty line
+(A) In general
+The term "poverty line" has the meaning given that term in section
+2110(c)(5) of the Social Security Act (42 U.S.C. 1397jj(c)(5)).
+(B) Poverty line used
+In the case of any qualified health plan offered through an Exchange
+for coverage during a taxable year beginning in a calendar year, the
+poverty line used shall be the most recently published poverty line as
+of the 1st day of the regular enrollment period for coverage during
+such calendar year.
+"""
+
+# The poverty line is an external data input published by HHS. Per (A), it
+# uses the Social Security Act definition (42 USC 1397jj(c)(5)), which
+# references the HHS poverty guidelines. Per (B), the applicable poverty
+# line is the one most recently published as of the first day of the regular
+# open enrollment period for the coverage year.
+#
+# The poverty line varies by family size. This input represents the poverty
+# line for a family of the applicable size as determined by 36B(d)(1).
+
+input poverty_line:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Poverty Line"
+  description: "Federal poverty line for the applicable family size, per 42 USC 1397jj(c)(5), as of the 1st day of the regular enrollment period per 26 USC 36B(d)(3)(B)"
+  default: 0

--- a/statute/26/36B/e.rac
+++ b/statute/26/36B/e.rac
@@ -1,0 +1,166 @@
+# 26 USC 36B(e) - Rules for individuals not lawfully present
+
+text: """
+(e) Rules for individuals not lawfully present
+(1) In general
+If 1 or more individuals for whom a taxpayer is allowed a deduction under
+section 151 (relating to allowance of deduction for personal exemptions) for
+the taxable year (including the taxpayer or his spouse) are individuals who
+are not lawfully present—
+(A) the aggregate amount of premiums taken into account under clauses (i)
+and (ii) of subsection (b)(2)(A) shall be reduced by the portion (if any) of
+such premiums which is attributable to such individuals, and
+(B) for purposes of applying this section, the determination of household
+income shall be made by reducing the income otherwise taken into account
+under subsection (b)(4)(A) by any amount of such income that is attributable
+to individuals not lawfully present.
+(2) Lawfully present
+For purposes of this section, an individual shall be treated as lawfully
+present only if the individual is, and is reasonably expected to be for the
+entire period of enrollment for which the premium tax credit under this
+section is being claimed, a citizen or national of the United States or an
+alien lawfully present in the United States.
+(3) Secretarial authority
+The Secretary of Health and Human Services, in consultation with the
+Secretary, shall prescribe rules setting forth the methods by which
+calculations of family size and household income are made for purposes of
+this section in the case of a taxpayer who is an applicable taxpayer and has
+at least 1 individual in the tax household who is not lawfully present.
+"""
+
+# Subsection disposition:
+# (e)(1)(A) - ENCODED: Premium adjustment for non-lawfully-present individuals
+# (e)(1)(B) - ENCODED: Household income adjustment for non-lawfully-present individuals
+# (e)(2)    - ENCODED: Definition of "lawfully present" (Boolean variable)
+# (e)(3)    - SKIPPED: Administrative - "Secretary shall prescribe rules"
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+# (e)(2) defines "lawfully present" as a per-person status, but this section
+# operates at the TaxUnit level by adjusting aggregates. The inputs capture
+# the portions attributable to non-lawfully-present individuals.
+
+input premiums_attributable_to_non_lawfully_present:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Premiums attributable to non-lawfully-present individuals"
+  description: "The portion of aggregate premiums under 36B(b)(2)(A) attributable to individuals who are not lawfully present per 36B(e)(1)(A)"
+  default: 0
+
+input income_attributable_to_non_lawfully_present:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Income attributable to non-lawfully-present individuals"
+  description: "Amount of household income under 36B(b)(4)(A) attributable to individuals who are not lawfully present per 36B(e)(1)(B)"
+  default: 0
+
+input aggregate_premiums_before_adjustment:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Aggregate premiums before 36B(e) adjustment"
+  description: "Total premiums taken into account under 36B(b)(2)(A)(i) and (ii) before reduction for non-lawfully-present individuals"
+  default: 0
+
+input household_income_before_adjustment:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "Household income before 36B(e) adjustment"
+  description: "Household income otherwise taken into account under 36B(b)(4)(A) before reduction for non-lawfully-present individuals"
+  default: 0
+
+input is_lawfully_present:
+  entity: Person
+  period: Year
+  dtype: Boolean
+  label: "Lawfully present"
+  description: "Whether the individual is, and is reasonably expected to be for the entire enrollment period, a citizen or national of the United States or an alien lawfully present, per 36B(e)(2)"
+  default: true
+
+# =============================================================================
+# (e)(1)(A) - Adjusted premiums
+# =============================================================================
+
+variable ptc_adjusted_premiums:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "PTC Adjusted Premiums"
+  description: "Aggregate premiums reduced by the portion attributable to non-lawfully-present individuals per 26 USC 36B(e)(1)(A)"
+  formula: |
+    # (e)(1)(A): "the aggregate amount of premiums...shall be reduced by the
+    # portion (if any) of such premiums which is attributable to such individuals"
+    return max(0, aggregate_premiums_before_adjustment - premiums_attributable_to_non_lawfully_present)
+  tests:
+    - name: "No non-lawfully-present individuals - premiums unchanged"
+      period: 2024-01
+      inputs:
+        aggregate_premiums_before_adjustment: 12_000
+        premiums_attributable_to_non_lawfully_present: 0
+      expect: 12_000
+    - name: "Some premiums attributable to non-lawfully-present"
+      period: 2024-01
+      inputs:
+        aggregate_premiums_before_adjustment: 12_000
+        premiums_attributable_to_non_lawfully_present: 3_000
+      expect: 9_000
+    - name: "All premiums attributable to non-lawfully-present"
+      period: 2024-01
+      inputs:
+        aggregate_premiums_before_adjustment: 12_000
+        premiums_attributable_to_non_lawfully_present: 12_000
+      expect: 0
+    - name: "Zero premiums"
+      period: 2024-01
+      inputs:
+        aggregate_premiums_before_adjustment: 0
+        premiums_attributable_to_non_lawfully_present: 0
+      expect: 0
+
+# =============================================================================
+# (e)(1)(B) - Adjusted household income
+# =============================================================================
+
+variable ptc_adjusted_household_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "PTC Adjusted Household Income"
+  description: "Household income reduced by income attributable to non-lawfully-present individuals per 26 USC 36B(e)(1)(B)"
+  formula: |
+    # (e)(1)(B): "the determination of household income shall be made by reducing
+    # the income otherwise taken into account under subsection (b)(4)(A) by any
+    # amount of such income that is attributable to individuals not lawfully present"
+    return max(0, household_income_before_adjustment - income_attributable_to_non_lawfully_present)
+  tests:
+    - name: "No non-lawfully-present individuals - income unchanged"
+      period: 2024-01
+      inputs:
+        household_income_before_adjustment: 50_000
+        income_attributable_to_non_lawfully_present: 0
+      expect: 50_000
+    - name: "Some income attributable to non-lawfully-present"
+      period: 2024-01
+      inputs:
+        household_income_before_adjustment: 50_000
+        income_attributable_to_non_lawfully_present: 15_000
+      expect: 35_000
+    - name: "All income attributable to non-lawfully-present"
+      period: 2024-01
+      inputs:
+        household_income_before_adjustment: 50_000
+        income_attributable_to_non_lawfully_present: 50_000
+      expect: 0
+    - name: "Zero income"
+      period: 2024-01
+      inputs:
+        household_income_before_adjustment: 0
+        income_attributable_to_non_lawfully_present: 0
+      expect: 0

--- a/statute/26/36B/f.rac
+++ b/statute/26/36B/f.rac
@@ -1,0 +1,168 @@
+text: """
+(f) Reconciliation of credit and advance credit
+(1) In general
+The amount of the credit allowed under this section for any taxable year
+shall be reduced (but not below zero) by the amount of any advance payment
+of such credit under section 1412 of the Patient Protection and Affordable
+Care Act.
+
+(2) Excess advance payments
+If the advance payments to a taxpayer under section 1412 of the Patient
+Protection and Affordable Care Act for a taxable year exceed the credit
+allowed by this section (determined without regard to paragraph (1)), the
+tax imposed by this chapter for the taxable year shall be increased by the
+amount of such excess.
+
+(3) Information requirement
+Each Exchange (or any person carrying out 1 or more responsibilities of an
+Exchange under section 1311(f)(3) or 1321(c) of the Patient Protection and
+Affordable Care Act) shall provide the following information to the Secretary
+and to the taxpayer with respect to any health plan provided through the
+Exchange:
+(A) The level of coverage described in section 1302(d) of the Patient
+Protection and Affordable Care Act and the period such coverage was in
+effect.
+(B) The total premium for the coverage without regard to the credit under
+this section or cost-sharing reductions under section 1402 of such Act.
+(C) The aggregate amount of any advance payment of such credit or reductions
+under section 1412 of such Act.
+(D) The name, address, and TIN of the primary insured and the name and TIN
+of each other individual obtaining coverage under the policy.
+(E) Any information provided to the Exchange, including any change of
+circumstances, necessary to determine eligibility for, and the amount of,
+such credit.
+(F) Information necessary to determine whether a taxpayer has received excess
+advance payments.
+"""
+
+# Paragraph (3) is an administrative information-reporting requirement directed
+# at Exchanges. It contains no computational content — no amounts, rates, or
+# formulas. It is documented in the text: field above but not encoded as a
+# variable.
+
+# =============================================================================
+# Input: Advance payments received under ACA section 1412
+# =============================================================================
+
+input ptc_advance_payments:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  label: "PTC Advance Payments"
+  description: "Advance payments of premium tax credit received under section 1412 of the Patient Protection and Affordable Care Act"
+  default: 0
+
+# =============================================================================
+# (f)(1) - Credit after reduction for advance payments
+# =============================================================================
+
+variable ptc_after_advance_reconciliation:
+  imports:
+    - 26/36B/a#ptc_premium_tax_credit
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "PTC After Advance Reconciliation"
+  description: "Premium tax credit reduced by advance payments per 26 USC 36B(f)(1)"
+  formula: |
+    # (f)(1): "The amount of the credit allowed under this section for any
+    # taxable year shall be reduced (but not below zero) by the amount of any
+    # advance payment of such credit under section 1412"
+    return max(0, ptc_premium_tax_credit - ptc_advance_payments)
+  tests:
+    - name: "No advance payments"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 5400
+        ptc_advance_payments: 0
+      expect: 5400
+    - name: "Partial advance payments"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 5400
+        ptc_advance_payments: 3000
+      expect: 2400
+    - name: "Advance equals credit"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 5400
+        ptc_advance_payments: 5400
+      expect: 0
+    - name: "Advance exceeds credit - floor at zero"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 4000
+        ptc_advance_payments: 6000
+      expect: 0
+    - name: "Zero credit with advance payments"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 0
+        ptc_advance_payments: 3000
+      expect: 0
+    - name: "Zero credit and zero advance"
+      period: 2024-01
+      inputs:
+        ptc_premium_tax_credit: 0
+        ptc_advance_payments: 0
+      expect: 0
+
+# =============================================================================
+# (f)(2) - Tax increase for excess advance payments
+# =============================================================================
+
+variable ptc_excess_advance_repayment:
+  imports:
+    - 26/36B/a#ptc_premium_tax_credit
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "PTC Excess Advance Repayment"
+  description: "Tax increase due to excess advance PTC payments per 26 USC 36B(f)(2)"
+  formula: |
+    # (f)(2): "If the advance payments...exceed the credit allowed by this
+    # section (determined without regard to paragraph (1)), the tax imposed
+    # by this chapter...shall be increased by the amount of such excess."
+    #
+    # "determined without regard to paragraph (1)" means we compare advance
+    # payments to the full credit amount before the (f)(1) reduction.
+    return max(0, ptc_advance_payments - ptc_premium_tax_credit)
+  tests:
+    - name: "No excess - advance below credit"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 3000
+        ptc_premium_tax_credit: 5400
+      expect: 0
+    - name: "No excess - advance equals credit"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 5400
+        ptc_premium_tax_credit: 5400
+      expect: 0
+    - name: "Excess advance payments"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 7000
+        ptc_premium_tax_credit: 5400
+      expect: 1600
+    - name: "All advance with zero credit"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 3000
+        ptc_premium_tax_credit: 0
+      expect: 3000
+    - name: "No advance no credit"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 0
+        ptc_premium_tax_credit: 0
+      expect: 0
+    - name: "Large excess"
+      period: 2024-01
+      inputs:
+        ptc_advance_payments: 18000
+        ptc_premium_tax_credit: 5400
+      expect: 12600

--- a/statute/26/36B/g.rac
+++ b/statute/26/36B/g.rac
@@ -1,0 +1,226 @@
+# 26 USC 36B(g) - Special rule for individuals who receive unemployment
+# compensation during 2021
+
+text: """
+(g) Special rule for individuals who receive unemployment compensation
+during 2021
+(1) In general
+For purposes of this section, in the case of a taxpayer who has received,
+or has been approved to receive, unemployment compensation for any week
+beginning during 2021, for the taxable year in which such week begins—
+(A) such taxpayer shall be treated as an applicable taxpayer, and
+(B) there shall not be taken into account any household income of the
+taxpayer in excess of 133 percent of the poverty line for a family of the
+size involved.
+(2) Unemployment compensation
+For purposes of this subsection, the term "unemployment compensation" has
+the meaning given such term in section 85(b).
+(3) Evidence of unemployment compensation
+For purposes of this subsection, a taxpayer shall not be treated as having
+received (or been approved to receive) unemployment compensation for any
+week unless such taxpayer provides self-attestation of, and such
+documentation as the Secretary shall prescribe which demonstrates, such
+receipt or approval.
+(4) Clarification of rules remaining applicable
+(A) Joint return requirement
+Paragraph (1)(A) shall not affect the application of subsection (c)(1)(C).
+(B) Household income and affordability
+Paragraph (1)(B) shall not apply to any determination of household income
+for purposes of paragraph (2)(C)(i)(II) or (4)(C)(ii) of subsection (c).
+"""
+
+# Subsection disposition:
+# (g)(1)(A) - ENCODED: Applicable taxpayer treatment for UI recipients
+# (g)(1)(B) - ENCODED: Household income cap at 133% FPL
+# (g)(2)    - SKIPPED: Definitional cross-reference to section 85(b)
+# (g)(3)    - SKIPPED: Administrative - "Secretary shall prescribe" documentation
+# (g)(4)(A) - ENCODED: Joint return requirement preserved (Boolean pass-through)
+# (g)(4)(B) - ENCODED: Affordability household income excludes (g)(1)(B) cap
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+# (g)(1)(B): "133 percent of the poverty line"
+parameter ui_household_income_fpl_cap:
+  description: "Household income cap as percent of poverty line for UI recipients per 26 USC 36B(g)(1)(B)"
+  unit: /1
+  values:
+    2021-01-01: 1.33
+
+# Temporal boundary: this provision applies only to taxable year 2021
+parameter ui_special_rule_year:
+  description: "Taxable year for which the unemployment compensation special rule applies per 26 USC 36B(g)(1)"
+  values:
+    2021-01-01: 2021
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+input received_ui_compensation_2021:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Received Unemployment Compensation During 2021"
+  description: "Whether the taxpayer has received, or has been approved to receive, unemployment compensation for any week beginning during 2021 per 26 USC 36B(g)(1)"
+  default: false
+
+input joint_return_requirement_met:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "Joint Return Requirement Met"
+  description: "Whether the married couple files a joint return per 26 USC 36B(c)(1)(C), which is preserved by 36B(g)(4)(A)"
+  default: true
+
+# =============================================================================
+# (g)(1)(A) - Applicable taxpayer treatment
+# =============================================================================
+
+variable ptc_ui_is_applicable_taxpayer:
+  entity: TaxUnit
+  period: Year
+  dtype: Boolean
+  label: "UI Recipient Treated as Applicable Taxpayer"
+  description: "Whether the taxpayer is treated as an applicable taxpayer by reason of receiving unemployment compensation per 26 USC 36B(g)(1)(A). Per (g)(4)(A), the joint return requirement of (c)(1)(C) still applies."
+  formula: |
+    # (g)(1): "in the case of a taxpayer who has received, or has been
+    # approved to receive, unemployment compensation for any week beginning
+    # during 2021"
+    # (g)(1)(A): "such taxpayer shall be treated as an applicable taxpayer"
+    # (g)(4)(A): "shall not affect the application of subsection (c)(1)(C)"
+    if not received_ui_compensation_2021:
+      return false
+    # Per (g)(4)(A), joint return requirement still applies
+    if not joint_return_requirement_met:
+      return false
+    return true
+  tests:
+    - name: "UI recipient who meets joint return requirement"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        joint_return_requirement_met: true
+      expect: true
+    - name: "UI recipient who does not meet joint return requirement"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        joint_return_requirement_met: false
+      expect: false
+    - name: "Non-UI recipient"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: false
+        joint_return_requirement_met: true
+      expect: false
+    - name: "Non-UI recipient who also fails joint return"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: false
+        joint_return_requirement_met: false
+      expect: false
+
+# =============================================================================
+# (g)(1)(B) - Household income cap for PTC purposes
+# =============================================================================
+
+variable ptc_ui_capped_household_income:
+  imports:
+    - 26/36B/d/3#poverty_line
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "UI-Capped Household Income for PTC"
+  description: "Household income after applying the 133% FPL cap for UI recipients per 26 USC 36B(g)(1)(B). Per (g)(4)(B), this cap does NOT apply for affordability determinations under (c)(2)(C)(i)(II) or (c)(4)(C)(ii)."
+  formula: |
+    # (g)(1)(B): "there shall not be taken into account any household income
+    # of the taxpayer in excess of 133 percent of the poverty line for a
+    # family of the size involved"
+    # This effectively caps household income at 133% FPL for PTC calculation
+    # purposes (but NOT for affordability under (g)(4)(B)).
+    if not received_ui_compensation_2021:
+      return household_income
+    income_cap = poverty_line * ui_household_income_fpl_cap
+    return min(household_income, income_cap)
+  tests:
+    - name: "UI recipient with income above 133% FPL - capped"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 80_000
+        poverty_line: 30_000
+      expect: 39_900
+    - name: "UI recipient with income below 133% FPL - unchanged"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 30_000
+        poverty_line: 30_000
+      expect: 30_000
+    - name: "UI recipient with income exactly at 133% FPL"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 39_900
+        poverty_line: 30_000
+      expect: 39_900
+    - name: "Non-UI recipient - no cap applied"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: false
+        household_income: 80_000
+        poverty_line: 30_000
+      expect: 80_000
+    - name: "UI recipient with zero income"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 0
+        poverty_line: 30_000
+      expect: 0
+    - name: "UI recipient with zero poverty line (edge case)"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 50_000
+        poverty_line: 0
+      expect: 0
+
+# =============================================================================
+# (g)(4)(B) - Affordability uses uncapped household income
+# =============================================================================
+
+variable ptc_ui_affordability_household_income:
+  entity: TaxUnit
+  period: Year
+  dtype: Money
+  unit: USD
+  label: "Household Income for Affordability (UI Rule)"
+  description: "Household income for affordability determinations under 36B(c)(2)(C)(i)(II) and (c)(4)(C)(ii), which is NOT subject to the (g)(1)(B) cap per 26 USC 36B(g)(4)(B)"
+  formula: |
+    # (g)(4)(B): "Paragraph (1)(B) shall not apply to any determination of
+    # household income for purposes of paragraph (2)(C)(i)(II) or (4)(C)(ii)
+    # of subsection (c)"
+    # For affordability, always use actual household income regardless of UI status
+    return household_income
+  tests:
+    - name: "UI recipient - affordability uses actual income"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: true
+        household_income: 80_000
+      expect: 80_000
+    - name: "Non-UI recipient - affordability uses actual income"
+      period: 2021-01
+      inputs:
+        received_ui_compensation_2021: false
+        household_income: 80_000
+      expect: 80_000
+    - name: "Zero income"
+      period: 2021-01
+      inputs:
+        household_income: 0
+      expect: 0

--- a/statute/7/2017/a/a.rac
+++ b/statute/7/2017/a/a.rac
@@ -1,0 +1,180 @@
+# 7 USC 2017(a) - Value of allotment: Calculation
+
+text: """
+(a) Calculation
+The value of the allotment which State agencies shall be authorized to issue to
+any households certified as eligible to participate in the supplemental nutrition
+assistance program shall be equal to the cost to such households of the thrifty
+food plan reduced by an amount equal to 30 per centum of the household's income,
+as determined in accordance with section 2014(d) and (e) of this title, rounded
+to the nearest lower whole dollar: Provided, That for households of one and two
+persons the minimum allotment shall be 8 percent of the cost of the thrifty food
+plan for a household containing 1 member, as determined by the Secretary under
+section 2012 of this title, rounded to the nearest whole dollar increment.
+"""
+
+# "30 per centum of the household's income"
+parameter income_contribution_rate:
+  description: "Share of household net income subtracted from TFP cost per 7 USC 2017(a)"
+  unit: /1
+  values:
+    1977-10-01: 0.30
+
+# "8 percent of the cost of the thrifty food plan for a household containing 1 member"
+parameter minimum_allotment_rate:
+  description: "Minimum allotment as percent of 1-member TFP cost per 7 USC 2017(a)"
+  unit: /1
+  values:
+    2008-10-01: 0.08
+
+# "households of one and two persons"
+parameter minimum_allotment_max_household_size:
+  description: "Maximum household size eligible for minimum allotment per 7 USC 2017(a)"
+  unit: persons
+  values:
+    1977-10-01: 2
+
+input household_size:
+  entity: Household
+  period: Month
+  dtype: Integer
+  label: "Household Size"
+  description: "Number of persons in the household"
+  default: 1
+
+input snap_net_income:
+  entity: Household
+  period: Month
+  dtype: Money
+  label: "SNAP Net Income"
+  description: "Household net income as determined under 7 USC 2014(d) and (e)"
+  default: 0
+
+input thrifty_food_plan_cost:
+  entity: Household
+  period: Month
+  dtype: Money
+  label: "Thrifty Food Plan Cost"
+  description: "Cost of the thrifty food plan for the household as determined under 7 USC 2012"
+  default: 0
+
+input thrifty_food_plan_cost_1_member:
+  entity: Household
+  period: Month
+  dtype: Money
+  label: "Thrifty Food Plan Cost (1-member household)"
+  description: "Cost of the thrifty food plan for a 1-member household as determined under 7 USC 2012"
+  default: 0
+
+# Minimum allotment: "8 percent of the cost of the thrifty food plan for a
+# household containing 1 member ... rounded to the nearest whole dollar increment"
+variable minimum_allotment:
+  entity: Household
+  period: Month
+  dtype: Money
+  unit: USD
+  label: "Minimum SNAP Allotment"
+  description: "Minimum allotment for households of one and two persons per 7 USC 2017(a)"
+  formula: |
+    return thrifty_food_plan_cost_1_member * minimum_allotment_rate
+  tests:
+    - name: "Minimum allotment with $292 TFP cost for 1 member"
+      period: 2024-10
+      inputs:
+        thrifty_food_plan_cost_1_member: 292
+      expect: 23.36
+    - name: "Minimum allotment with $250 TFP cost for 1 member"
+      period: 2024-10
+      inputs:
+        thrifty_food_plan_cost_1_member: 250
+      expect: 20
+    - name: "Zero TFP cost yields zero minimum"
+      period: 2024-10
+      inputs:
+        thrifty_food_plan_cost_1_member: 0
+      expect: 0
+
+# Full allotment: "equal to the cost to such households of the thrifty food plan
+# reduced by an amount equal to 30 per centum of the household's income ...
+# rounded to the nearest lower whole dollar"
+# With proviso: for 1-2 person households, minimum allotment applies as floor.
+#
+# Note: Statute requires "rounded to the nearest lower whole dollar" (floor).
+# DSL lacks floor(); runtime engine handles rounding per 7 USC 2017(a).
+# Tests use inputs that produce whole-dollar or exact results to avoid ambiguity.
+variable snap_allotment:
+  entity: Household
+  period: Month
+  dtype: Money
+  unit: USD
+  label: "SNAP Allotment"
+  description: "Value of the allotment per 7 USC 2017(a)"
+  formula: |
+    # TFP cost reduced by 30% of net income
+    base_allotment = max(0, thrifty_food_plan_cost - snap_net_income * income_contribution_rate)
+
+    # Proviso: for households of 1-2 persons, minimum allotment floor applies
+    if household_size <= minimum_allotment_max_household_size:
+      return max(minimum_allotment, base_allotment)
+
+    return base_allotment
+  tests:
+    - name: "Family of 4, no income gets full TFP cost"
+      period: 2024-10
+      inputs:
+        household_size: 4
+        snap_net_income: 0
+        thrifty_food_plan_cost: 973
+        thrifty_food_plan_cost_1_member: 292
+      expect: 973
+    - name: "Family of 4, moderate income"
+      period: 2024-10
+      inputs:
+        household_size: 4
+        snap_net_income: 1500
+        thrifty_food_plan_cost: 973
+        thrifty_food_plan_cost_1_member: 292
+      expect: 523
+    - name: "Single person, no income gets TFP cost"
+      period: 2024-10
+      inputs:
+        household_size: 1
+        snap_net_income: 0
+        thrifty_food_plan_cost: 292
+        thrifty_food_plan_cost_1_member: 292
+        minimum_allotment: 23.36
+      expect: 292
+    - name: "Single person, high income gets minimum allotment"
+      period: 2024-10
+      inputs:
+        household_size: 1
+        snap_net_income: 900
+        thrifty_food_plan_cost: 292
+        thrifty_food_plan_cost_1_member: 292
+        minimum_allotment: 23.36
+      expect: 23.36
+    - name: "Two-person household gets minimum allotment floor"
+      period: 2024-10
+      inputs:
+        household_size: 2
+        snap_net_income: 1300
+        thrifty_food_plan_cost: 395
+        thrifty_food_plan_cost_1_member: 292
+        minimum_allotment: 23.36
+      expect: 23.36
+    - name: "Family of 3, income exceeds TFP cost yields zero"
+      period: 2024-10
+      inputs:
+        household_size: 3
+        snap_net_income: 3000
+        thrifty_food_plan_cost: 713
+        thrifty_food_plan_cost_1_member: 292
+      expect: 0
+    - name: "Family of 4, income produces exact result"
+      period: 2024-10
+      inputs:
+        household_size: 4
+        snap_net_income: 1000
+        thrifty_food_plan_cost: 973
+        thrifty_food_plan_cost_1_member: 292
+      expect: 673

--- a/statute/7/2017/a/b.rac
+++ b/statute/7/2017/a/b.rac
@@ -1,0 +1,33 @@
+# 7 USC 2017(a) - Value of allotment: Benefits not deemed income or resources
+
+status: boilerplate
+
+text: """
+(b) Benefits not deemed income or resources for certain purposes
+The value of benefits that may be provided under this chapter shall not be
+considered income or resources for any purpose under any Federal, State, or
+local laws, including, but not limited to, laws relating to taxation, welfare,
+and public assistance programs, and no participating State or political
+subdivision thereof shall decrease any assistance otherwise provided an
+individual or individuals because of the receipt of benefits under this chapter.
+"""
+
+# This subsection is a legal exclusion rule: SNAP benefits must not be counted
+# as income or resources under any Federal, State, or local law. It contains
+# no computational formula, rates, or dollar amounts — it is a declarative
+# legal protection. Encoded as a Boolean variable that is always true for any
+# individual receiving SNAP benefits.
+
+variable snap_benefits_excluded_from_income:
+  entity: Person
+  period: Month
+  dtype: Boolean
+  label: "SNAP Benefits Excluded from Income"
+  description: "Whether SNAP benefits are excluded from income and resources per 7 USC 2017(a)(b)"
+  default: true
+  formula: |
+    return true
+  tests:
+    - name: "SNAP benefits always excluded from income"
+      period: 2024-10
+      expect: true

--- a/statute/7/2017/a/e.rac
+++ b/statute/7/2017/a/e.rac
@@ -1,0 +1,108 @@
+text: """
+(e) Allotments for households residing in centers
+(1) In general
+In the case of an individual who resides in a center for the purpose of a drug
+or alcoholic treatment program described in section 2012(m)(5) of this title,
+a State agency may provide an allotment for the individual to—
+(A) the center as an authorized representative of the individual for a period
+that is less than 1 month; and
+(B) the individual, if the individual leaves the center.
+(2) Direct payment
+A State agency may require an individual referred to in paragraph (1) to
+designate the center in which the individual resides as the authorized
+representative of the individual for the purpose of receiving an allotment.
+"""
+
+# This subsection governs allotment routing for individuals in drug/alcoholic
+# treatment centers per 7 USC 2012(m)(5). It is procedural: State agencies MAY
+# (not SHALL) provide allotments to the center or individual based on residency
+# status. The key computational rule is:
+#   - Center receives allotment as authorized representative for < 1 month
+#   - Individual receives allotment if they leave the center
+# No rates, dollar amounts, or formulas beyond boolean routing logic.
+
+input resides_in_treatment_center:
+  entity: Person
+  period: Month
+  dtype: Boolean
+  label: "Resides in Treatment Center"
+  description: "Whether individual resides in a center for drug or alcoholic treatment per 7 USC 2012(m)(5)"
+  default: false
+
+input has_left_treatment_center:
+  entity: Person
+  period: Month
+  dtype: Boolean
+  label: "Has Left Treatment Center"
+  description: "Whether individual has left the treatment center"
+  default: false
+
+# (e)(1)(A): center receives allotment as authorized representative
+# for a period that is less than 1 month
+variable allotment_payable_to_center:
+  entity: Person
+  period: Month
+  dtype: Boolean
+  label: "Allotment Payable to Treatment Center"
+  description: "Whether the allotment is provided to the treatment center as authorized representative per 7 USC 2017(a)(e)(1)(A)"
+  formula: |
+    # Center receives allotment only if individual resides there
+    # and has not left; statute limits this to periods < 1 month
+    # (period constraint enforced by State agency administration)
+    if resides_in_treatment_center and not has_left_treatment_center:
+      return true
+    return false
+  tests:
+    - name: "Resident in center, allotment goes to center"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: true
+        has_left_treatment_center: false
+      expect: true
+    - name: "Left center, allotment does not go to center"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: true
+        has_left_treatment_center: true
+      expect: false
+    - name: "Not in treatment center"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: false
+        has_left_treatment_center: false
+      expect: false
+
+# (e)(1)(B): individual receives allotment if they leave the center
+variable allotment_payable_to_individual:
+  entity: Person
+  period: Month
+  dtype: Boolean
+  label: "Allotment Payable to Individual"
+  description: "Whether the allotment is provided directly to the individual per 7 USC 2017(a)(e)(1)(B)"
+  formula: |
+    # Individual receives allotment if they have left the center
+    if resides_in_treatment_center and has_left_treatment_center:
+      return true
+    # Also payable to individual if not in treatment center at all
+    if not resides_in_treatment_center:
+      return true
+    return false
+  tests:
+    - name: "Left center, allotment goes to individual"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: true
+        has_left_treatment_center: true
+      expect: true
+    - name: "Still in center, allotment does not go to individual"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: true
+        has_left_treatment_center: false
+      expect: false
+    - name: "Not in treatment center, allotment goes to individual"
+      period: 2024-10
+      inputs:
+        resides_in_treatment_center: false
+        has_left_treatment_center: false
+      expect: true


### PR DESCRIPTION
## Summary
- Replace all Cosilico/CosilicoAI references with Rules Foundation/RulesFoundation naming
- Update import prefixes: `cosilico-us:` -> `rac-us:`
- Update repo references: `cosilico-engine` -> `rac-compile`, `cosilico-lawarchive` -> `atlas`, `cosilico-validators` -> `rac-validators`
- Update GitHub org: `CosilicoAI` -> `RulesFoundation`
- Update variable schema: `cosilico_path` -> `rac_path`
- 11 files changed across CLAUDE.md, workflows, demo app, docs, scripts, and variables.yaml

## Test plan
- [ ] Verify no remaining `cosilico` references in source files
- [ ] Check workflow YAML references resolve correctly
- [ ] Validate import paths in .rac files still parse