### PR TITLE
Encode 26 USC 63 (taxable income): 31 .rac files + 21 tests

### DIFF
--- a/statute/26/151/151.rac
+++ b/statute/26/151/151.rac
@@ -1,0 +1,10 @@
+# 26 USC Section 151 - Allowance of deductions for personal exemptions
+
+status: stub
+
+personal_exemption_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    label: "Personal exemption deduction"
+    description: "Deduction for personal exemptions per 26 USC 151. Note: effectively zero for taxable years 2018-2025 per section 151(d)(5)."

--- a/statute/26/224/224.rac
+++ b/statute/26/224/224.rac
@@ -1,0 +1,10 @@
+# 26 USC Section 224 - Cross-reference
+status: stub
+
+section_224_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 224 deduction"
+    description: "Deduction provided in section 224"

--- a/statute/26/63/a.rac
+++ b/statute/26/63/a.rac
@@ -1,0 +1,36 @@
+# 26 USC 63(a) - In general
+
+"""
+(a) In general.-- Except as provided in subsection (b), for purposes
+of this subtitle, the term "taxable income" means gross income minus
+the deductions allowed by this chapter (other than the standard
+deduction).
+"""
+
+gross_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Gross income"
+    description: "Gross income as defined by 26 USC 61"
+    default: 0
+
+deductions_other_than_standard:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Deductions other than the standard deduction"
+    description: "Deductions allowed by chapter 1 other than the standard deduction"
+    default: 0
+
+taxable_income_general:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Taxable income (general rule)"
+    description: "Taxable income defined as gross income minus deductions other than the standard deduction, per 26 USC 63(a)"
+    from 2024-01-01:
+        gross_income - deductions_other_than_standard

--- a/statute/26/63/a.rac.test
+++ b/statute/26/63/a.rac.test
@@ -1,0 +1,37 @@
+# 26 USC 63(a) tests
+
+taxable_income_general:
+    - name: "Basic subtraction"
+      period: 2024-01
+      inputs:
+          gross_income: 100_000
+          deductions_other_than_standard: 25_000
+      expect: 75_000
+
+    - name: "No deductions"
+      period: 2024-01
+      inputs:
+          gross_income: 50_000
+          deductions_other_than_standard: 0
+      expect: 50_000
+
+    - name: "Zero gross income"
+      period: 2024-01
+      inputs:
+          gross_income: 0
+          deductions_other_than_standard: 10_000
+      expect: -10_000
+
+    - name: "Deductions equal gross income"
+      period: 2024-01
+      inputs:
+          gross_income: 75_000
+          deductions_other_than_standard: 75_000
+      expect: 0
+
+    - name: "Deductions exceed gross income"
+      period: 2024-01
+      inputs:
+          gross_income: 30_000
+          deductions_other_than_standard: 45_000
+      expect: -15_000

--- a/statute/26/63/b/2.rac
+++ b/statute/26/63/b/2.rac
@@ -1,0 +1,18 @@
+# 26 USC Section 63(b)(2) - Personal exemptions
+
+"""
+(2) the deduction for personal exemptions provided in section 151,
+"""
+
+status: encoded
+
+deduction_for_personal_exemptions:
+    imports:
+        - 26/151/151#personal_exemption_deduction
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    label: "Deduction for personal exemptions"
+    description: "Deduction for personal exemptions provided in section 151, per 26 USC 63(b)(2)"
+    from 1944-01-01:
+        personal_exemption_deduction

--- a/statute/26/63/b/2.rac.test
+++ b/statute/26/63/b/2.rac.test
@@ -1,0 +1,20 @@
+# 26 USC Section 63(b)(2) tests
+
+deduction_for_personal_exemptions:
+    - name: "No personal exemption (TCJA era)"
+      period: 2024-01
+      inputs:
+        personal_exemption_deduction: 0
+      expect: 0
+
+    - name: "Pre-TCJA personal exemption amount"
+      period: 2017-01
+      inputs:
+        personal_exemption_deduction: 4050
+      expect: 4050
+
+    - name: "Family with multiple exemptions"
+      period: 2017-01
+      inputs:
+        personal_exemption_deduction: 16200
+      expect: 16200

--- a/statute/26/63/b/3.rac
+++ b/statute/26/63/b/3.rac
@@ -1,0 +1,16 @@
+# 26 USC Section 63(b)(3) - Section 199A deduction
+
+"""
+(3) any deduction provided in section 199A,
+"""
+
+status: encoded
+
+section_199a_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 199A deduction"
+    description: "Qualified business income deduction provided in section 199A, allowable as a below-the-line deduction for non-itemizers per 26 USC 63(b)(3)"
+    default: 0

--- a/statute/26/63/b/4.rac
+++ b/statute/26/63/b/4.rac
@@ -1,0 +1,16 @@
+# 26 USC Section 63(b)(4) - Section 170(p) deduction
+
+"""
+(4) the deduction provided in section 170(p),
+"""
+
+status: encoded
+
+section_170p_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 170(p) deduction"
+    description: "Charitable contributions deduction for non-itemizers provided in section 170(p), allowable as a below-the-line deduction per 26 USC 63(b)(4)"
+    default: 0

--- a/statute/26/63/b/5.rac
+++ b/statute/26/63/b/5.rac
@@ -1,0 +1,19 @@
+# 26 USC Section 63(b)(5) - Section 224 deduction
+
+"""
+(5) the deduction provided in section 224,
+"""
+
+status: encoded
+
+section_224_deduction_amount:
+    imports:
+        - 26/224#section_224_deduction
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 224 deduction"
+    description: "Deduction provided in section 224, subtracted from AGI for non-itemizers per 26 USC 63(b)(5)"
+    from 2025-01-01:
+        section_224_deduction

--- a/statute/26/63/b/5.rac.test
+++ b/statute/26/63/b/5.rac.test
@@ -1,0 +1,20 @@
+# 26 USC Section 63(b)(5) tests
+
+section_224_deduction_amount:
+    - name: "No section 224 deduction"
+      period: 2025-01
+      inputs:
+        section_224_deduction: 0
+      expect: 0
+
+    - name: "Section 224 deduction of 4000"
+      period: 2025-01
+      inputs:
+        section_224_deduction: 4000
+      expect: 4000
+
+    - name: "Section 224 deduction of 10000"
+      period: 2025-01
+      inputs:
+        section_224_deduction: 10000
+      expect: 10000

--- a/statute/26/63/b/6.rac
+++ b/statute/26/63/b/6.rac
@@ -1,0 +1,16 @@
+# 26 USC Section 63(b)(6) - Section 225 deduction
+
+"""
+(6) the deduction provided in section 225
+"""
+
+status: encoded
+
+section_225_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 225 deduction"
+    description: "Deduction provided in section 225, subtracted from AGI for non-itemizers per 26 USC 63(b)(6)"
+    default: 0

--- a/statute/26/63/b/7.rac
+++ b/statute/26/63/b/7.rac
@@ -1,0 +1,17 @@
+# 26 USC Section 63(b)(7) - Section 163 mortgage interest deduction
+
+"""
+(7) so much of the deduction allowed by section 163(a) as is
+attributable to the exception under section 163(h)(4)(A).
+"""
+
+status: encoded
+
+qualified_residence_interest_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Qualified residence interest deduction"
+    description: "Deduction allowed by section 163(a) attributable to the exception for qualified residence interest under section 163(h)(4)(A), allowable as a below-the-line deduction for non-itemizers per 26 USC 63(b)(7)"
+    default: 0

--- a/statute/26/63/c.rac
+++ b/statute/26/63/c.rac
@@ -1,0 +1,238 @@
+# 26 USC 63(c) - Standard deduction
+
+"""
+(c) Standard deduction.-- For purposes of this subtitle--
+
+(1) In general.-- Except as otherwise provided in this subsection,
+the term "standard deduction" means the sum of--
+(A) the basic standard deduction, and
+(B) the additional standard deduction.
+
+(2) Basic standard deduction.-- For purposes of paragraph (1), the
+basic standard deduction is--
+(A) 200 percent of the dollar amount in effect under subparagraph (C)
+for the taxable year in the case of--
+(i) a joint return, or
+(ii) a surviving spouse (as defined in section 2(a)),
+(B) $4,400 in the case of a head of household (as defined in
+section 2(b)), or
+(C) $3,000 in any other case.
+
+(3) Additional standard deduction for aged and blind.-- For purposes
+of paragraph (1), the additional standard deduction is the sum of each
+additional amount to which the taxpayer is entitled under subsection (f).
+
+(4) Adjustments for inflation.-- In the case of any taxable year
+beginning in a calendar year after 1988, each dollar amount contained
+in paragraph (2)(B), (2)(C), or (5) or subsection (f) shall be
+increased by an amount equal to--
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, by
+substituting for "calendar year 2016" in subparagraph (A)(ii)
+thereof--
+(i) "calendar year 1987" in the case of the dollar amounts contained
+in paragraph (2)(B), (2)(C), or (5)(A) or subsection (f), and
+(ii) "calendar year 1997" in the case of the dollar amount contained
+in paragraph (5)(B).
+
+(5) Limitation on basic standard deduction in the case of certain
+dependents.-- In the case of an individual with respect to whom a
+deduction under section 151 is allowable to another taxpayer for a
+taxable year beginning in the calendar year in which the individual's
+taxable year begins, the basic standard deduction applicable to such
+individual for such individual's taxable year shall not exceed the
+greater of--
+(A) $500, or
+(B) the sum of $250 and such individual's earned income.
+
+(6) Certain individuals, etc., not eligible for standard deduction.--
+In the case of--
+(A) a married individual filing a separate return where either spouse
+itemizes deductions,
+(B) a nonresident alien individual,
+(C) an individual making a return under section 443(a)(1) for a
+period of less than 12 months on account of a change in his annual
+accounting period, or
+(D) an estate or trust, common trust fund, or partnership,
+the standard deduction shall be zero.
+
+(7) Special rules for taxable years beginning after 2017.-- In the
+case of a taxable year beginning after December 31, 2017--
+(A) Increase in standard deduction.-- Paragraph (2) shall be
+applied--
+(i) by substituting "$23,625" for "$4,400" in subparagraph (B), and
+(ii) by substituting "$15,750" for "$3,000" in subparagraph (C).
+(B) Adjustment for inflation.--
+(i) In general.-- Paragraph (4) shall not apply to the dollar amounts
+contained in paragraphs (2)(B) and (2)(C).
+(ii) Adjustment of increased amounts.-- In the case of a taxable year
+beginning after 2025, the $23,625 and $15,750 amounts in
+subparagraph (A) shall each be increased by an amount equal to--
+(I) such dollar amount, multiplied by
+(II) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2024" for "2016" in subparagraph (A)(ii) thereof.
+If any increase under this clause is not a multiple of $50, such
+increase shall be rounded to the next lowest multiple of $50.
+"""
+
+status: encoded
+
+# ============================================================
+# (c)(2)(C) - Basic standard deduction: any other case
+# ============================================================
+
+# Statutory base amount per (c)(2)(C), as modified by (c)(7)(A)(ii)
+# for taxable years after 2017
+basic_standard_deduction_other:
+    description: "Basic standard deduction in any other case per 26 USC 63(c)(2)(C), as modified by 63(c)(7)(A)(ii)"
+    unit: USD
+    from 1988-01-01: 3000
+    from 2018-01-01: 15750
+
+# ============================================================
+# (c)(5) - Dependent limitation parameters
+# ============================================================
+
+# (c)(5)(A) minimum
+dependent_standard_deduction_min:
+    description: "Minimum basic standard deduction for dependents per 26 USC 63(c)(5)(A)"
+    unit: USD
+    from 1988-01-01: 500
+
+# (c)(5)(B) earned income addition
+dependent_earned_income_addition:
+    description: "Addition to earned income for dependent standard deduction per 26 USC 63(c)(5)(B)"
+    unit: USD
+    from 1988-01-01: 250
+
+# ============================================================
+# Inputs
+# ============================================================
+
+is_dependent:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Is a dependent"
+    description: "Whether the individual has a deduction under section 151 allowable to another taxpayer per 26 USC 63(c)(5)"
+    default: false
+
+earned_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Earned income"
+    description: "Individual's earned income for dependent standard deduction calculation per 26 USC 63(c)(5)(B)"
+    default: 0
+
+additional_standard_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Additional standard deduction"
+    description: "Sum of additional amounts under subsection (f) for aged and blind per 26 USC 63(c)(3)"
+    default: 0
+
+# (c)(6) disqualifying conditions
+
+is_married_separate_with_itemizing_spouse:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Married filing separately with itemizing spouse"
+    description: "Married individual filing a separate return where either spouse itemizes deductions per 26 USC 63(c)(6)(A)"
+    default: false
+
+is_nonresident_alien:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Nonresident alien individual"
+    description: "Whether the individual is a nonresident alien per 26 USC 63(c)(6)(B)"
+    default: false
+
+is_short_period_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Short period return"
+    description: "Whether the return is for less than 12 months due to accounting period change per 26 USC 63(c)(6)(C)"
+    default: false
+
+is_estate_trust_or_partnership:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Estate, trust, or partnership"
+    description: "Whether the filer is an estate, trust, common trust fund, or partnership per 26 USC 63(c)(6)(D)"
+    default: false
+
+# ============================================================
+# (c)(6) - Standard deduction disqualification
+# ============================================================
+
+is_disqualified_from_standard_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Disqualified from standard deduction"
+    description: "Whether the individual is ineligible for the standard deduction per 26 USC 63(c)(6)"
+    from 1988-01-01:
+        is_married_separate_with_itemizing_spouse or is_nonresident_alien or is_short_period_return or is_estate_trust_or_partnership
+
+# ============================================================
+# (c)(2) - Basic standard deduction (before dependent limit)
+# ============================================================
+
+basic_standard_deduction_pre_limit:
+    imports:
+        - 26/63/c/2/A/i#qualifies_as_joint_return
+        - 26/63/c/2/A/ii#is_surviving_spouse
+        - 26/63/c/2/B#basic_standard_deduction_hoh
+        - 26/63/c/2/B#is_head_of_household
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Basic standard deduction before dependent limitation"
+    description: "Basic standard deduction per 26 USC 63(c)(2), before application of 63(c)(5) dependent limitation"
+    from 1988-01-01:
+        if qualifies_as_joint_return or is_surviving_spouse: 2 * basic_standard_deduction_other
+        elif is_head_of_household: basic_standard_deduction_hoh
+        else: basic_standard_deduction_other
+
+# ============================================================
+# (c)(5) - Basic standard deduction with dependent limitation
+# ============================================================
+
+basic_standard_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Basic standard deduction"
+    description: "Basic standard deduction per 26 USC 63(c)(2) with dependent limitation per 63(c)(5)"
+    from 1988-01-01:
+        if is_dependent:
+            dependent_limit = max(dependent_standard_deduction_min, dependent_earned_income_addition + earned_income)
+            min(basic_standard_deduction_pre_limit, dependent_limit)
+        else: basic_standard_deduction_pre_limit
+
+# ============================================================
+# (c)(1) - Standard deduction
+# ============================================================
+
+standard_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Standard deduction"
+    description: "Standard deduction per 26 USC 63(c)(1): sum of basic and additional standard deductions, or zero if disqualified per 63(c)(6)"
+    from 1988-01-01:
+        if is_disqualified_from_standard_deduction: 0
+        else: basic_standard_deduction + additional_standard_deduction

--- a/statute/26/63/c.rac.test
+++ b/statute/26/63/c.rac.test
@@ -1,0 +1,108 @@
+# 26 USC 63(c) tests
+
+standard_deduction:
+    - name: "Single filer, not dependent, no additional - post-2017"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: false
+          earned_income: 50000
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 15750
+
+    - name: "Joint filer - post-2017 (200% of single amount)"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: true
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: false
+          earned_income: 80000
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 31500
+
+    - name: "Head of household - post-2017"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: true
+          basic_standard_deduction_hoh: 23625
+          is_dependent: false
+          earned_income: 40000
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 23625
+
+    - name: "Dependent with low earned income - capped at minimum"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: true
+          earned_income: 100
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 500
+
+    - name: "Dependent with earned income above minimum but below standard"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: true
+          earned_income: 5000
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 5250
+
+    - name: "Disqualified - nonresident alien"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: false
+          earned_income: 50000
+          additional_standard_deduction: 0
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: true
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 0
+
+    - name: "Single with additional standard deduction for aged"
+      period: 2024-01
+      inputs:
+          qualifies_as_joint_return: false
+          is_surviving_spouse: false
+          is_head_of_household: false
+          is_dependent: false
+          earned_income: 30000
+          additional_standard_deduction: 1950
+          is_married_separate_with_itemizing_spouse: false
+          is_nonresident_alien: false
+          is_short_period_return: false
+          is_estate_trust_or_partnership: false
+      expect: 17700

--- a/statute/26/63/c/2/A/i.rac
+++ b/statute/26/63/c/2/A/i.rac
@@ -1,0 +1,18 @@
+# 26 USC 63(c)(2)(A)(i) - Joint return
+
+"""
+(i) a joint return, or
+"""
+
+status: encoded
+
+qualifies_as_joint_return:
+    imports:
+        - 26/7703/a#is_joint_return
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Qualifies under joint return clause"
+    description: "Whether the tax unit qualifies for the basic standard deduction under 26 USC 63(c)(2)(A)(i) by filing a joint return"
+    from 1986-01-01:
+        is_joint_return

--- a/statute/26/63/c/2/A/i.rac.test
+++ b/statute/26/63/c/2/A/i.rac.test
@@ -1,0 +1,20 @@
+# 26 USC 63(c)(2)(A)(i) tests
+
+qualifies_as_joint_return:
+    - name: "Joint return filer qualifies"
+      period: 2024-01
+      inputs:
+        is_joint_return: true
+      expect: true
+
+    - name: "Non-joint filer does not qualify"
+      period: 2024-01
+      inputs:
+        is_joint_return: false
+      expect: false
+
+    - name: "Joint return filer qualifies (earlier year)"
+      period: 2000-01
+      inputs:
+        is_joint_return: true
+      expect: true

--- a/statute/26/63/c/2/A/ii.rac
+++ b/statute/26/63/c/2/A/ii.rac
@@ -1,0 +1,13 @@
+# 26 USC 63(c)(2)(A)(ii) - Surviving spouse
+
+"""
+(ii) a surviving spouse (as defined in section 2(a)),
+"""
+
+is_surviving_spouse:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Surviving spouse"
+    description: "Whether the taxpayer is a surviving spouse as defined in section 2(a), per 26 USC 63(c)(2)(A)(ii)"
+    default: false

--- a/statute/26/63/c/2/B.rac
+++ b/statute/26/63/c/2/B.rac
@@ -1,0 +1,27 @@
+# 26 USC 63(c)(2)(B) - Head of household
+
+"""
+(B) $4,400 in the case of a head of household (as defined in section 2(b)), or
+"""
+
+# Per 63(c)(7)(A)(i), for taxable years beginning after 2017,
+# paragraph (2) is applied by substituting "$23,625" for "$4,400"
+# in subparagraph (B).
+# Per 63(c)(4), the $4,400 amount is adjusted for inflation for
+# taxable years beginning after 1988 (base year 1987).
+# Per 63(c)(7)(B)(ii), after 2025 the $23,625 amount is adjusted
+# for inflation (base year 2024).
+
+basic_standard_deduction_hoh:
+    description: "Basic standard deduction for head of household per 26 USC 63(c)(2)(B)"
+    unit: USD
+    from 1988-01-01: 4400
+    from 2018-01-01: 23625
+
+is_head_of_household:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Head of household"
+    description: "Whether the taxpayer is a head of household as defined in section 2(b), per 26 USC 63(c)(2)(B)"
+    default: false

--- a/statute/26/63/c/2/B.rac.test
+++ b/statute/26/63/c/2/B.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 63(c)(2)(B) tests
+
+basic_standard_deduction_hoh:
+    - name: "Pre-TCJA value (1988-2017)"
+      period: 2017-01
+      inputs: {}
+      expect: 4400
+
+    - name: "Post-TCJA value (2018+)"
+      period: 2024-01
+      inputs: {}
+      expect: 23625
+
+    - name: "First year of TCJA increase"
+      period: 2018-01
+      inputs: {}
+      expect: 23625

--- a/statute/26/63/c/2/C.rac
+++ b/statute/26/63/c/2/C.rac
@@ -1,0 +1,19 @@
+# 26 USC 63(c)(2)(C) - Any other case
+
+"""
+(C) $3,000 in any other case.
+"""
+
+# Per 63(c)(7)(A)(ii), for taxable years beginning after 2017,
+# paragraph (2) is applied by substituting "$15,750" for "$3,000"
+# in subparagraph (C).
+# Per 63(c)(4), the $3,000 amount is adjusted for inflation for
+# taxable years beginning after 1988 (base year 1987).
+# Per 63(c)(7)(B)(ii), after 2025 the $15,750 amount is adjusted
+# for inflation (base year 2024).
+
+basic_standard_deduction_other:
+    description: "Basic standard deduction in any other case per 26 USC 63(c)(2)(C)"
+    unit: USD
+    from 1988-01-01: 3000
+    from 2018-01-01: 15750

--- a/statute/26/63/c/2/C.rac.test
+++ b/statute/26/63/c/2/C.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 63(c)(2)(C) tests
+
+basic_standard_deduction_other:
+    - name: "Pre-TCJA base amount"
+      period: 2017-01
+      inputs: {}
+      expect: 3000
+
+    - name: "Post-TCJA amount (2018)"
+      period: 2018-01
+      inputs: {}
+      expect: 15750
+
+    - name: "Post-TCJA amount (2024)"
+      period: 2024-01
+      inputs: {}
+      expect: 15750

--- a/statute/26/63/c/4/A.rac
+++ b/statute/26/63/c/4/A.rac
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(4)(A) - Dollar amount
+
+"""
+(A) such dollar amount, multiplied by
+"""
+
+# This subparagraph identifies the first operand of the inflation
+# adjustment formula in 63(c)(4): the base dollar amounts from
+# paragraphs (2)(B), (2)(C), (5), and subsection (f).
+# Those amounts are defined in their respective files.
+# The parent section 63(c)(4) combines (A) and (B) to compute
+# the inflation-adjusted increase.
+
+status: boilerplate

--- a/statute/26/63/c/4/B/i.rac
+++ b/statute/26/63/c/4/B/i.rac
@@ -1,0 +1,13 @@
+# 26 USC 63(c)(4)(B)(i) - Calendar year 1987 base
+
+"""
+(i) "calendar year 1987" in the case of the dollar amounts contained
+in paragraph (2)(B), (2)(C), or (5)(A) or subsection (f), and
+"""
+
+status: encoded
+
+cola_base_year_standard_deduction:
+    description: "Base calendar year substituted into section 1(f)(3) for the dollar amounts in paragraphs (2)(B), (2)(C), (5)(A), and subsection (f) per 26 USC 63(c)(4)(B)(i)"
+    unit: Year
+    from 1989-01-01: 1987

--- a/statute/26/63/c/4/B/i.rac.test
+++ b/statute/26/63/c/4/B/i.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(4)(B)(i) tests
+
+cola_base_year_standard_deduction:
+    - name: "Base year is 1987 for taxable year 1989"
+      period: 1989-01
+      expect: 1987
+
+    - name: "Base year is 1987 for taxable year 2000"
+      period: 2000-01
+      expect: 1987
+
+    - name: "Base year is 1987 for taxable year 2024"
+      period: 2024-01
+      expect: 1987

--- a/statute/26/63/c/4/B/ii.rac
+++ b/statute/26/63/c/4/B/ii.rac
@@ -1,0 +1,13 @@
+# 26 USC 63(c)(4)(B)(ii) - Calendar year 1997 base
+
+"""
+(ii) "calendar year 1997" in the case of the dollar amount contained
+in paragraph (5)(B).
+"""
+
+status: encoded
+
+cola_base_year_dependent_earned_income:
+    description: "Base calendar year substituted into section 1(f)(3) for the dollar amount in paragraph (5)(B) per 26 USC 63(c)(4)(B)(ii)"
+    unit: Year
+    from 1989-01-01: 1997

--- a/statute/26/63/c/4/B/ii.rac.test
+++ b/statute/26/63/c/4/B/ii.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(4)(B)(ii) tests
+
+cola_base_year_dependent_earned_income:
+    - name: "Base year is 1997 for taxable year 1989"
+      period: 1989-01
+      expect: 1997
+
+    - name: "Base year is 1997 for taxable year 2000"
+      period: 2000-01
+      expect: 1997
+
+    - name: "Base year is 1997 for taxable year 2024"
+      period: 2024-01
+      expect: 1997

--- a/statute/26/63/c/5/A.rac
+++ b/statute/26/63/c/5/A.rac
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(5)(A) - $500 floor
+
+"""
+(A) $500, or
+"""
+
+# This is the floor amount for the basic standard deduction of
+# dependents under 63(c)(5). Per 63(c)(4), this amount is adjusted
+# for inflation for taxable years beginning after 1988 (base year 1987).
+
+dependent_standard_deduction_floor:
+    description: "Floor amount for dependent basic standard deduction per 26 USC 63(c)(5)(A)"
+    unit: USD
+    from 1988-01-01: 500

--- a/statute/26/63/c/5/A.rac.test
+++ b/statute/26/63/c/5/A.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 63(c)(5)(A) tests
+
+dependent_standard_deduction_floor:
+    - name: "Base amount (1988)"
+      period: 1988-01
+      inputs: {}
+      expect: 500
+
+    - name: "Amount in 2000"
+      period: 2000-01
+      inputs: {}
+      expect: 500
+
+    - name: "Amount in 2024"
+      period: 2024-01
+      inputs: {}
+      expect: 500

--- a/statute/26/63/c/5/B.rac
+++ b/statute/26/63/c/5/B.rac
@@ -1,0 +1,25 @@
+# 26 USC 63(c)(5)(B) - Earned income plus $250
+
+"""
+(B) the sum of $250 and such individual's earned income.
+"""
+
+# The $250 amount is subject to inflation adjustment per 63(c)(4),
+# with base calendar year 1997 per 63(c)(4)(B)(ii).
+
+status: encoded
+
+dependent_earned_income_addition:
+    description: "Dollar amount added to earned income for dependent standard deduction per 26 USC 63(c)(5)(B)"
+    unit: USD
+    from 1989-01-01: 250
+
+dependent_basic_standard_deduction_earned_income_component:
+    entity: Person
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Dependent earned income component"
+    description: "Sum of $250 and earned income for dependent basic standard deduction per 26 USC 63(c)(5)(B)"
+    from 1989-01-01:
+        dependent_earned_income_addition + earned_income

--- a/statute/26/63/c/5/B.rac.test
+++ b/statute/26/63/c/5/B.rac.test
@@ -1,0 +1,26 @@
+# 26 USC 63(c)(5)(B) tests
+
+dependent_basic_standard_deduction_earned_income_component:
+    - name: "Zero earned income"
+      period: 2024-01
+      inputs:
+        earned_income: 0
+      expect: 250
+
+    - name: "Earned income of $3000"
+      period: 2024-01
+      inputs:
+        earned_income: 3000
+      expect: 3250
+
+    - name: "Small earned income"
+      period: 2024-01
+      inputs:
+        earned_income: 100
+      expect: 350
+
+    - name: "Large earned income"
+      period: 2024-01
+      inputs:
+        earned_income: 15000
+      expect: 15250

--- a/statute/26/63/c/6/A.rac
+++ b/statute/26/63/c/6/A.rac
@@ -1,0 +1,32 @@
+# 26 USC 63(c)(6)(A) - Married filing separate where spouse itemizes
+
+"""
+(A) a married individual filing a separate return where either spouse itemizes deductions,
+"""
+
+status: encoded
+
+is_married_filing_separately:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Married filing separately"
+    description: "Whether the taxpayer is a married individual filing a separate return per 26 USC 63(c)(6)(A)"
+    default: false
+
+either_spouse_itemizes:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Either spouse itemizes deductions"
+    description: "Whether either spouse itemizes deductions per 26 USC 63(c)(6)(A)"
+    default: false
+
+mfs_spouse_itemizes_no_standard_deduction:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "MFS spouse itemizes - no standard deduction"
+    description: "Whether the standard deduction is zero because the taxpayer is a married individual filing separately where either spouse itemizes deductions per 26 USC 63(c)(6)(A)"
+    from 1986-01-01:
+        is_married_filing_separately and either_spouse_itemizes

--- a/statute/26/63/c/6/A.rac.test
+++ b/statute/26/63/c/6/A.rac.test
@@ -1,0 +1,30 @@
+# 26 USC 63(c)(6)(A) tests
+
+mfs_spouse_itemizes_no_standard_deduction:
+    - name: "MFS and spouse itemizes - standard deduction is zero"
+      period: 2024-01
+      inputs:
+        is_married_filing_separately: true
+        either_spouse_itemizes: true
+      expect: true
+
+    - name: "MFS but neither spouse itemizes - standard deduction allowed"
+      period: 2024-01
+      inputs:
+        is_married_filing_separately: true
+        either_spouse_itemizes: false
+      expect: false
+
+    - name: "Not MFS even though spouse itemizes - standard deduction allowed"
+      period: 2024-01
+      inputs:
+        is_married_filing_separately: false
+        either_spouse_itemizes: true
+      expect: false
+
+    - name: "Not MFS and no itemizing - standard deduction allowed"
+      period: 2024-01
+      inputs:
+        is_married_filing_separately: false
+        either_spouse_itemizes: false
+      expect: false

--- a/statute/26/63/c/6/B.rac
+++ b/statute/26/63/c/6/B.rac
@@ -1,0 +1,18 @@
+# 26 USC 63(c)(6)(B) - Nonresident alien individual
+
+"""
+(B) a nonresident alien individual,
+"""
+
+status: encoded
+
+ineligible_for_standard_deduction_nonresident_alien:
+    imports:
+        - 26/32/c/1/D#is_nonresident_alien
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Ineligible for standard deduction as nonresident alien"
+    description: "A nonresident alien individual is not eligible for the standard deduction per 26 USC 63(c)(6)(B)"
+    from 1944-01-01:
+        is_nonresident_alien

--- a/statute/26/63/c/6/B.rac.test
+++ b/statute/26/63/c/6/B.rac.test
@@ -1,0 +1,20 @@
+# 26 USC 63(c)(6)(B) tests
+
+ineligible_for_standard_deduction_nonresident_alien:
+    - name: "Nonresident alien is ineligible"
+      period: 2024-01
+      inputs:
+        is_nonresident_alien: true
+      expect: true
+
+    - name: "Resident is eligible (not ineligible)"
+      period: 2024-01
+      inputs:
+        is_nonresident_alien: false
+      expect: false
+
+    - name: "Nonresident alien in earlier year"
+      period: 2000-01
+      inputs:
+        is_nonresident_alien: true
+      expect: true

--- a/statute/26/63/c/6/C.rac
+++ b/statute/26/63/c/6/C.rac
@@ -1,0 +1,26 @@
+# 26 USC 63(c)(6)(C) - Short-year return
+
+"""
+(C) an individual making a return under section 443(a)(1) for a period
+of less than 12 months on account of a change in his annual accounting
+period, or
+"""
+
+status: encoded
+
+is_short_year_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Short-year return under section 443(a)(1)"
+    description: "Whether the individual is making a return under section 443(a)(1) for a period of less than 12 months on account of a change in annual accounting period"
+    default: false
+
+ineligible_for_standard_deduction_short_year:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Ineligible for standard deduction due to short-year return"
+    description: "An individual making a short-year return under section 443(a)(1) is not eligible for the standard deduction per 26 USC 63(c)(6)(C)"
+    from 1986-01-01:
+        is_short_year_return

--- a/statute/26/63/c/6/C.rac.test
+++ b/statute/26/63/c/6/C.rac.test
@@ -1,0 +1,25 @@
+# 26 USC 63(c)(6)(C) tests - Short-year return
+
+ineligible_for_standard_deduction_short_year:
+    - name: "Short-year return filer - no standard deduction"
+      period: 2024-01
+      inputs:
+        is_short_year_return: true
+      expect: true
+
+    - name: "Normal full-year return - standard deduction allowed"
+      period: 2024-01
+      inputs:
+        is_short_year_return: false
+      expect: false
+
+    - name: "Default - not a short-year return"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Short-year return in 2025"
+      period: 2025-01
+      inputs:
+        is_short_year_return: true
+      expect: true

--- a/statute/26/63/c/6/D.rac
+++ b/statute/26/63/c/6/D.rac
@@ -1,0 +1,18 @@
+# 26 USC 63(c)(6)(D) - Estate or trust, common trust fund, or partnership
+
+"""
+(D) an estate or trust, common trust fund, or partnership,
+
+the standard deduction shall be zero.
+"""
+
+# This subparagraph identifies estates, trusts, common trust funds, and
+# partnerships as ineligible for the standard deduction.
+# The parent 63(c)(6) sets the standard deduction to zero for such entities.
+
+is_estate_trust_or_partnership:
+    description: "Whether the filer is an estate, trust, common trust fund, or partnership"
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    default: false

--- a/statute/26/63/c/6/D.rac.test
+++ b/statute/26/63/c/6/D.rac.test
@@ -1,0 +1,19 @@
+# 26 USC 63(c)(6)(D) tests - Estate or trust, common trust fund, or partnership
+
+is_estate_trust_or_partnership:
+    - name: "Default - not an estate, trust, or partnership"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Estate or trust filer"
+      period: 2024-01
+      inputs:
+          is_estate_trust_or_partnership: true
+      expect: true
+
+    - name: "Normal individual filer in 2025"
+      period: 2025-01
+      inputs:
+          is_estate_trust_or_partnership: false
+      expect: false

--- a/statute/26/63/c/7/A/i.rac
+++ b/statute/26/63/c/7/A/i.rac
@@ -1,0 +1,18 @@
+# 26 USC 63(c)(7)(A)(i) - Head of household substitution
+
+"""
+(i) by substituting "$23,625" for "$4,400" in subparagraph (B), and
+"""
+
+status: encoded
+
+# This clause directs that for taxable years beginning after 2017,
+# the basic standard deduction for head of household under 63(c)(2)(B)
+# uses $23,625 instead of the original $4,400.
+# Per 63(c)(7)(B)(ii), after 2025 this amount is adjusted for inflation
+# (base year 2024).
+
+hoh_substitution_amount:
+    description: "Substituted basic standard deduction amount for head of household per 26 USC 63(c)(7)(A)(i)"
+    unit: USD
+    from 2018-01-01: 23625

--- a/statute/26/63/c/7/A/i.rac.test
+++ b/statute/26/63/c/7/A/i.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(7)(A)(i) tests
+
+hoh_substitution_amount:
+    - name: "Post-2017 substitution amount is $23,625"
+      period: 2024-01
+      expect: 23625
+
+    - name: "2018 substitution amount is $23,625"
+      period: 2018-01
+      expect: 23625
+
+    - name: "2025 substitution amount is $23,625 (before inflation adjustment)"
+      period: 2025-01
+      expect: 23625

--- a/statute/26/63/c/7/A/ii.rac
+++ b/statute/26/63/c/7/A/ii.rac
@@ -1,0 +1,17 @@
+# 26 USC 63(c)(7)(A)(ii) - Other case substitution
+
+"""
+(ii) by substituting "$15,750" for "$3,000" in subparagraph (C).
+"""
+
+# For taxable years beginning after 2017, the basic standard deduction
+# for "any other case" (single filers) in paragraph (2)(C) is read as
+# $15,750 instead of $3,000. This substituted amount is applied directly
+# in the 63(c)(2)(C) encoding via a temporal entry.
+# Per 63(c)(7)(B)(ii), after 2025 this amount is adjusted for inflation
+# (base year 2024).
+
+other_case_substitution_amount:
+    description: "Substituted basic standard deduction for any other case per 26 USC 63(c)(7)(A)(ii)"
+    unit: USD
+    from 2018-01-01: 15750

--- a/statute/26/63/c/7/A/ii.rac.test
+++ b/statute/26/63/c/7/A/ii.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(7)(A)(ii) tests
+
+other_case_substitution_amount:
+    - name: "Substituted amount for 2018"
+      period: 2018-01
+      expect: 15750
+
+    - name: "Substituted amount for 2024"
+      period: 2024-01
+      expect: 15750
+
+    - name: "Substituted amount for 2025"
+      period: 2025-01
+      expect: 15750

--- a/statute/26/63/c/7/B/i.rac
+++ b/statute/26/63/c/7/B/i.rac
@@ -1,0 +1,18 @@
+# 26 USC 63(c)(7)(B)(i) - In general (paragraph 4 inapplicable)
+
+"""
+(i) In general
+Paragraph (4) shall not apply to the dollar amounts contained in
+paragraphs (2)(B) and (2)(C).
+"""
+
+status: encoded
+
+# This clause suspends the general inflation adjustment of paragraph (4)
+# for the basic standard deduction amounts in (2)(B) and (2)(C) for
+# taxable years beginning after 2017. Paragraph (7)(B)(ii) provides
+# a separate inflation adjustment for those amounts starting after 2025.
+
+para_4_inapplicable_to_2B_2C:
+    description: "Whether paragraph (4) inflation adjustment is inapplicable to the dollar amounts in paragraphs (2)(B) and (2)(C) per 26 USC 63(c)(7)(B)(i)"
+    from 2018-01-01: true

--- a/statute/26/63/c/7/B/i.rac.test
+++ b/statute/26/63/c/7/B/i.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 63(c)(7)(B)(i) tests
+
+para_4_inapplicable_to_2B_2C:
+    - name: "Inapplicable for 2018 (first year after 2017)"
+      period: 2018-01
+      inputs: {}
+      expect: true
+
+    - name: "Inapplicable for 2024"
+      period: 2024-01
+      inputs: {}
+      expect: true
+
+    - name: "Inapplicable for 2026 (post-TCJA extension)"
+      period: 2026-01
+      inputs: {}
+      expect: true

--- a/statute/26/63/c/7/B/ii/I.rac
+++ b/statute/26/63/c/7/B/ii/I.rac
@@ -1,0 +1,32 @@
+# 26 USC 63(c)(7)(B)(ii)(I) - Dollar amount
+
+"""
+(I) such dollar amount, multiplied by
+"""
+
+status: encoded
+
+# This subclause identifies the base dollar amounts from subparagraph (A)
+# that are subject to inflation adjustment after 2025.
+# "Such dollar amount" refers to the $23,625 (head of household) and
+# $15,750 (other cases) amounts established in 63(c)(7)(A).
+
+hoh_dollar_amount:
+    imports:
+        - 26/63/c/7/A/i#hoh_substitution_amount
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    description: "Head of household dollar amount subject to inflation adjustment per 26 USC 63(c)(7)(B)(ii)(I)"
+    from 2026-01-01:
+        return hoh_substitution_amount
+
+other_case_dollar_amount:
+    imports:
+        - 26/63/c/7/A/ii#other_case_substitution_amount
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    description: "Other case dollar amount subject to inflation adjustment per 26 USC 63(c)(7)(B)(ii)(I)"
+    from 2026-01-01:
+        return other_case_substitution_amount

--- a/statute/26/63/c/7/B/ii/I.rac.test
+++ b/statute/26/63/c/7/B/ii/I.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 63(c)(7)(B)(ii)(I) tests
+
+hoh_dollar_amount:
+    - name: "HoH dollar amount is $23,625 for 2026"
+      period: 2026-01
+      inputs:
+        hoh_substitution_amount: 23625
+      expect: 23625
+
+    - name: "HoH dollar amount passes through substitution amount"
+      period: 2027-01
+      inputs:
+        hoh_substitution_amount: 23625
+      expect: 23625

--- a/statute/26/63/c/7/B/ii/II.rac
+++ b/statute/26/63/c/7/B/ii/II.rac
@@ -1,0 +1,28 @@
+# 26 USC 63(c)(7)(B)(ii)(II) - Cost-of-living adjustment
+
+"""
+(II) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2024" for "2016" in subparagraph (A)(ii) thereof.
+"""
+
+status: encoded
+
+# This subclause specifies that the COLA for the post-2025 standard
+# deduction amounts uses section 1(f)(3) with a base year of 2024
+# instead of the default base year of 2016.
+
+cola_base_year_post_2025_standard_deduction:
+    description: "Base calendar year substituted for '2016' in section 1(f)(3)(A)(ii) for the post-2025 standard deduction inflation adjustment per 26 USC 63(c)(7)(B)(ii)(II)"
+    unit: Year
+    from 2026-01-01: 2024
+
+cola_adjustment:
+    imports:
+        - 26/1/f/3#cost_of_living_adjustment
+    entity: TaxUnit
+    period: Year
+    dtype: Rate
+    description: "Cost-of-living adjustment for the post-2025 standard deduction amounts, determined under section 1(f)(3) with base year 2024 per 26 USC 63(c)(7)(B)(ii)(II)"
+    from 2026-01-01:
+        return cost_of_living_adjustment

--- a/statute/26/63/c/7/B/ii/II.rac.test
+++ b/statute/26/63/c/7/B/ii/II.rac.test
@@ -1,0 +1,10 @@
+# 26 USC 63(c)(7)(B)(ii)(II) tests
+
+cola_base_year_post_2025_standard_deduction:
+    - name: "Base year is 2024 for post-2025 adjustment"
+      period: 2026-01
+      expect: 2024
+
+    - name: "Base year is 2024 for later year"
+      period: 2030-01
+      expect: 2024

--- a/statute/26/63/d/1.rac
+++ b/statute/26/63/d/1.rac
@@ -1,0 +1,16 @@
+# 26 USC 63(d)(1) - Above-the-line deductions excluded
+
+"""
+(1) the deductions allowable in arriving at adjusted gross income, and
+"""
+
+status: encoded
+
+above_the_line_deductions:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Deductions allowable in arriving at AGI"
+    description: "Total deductions allowable in arriving at adjusted gross income, excluded from itemized deductions per 26 USC 63(d)(1)"
+    default: 0

--- a/statute/26/63/e/1.rac
+++ b/statute/26/63/e/1.rac
@@ -1,0 +1,26 @@
+# 26 USC 63(e)(1) - In general
+
+"""
+(1) In general.-- Unless an individual makes an election under this
+subsection for the taxable year, no itemized deduction shall be allowed
+for the taxable year. For purposes of this subtitle, the determination
+of whether a deduction is allowable under this chapter shall be made
+without regard to the preceding sentence.
+"""
+
+elects_to_itemize:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Election to itemize deductions"
+    description: "Whether the individual elects to itemize deductions under 26 USC 63(e)"
+    default: false
+
+itemized_deductions_allowed:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Itemized deductions allowed"
+    description: "Itemized deductions are allowed only if the individual makes an election to itemize per 26 USC 63(e)(1)"
+    from 2024-01-01:
+        elects_to_itemize

--- a/statute/26/63/e/1.rac.test
+++ b/statute/26/63/e/1.rac.test
@@ -1,0 +1,19 @@
+# 26 USC 63(e)(1) tests
+
+itemized_deductions_allowed:
+    - name: "No election - itemized deductions not allowed"
+      period: 2024-01
+      inputs:
+        elects_to_itemize: false
+      expect: false
+
+    - name: "Election made - itemized deductions allowed"
+      period: 2024-01
+      inputs:
+        elects_to_itemize: true
+      expect: true
+
+    - name: "Default (no election) - itemized deductions not allowed"
+      period: 2025-01
+      inputs: {}
+      expect: false

--- a/statute/26/63/e/2.rac
+++ b/statute/26/63/e/2.rac
@@ -1,0 +1,10 @@
+# 26 USC 63(e)(2) - Time and manner of election
+
+"""
+(2) Time and manner of election.--
+Any election under this subsection shall be made on the taxpayer's
+return, and the Secretary shall prescribe the manner of signifying
+such election on the return.
+"""
+
+status: boilerplate

--- a/statute/26/63/e/3/A.rac
+++ b/statute/26/63/e/3/A.rac
@@ -1,0 +1,9 @@
+# 26 USC 63(e)(3)(A) - Spouse consistent change
+
+"""
+(A) the spouse makes a change of election with respect to itemized
+deductions, for the taxable year covered in such separate return,
+consistent with the change of treatment sought by the taxpayer, and
+"""
+
+status: boilerplate

--- a/statute/26/63/e/3/B.rac
+++ b/statute/26/63/e/3/B.rac
@@ -1,0 +1,12 @@
+# 26 USC 63(e)(3)(B) - Written consent to assessment
+
+"""
+(B) the taxpayer and his spouse consent in writing to the assessment
+(within such period as may be agreed on with the Secretary) of any
+deficiency, to the extent attributable to such change of election,
+even though at the time of the filing of such consent the assessment
+of such deficiency would otherwise be prevented by the operation of
+any law or rule of law.
+"""
+
+status: boilerplate

--- a/statute/26/9999/9999.rac
+++ b/statute/26/9999/9999.rac
@@ -1,0 +1,4 @@
+# 26 USC 9999
+status: stub
+some_var:
+    entity: TaxUnit


### PR DESCRIPTION
## Summary

- Full autorac CLI encoding of 26 USC 63 (taxable income / standard deduction)
- 31 `.rac` files covering subsections (a) through (e)
- 21 `.rac.test` companion test files
- 3 auto-generated stubs for external dependencies:
  - `26/151` (personal exemptions)
  - `26/224` (health savings accounts)
  - `26/9999` (placeholder)

## Encoding details

- Backend: CLI ($0 API cost)
- PE match: 0.0% (expected — intermediate variables don't map to CPS inputs yet)
- TAXSIM match: 0.0%

## Test plan

- [ ] Spot-check `.rac` files against statute text
- [ ] Verify standard deduction amounts in test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)