### PR TITLE
Add stub files for external dependencies and resolve imports

### DIFF
--- a/statute/26/152/f/2.rac
+++ b/statute/26/152/f/2.rac
@@ -1,0 +1,30 @@
+# 26 USC Section 152(f)(2) - Student defined
+
+"""
+(2) Student defined.-- The term "student" means an individual who
+during each of 5 calendar months during the calendar year in which the
+taxable year of the taxpayer begins is a full-time student at an
+educational organization described in section 170(b)(1)(A)(ii).
+"""
+
+status: stub
+
+required_student_months:
+    description: "Number of calendar months of full-time enrollment required"
+    from 2002-01-01: 5
+
+full_time_student_months:
+    entity: Person
+    period: Year
+    dtype: Integer
+    label: "Months as full-time student"
+    description: "Number of calendar months the individual was a full-time student at a qualifying educational organization per 26 USC 152(f)(2)"
+
+is_full_time_student:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Is full-time student"
+    description: "Whether the individual qualifies as a student under 26 USC 152(f)(2) - enrolled full-time for at least 5 months"
+    from 2002-01-01:
+        full_time_student_months >= required_student_months

--- a/statute/26/21/a/1.rac
+++ b/statute/26/21/a/1.rac
@@ -27,13 +27,15 @@ applicable_percentage:
     description: "Applicable percentage of employment-related expenses per 26 USC 21(a)(2): 50% reduced by (A) and further reduced by (B)"
     from 2002-01-01:
         result = base_applicable_percentage - first_reduction - further_reduction
-        return max(0, result)
+        max(0, result)
 
 creditable_expenses:
     imports:
         - 26/21/c/1#expense_limit_one_qualifying_individual
         - 26/21/c/2#expense_limit_two_or_more_qualifying_individuals
         - 26/21/d#earned_income_limit
+        - 26/21/b#employment_related_expenses
+        - 26/21/b#number_of_qualifying_individuals
     entity: TaxUnit
     period: Year
     dtype: Money
@@ -41,14 +43,13 @@ creditable_expenses:
     label: "Creditable employment-related expenses"
     description: "Employment-related expenses subject to dollar limit per 26 USC 21(c) and earned income limit per 26 USC 21(d)"
     from 2002-01-01:
-        if number_of_qualifying_individuals >= 2:
-            dollar_limit = expense_limit_two_or_more_qualifying_individuals
-        else:
-            dollar_limit = expense_limit_one_qualifying_individual
+        dollar_limit = if number_of_qualifying_individuals >= 2: expense_limit_two_or_more_qualifying_individuals else: expense_limit_one_qualifying_individual
         capped = min(employment_related_expenses, dollar_limit)
-        return min(capped, earned_income_limit)
+        min(capped, earned_income_limit)
 
 child_and_dependent_care_credit:
+    imports:
+        - 26/21/b#number_of_qualifying_individuals
     entity: TaxUnit
     period: Year
     dtype: Money
@@ -57,5 +58,6 @@ child_and_dependent_care_credit:
     description: "Credit for household and dependent care services per 26 USC 21(a)(1): applicable percentage of creditable employment-related expenses"
     from 2002-01-01:
         if number_of_qualifying_individuals >= 1:
-            return applicable_percentage * creditable_expenses
-        return 0
+            applicable_percentage * creditable_expenses
+        else:
+            0

--- a/statute/26/21/a/2/A.rac
+++ b/statute/26/21/a/2/A.rac
@@ -29,6 +29,8 @@ first_reduction_floor:
     from 2002-01-01: 0.35
 
 first_reduction:
+    imports:
+        - 26/62#adjusted_gross_income
     entity: TaxUnit
     period: Year
     dtype: Rate

--- a/statute/26/21/a/2/B.rac
+++ b/statute/26/21/a/2/B.rac
@@ -40,6 +40,9 @@ further_reduction_floor:
     from 2002-01-01: 0.20
 
 further_reduction:
+    imports:
+        - 26/62#adjusted_gross_income
+        - 26/7703/a#is_joint_return
     entity: TaxUnit
     period: Year
     dtype: Rate

--- a/statute/26/21/b.rac
+++ b/statute/26/21/b.rac
@@ -1,0 +1,26 @@
+# 26 USC Section 21(b) - Employment-related expenses
+
+"""
+(b) Employment-related expenses.-- For purposes of this section--
+(1) In general.-- The term "employment-related expenses" means amounts
+paid for the following expenses, but only if such expenses are incurred
+to enable the taxpayer to be gainfully employed for any period for which
+there are 1 or more qualifying individuals with respect to the taxpayer...
+"""
+
+status: stub
+
+employment_related_expenses:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Employment-related expenses"
+    description: "Total employment-related expenses per 26 USC 21(b) - amounts paid for household services and care of qualifying individuals to enable gainful employment"
+
+number_of_qualifying_individuals:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Number of qualifying individuals"
+    description: "Count of qualifying individuals with respect to the taxpayer per 26 USC 21(b)(1) - dependents under 13, incapable dependents, or incapable spouse"

--- a/statute/26/21/d.rac
+++ b/statute/26/21/d.rac
@@ -31,6 +31,12 @@ earned_income_limit:
         - 26/21/d/1/B#married_earned_income_limit
         - 26/21/d/2/A#deemed_earned_income_one_qualifying
         - 26/21/d/2/B#deemed_earned_income_two_or_more_qualifying
+        - 26/32/c/2#earned_income
+        - 26/7703/a#is_married
+        - 26/32/c/2#spouse_earned_income
+        - 26/21/b#number_of_qualifying_individuals
+        - 26/21/d/2#spouse_is_student_or_incapable
+        - 26/21/d/2#months_spouse_student_or_incapable
     entity: TaxUnit
     period: Year
     dtype: Money

--- a/statute/26/21/d/1/A.rac
+++ b/statute/26/21/d/1/A.rac
@@ -8,6 +8,9 @@ such year, such individual's earned income for such year, or
 status: encoded
 
 unmarried_earned_income_limit:
+    imports:
+        - 26/32/c/2#earned_income
+        - 26/7703/a#is_married
     entity: TaxUnit
     period: Year
     dtype: Money

--- a/statute/26/21/d/1/B.rac
+++ b/statute/26/21/d/1/B.rac
@@ -9,6 +9,10 @@ income of his spouse for such year.
 status: encoded
 
 married_earned_income_limit:
+    imports:
+        - 26/32/c/2#earned_income
+        - 26/7703/a#is_married
+        - 26/32/c/2#spouse_earned_income
     entity: TaxUnit
     period: Year
     dtype: Money

--- a/statute/26/21/d/2.rac
+++ b/statute/26/21/d/2.rac
@@ -1,0 +1,30 @@
+# 26 USC Section 21(d)(2) - Spouse deemed to be gainfully employed
+
+"""
+(2) Special rule for spouse who is a student or incapable of caring
+for himself.-- In the case of a spouse who is a student or a qualifying
+individual described in subsection (b)(1)(C), for purposes of paragraph
+(1), such spouse shall be deemed for each month during which such spouse
+is a full-time student at an educational organization described in
+section 170(b)(1)(A)(ii) or is such a qualifying individual to be
+gainfully employed and to have earned income of not less than--
+"""
+
+status: stub
+
+spouse_is_student_or_incapable:
+    imports:
+        - 26/152/f/2#is_full_time_student
+        - 26/21/b/1/C#is_spouse_qualifying_individual
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Spouse is student or incapable of self-care"
+    description: "Whether the spouse qualifies for deemed earned income under 26 USC 21(d)(2) - is a full-time student or incapable of self-care"
+
+months_spouse_student_or_incapable:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Months spouse is student or incapable"
+    description: "Number of months during the taxable year the spouse was a full-time student or incapable of self-care per 26 USC 21(d)(2)"

--- a/statute/26/21/e/2.rac
+++ b/statute/26/21/e/2.rac
@@ -10,6 +10,9 @@ file a joint return for the taxable year.
 status: encoded
 
 joint_return_required:
+    imports:
+        - 26/7703/a#files_joint_return
+        - 26/7703/a#is_married
     entity: TaxUnit
     period: Year
     dtype: Boolean

--- a/statute/26/21/e/3.rac
+++ b/statute/26/21/e/3.rac
@@ -17,6 +17,8 @@ legally_separated:
     default: false
 
 is_married_for_cdctc:
+    imports:
+        - 26/7703/a#is_married
     entity: Person
     period: Year
     dtype: Boolean

--- a/statute/26/21/e/7.rac
+++ b/statute/26/21/e/7.rac
@@ -15,6 +15,8 @@ required_full_time_student_months:
     from 2002-01-01: 5
 
 is_student_for_cdctc:
+    imports:
+        - 26/152/f/2#full_time_student_months
     entity: Person
     period: Year
     dtype: Boolean

--- a/statute/26/21/g/4/B.rac
+++ b/statute/26/21/g/4/B.rac
@@ -31,6 +31,8 @@ phaseout_rate_per_increment:
     from 2021-01-01: 0.01
 
 phaseout_percentage:
+    imports:
+        - 26/62#adjusted_gross_income
     entity: TaxUnit
     period: Year
     dtype: Rate

--- a/statute/26/32/c/2.rac
+++ b/statute/26/32/c/2.rac
@@ -1,0 +1,28 @@
+# 26 USC Section 32(c)(2) - Earned income
+
+"""
+(2) Earned income.--
+(A) The term "earned income" means--
+(i) wages, salaries, tips, and other employee compensation, but only
+if such amounts are includible in gross income for the taxable year, plus
+(ii) the amount of the taxpayer's net earnings from self-employment
+for the taxable year (within the meaning of section 1402(a)).
+"""
+
+status: stub
+
+earned_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Earned income"
+    description: "Earned income as defined by 26 USC 32(c)(2) - wages, salaries, tips, employee compensation, plus net self-employment earnings"
+
+spouse_earned_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Spouse's earned income"
+    description: "Earned income of the taxpayer's spouse, per the same definition in 26 USC 32(c)(2)"

--- a/statute/26/62/62.rac
+++ b/statute/26/62/62.rac
@@ -1,0 +1,17 @@
+# 26 USC Section 62 - Adjusted gross income defined
+
+"""
+(a) General rule.-- For purposes of this subtitle, the term "adjusted
+gross income" means, in the case of an individual, gross income minus
+the deductions specified in subsection (a).
+"""
+
+status: stub
+
+adjusted_gross_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Adjusted gross income"
+    description: "AGI as defined by 26 USC 62 - gross income minus specified deductions"

--- a/statute/26/7703/a.rac
+++ b/statute/26/7703/a.rac
@@ -1,0 +1,35 @@
+# 26 USC Section 7703(a) - Determination of marital status
+
+"""
+(a) General rule.-- For purposes of part V of subchapter B of chapter 1
+and those provisions of this title which refer to this subsection--
+(1) the determination of whether an individual is married shall be
+made as of the close of his taxable year; except that if his spouse dies
+during his taxable year such determination shall be made as of the time
+of such death; and
+(2) an individual legally separated from his spouse under a decree of
+divorce or of separate maintenance shall not be considered as married.
+"""
+
+status: stub
+
+is_married:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Is married"
+    description: "Whether the individual is married as determined under 26 USC 7703(a) - determined as of close of taxable year, or time of spouse's death"
+
+is_joint_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Files joint return"
+    description: "Whether the taxpayer files a joint return with spouse under 26 USC 6013"
+
+files_joint_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Files joint return"
+    description: "Alias for is_joint_return - whether the taxpayer files a joint return"


### PR DESCRIPTION
## Summary
- Creates 6 stub `.rac` files for variables referenced by 26 USC 21 encodings but defined in other IRC sections (AGI, earned income, marital status, student definition, etc.)
- Adds `imports:` blocks to 10 encoded `.rac` files to resolve all external variable references
- Stubs include statute text, proper entity/period/dtype metadata, and formulas where the statute provides a computable definition (e.g., `is_full_time_student` in 26 USC 152(f)(2))

## Test plan
- [ ] `python -m rac.validate imports statute/` passes (all imports resolve)
- [ ] `python -m rac.validate schema statute/` passes (all files valid)
- [ ] Stub files are accessible on ruleatlas.org after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)