### PR TITLE
Encode 26 USC 24 (CTC): 53 .rac files + 46 tests

### DIFF
--- a/statute/26/1401/1401.rac
+++ b/statute/26/1401/1401.rac
@@ -1,0 +1,113 @@
+# 26 USC 1401
+
+"""
+§ 1401. Rate of tax
+(a) Old-age, survivors, and disability insurance.-- In addition to other
+taxes, there shall be imposed for each taxable year, on the self-employment
+income of every individual, a tax equal to 12.4 percent of the amount of the
+self-employment income for such taxable year.
+
+(b) Hospital insurance.--
+(1) In general.-- In addition to the tax imposed by the preceding
+subsection, there shall be imposed for each taxable year, on the
+self-employment income of every individual, a tax equal to 2.9 percent of the
+amount of the self-employment income for such taxable year.
+
+(2) Additional tax.--
+(A) In general.-- In addition to the tax imposed by paragraph (1) and the
+preceding subsection, there is hereby imposed on every taxpayer (other than a
+corporation, estate, or trust) for each taxable year beginning after
+December 31, 2012, a tax equal to 0.9 percent of the self-employment income
+for such taxable year which is in excess of--
+  (i) in the case of a joint return, $250,000,
+  (ii) in the case of a married taxpayer (as defined in section 7703) filing
+      a separate return, 1/2 of the dollar amount determined under clause (i),
+      and
+  (iii) in any other case, $200,000.
+
+(B) Coordination with FICA.-- The amounts under clause (i), (ii), or (iii)
+(whichever is applicable) of subparagraph (A) shall be reduced (but not below
+zero) by the amount of wages taken into account in determining the tax imposed
+under section 3121(b)(2) with respect to the taxpayer.
+
+(c) Relief from taxes in cases covered by certain international agreements.--
+During any period in which there is in effect an agreement entered into
+pursuant to section 233 of the Social Security Act with any foreign country,
+the self-employment income of an individual shall be exempt from the taxes
+imposed by this section to the extent that such self-employment income is
+subject under such agreement exclusively to the laws applicable to the social
+security system of such foreign country.
+"""
+
+status: encoded
+
+# Self-employment income (from 26 USC 1402, not yet encoded)
+self_employment_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    status: input
+    label: "Self-employment income"
+    description: "Self-employment income as defined in 26 USC 1402"
+    default: 0
+
+# (a) OASDI rate for self-employment
+se_oasdi_rate:
+    description: "Old-age, survivors, and disability insurance tax rate on self-employment income per 26 USC 1401(a)"
+    unit: rate
+    from 2014-01-01: 0.124
+
+# (b)(1) HI rate for self-employment
+se_hi_rate:
+    description: "Hospital insurance tax rate on self-employment income per 26 USC 1401(b)(1)"
+    unit: rate
+    from 2010-01-01: 0.029
+
+# (b)(2) Additional Medicare tax rate on self-employment
+se_additional_medicare_tax_rate:
+    description: "Additional hospital insurance tax rate on self-employment income per 26 USC 1401(b)(2)"
+    unit: rate
+    from 2013-01-01: 0.009
+
+# (b)(2)(A)(i) Threshold for joint return
+se_additional_medicare_threshold_joint:
+    description: "Self-employment income threshold for additional Medicare tax on a joint return per 26 USC 1401(b)(2)(A)(i)"
+    unit: USD
+    from 2013-01-01: 250000
+
+# (b)(2)(A)(ii) Threshold for married filing separately (half of joint)
+se_additional_medicare_threshold_separate:
+    description: "Self-employment income threshold for additional Medicare tax for married filing separately per 26 USC 1401(b)(2)(A)(ii)"
+    unit: USD
+    from 2013-01-01: 125000
+
+# (b)(2)(A)(iii) Threshold for all other filers
+se_additional_medicare_threshold_other:
+    description: "Self-employment income threshold for additional Medicare tax for filers other than joint or married separate per 26 USC 1401(b)(2)(A)(iii)"
+    unit: USD
+    from 2013-01-01: 200000
+
+# Total self-employment tax under section 1401
+self_employment_tax:
+    imports:
+        - 26/7703/a#is_joint_return
+        - 26/7703/a#is_married
+        - 26/3121/a#wages_under_3121a
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Self-employment tax"
+    description: "Total self-employment tax imposed by 26 USC 1401: OASDI tax (subsection a) plus hospital insurance tax (subsection b(1)) plus additional Medicare tax on self-employment income in excess of applicable threshold (subsection b(2)), with threshold reduced by wages subject to FICA additional Medicare tax (subsection b(2)(B))"
+    from 2013-01-01:
+        oasdi_tax = se_oasdi_rate * self_employment_income
+        hi_tax = se_hi_rate * self_employment_income
+        base_threshold = (
+            if is_joint_return: se_additional_medicare_threshold_joint
+            elif is_married: se_additional_medicare_threshold_separate
+            else: se_additional_medicare_threshold_other
+        )
+        adjusted_threshold = max(base_threshold - wages_under_3121a, 0)
+        excess_se_income = max(self_employment_income - adjusted_threshold, 0)
+        additional_medicare_tax = se_additional_medicare_tax_rate * excess_se_income
+        oasdi_tax + hi_tax + additional_medicare_tax

--- a/statute/26/2/a.rac
+++ b/statute/26/2/a.rac
@@ -1,0 +1,34 @@
+# 26 USC 2(a) - Surviving spouse
+
+"""
+(a) Definition of surviving spouse.--
+(1) In general.-- For purposes of section 1, the term "surviving spouse"
+means a taxpayer--
+  (A) whose spouse died during either of his two preceding taxable years, and
+  (B) who maintains as his home a household which constitutes for the taxable
+  year the principal place of abode (as a member of such household) of a
+  dependent (i) who (within the meaning of section 152, determined without
+  regard to subsections (b)(1), (b)(2), and (d)(1)(B) thereof) is a son,
+  stepdaughter, or daughter of the taxpayer, and (ii) with respect to whom
+  the taxpayer is entitled to a deduction for the taxable year under section
+  151.
+For purposes of this paragraph, an individual shall be considered as
+maintaining a household only if over half of the cost of maintaining the
+household during the taxable year is furnished by such individual.
+(2) Limitations.-- Notwithstanding paragraph (1), for purposes of this
+subtitle a taxpayer shall not be considered to be a surviving spouse--
+  (A) if the taxpayer has remarried at any time before the close of the
+  taxable year, or
+  (B) unless, for the taxpayer's taxable year during which his spouse died,
+  a joint return could have been made under the provisions of section 6013
+  (without regard to subsection (a)(3) thereof).
+"""
+
+status: stub
+
+is_surviving_spouse:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Surviving spouse filing status"
+    description: "Whether the taxpayer qualifies as a surviving spouse per 26 USC 2(a) - spouse died in one of two preceding taxable years, taxpayer maintains household for qualifying dependent child, and has not remarried"

--- a/statute/26/24/24.rac
+++ b/statute/26/24/24.rac
@@ -1,0 +1,57 @@
+# 26 USC Section 24 - Child tax credit
+
+"""
+Sec. 24. Child tax credit.
+
+(a) Allowance of credit.-- Credit against tax for each qualifying child.
+(b) Limitations.-- Phase-out based on modified AGI exceeding threshold amount.
+(c) Qualifying child.-- As defined in section 152(c), under age 17.
+(d) Portion of credit refundable.-- Additional child tax credit.
+(h) Special rules for taxable years 2018 through 2025.-- Modifies credit
+    amount, thresholds, adds other dependents credit, SSN requirements.
+(i) Cost-of-living adjustments.-- Inflation adjustments for credit amounts.
+(j) Reconciliation of credit and advance credit.-- Reduces credit by advance
+    payments under section 7527A.
+"""
+
+status: encoded
+
+child_tax_credit:
+    imports:
+        - 26/24/a#ctc_per_child_amount
+        - 26/24/a#qualifying_child_count
+        - 26/24/b/1#ctc_after_phaseout
+        - 26/24/b/1#ctc_modified_agi
+        - 26/24/b/1#ctc_phaseout_reduction_per_increment
+        - 26/24/b/1#ctc_phaseout_income_increment
+        - 26/24/h/1#post_2017_ctc_rules_apply
+        - 26/24/h/2#ctc_h2_credit_amount
+        - 26/24/h/3#ctc_h3_threshold_amount
+        - 26/24/h/4/A#other_dependents_credit
+        - 26/24/j/1#advance_ctc_payments
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Child tax credit"
+    description: "Final child tax credit under 26 USC 24, combining base rules from (a)-(b) with post-2017 modifications from (h) and advance payment reconciliation from (j)"
+    from 1998-01-01:
+        ctc_after_phaseout
+    from 2018-01-01:
+        credit = ctc_h2_credit_amount * qualifying_child_count + other_dependents_credit
+        excess = max(0, ctc_modified_agi - ctc_h3_threshold_amount)
+        increments = ceil(excess / ctc_phaseout_income_increment)
+        phaseout = increments * ctc_phaseout_reduction_per_increment
+        before_advance = max(0, credit - phaseout)
+        max(0, before_advance - advance_ctc_payments)
+
+credit_qualified_children:
+    imports:
+        - 26/24/c#qualifying_child_count
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Number of qualified children for credit"
+    description: "Number of qualified children taken into account in determining the credit allowed under 26 USC 24 for the taxable year, per 24(j)(2)(B)(iv)(II)"
+    from 1998-01-01:
+        qualifying_child_count

--- a/statute/26/24/a.rac
+++ b/statute/26/24/a.rac
@@ -1,0 +1,33 @@
+# 26 USC Section 24(a) - Allowance of credit
+
+"""
+(a) Allowance of credit.-- There shall be allowed as a credit against the tax
+imposed by this chapter for the taxable year with respect to each qualifying
+child of the taxpayer for which the taxpayer is allowed a deduction under
+section 151 an amount equal to $1,000.
+"""
+
+status: encoded
+
+ctc_per_child_amount:
+    description: "Credit amount per qualifying child under 26 USC 24(a)"
+    unit: USD
+    from 1998-01-01: 1000
+
+qualifying_child_count:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Number of qualifying children"
+    description: "Number of qualifying children for CTC purposes"
+    default: 0
+
+ctc_allowance:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Child tax credit allowance"
+    description: "Credit allowed under 26 USC 24(a): per-child amount times number of qualifying children"
+    from 1998-01-01:
+        ctc_per_child_amount * qualifying_child_count

--- a/statute/26/24/a.rac.test
+++ b/statute/26/24/a.rac.test
@@ -1,0 +1,26 @@
+# 26 USC Section 24(a) tests
+
+ctc_allowance:
+    - name: "No qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 0
+      expect: 0
+
+    - name: "One qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 1
+      expect: 1000
+
+    - name: "Two qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 2
+      expect: 2000
+
+    - name: "Three qualifying children"
+      period: 2024-01
+      inputs:
+        qualifying_child_count: 3
+      expect: 3000

--- a/statute/26/24/b.rac
+++ b/statute/26/24/b.rac
@@ -1,0 +1,33 @@
+# 26 USC 24(b) - Limitation based on adjusted gross income
+
+"""
+(b) Limitation based on adjusted gross income.--
+(1) Limitation based on adjusted gross income.-- The amount of the credit
+allowable under subsection (a) shall be reduced (but not below zero) by $50
+for each $1,000 (or fraction thereof) by which the taxpayer's modified
+adjusted gross income exceeds the threshold amount. For purposes of the
+preceding sentence, the term "modified adjusted gross income" means adjusted
+gross income increased by any amount excluded from gross income under
+section 911, 931, or 933.
+(2) Threshold amount.-- For purposes of paragraph (1), the term
+"threshold amount" means--
+(A) $110,000 in the case of a joint return,
+(B) $75,000 in the case of an individual who is not married, and
+(C) $55,000 in the case of a married individual filing a separate return.
+For purposes of this paragraph, marital status shall be determined under
+section 7703.
+"""
+
+status: encoded
+
+ctc_phaseout_reduction:
+    imports:
+        - 26/24/b/1#ctc_phaseout_reduction as b1_ctc_phaseout_reduction
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "CTC phase-out reduction"
+    description: "Reduction in CTC based on modified AGI exceeding threshold, per 26 USC 24(b)"
+    from 2001-01-01:
+        b1_ctc_phaseout_reduction

--- a/statute/26/24/b/1.rac
+++ b/statute/26/24/b/1.rac
@@ -1,0 +1,95 @@
+# 26 USC Section 24(b)(1) - Limitation based on adjusted gross income
+
+"""
+(1) Limitation based on adjusted gross income.-- The amount of the credit
+allowable under subsection (a) shall be reduced (but not below zero) by $50
+for each $1,000 (or fraction thereof) by which the taxpayer's modified
+adjusted gross income exceeds the threshold amount. For purposes of the
+preceding sentence, the term "modified adjusted gross income" means adjusted
+gross income increased by any amount excluded from gross income under
+section 911, 931, or 933.
+"""
+
+status: encoded
+
+ctc_phaseout_reduction_per_increment:
+    description: "Reduction amount per income increment over threshold"
+    unit: USD
+    from 2001-01-01: 50
+
+ctc_phaseout_income_increment:
+    description: "Income increment for phase-out calculation"
+    unit: USD
+    from 2001-01-01: 1000
+
+adjusted_gross_income:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Adjusted gross income"
+    description: "Adjusted gross income of the taxpayer"
+    default: 0
+
+sec_911_exclusion:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 911 exclusion"
+    description: "Amount excluded from gross income under section 911"
+    default: 0
+
+sec_931_exclusion:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 931 exclusion"
+    description: "Amount excluded from gross income under section 931"
+    default: 0
+
+sec_933_exclusion:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Section 933 exclusion"
+    description: "Amount excluded from gross income under section 933"
+    default: 0
+
+ctc_modified_agi:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Modified adjusted gross income for CTC"
+    description: "AGI increased by amounts excluded under sections 911, 931, or 933, per 26 USC 24(b)(1)"
+    from 2001-01-01:
+        adjusted_gross_income + sec_911_exclusion + sec_931_exclusion + sec_933_exclusion
+
+ctc_phaseout_reduction:
+    imports:
+        - 26/24/b/2#threshold_amount
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "CTC phase-out reduction"
+    description: "Reduction in CTC based on modified AGI exceeding threshold, per 26 USC 24(b)(1): $50 for each $1,000 (or fraction thereof) of excess income"
+    from 2001-01-01:
+        excess = max(0, ctc_modified_agi - threshold_amount)
+        increments = ceil(excess / ctc_phaseout_income_increment)
+        increments * ctc_phaseout_reduction_per_increment
+
+ctc_after_phaseout:
+    imports:
+        - 26/24/a#ctc_allowance
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Child tax credit after phase-out"
+    description: "CTC allowance reduced (but not below zero) by income-based phase-out per 26 USC 24(b)(1)"
+    from 2001-01-01:
+        max(0, ctc_allowance - ctc_phaseout_reduction)

--- a/statute/26/24/b/1.rac.test
+++ b/statute/26/24/b/1.rac.test
@@ -1,0 +1,78 @@
+# 26 USC Section 24(b)(1) tests
+
+ctc_modified_agi:
+    - name: "AGI only, no exclusions"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 100000
+        sec_911_exclusion: 0
+        sec_931_exclusion: 0
+        sec_933_exclusion: 0
+      expect: 100000
+
+    - name: "AGI with section 911 exclusion"
+      period: 2024-01
+      inputs:
+        adjusted_gross_income: 80000
+        sec_911_exclusion: 20000
+        sec_931_exclusion: 0
+        sec_933_exclusion: 0
+      expect: 100000
+
+ctc_phaseout_reduction:
+    - name: "Income below threshold - no reduction"
+      period: 2024-01
+      inputs:
+        ctc_modified_agi: 100000
+        threshold_amount: 110000
+      expect: 0
+
+    - name: "Income exactly at threshold"
+      period: 2024-01
+      inputs:
+        ctc_modified_agi: 110000
+        threshold_amount: 110000
+      expect: 0
+
+    - name: "Income $1000 over threshold - one increment"
+      period: 2024-01
+      inputs:
+        ctc_modified_agi: 111000
+        threshold_amount: 110000
+      expect: 50
+
+    - name: "Income $1500 over threshold - fraction rounds up"
+      period: 2024-01
+      inputs:
+        ctc_modified_agi: 111500
+        threshold_amount: 110000
+      expect: 100
+
+    - name: "Income $10000 over threshold"
+      period: 2024-01
+      inputs:
+        ctc_modified_agi: 120000
+        threshold_amount: 110000
+      expect: 500
+
+ctc_after_phaseout:
+    - name: "No phase-out needed"
+      period: 2024-01
+      inputs:
+        ctc_allowance: 2000
+        ctc_phaseout_reduction: 0
+      expect: 2000
+
+    - name: "Partial phase-out"
+      period: 2024-01
+      inputs:
+        ctc_allowance: 2000
+        ctc_phaseout_reduction: 500
+      expect: 1500
+
+    - name: "Full phase-out - not below zero"
+      period: 2024-01
+      inputs:
+        ctc_allowance: 2000
+        ctc_phaseout_reduction: 3000
+      expect: 0

--- a/statute/26/24/b/2.rac
+++ b/statute/26/24/b/2.rac
@@ -1,0 +1,31 @@
+# 26 USC Section 24(b)(2) - Threshold amount
+
+"""
+(2) Threshold amount.-- For purposes of paragraph (1), the term
+"threshold amount" means--
+(A) $110,000 in the case of a joint return,
+(B) $75,000 in the case of an individual who is not married, and
+(C) $55,000 in the case of a married individual filing a separate return.
+For purposes of this paragraph, marital status shall be determined under
+section 7703.
+"""
+
+status: encoded
+
+threshold_amount:
+    imports:
+        - 26/24/b/2/A#ctc_threshold_joint
+        - 26/24/b/2/B#ctc_threshold_unmarried
+        - 26/24/b/2/C#ctc_threshold_married_separate
+        - 26/7703/a#is_joint_return
+        - 26/7703/a#is_married
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "CTC phase-out threshold amount"
+    description: "Threshold amount for CTC phase-out per 26 USC 24(b)(2): $110,000 for joint returns, $75,000 for unmarried, $55,000 for married filing separately. Marital status determined under section 7703."
+    from 2001-01-01:
+        if is_joint_return: ctc_threshold_joint
+        elif not is_married: ctc_threshold_unmarried
+        else: ctc_threshold_married_separate

--- a/statute/26/24/b/2.rac.test
+++ b/statute/26/24/b/2.rac.test
@@ -1,0 +1,52 @@
+# 26 USC Section 24(b)(2) tests
+
+threshold_amount:
+    - name: "Joint return threshold"
+      period: 2024-01
+      inputs:
+        is_joint_return: true
+        is_married: true
+        ctc_threshold_joint: 110000
+        ctc_threshold_unmarried: 75000
+        ctc_threshold_married_separate: 55000
+      expect: 110000
+
+    - name: "Unmarried individual threshold"
+      period: 2024-01
+      inputs:
+        is_joint_return: false
+        is_married: false
+        ctc_threshold_joint: 110000
+        ctc_threshold_unmarried: 75000
+        ctc_threshold_married_separate: 55000
+      expect: 75000
+
+    - name: "Married filing separately threshold"
+      period: 2024-01
+      inputs:
+        is_joint_return: false
+        is_married: true
+        ctc_threshold_joint: 110000
+        ctc_threshold_unmarried: 75000
+        ctc_threshold_married_separate: 55000
+      expect: 55000
+
+    - name: "Joint return threshold (earlier year)"
+      period: 2010-01
+      inputs:
+        is_joint_return: true
+        is_married: true
+        ctc_threshold_joint: 110000
+        ctc_threshold_unmarried: 75000
+        ctc_threshold_married_separate: 55000
+      expect: 110000
+
+    - name: "Unmarried individual threshold (earlier year)"
+      period: 2005-01
+      inputs:
+        is_joint_return: false
+        is_married: false
+        ctc_threshold_joint: 110000
+        ctc_threshold_unmarried: 75000
+        ctc_threshold_married_separate: 55000
+      expect: 75000

--- a/statute/26/24/b/2/A.rac
+++ b/statute/26/24/b/2/A.rac
@@ -1,0 +1,12 @@
+# 26 USC Section 24(b)(2)(A) - Joint return threshold
+
+"""
+(A) $110,000 in the case of a joint return,
+"""
+
+status: encoded
+
+ctc_threshold_joint:
+    description: "CTC phase-out threshold amount for joint returns"
+    unit: USD
+    from 2001-01-01: 110000

--- a/statute/26/24/b/2/A.rac.test
+++ b/statute/26/24/b/2/A.rac.test
@@ -1,0 +1,14 @@
+# 26 USC Section 24(b)(2)(A) tests
+
+ctc_threshold_joint:
+    - name: "Joint return threshold for 2024"
+      period: 2024-01
+      expect: 110000
+
+    - name: "Joint return threshold for 2001"
+      period: 2001-01
+      expect: 110000
+
+    - name: "Joint return threshold for 2010"
+      period: 2010-01
+      expect: 110000

--- a/statute/26/24/b/2/B.rac
+++ b/statute/26/24/b/2/B.rac
@@ -1,0 +1,12 @@
+# 26 USC 24(b)(2)(B) - Unmarried threshold
+
+"""
+(B) $75,000 in the case of an individual who is not married, and
+"""
+
+status: encoded
+
+ctc_threshold_unmarried:
+    description: "CTC phase-out threshold for unmarried individuals"
+    unit: USD
+    from 1998-01-01: 75000

--- a/statute/26/24/b/2/B.rac.test
+++ b/statute/26/24/b/2/B.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 24(b)(2)(B) tests
+
+ctc_threshold_unmarried:
+    - name: "Unmarried threshold is $75,000"
+      period: 2024-01
+      expect: 75000
+
+    - name: "Unmarried threshold in 2010"
+      period: 2010-01
+      expect: 75000
+
+    - name: "Unmarried threshold at effective date"
+      period: 1998-01
+      expect: 75000

--- a/statute/26/24/b/2/C.rac
+++ b/statute/26/24/b/2/C.rac
@@ -1,0 +1,10 @@
+# 26 USC 24(b)(2)(C) - Married filing separate threshold
+
+"""
+(C) $55,000 in the case of a married individual filing a separate return.
+"""
+
+ctc_threshold_married_separate:
+    description: "CTC phase-out threshold for married filing separately"
+    unit: USD
+    from 2001-01-01: 55000

--- a/statute/26/24/b/2/C.rac.test
+++ b/statute/26/24/b/2/C.rac.test
@@ -1,0 +1,14 @@
+# 26 USC 24(b)(2)(C) tests
+
+ctc_threshold_married_separate:
+    - name: "Threshold value in 2024"
+      period: 2024-01
+      expect: 55000
+
+    - name: "Threshold value in 2001"
+      period: 2001-01
+      expect: 55000
+
+    - name: "Threshold value in 2025"
+      period: 2025-01
+      expect: 55000

--- a/statute/26/24/c.rac
+++ b/statute/26/24/c.rac
@@ -1,0 +1,24 @@
+# 26 USC 24(c) - Qualifying child
+
+"""
+(c) Qualifying child.--
+For purposes of this section--
+(1) In general.-- The term "qualifying child" means a qualifying child of
+the taxpayer (as defined in section 152(c)) who has not attained age 17.
+(2) Exception for certain noncitizens.-- The term "qualifying child" shall
+not include any individual who would not be a dependent if subparagraph (A)
+of section 152(b)(3) were applied without regard to all that follows
+"resident of the United States".
+"""
+
+status: stub
+
+qualifying_child_count:
+    imports:
+        - 26/24/c/1#ctc_qualifying_child
+        - 26/24/c/2#ctc_meets_citizenship_requirement
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Number of CTC qualifying children"
+    description: "Number of qualifying children for CTC purposes per 26 USC 24(c): count of members who are qualifying children under (c)(1) and meet the citizenship requirement under (c)(2). Requires entity aggregation to count persons within the tax unit."

--- a/statute/26/24/c/1.rac
+++ b/statute/26/24/c/1.rac
@@ -1,0 +1,24 @@
+# 26 USC Section 24(c)(1) - Qualifying child - In general
+
+"""
+(1) In general.-- The term "qualifying child" means a qualifying child of
+the taxpayer (as defined in section 152(c)) who has not attained age 17.
+"""
+
+status: encoded
+
+ctc_qualifying_child_age_limit:
+    description: "Maximum age (exclusive) for a qualifying child for CTC purposes"
+    unit: years
+    from 1998-01-01: 17
+
+ctc_qualifying_child:
+    imports:
+        - 26/152/c#qualifying_child_of_taxpayer
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "CTC qualifying child"
+    description: "A qualifying child for CTC purposes is a qualifying child of the taxpayer (per section 152(c)) who has not attained age 17, per 26 USC 24(c)(1)"
+    from 1998-01-01:
+        qualifying_child_of_taxpayer and age < ctc_qualifying_child_age_limit

--- a/statute/26/24/c/1.rac.test
+++ b/statute/26/24/c/1.rac.test
@@ -1,0 +1,37 @@
+# 26 USC Section 24(c)(1) tests
+
+ctc_qualifying_child:
+    - name: "Child under 17 who is qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_child_of_taxpayer: true
+        age: 10
+      expect: true
+
+    - name: "Child exactly 17 is not qualifying"
+      period: 2024-01
+      inputs:
+        qualifying_child_of_taxpayer: true
+        age: 17
+      expect: false
+
+    - name: "Child under 17 but not qualifying child per 152(c)"
+      period: 2024-01
+      inputs:
+        qualifying_child_of_taxpayer: false
+        age: 10
+      expect: false
+
+    - name: "Newborn qualifying child"
+      period: 2024-01
+      inputs:
+        qualifying_child_of_taxpayer: true
+        age: 0
+      expect: true
+
+    - name: "16-year-old qualifying child (boundary)"
+      period: 2024-01
+      inputs:
+        qualifying_child_of_taxpayer: true
+        age: 16
+      expect: true

--- a/statute/26/24/c/2.rac
+++ b/statute/26/24/c/2.rac
@@ -1,0 +1,27 @@
+# 26 USC Section 24(c)(2) - Exception for certain noncitizens
+
+"""
+(2) Exception for certain noncitizens.-- The term "qualifying child" shall
+not include any individual who would not be a dependent if subparagraph (A)
+of section 152(b)(3) were applied without regard to all that follows
+"resident of the United States".
+"""
+
+status: encoded
+
+is_us_citizen_national_or_resident:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "US citizen, national, or resident"
+    description: "Whether the individual is a citizen or national of the United States, or a resident of the United States. For CTC purposes, section 152(b)(3)(A) is applied without regard to the exception for residents of Canada or Mexico."
+    default: false
+
+ctc_meets_citizenship_requirement:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Meets CTC citizenship requirement"
+    description: "Whether the individual meets the citizenship/residency requirement for CTC qualifying child status. Under 26 USC 24(c)(2), the child must be a US citizen, national, or resident — the usual 152(b)(3)(A) exception for residents of Canada or Mexico does not apply."
+    from 1998-01-01:
+        is_us_citizen_national_or_resident

--- a/statute/26/24/c/2.rac.test
+++ b/statute/26/24/c/2.rac.test
@@ -1,0 +1,19 @@
+# 26 USC Section 24(c)(2) tests
+
+ctc_meets_citizenship_requirement:
+    - name: "US citizen meets requirement"
+      period: 2024-01
+      inputs:
+        is_us_citizen_national_or_resident: true
+      expect: true
+
+    - name: "Non-US citizen/national/resident does not meet requirement"
+      period: 2024-01
+      inputs:
+        is_us_citizen_national_or_resident: false
+      expect: false
+
+    - name: "Default (no citizenship info) does not meet requirement"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/26/24/d/1.rac
+++ b/statute/26/24/d/1.rac
@@ -1,0 +1,35 @@
+# 26 USC 24(d)(1) - Additional child tax credit (refundable portion)
+
+"""
+(1) In general.— If the aggregate amount of credits allowed by this
+subpart (determined without regard to this subsection) would exceed
+the tax liability limitation described in section 26(a), then the
+taxpayer's credit allowed under this section for the taxable year
+shall include a credit equal to the lesser of—
+(A) the credit which would be allowed under this section without
+regard to this subsection and the limitation under section 26(a), or
+(B) the greater of—
+(i) 15 percent of so much of the taxpayer's earned income (within
+the meaning of section 32) which is taken into account in computing
+taxable income for the taxable year as exceeds $3,000, or
+(ii) in the case of a taxpayer with 3 or more qualifying children,
+the excess (if any) of the taxpayer's social security taxes for the
+taxable year, over the credit allowed under section 32 for the
+taxable year.
+"""
+
+status: encoded
+
+ctc_refundable_amount:
+    imports:
+        - 26/24/d/1/A#ctc_without_limitations
+        - 26/24/d/1/B/i#earned_income_component
+        - 26/24/d/1/B/ii#three_plus_children_alternative
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Additional child tax credit (refundable portion)"
+    description: "Refundable portion of the child tax credit, equal to the lesser of the credit without limitations or the greater of the earned income component and the 3+ children alternative, per 26 USC 24(d)(1)"
+    from 2001-01-01:
+        min(ctc_without_limitations, max(earned_income_component, three_plus_children_alternative))

--- a/statute/26/24/h/1.rac
+++ b/statute/26/24/h/1.rac
@@ -1,0 +1,29 @@
+# 26 USC 24(h)(1) - In general
+
+"""
+(1) In general.—
+In the case of a taxable year beginning after December 31, 2017,
+this section shall be applied as provided in paragraphs (2) through (7).
+"""
+
+post_2017_applicability_start_year:
+    description: "Year after which the special rules in paragraphs (2) through (7) apply"
+    unit: Year
+    from 2017-12-22: 2017
+
+post_2017_ctc_rules_apply:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Post-2017 CTC rules apply"
+    description: "Whether the taxable year begins after December 31, 2017, triggering application of paragraphs (2) through (7)"
+    from 2017-12-22:
+        tax_year > post_2017_applicability_start_year
+
+tax_year:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Tax year"
+    description: "The taxable year for which the return is filed"
+    default: 0

--- a/statute/26/24/h/1.rac.test
+++ b/statute/26/24/h/1.rac.test
@@ -1,0 +1,26 @@
+# 26 USC 24(h)(1) tests
+
+post_2017_ctc_rules_apply:
+    - name: "Tax year 2017 - rules do not apply"
+      period: 2018-01
+      inputs:
+          tax_year: 2017
+      expect: false
+
+    - name: "Tax year 2018 - rules apply"
+      period: 2018-01
+      inputs:
+          tax_year: 2018
+      expect: true
+
+    - name: "Tax year 2024 - rules apply"
+      period: 2024-01
+      inputs:
+          tax_year: 2024
+      expect: true
+
+    - name: "Tax year 2016 - rules do not apply"
+      period: 2018-01
+      inputs:
+          tax_year: 2016
+      expect: false

--- a/statute/26/24/h/2.rac
+++ b/statute/26/24/h/2.rac
@@ -1,0 +1,14 @@
+# 26 USC Section 24(h)(2) - Credit amount
+
+"""
+(2) Credit amount.—
+Subsection (a) shall be applied by substituting "$2,200" for "$1,000".
+"""
+
+status: encoded
+
+ctc_h2_credit_amount:
+    description: "Credit amount per qualifying child substituted for $1,000 in subsection (a) per 26 USC 24(h)(2)"
+    unit: USD
+    from 2018-01-01: 2000
+    from 2025-01-01: 2200

--- a/statute/26/24/h/2.rac.test
+++ b/statute/26/24/h/2.rac.test
@@ -1,0 +1,17 @@
+# 26 USC Section 24(h)(2) tests
+
+ctc_h2_credit_amount:
+    - name: "Post-TCJA credit amount (2018-2024)"
+      period: 2024-01
+      inputs: {}
+      expect: 2000
+
+    - name: "Post-2025 amendment credit amount"
+      period: 2025-01
+      inputs: {}
+      expect: 2200
+
+    - name: "First year of TCJA applicability"
+      period: 2018-01
+      inputs: {}
+      expect: 2000

--- a/statute/26/24/h/3.rac
+++ b/statute/26/24/h/3.rac
@@ -1,0 +1,33 @@
+# 26 USC Section 24(h)(3) - Limitation
+
+"""
+(3) Limitation.—
+In lieu of the amount determined under subsection (b)(2), the threshold
+amount shall be $400,000 in the case of a joint return ($200,000 in any
+other case).
+"""
+
+status: encoded
+
+ctc_h3_threshold_joint:
+    description: "CTC phase-out threshold for joint returns per 26 USC 24(h)(3), replacing (b)(2) amount"
+    unit: USD
+    from 2018-01-01: 400000
+
+ctc_h3_threshold_other:
+    description: "CTC phase-out threshold for all other filers per 26 USC 24(h)(3), replacing (b)(2) amount"
+    unit: USD
+    from 2018-01-01: 200000
+
+ctc_h3_threshold_amount:
+    imports:
+        - 26/7703/a#is_joint_return
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "CTC phase-out threshold (post-2017)"
+    description: "Threshold amount for CTC phase-out for taxable years beginning after 2017: $400,000 for joint returns, $200,000 in any other case, per 26 USC 24(h)(3)"
+    from 2018-01-01:
+        if is_joint_return: ctc_h3_threshold_joint
+        else: ctc_h3_threshold_other

--- a/statute/26/24/h/3.rac.test
+++ b/statute/26/24/h/3.rac.test
@@ -1,0 +1,26 @@
+# 26 USC Section 24(h)(3) tests
+
+ctc_h3_threshold_amount:
+    - name: "Joint return threshold is $400,000"
+      period: 2024-01
+      inputs:
+        is_joint_return: true
+      expect: 400000
+
+    - name: "Non-joint return threshold is $200,000"
+      period: 2024-01
+      inputs:
+        is_joint_return: false
+      expect: 200000
+
+    - name: "Joint return threshold in first applicable year"
+      period: 2018-01
+      inputs:
+        is_joint_return: true
+      expect: 400000
+
+    - name: "Single filer threshold in 2025"
+      period: 2025-01
+      inputs:
+        is_joint_return: false
+      expect: 200000

--- a/statute/26/24/h/4/A.rac
+++ b/statute/26/24/h/4/A.rac
@@ -1,0 +1,34 @@
+# 26 USC Section 24(h)(4)(A) - Other dependents credit - In general
+
+"""
+(A) In general.--
+The credit determined under subsection (a) (after the application of
+paragraph (2)) shall be increased by $500 for each dependent of the
+taxpayer (as defined in section 152) other than a qualifying child
+described in subsection (c).
+"""
+
+status: encoded
+
+other_dependent_credit_amount:
+    description: "Credit amount per other dependent (non-qualifying-child) per 26 USC 24(h)(4)(A)"
+    unit: USD
+    from 2018-01-01: 500
+
+other_dependent_count:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Number of other dependents"
+    description: "Number of dependents (as defined in section 152) other than qualifying children described in subsection (c)"
+    default: 0
+
+other_dependents_credit:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Other dependents credit"
+    description: "Credit increase for dependents who are not qualifying children, per 26 USC 24(h)(4)(A)"
+    from 2018-01-01:
+        other_dependent_credit_amount * other_dependent_count

--- a/statute/26/24/h/4/A.rac.test
+++ b/statute/26/24/h/4/A.rac.test
@@ -1,0 +1,26 @@
+# 26 USC Section 24(h)(4)(A) tests
+
+other_dependents_credit:
+    - name: "No other dependents"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 0
+      expect: 0
+
+    - name: "One other dependent"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 1
+      expect: 500
+
+    - name: "Two other dependents"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 2
+      expect: 1000
+
+    - name: "Three other dependents"
+      period: 2024-01
+      inputs:
+        other_dependent_count: 3
+      expect: 1500

--- a/statute/26/24/h/4/B.rac
+++ b/statute/26/24/h/4/B.rac
@@ -1,0 +1,22 @@
+# 26 USC Section 24(h)(4)(B) - Exception for certain noncitizens
+
+"""
+(B) Exception for certain noncitizens.--
+Subparagraph (A) shall not apply with respect to any individual who
+would not be a dependent if subparagraph (A) of section 152(b)(3)
+were applied without regard to all that follows "resident of the
+United States".
+"""
+
+status: encoded
+
+other_dependent_meets_citizenship_requirement:
+    imports:
+        - 26/24/c/2#is_us_citizen_national_or_resident
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Other dependent meets citizenship requirement"
+    description: "Whether the individual meets the citizenship/residency requirement for the other dependents credit under 26 USC 24(h)(4)(B). Same noncitizen exception as 24(c)(2) — section 152(b)(3)(A) is applied without regard to the exception for residents of Canada or Mexico."
+    from 2018-01-01:
+        is_us_citizen_national_or_resident

--- a/statute/26/24/h/4/B.rac.test
+++ b/statute/26/24/h/4/B.rac.test
@@ -1,0 +1,20 @@
+# 26 USC Section 24(h)(4)(B) tests
+
+other_dependent_meets_citizenship_requirement:
+    - name: "US citizen meets requirement"
+      period: 2024-01
+      inputs:
+        is_us_citizen_national_or_resident: true
+      expect: true
+
+    - name: "Non-US-citizen/resident does not meet requirement"
+      period: 2024-01
+      inputs:
+        is_us_citizen_national_or_resident: false
+      expect: false
+
+    - name: "Effective date - applies from 2018"
+      period: 2018-01
+      inputs:
+        is_us_citizen_national_or_resident: true
+      expect: true

--- a/statute/26/24/h/4/C.rac
+++ b/statute/26/24/h/4/C.rac
@@ -1,0 +1,21 @@
+# 26 USC Section 24(h)(4)(C) - Certain qualifying children
+
+"""
+(C) Certain qualifying children.--
+In the case of any qualifying child with respect to whom a credit is
+not allowed under this section by reason of paragraph (7), such child
+shall be treated as a dependent to whom subparagraph (A) applies.
+"""
+
+status: encoded
+
+ctc_h4c_child_treated_as_other_dependent:
+    imports:
+        - 26/24/h/7/A#ctc_ssn_requirement_met
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Qualifying child treated as other dependent"
+    description: "A qualifying child for whom CTC is disallowed by reason of the SSN requirement in paragraph (7) is treated as a dependent eligible for the $500 other dependents credit under subparagraph (A), per 26 USC 24(h)(4)(C)"
+    from 2018-01-01:
+        not ctc_ssn_requirement_met

--- a/statute/26/24/h/4/C.rac.test
+++ b/statute/26/24/h/4/C.rac.test
@@ -1,0 +1,26 @@
+# 26 USC Section 24(h)(4)(C) tests
+
+ctc_h4c_child_treated_as_other_dependent:
+    - name: "Child without SSN - treated as other dependent"
+      period: 2024-01
+      inputs:
+        ctc_ssn_requirement_met: false
+      expect: true
+
+    - name: "Child with SSN - not treated as other dependent"
+      period: 2024-01
+      inputs:
+        ctc_ssn_requirement_met: true
+      expect: false
+
+    - name: "Child without SSN in first year of provision"
+      period: 2018-01
+      inputs:
+        ctc_ssn_requirement_met: false
+      expect: true
+
+    - name: "Child with SSN in 2025"
+      period: 2025-01
+      inputs:
+        ctc_ssn_requirement_met: true
+      expect: false

--- a/statute/26/24/h/5.rac
+++ b/statute/26/24/h/5.rac
@@ -1,0 +1,28 @@
+# 26 USC Section 24(h)(5) - Maximum amount of refundable credit
+
+"""
+(5) Maximum amount of refundable credit.—
+The amount determined under subsection (d)(1)(A) with respect to any
+qualifying child shall not exceed $1,400, and such subsection shall be
+applied without regard to paragraph (4) of this subsection.
+"""
+
+status: encoded
+
+max_refundable_credit_per_child:
+    description: "Maximum refundable credit per qualifying child per 26 USC 24(h)(5)"
+    unit: USD
+    from 2018-01-01: 1400
+
+max_refundable_credit_amount:
+    imports:
+        - 26/24/d/1/A#ctc_without_limitations
+        - 26/24/a#qualifying_child_count
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Maximum refundable credit amount"
+    description: "Cap on refundable portion of CTC: lesser of credit under (d)(1)(A) (without regard to (h)(4)) and $1,400 per qualifying child"
+    from 2018-01-01:
+        min(ctc_without_limitations, max_refundable_credit_per_child * qualifying_child_count)

--- a/statute/26/24/h/5.rac.test
+++ b/statute/26/24/h/5.rac.test
@@ -1,0 +1,48 @@
+# 26 USC Section 24(h)(5) tests
+
+max_refundable_credit_per_child:
+    - name: "Base refundable cap amount"
+      period: 2024-01
+      inputs: {}
+      expect: 1400
+
+    - name: "First year of TCJA applicability"
+      period: 2018-01
+      inputs: {}
+      expect: 1400
+
+max_refundable_credit_amount:
+    - name: "Credit below cap - credit is the limit"
+      period: 2024-01
+      inputs:
+          ctc_without_limitations: 1000
+          qualifying_child_count: 1
+      expect: 1000
+
+    - name: "Credit above cap - capped at $1,400 per child"
+      period: 2024-01
+      inputs:
+          ctc_without_limitations: 2000
+          qualifying_child_count: 1
+      expect: 1400
+
+    - name: "Two qualifying children, credit above total cap"
+      period: 2024-01
+      inputs:
+          ctc_without_limitations: 4000
+          qualifying_child_count: 2
+      expect: 2800
+
+    - name: "Zero qualifying children"
+      period: 2024-01
+      inputs:
+          ctc_without_limitations: 2000
+          qualifying_child_count: 0
+      expect: 0
+
+    - name: "Zero credit amount"
+      period: 2024-01
+      inputs:
+          ctc_without_limitations: 0
+          qualifying_child_count: 2
+      expect: 0

--- a/statute/26/24/h/6.rac
+++ b/statute/26/24/h/6.rac
@@ -1,0 +1,13 @@
+# 26 USC Section 24(h)(6) - Earned income threshold for refundable credit
+
+"""
+(6) Earned income threshold for refundable credit.—
+Subsection (d)(1)(B)(i) shall be applied by substituting "$2,500" for "$3,000".
+"""
+
+status: encoded
+
+ctc_h6_earned_income_threshold:
+    description: "Earned income threshold substituted for $3,000 in subsection (d)(1)(B)(i) per 26 USC 24(h)(6)"
+    unit: USD
+    from 2018-01-01: 2500

--- a/statute/26/24/h/6.rac.test
+++ b/statute/26/24/h/6.rac.test
@@ -1,0 +1,17 @@
+# 26 USC Section 24(h)(6) tests
+
+ctc_h6_earned_income_threshold:
+    - name: "Threshold is $2,500 for post-2017 years"
+      period: 2024-01
+      inputs: {}
+      expect: 2500
+
+    - name: "Threshold is $2,500 in first applicable year"
+      period: 2018-01
+      inputs: {}
+      expect: 2500
+
+    - name: "Threshold is $2,500 for 2025"
+      period: 2025-01
+      inputs: {}
+      expect: 2500

--- a/statute/26/24/h/7/A.rac
+++ b/statute/26/24/h/7/A.rac
@@ -1,0 +1,25 @@
+# 26 USC 24(h)(7)(A) - SSN required: in general
+
+"""
+(A) In general.--
+No credit shall be allowed under this section to a taxpayer with respect
+to any qualifying child unless the taxpayer includes on the return of tax
+for the taxable year--
+  (i) the taxpayer's social security number (or, in the case of a joint
+  return, the social security number of at least 1 spouse), and
+  (ii) the social security number of such qualifying child.
+"""
+
+status: encoded
+
+ctc_ssn_requirement_met:
+    imports:
+        - 26/24/h/7/A/i#ctc_taxpayer_ssn_requirement_met
+        - 26/24/h/7/A/ii#ctc_child_ssn_requirement_met
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "CTC SSN requirement met"
+    description: "No credit allowed unless taxpayer includes on return: (i) taxpayer's SSN (or at least 1 spouse's SSN for joint returns), and (ii) the qualifying child's SSN, per 26 USC 24(h)(7)(A)"
+    from 2018-01-01:
+        ctc_taxpayer_ssn_requirement_met and ctc_child_ssn_requirement_met

--- a/statute/26/24/h/7/A.rac.test
+++ b/statute/26/24/h/7/A.rac.test
@@ -1,0 +1,30 @@
+# 26 USC 24(h)(7)(A) tests
+
+ctc_ssn_requirement_met:
+    - name: "Both taxpayer and child SSN requirements met"
+      period: 2024-01
+      inputs:
+        ctc_taxpayer_ssn_requirement_met: true
+        ctc_child_ssn_requirement_met: true
+      expect: true
+
+    - name: "Taxpayer SSN requirement not met"
+      period: 2024-01
+      inputs:
+        ctc_taxpayer_ssn_requirement_met: false
+        ctc_child_ssn_requirement_met: true
+      expect: false
+
+    - name: "Child SSN requirement not met"
+      period: 2024-01
+      inputs:
+        ctc_taxpayer_ssn_requirement_met: true
+        ctc_child_ssn_requirement_met: false
+      expect: false
+
+    - name: "Neither requirement met"
+      period: 2024-01
+      inputs:
+        ctc_taxpayer_ssn_requirement_met: false
+        ctc_child_ssn_requirement_met: false
+      expect: false

--- a/statute/26/24/h/7/A/i.rac
+++ b/statute/26/24/h/7/A/i.rac
@@ -1,0 +1,42 @@
+# 26 USC 24(h)(7)(A)(i) - Taxpayer SSN requirement
+
+"""
+(i) the taxpayer's social security number (or, in the case of a
+joint return, the social security number of at least 1 spouse),
+"""
+
+status: encoded
+
+taxpayer_has_ssn:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Taxpayer has valid SSN"
+    description: "Whether the taxpayer has a social security number as defined in 26 USC 24(h)(7)(B)"
+    default: false
+
+is_joint_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "Joint return filed"
+    description: "Whether the taxpayer files a joint return"
+    default: false
+
+spouse_has_ssn:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Spouse has valid SSN"
+    description: "Whether the spouse has a social security number as defined in 26 USC 24(h)(7)(B)"
+    default: false
+
+ctc_taxpayer_ssn_requirement_met:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    label: "CTC taxpayer SSN requirement met"
+    description: "Whether the taxpayer meets the SSN requirement: taxpayer must include their SSN, or for joint returns, at least 1 spouse's SSN, per 26 USC 24(h)(7)(A)(i)"
+    from 2018-01-01:
+        if is_joint_return: taxpayer_has_ssn or spouse_has_ssn
+        else: taxpayer_has_ssn

--- a/statute/26/24/h/7/A/i.rac.test
+++ b/statute/26/24/h/7/A/i.rac.test
@@ -1,0 +1,40 @@
+# 26 USC 24(h)(7)(A)(i) tests - Taxpayer SSN requirement
+
+ctc_taxpayer_ssn_requirement_met:
+    - name: "Single filer with SSN meets requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: true
+        is_joint_return: false
+      expect: true
+
+    - name: "Single filer without SSN fails requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: false
+        is_joint_return: false
+      expect: false
+
+    - name: "Joint return where taxpayer has SSN meets requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: true
+        is_joint_return: true
+        spouse_has_ssn: false
+      expect: true
+
+    - name: "Joint return where spouse has SSN meets requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: false
+        is_joint_return: true
+        spouse_has_ssn: true
+      expect: true
+
+    - name: "Joint return where neither has SSN fails requirement"
+      period: 2024-01
+      inputs:
+        taxpayer_has_ssn: false
+        is_joint_return: true
+        spouse_has_ssn: false
+      expect: false

--- a/statute/26/24/h/7/A/ii.rac
+++ b/statute/26/24/h/7/A/ii.rac
@@ -1,0 +1,26 @@
+# 26 USC Section 24(h)(7)(A)(ii) - Child SSN requirement
+
+"""
+(ii) the social security number of such qualifying child.
+"""
+
+status: encoded
+
+child_ssn_included_on_return:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Child SSN included on return"
+    description: "Whether the social security number of the qualifying child is included on the taxpayer's return, per 26 USC 24(h)(7)(A)(ii)"
+    default: true
+
+ctc_child_ssn_requirement_met:
+    imports:
+        - 26/24/h/7/B#has_valid_social_security_number
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "CTC child SSN requirement met"
+    description: "The qualifying child's social security number must be included on the return per 26 USC 24(h)(7)(A)(ii)"
+    from 2018-01-01:
+        child_ssn_included_on_return and has_valid_social_security_number

--- a/statute/26/24/h/7/A/ii.rac.test
+++ b/statute/26/24/h/7/A/ii.rac.test
@@ -1,0 +1,37 @@
+# 26 USC Section 24(h)(7)(A)(ii) tests
+
+ctc_child_ssn_requirement_met:
+    - name: "Child has valid SSN included on return"
+      period: 2024-01
+      inputs:
+          child_ssn_included_on_return: true
+          has_valid_social_security_number: true
+      expect: true
+
+    - name: "Child SSN not included on return"
+      period: 2024-01
+      inputs:
+          child_ssn_included_on_return: false
+          has_valid_social_security_number: true
+      expect: false
+
+    - name: "Child does not have valid SSN"
+      period: 2024-01
+      inputs:
+          child_ssn_included_on_return: true
+          has_valid_social_security_number: false
+      expect: false
+
+    - name: "Neither SSN included nor valid"
+      period: 2024-01
+      inputs:
+          child_ssn_included_on_return: false
+          has_valid_social_security_number: false
+      expect: false
+
+    - name: "First applicable year (2018)"
+      period: 2018-01
+      inputs:
+          child_ssn_included_on_return: true
+          has_valid_social_security_number: true
+      expect: true

--- a/statute/26/24/h/7/B.rac
+++ b/statute/26/24/h/7/B.rac
@@ -1,0 +1,47 @@
+# 26 USC 24(h)(7)(B) - Social security number
+
+"""
+(B) Social security number.--
+For purposes of this paragraph, the term "social security number" means
+a social security number issued to an individual by the Social Security
+Administration, but only if the social security number is issued--
+  (i) to a citizen of the United States or pursuant to subclause (I)
+  (or that portion of subclause (III) that relates to subclause (I)) of
+  section 205(c)(2)(B)(i) of the Social Security Act, and
+  (ii) before the due date for such return.
+"""
+
+status: encoded
+
+ssn_issued_by_ssa:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "SSN issued by Social Security Administration"
+    description: "Whether the individual's social security number was issued by the Social Security Administration"
+    default: false
+
+ssn_issued_to_citizen_or_qualified:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "SSN issued to citizen or qualified individual"
+    description: "Whether the SSN was issued to a citizen of the United States or pursuant to subclause (I) (or that portion of subclause (III) that relates to subclause (I)) of section 205(c)(2)(B)(i) of the Social Security Act"
+    default: false
+
+ssn_issued_before_return_due_date:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "SSN issued before return due date"
+    description: "Whether the social security number was issued before the due date for the return"
+    default: false
+
+has_valid_social_security_number:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Has valid social security number for CTC"
+    description: "Whether the individual has a valid social security number as defined in 26 USC 24(h)(7)(B): issued by SSA, to a citizen or qualified individual under the Social Security Act, and before the return due date"
+    from 2018-01-01:
+        ssn_issued_by_ssa and ssn_issued_to_citizen_or_qualified and ssn_issued_before_return_due_date

--- a/statute/26/24/h/7/B.rac.test
+++ b/statute/26/24/h/7/B.rac.test
@@ -1,0 +1,42 @@
+# 26 USC 24(h)(7)(B) tests - Social security number definition
+
+has_valid_social_security_number:
+    - name: "All conditions met - valid SSN"
+      period: 2024-01
+      inputs:
+        ssn_issued_by_ssa: true
+        ssn_issued_to_citizen_or_qualified: true
+        ssn_issued_before_return_due_date: true
+      expect: true
+
+    - name: "SSN not issued by SSA (e.g. ITIN)"
+      period: 2024-01
+      inputs:
+        ssn_issued_by_ssa: false
+        ssn_issued_to_citizen_or_qualified: true
+        ssn_issued_before_return_due_date: true
+      expect: false
+
+    - name: "SSN not issued to citizen or qualified individual"
+      period: 2024-01
+      inputs:
+        ssn_issued_by_ssa: true
+        ssn_issued_to_citizen_or_qualified: false
+        ssn_issued_before_return_due_date: true
+      expect: false
+
+    - name: "SSN issued after return due date"
+      period: 2024-01
+      inputs:
+        ssn_issued_by_ssa: true
+        ssn_issued_to_citizen_or_qualified: true
+        ssn_issued_before_return_due_date: false
+      expect: false
+
+    - name: "No conditions met"
+      period: 2024-01
+      inputs:
+        ssn_issued_by_ssa: false
+        ssn_issued_to_citizen_or_qualified: false
+        ssn_issued_before_return_due_date: false
+      expect: false

--- a/statute/26/24/h/7/B/i.rac
+++ b/statute/26/24/h/7/B/i.rac
@@ -1,0 +1,17 @@
+# 26 USC 24(h)(7)(B)(i) - SSN issued to citizen or eligible noncitizen
+
+"""
+(i) to a citizen of the United States or pursuant to subclause (I)
+(or that portion of subclause (III) that relates to subclause (I))
+of section 205(c)(2)(B)(i) of the Social Security Act, and
+"""
+
+status: encoded
+
+ssn_issued_to_citizen_or_eligible_noncitizen:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "SSN issued to citizen or eligible noncitizen"
+    description: "Whether the social security number was issued to a citizen of the United States or pursuant to subclause (I) (or that portion of subclause (III) that relates to subclause (I)) of section 205(c)(2)(B)(i) of the Social Security Act, per 26 USC 24(h)(7)(B)(i)"
+    default: true

--- a/statute/26/24/h/7/B/ii.rac
+++ b/statute/26/24/h/7/B/ii.rac
@@ -1,0 +1,15 @@
+# 26 USC 24(h)(7)(B)(ii) - SSN issued before due date
+
+"""
+(ii) before the due date for such return.
+"""
+
+status: encoded
+
+ssn_issued_before_due_date:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "SSN issued before return due date"
+    description: "Whether the social security number was issued before the due date for the taxpayer's return, per 26 USC 24(h)(7)(B)(ii)"
+    default: true

--- a/statute/26/24/i/1.rac
+++ b/statute/26/24/i/1.rac
@@ -1,0 +1,40 @@
+# 26 USC 24(i)(1) - Maximum amount of refundable credit
+
+"""
+(1) Maximum amount of refundable credit.--
+In the case of a taxable year beginning after 2024, the $1,400 amount
+in subsection (h)(5) shall be increased by an amount equal to--
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2017" for "2016" in subparagraph (A)(ii) thereof.
+"""
+
+status: encoded
+
+refundable_credit_increase:
+    imports:
+        - 26/24/i/1/A#refundable_credit_base_amount
+        - 26/24/i/1/B#ctc_refundable_cola
+        - 26/24/i/3#rounding_multiple
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Refundable credit inflation increase"
+    description: "Inflation increase to the $1,400 refundable credit maximum per 26 USC 24(i)(1), equal to the base dollar amount multiplied by the COLA, rounded down per (i)(3)"
+    from 2025-01-01:
+        raw_increase = refundable_credit_base_amount * ctc_refundable_cola
+        floor(raw_increase / rounding_multiple) * rounding_multiple
+
+adjusted_refundable_credit_max:
+    imports:
+        - 26/24/i/1/A#refundable_credit_base_amount
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Inflation-adjusted maximum refundable credit"
+    description: "The maximum refundable credit amount after inflation adjustment per 26 USC 24(i)(1)"
+    from 2025-01-01:
+        refundable_credit_base_amount + refundable_credit_increase

--- a/statute/26/24/i/1.rac.test
+++ b/statute/26/24/i/1.rac.test
@@ -1,0 +1,41 @@
+# 26 USC 24(i)(1) tests
+
+refundable_credit_increase:
+    - name: "No COLA means no increase"
+      period: 2025-01
+      inputs:
+        refundable_credit_base_amount: 1400
+        ctc_refundable_cola: 0
+        rounding_multiple: 100
+      expect: 0
+
+    - name: "10% COLA yields $100 increase (1400 * 0.10 = 140, rounded down to 100)"
+      period: 2025-01
+      inputs:
+        refundable_credit_base_amount: 1400
+        ctc_refundable_cola: 0.10
+        rounding_multiple: 100
+      expect: 100
+
+    - name: "20% COLA yields $200 increase (1400 * 0.20 = 280, rounded down to 200)"
+      period: 2025-01
+      inputs:
+        refundable_credit_base_amount: 1400
+        ctc_refundable_cola: 0.20
+        rounding_multiple: 100
+      expect: 200
+
+adjusted_refundable_credit_max:
+    - name: "No increase means base amount"
+      period: 2025-01
+      inputs:
+        refundable_credit_base_amount: 1400
+        refundable_credit_increase: 0
+      expect: 1400
+
+    - name: "With $200 increase"
+      period: 2025-01
+      inputs:
+        refundable_credit_base_amount: 1400
+        refundable_credit_increase: 200
+      expect: 1600

--- a/statute/26/24/i/1/A.rac
+++ b/statute/26/24/i/1/A.rac
@@ -1,0 +1,22 @@
+# 26 USC 24(i)(1)(A) - Dollar amount multiplier
+
+"""
+(A) such dollar amount, multiplied by
+"""
+
+status: encoded
+
+refundable_credit_base_amount:
+    description: "The $1,400 dollar amount in subsection (h)(5) used as the base for inflation adjustment per 26 USC 24(i)(1)"
+    unit: USD
+    from 2025-01-01: 1400
+
+dollar_amount_multiplier:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Dollar amount multiplier"
+    description: "The base dollar amount component of the inflation adjustment for the maximum refundable credit per 26 USC 24(i)(1)(A)"
+    from 2025-01-01:
+        refundable_credit_base_amount

--- a/statute/26/24/i/1/A.rac.test
+++ b/statute/26/24/i/1/A.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 24(i)(1)(A) tests
+
+dollar_amount_multiplier:
+    - name: "Base dollar amount for inflation adjustment"
+      period: 2025-01
+      inputs: {}
+      expect: 1400
+
+    - name: "Base dollar amount for 2026"
+      period: 2026-01
+      inputs: {}
+      expect: 1400
+
+    - name: "Base dollar amount for 2030"
+      period: 2030-01
+      inputs: {}
+      expect: 1400

--- a/statute/26/24/i/1/B.rac
+++ b/statute/26/24/i/1/B.rac
@@ -1,0 +1,25 @@
+# 26 USC Section 24(i)(1)(B) - COLA determination
+
+"""
+(B) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2017" for "2016" in subparagraph (A)(ii) thereof.
+"""
+
+status: encoded
+
+ctc_refundable_cola_base_year:
+    description: "Base calendar year substituted for '2016' in section 1(f)(3)(A)(ii) for the CTC refundable credit inflation adjustment per 26 USC 24(i)(1)(B)"
+    unit: Year
+    from 2025-01-01: 2017
+
+ctc_refundable_cola:
+    imports:
+        - 26/1/f/3#cost_of_living_adjustment
+    entity: TaxUnit
+    period: Year
+    dtype: Rate
+    label: "CTC refundable credit COLA"
+    description: "Cost-of-living adjustment for the maximum refundable CTC amount, determined under section 1(f)(3) with base year 2017 per 26 USC 24(i)(1)(B)"
+    from 2025-01-01:
+        cost_of_living_adjustment

--- a/statute/26/24/i/1/B.rac.test
+++ b/statute/26/24/i/1/B.rac.test
@@ -1,0 +1,12 @@
+# 26 USC Section 24(i)(1)(B) tests
+
+ctc_refundable_cola_base_year:
+    - name: "Base year is 2017 for tax year 2025"
+      period: 2025-01
+      inputs: {}
+      expect: 2017
+
+    - name: "Base year is 2017 for tax year 2026"
+      period: 2026-01
+      inputs: {}
+      expect: 2017

--- a/statute/26/24/i/2.rac
+++ b/statute/26/24/i/2.rac
@@ -1,0 +1,40 @@
+# 26 USC 24(i)(2) - Special rule for adjustment of credit amount
+
+"""
+(2) Special rule for adjustment of credit amount.--
+In the case of a taxable year beginning after 2025, the $2,200 amount
+in subsection (h)(2) shall be increased by an amount equal to--
+(A) such dollar amount, multiplied by
+(B) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2024" for "2016" in subparagraph (A)(ii) thereof.
+"""
+
+status: encoded
+
+credit_amount_increase:
+    imports:
+        - 26/24/i/2/A#credit_amount_base
+        - 26/24/i/2/B#ctc_credit_amount_cola
+        - 26/24/i/3#rounding_multiple
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Credit amount inflation increase"
+    description: "Inflation increase to the $2,200 credit amount per 26 USC 24(i)(2), equal to the base dollar amount multiplied by the COLA, rounded down per (i)(3)"
+    from 2026-01-01:
+        raw_increase = credit_amount_base * ctc_credit_amount_cola
+        floor(raw_increase / rounding_multiple) * rounding_multiple
+
+adjusted_credit_amount:
+    imports:
+        - 26/24/h/2#ctc_h2_credit_amount
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Inflation-adjusted credit amount"
+    description: "The credit amount per qualifying child after inflation adjustment per 26 USC 24(i)(2)"
+    from 2026-01-01:
+        ctc_h2_credit_amount + credit_amount_increase

--- a/statute/26/24/i/2.rac.test
+++ b/statute/26/24/i/2.rac.test
@@ -1,0 +1,49 @@
+# 26 USC 24(i)(2) - Special rule for adjustment of credit amount tests
+
+credit_amount_increase:
+    - name: "5% COLA on $2,200 base, rounded down"
+      period: 2026-01
+      inputs:
+        credit_amount_base: 2200
+        ctc_credit_amount_cola: 0.05
+        rounding_multiple: 100
+      expect: 100
+
+    - name: "10% COLA on $2,200 base, exact multiple"
+      period: 2026-01
+      inputs:
+        credit_amount_base: 2200
+        ctc_credit_amount_cola: 0.10
+        rounding_multiple: 100
+      expect: 200
+
+    - name: "Zero COLA"
+      period: 2026-01
+      inputs:
+        credit_amount_base: 2200
+        ctc_credit_amount_cola: 0
+        rounding_multiple: 100
+      expect: 0
+
+    - name: "Small COLA rounds to zero"
+      period: 2026-01
+      inputs:
+        credit_amount_base: 2200
+        ctc_credit_amount_cola: 0.03
+        rounding_multiple: 100
+      expect: 0
+
+adjusted_credit_amount:
+    - name: "Base amount plus rounded increase"
+      period: 2026-01
+      inputs:
+        ctc_h2_credit_amount: 2200
+        credit_amount_increase: 100
+      expect: 2300
+
+    - name: "No inflation increase"
+      period: 2026-01
+      inputs:
+        ctc_h2_credit_amount: 2200
+        credit_amount_increase: 0
+      expect: 2200

--- a/statute/26/24/i/2/A.rac
+++ b/statute/26/24/i/2/A.rac
@@ -1,0 +1,22 @@
+# 26 USC 24(i)(2)(A) - Dollar amount multiplier
+
+"""
+(A) such dollar amount, multiplied by
+"""
+
+status: encoded
+
+credit_amount_base:
+    description: "The $2,200 dollar amount in subsection (h)(2) used as the base for inflation adjustment per 26 USC 24(i)(2)"
+    unit: USD
+    from 2026-01-01: 2200
+
+dollar_amount_multiplier:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Dollar amount multiplier"
+    description: "The base dollar amount component of the inflation adjustment for the credit amount per 26 USC 24(i)(2)(A)"
+    from 2026-01-01:
+        credit_amount_base

--- a/statute/26/24/i/2/A.rac.test
+++ b/statute/26/24/i/2/A.rac.test
@@ -1,0 +1,17 @@
+# 26 USC 24(i)(2)(A) tests
+
+dollar_amount_multiplier:
+    - name: "Base dollar amount for inflation adjustment"
+      period: 2026-01
+      inputs: {}
+      expect: 2200
+
+    - name: "Base dollar amount for 2027"
+      period: 2027-01
+      inputs: {}
+      expect: 2200
+
+    - name: "Base dollar amount for 2030"
+      period: 2030-01
+      inputs: {}
+      expect: 2200

--- a/statute/26/24/i/2/B.rac
+++ b/statute/26/24/i/2/B.rac
@@ -1,0 +1,25 @@
+# 26 USC Section 24(i)(2)(B) - COLA determination
+
+"""
+(B) the cost-of-living adjustment determined under section 1(f)(3)
+for the calendar year in which the taxable year begins, determined
+by substituting "2024" for "2016" in subparagraph (A)(ii) thereof.
+"""
+
+status: encoded
+
+ctc_credit_amount_cola_base_year:
+    description: "Base calendar year substituted for '2016' in section 1(f)(3)(A)(ii) for the CTC credit amount inflation adjustment per 26 USC 24(i)(2)(B)"
+    unit: Year
+    from 2026-01-01: 2024
+
+ctc_credit_amount_cola:
+    imports:
+        - 26/1/f/3#cost_of_living_adjustment
+    entity: TaxUnit
+    period: Year
+    dtype: Rate
+    label: "CTC credit amount COLA"
+    description: "Cost-of-living adjustment for the CTC credit amount, determined under section 1(f)(3) with base year 2024 per 26 USC 24(i)(2)(B)"
+    from 2026-01-01:
+        cost_of_living_adjustment

--- a/statute/26/24/i/2/B.rac.test
+++ b/statute/26/24/i/2/B.rac.test
@@ -1,0 +1,29 @@
+# 26 USC Section 24(i)(2)(B) tests
+
+ctc_credit_amount_cola_base_year:
+    - name: "Base year is 2024 for credit amount COLA"
+      period: 2026-01
+      expect: 2024
+
+    - name: "Base year is 2024 for later year"
+      period: 2030-01
+      expect: 2024
+
+ctc_credit_amount_cola:
+    - name: "COLA equals cost-of-living adjustment"
+      period: 2026-01
+      inputs:
+          cost_of_living_adjustment: 0.05
+      expect: 0.05
+
+    - name: "Zero COLA when no cost-of-living increase"
+      period: 2026-01
+      inputs:
+          cost_of_living_adjustment: 0
+      expect: 0
+
+    - name: "COLA passes through larger adjustment"
+      period: 2028-01
+      inputs:
+          cost_of_living_adjustment: 0.12
+      expect: 0.12

--- a/statute/26/24/i/3.rac
+++ b/statute/26/24/i/3.rac
@@ -1,0 +1,23 @@
+# 26 USC 24(i)(3) - Rounding
+
+"""
+(3) Rounding.-- If any increase under this subsection is not a multiple
+of $100, such increase shall be rounded to the next lowest multiple of $100.
+"""
+
+status: encoded
+
+rounding_multiple:
+    description: "Rounding multiple for inflation increases under 26 USC 24(i)"
+    unit: USD
+    from 2025-01-01: 100
+
+rounded_increase:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Rounded inflation increase"
+    description: "Inflation increase under 26 USC 24(i), rounded down to the next lowest multiple of $100 per 26 USC 24(i)(3)"
+    from 2025-01-01:
+        floor(increase / rounding_multiple) * rounding_multiple

--- a/statute/26/24/i/3.rac.test
+++ b/statute/26/24/i/3.rac.test
@@ -1,0 +1,32 @@
+# 26 USC 24(i)(3) - Rounding tests
+
+rounded_increase:
+    - name: "Increase already a multiple of $100"
+      period: 2025-01
+      inputs:
+        increase: 300
+      expect: 300
+
+    - name: "Increase not a multiple - rounds down"
+      period: 2025-01
+      inputs:
+        increase: 350
+      expect: 300
+
+    - name: "Increase just under next multiple"
+      period: 2025-01
+      inputs:
+        increase: 199
+      expect: 100
+
+    - name: "Zero increase"
+      period: 2025-01
+      inputs:
+        increase: 0
+      expect: 0
+
+    - name: "Small increase below rounding multiple"
+      period: 2025-01
+      inputs:
+        increase: 99
+      expect: 0

--- a/statute/26/24/j/1.rac
+++ b/statute/26/24/j/1.rac
@@ -1,0 +1,33 @@
+# 26 USC Section 24(j)(1) - In general
+
+"""
+(1) In general.-- The amount of the credit allowed under this section to any
+taxpayer for any taxable year shall be reduced (but not below zero) by the
+aggregate amount of payments made under section 7527A to such taxpayer during
+such taxable year. Any failure to so reduce the credit shall be treated as
+arising out of a mathematical or clerical error and assessed according to
+section 6213(b)(1).
+"""
+
+status: encoded
+
+advance_ctc_payments:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Advance child tax credit payments"
+    description: "Aggregate amount of payments made under section 7527A to the taxpayer during the taxable year"
+    default: 0
+
+ctc_after_advance_payment_reduction:
+    imports:
+        - 26/24/a#ctc_allowance
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Child tax credit after advance payment reduction"
+    description: "CTC reduced (but not below zero) by aggregate advance payments under section 7527A, per 26 USC 24(j)(1)"
+    from 2021-01-01:
+        max(0, ctc_allowance - advance_ctc_payments)

--- a/statute/26/24/j/1.rac.test
+++ b/statute/26/24/j/1.rac.test
@@ -1,0 +1,37 @@
+# 26 USC Section 24(j)(1) tests
+
+ctc_after_advance_payment_reduction:
+    - name: "No advance payments - full credit preserved"
+      period: 2021-01
+      inputs:
+        ctc_allowance: 6000
+        advance_ctc_payments: 0
+      expect: 6000
+
+    - name: "Partial advance payments - credit reduced"
+      period: 2021-01
+      inputs:
+        ctc_allowance: 6000
+        advance_ctc_payments: 3000
+      expect: 3000
+
+    - name: "Advance payments equal credit - zero result"
+      period: 2021-01
+      inputs:
+        ctc_allowance: 4000
+        advance_ctc_payments: 4000
+      expect: 0
+
+    - name: "Advance payments exceed credit - floored at zero"
+      period: 2021-01
+      inputs:
+        ctc_allowance: 2000
+        advance_ctc_payments: 5000
+      expect: 0
+
+    - name: "No credit and no payments"
+      period: 2021-01
+      inputs:
+        ctc_allowance: 0
+        advance_ctc_payments: 0
+      expect: 0

--- a/statute/26/24/j/2/A.rac
+++ b/statute/26/24/j/2/A.rac
@@ -1,0 +1,36 @@
+# 26 USC Section 24(j)(2)(A) - In general (Excess advance payments)
+
+"""
+(A) In general.-- If the aggregate amount of payments under section 7527A to
+the taxpayer during the taxable year exceeds the amount of the credit allowed
+under this section to such taxpayer for such taxable year (determined without
+regard to paragraph (1)), the tax imposed by this chapter for such taxable year
+shall be increased by the amount of such excess. Any failure to so increase the
+tax shall be treated as arising out of a mathematical or clerical error and
+assessed according to section 6213(b)(1).
+"""
+
+status: encoded
+
+excess_advance_ctc_payments:
+    imports:
+        - 26/24/j/1#advance_ctc_payments
+        - 26/24/a#ctc_allowance
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Excess advance child tax credit payments"
+    description: "Amount by which advance CTC payments exceed the credit allowed (without regard to paragraph (1) reduction), per 26 USC 24(j)(2)(A)"
+    from 2021-01-01:
+        max(0, advance_ctc_payments - ctc_allowance)
+
+ctc_excess_advance_tax_increase:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Tax increase for excess advance CTC payments"
+    description: "Tax increase equal to excess advance CTC payments per 26 USC 24(j)(2)(A)"
+    from 2021-01-01:
+        excess_advance_ctc_payments

--- a/statute/26/24/j/2/A.rac.test
+++ b/statute/26/24/j/2/A.rac.test
@@ -1,0 +1,52 @@
+# 26 USC Section 24(j)(2)(A) tests
+
+excess_advance_ctc_payments:
+    - name: "No excess when advance payments equal credit"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 2000
+        ctc_allowance: 2000
+      expect: 0
+
+    - name: "No excess when advance payments less than credit"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 1000
+        ctc_allowance: 2000
+      expect: 0
+
+    - name: "Excess when advance payments exceed credit"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 5000
+        ctc_allowance: 2000
+      expect: 3000
+
+    - name: "No advance payments"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 0
+        ctc_allowance: 2000
+      expect: 0
+
+    - name: "No credit and advance payments received"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 3000
+        ctc_allowance: 0
+      expect: 3000
+
+ctc_excess_advance_tax_increase:
+    - name: "Tax increase equals excess advance payments"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 5000
+        ctc_allowance: 2000
+      expect: 3000
+
+    - name: "No tax increase when no excess"
+      period: 2024-01
+      inputs:
+        advance_ctc_payments: 1000
+        ctc_allowance: 2000
+      expect: 0

--- a/statute/26/24/j/2/B/i.rac
+++ b/statute/26/24/j/2/B/i.rac
@@ -1,0 +1,47 @@
+# 26 USC Section 24(j)(2)(B)(i) - In general (Safe harbor)
+
+"""
+(i) In general.-- In the case of a taxpayer whose modified adjusted gross income
+(as defined in subsection (b)) for the taxable year does not exceed 200 percent
+of the applicable income threshold, the amount of the increase determined under
+subparagraph (A) with respect to such taxpayer for such taxable year shall be
+reduced (but not below zero) by the safe harbor amount.
+"""
+
+status: encoded
+
+applicable_income_threshold:
+    imports:
+        - 26/24/j/2/B/iii#applicable_income_threshold_joint
+        - 26/24/j/2/B/iii#applicable_income_threshold_head_of_household
+        - 26/24/j/2/B/iii#applicable_income_threshold_other
+        - 26/7703/a#is_joint_return
+        - 26/2/a#is_surviving_spouse
+        - 26/63/c/2/B#is_head_of_household
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Applicable income threshold"
+    description: "Applicable income threshold based on filing status per 26 USC 24(j)(2)(B)(iii)"
+    from 2021-01-01:
+        if is_joint_return or is_surviving_spouse: applicable_income_threshold_joint
+        elif is_head_of_household: applicable_income_threshold_head_of_household
+        else: applicable_income_threshold_other
+
+safe_harbor_reduction:
+    imports:
+        - 26/24/j/2/A#ctc_excess_advance_tax_increase
+        - 26/24/j/2/B/iv#safe_harbor_amount
+        - 26/24/b/1#ctc_modified_agi
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Safe harbor reduction of excess advance CTC repayment"
+    description: "Reduction of excess advance CTC repayment by safe harbor amount when MAGI does not exceed 200% of applicable income threshold, per 26 USC 24(j)(2)(B)(i)"
+    from 2021-01-01:
+        magi_cap = 2 * applicable_income_threshold
+        if ctc_modified_agi <= magi_cap:
+            max(0, ctc_excess_advance_tax_increase - safe_harbor_amount)
+        else: ctc_excess_advance_tax_increase

--- a/statute/26/24/j/2/B/i.rac.test
+++ b/statute/26/24/j/2/B/i.rac.test
@@ -1,0 +1,117 @@
+# 26 USC Section 24(j)(2)(B)(i) tests
+
+applicable_income_threshold:
+    - name: "Joint return gets joint threshold"
+      period: 2021-01
+      inputs:
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: true
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 60000
+
+    - name: "Surviving spouse gets joint threshold"
+      period: 2021-01
+      inputs:
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: true
+        is_head_of_household: false
+      expect: 60000
+
+    - name: "Head of household gets HOH threshold"
+      period: 2021-01
+      inputs:
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: true
+      expect: 50000
+
+    - name: "Other filer gets other threshold"
+      period: 2021-01
+      inputs:
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 40000
+
+safe_harbor_reduction:
+    - name: "MAGI below cap - full safe harbor reduces excess to zero"
+      period: 2021-01
+      inputs:
+        ctc_excess_advance_tax_increase: 2000
+        safe_harbor_amount: 2000
+        ctc_modified_agi: 50000
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 0
+
+    - name: "MAGI below cap - safe harbor partially reduces excess"
+      period: 2021-01
+      inputs:
+        ctc_excess_advance_tax_increase: 5000
+        safe_harbor_amount: 2000
+        ctc_modified_agi: 50000
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 3000
+
+    - name: "MAGI exceeds 200% cap - no safe harbor reduction"
+      period: 2021-01
+      inputs:
+        ctc_excess_advance_tax_increase: 5000
+        safe_harbor_amount: 2000
+        ctc_modified_agi: 90000
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 5000
+
+    - name: "MAGI at exactly 200% cap - safe harbor applies"
+      period: 2021-01
+      inputs:
+        ctc_excess_advance_tax_increase: 4000
+        safe_harbor_amount: 2000
+        ctc_modified_agi: 80000
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 2000
+
+    - name: "Safe harbor exceeds excess - floor at zero"
+      period: 2021-01
+      inputs:
+        ctc_excess_advance_tax_increase: 1000
+        safe_harbor_amount: 4000
+        ctc_modified_agi: 30000
+        applicable_income_threshold_joint: 60000
+        applicable_income_threshold_head_of_household: 50000
+        applicable_income_threshold_other: 40000
+        is_joint_return: false
+        is_surviving_spouse: false
+        is_head_of_household: false
+      expect: 0

--- a/statute/26/24/j/2/B/ii.rac
+++ b/statute/26/24/j/2/B/ii.rac
@@ -1,0 +1,27 @@
+# 26 USC Section 24(j)(2)(B)(ii) - Phase out of safe harbor
+
+"""
+(ii) Phase out of safe harbor.-- In the case of a taxpayer whose modified adjusted
+gross income (as defined in subsection (b)) for the taxable year exceeds the applicable
+income threshold, the safe harbor amount otherwise in effect under clause (i) shall be
+reduced by the amount which bears the same ratio to such amount as such excess bears to
+the applicable income threshold.
+"""
+
+status: encoded
+
+phased_out_safe_harbor_amount:
+    imports:
+        - 26/24/j/2/B/iv#safe_harbor_amount
+        - 26/24/j/2/B/i#applicable_income_threshold
+        - 26/24/b/1#ctc_modified_agi
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Phased-out safe harbor amount"
+    description: "Safe harbor amount reduced proportionally when MAGI exceeds applicable income threshold per 26 USC 24(j)(2)(B)(ii)"
+    from 2021-01-01:
+        excess = max(0, ctc_modified_agi - applicable_income_threshold)
+        reduction = safe_harbor_amount * excess / max(1, applicable_income_threshold)
+        max(0, safe_harbor_amount - reduction)

--- a/statute/26/24/j/2/B/ii.rac.test
+++ b/statute/26/24/j/2/B/ii.rac.test
@@ -1,0 +1,42 @@
+# 26 USC Section 24(j)(2)(B)(ii) tests
+
+phased_out_safe_harbor_amount:
+    - name: "MAGI at applicable income threshold - no phase out"
+      period: 2021-01
+      inputs:
+        safe_harbor_amount: 2000
+        applicable_income_threshold: 60000
+        ctc_modified_agi: 60000
+      expect: 2000
+
+    - name: "MAGI at midpoint - 50% phase out"
+      period: 2021-01
+      inputs:
+        safe_harbor_amount: 2000
+        applicable_income_threshold: 60000
+        ctc_modified_agi: 90000
+      expect: 1000
+
+    - name: "MAGI at 200% of threshold - full phase out"
+      period: 2021-01
+      inputs:
+        safe_harbor_amount: 2000
+        applicable_income_threshold: 60000
+        ctc_modified_agi: 120000
+      expect: 0
+
+    - name: "MAGI below threshold - no reduction"
+      period: 2021-01
+      inputs:
+        safe_harbor_amount: 4000
+        applicable_income_threshold: 40000
+        ctc_modified_agi: 30000
+      expect: 4000
+
+    - name: "Zero safe harbor amount - no reduction possible"
+      period: 2021-01
+      inputs:
+        safe_harbor_amount: 0
+        applicable_income_threshold: 50000
+        ctc_modified_agi: 75000
+      expect: 0

--- a/statute/26/24/j/2/B/iii.rac
+++ b/statute/26/24/j/2/B/iii.rac
@@ -1,0 +1,26 @@
+# 26 USC Section 24(j)(2)(B)(iii) - Applicable income threshold
+
+"""
+(iii) Applicable income threshold
+For purposes of this subparagraph, the term "applicable income threshold" means—
+(I) $60,000 in the case of a joint return or surviving spouse (as defined in section 2(a)),
+(II) $50,000 in the case of a head of household, and
+(III) $40,000 in any other case.
+"""
+
+status: encoded
+
+applicable_income_threshold_joint:
+    description: "Applicable income threshold for joint returns or surviving spouses per 26 USC 24(j)(2)(B)(iii)(I)"
+    unit: USD
+    from 2021-01-01: 60000
+
+applicable_income_threshold_head_of_household:
+    description: "Applicable income threshold for head of household per 26 USC 24(j)(2)(B)(iii)(II)"
+    unit: USD
+    from 2021-01-01: 50000
+
+applicable_income_threshold_other:
+    description: "Applicable income threshold for all other filing statuses per 26 USC 24(j)(2)(B)(iii)(III)"
+    unit: USD
+    from 2021-01-01: 40000

--- a/statute/26/24/j/2/B/iii.rac.test
+++ b/statute/26/24/j/2/B/iii.rac.test
@@ -1,0 +1,16 @@
+# 26 USC Section 24(j)(2)(B)(iii) tests
+
+applicable_income_threshold_joint:
+    - name: "Joint return threshold is $60,000"
+      period: 2021-01
+      expect: 60000
+
+applicable_income_threshold_head_of_household:
+    - name: "Head of household threshold is $50,000"
+      period: 2021-01
+      expect: 50000
+
+applicable_income_threshold_other:
+    - name: "Other filing status threshold is $40,000"
+      period: 2021-01
+      expect: 40000

--- a/statute/26/24/j/2/B/iii/I.rac
+++ b/statute/26/24/j/2/B/iii/I.rac
@@ -1,0 +1,13 @@
+# 26 USC Section 24(j)(2)(B)(iii)(I) - Joint return threshold
+
+"""
+(I) $60,000 in the case of a joint return or surviving spouse
+(as defined in section 2(a)),
+"""
+
+status: encoded
+
+applicable_income_threshold_joint:
+    description: "Applicable income threshold for joint returns or surviving spouses for advance CTC safe harbor"
+    unit: USD
+    from 2021-01-01: 60000

--- a/statute/26/24/j/2/B/iii/I.rac.test
+++ b/statute/26/24/j/2/B/iii/I.rac.test
@@ -1,0 +1,14 @@
+# 26 USC Section 24(j)(2)(B)(iii)(I) tests
+
+applicable_income_threshold_joint:
+    - name: "Joint return threshold for 2021"
+      period: 2021-01
+      expect: 60000
+
+    - name: "Joint return threshold for 2024"
+      period: 2024-01
+      expect: 60000
+
+    - name: "Joint return threshold for 2025"
+      period: 2025-01
+      expect: 60000

--- a/statute/26/24/j/2/B/iii/II.rac
+++ b/statute/26/24/j/2/B/iii/II.rac
@@ -1,0 +1,12 @@
+# 26 USC Section 24(j)(2)(B)(iii)(II) - Head of household threshold
+
+"""
+(II) $50,000 in the case of a head of household,
+"""
+
+status: encoded
+
+applicable_income_threshold_head_of_household:
+    description: "Applicable income threshold for head of household for advance CTC safe harbor"
+    unit: USD
+    from 2021-01-01: 50000

--- a/statute/26/24/j/2/B/iii/II.rac.test
+++ b/statute/26/24/j/2/B/iii/II.rac.test
@@ -1,0 +1,14 @@
+# 26 USC Section 24(j)(2)(B)(iii)(II) tests
+
+applicable_income_threshold_head_of_household:
+    - name: "Head of household threshold is $50,000"
+      period: 2021-01
+      expect: 50000
+
+    - name: "Head of household threshold in 2023"
+      period: 2023-01
+      expect: 50000
+
+    - name: "Head of household threshold in 2024"
+      period: 2024-01
+      expect: 50000

--- a/statute/26/24/j/2/B/iii/III.rac
+++ b/statute/26/24/j/2/B/iii/III.rac
@@ -1,0 +1,12 @@
+# 26 USC Section 24(j)(2)(B)(iii)(III) - Other threshold
+
+"""
+(III) $40,000 in any other case.
+"""
+
+status: encoded
+
+applicable_income_threshold_other:
+    description: "Applicable income threshold for all other filing statuses for advance CTC safe harbor"
+    unit: USD
+    from 2021-01-01: 40000

--- a/statute/26/24/j/2/B/iii/III.rac.test
+++ b/statute/26/24/j/2/B/iii/III.rac.test
@@ -1,0 +1,14 @@
+# 26 USC Section 24(j)(2)(B)(iii)(III) tests
+
+applicable_income_threshold_other:
+    - name: "Other threshold for 2021"
+      period: 2021-01
+      expect: 40000
+
+    - name: "Other threshold for 2024"
+      period: 2024-01
+      expect: 40000
+
+    - name: "Other threshold for 2025"
+      period: 2025-01
+      expect: 40000

--- a/statute/26/24/j/2/B/iv.rac
+++ b/statute/26/24/j/2/B/iv.rac
@@ -1,0 +1,27 @@
+# 26 USC Section 24(j)(2)(B)(iv) - Safe harbor amount
+
+"""
+(iv) Safe harbor amount
+For purposes of this subparagraph, the term "safe harbor amount" means, with respect to
+any taxable year, the product of—
+(I) $2,000, multiplied by
+(II) the excess (if any) of the number of qualified children taken into account in
+determining the annual advance amount with respect to the taxpayer under section 7527A
+with respect to months beginning in such taxable year, over the number of qualified
+children taken into account in determining the credit allowed under this section for
+such taxable year.
+"""
+
+status: encoded
+
+safe_harbor_amount:
+    imports:
+        - 26/24/j/2/B/iv/I#safe_harbor_base_amount
+        - 26/24/j/2/B/iv/II#excess_children
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    label: "Safe harbor amount"
+    description: "Product of base amount and excess children per 26 USC 24(j)(2)(B)(iv)"
+    from 2021-01-01:
+        safe_harbor_base_amount * excess_children

--- a/statute/26/24/j/2/B/iv.rac.test
+++ b/statute/26/24/j/2/B/iv.rac.test
@@ -1,0 +1,23 @@
+# 26 USC Section 24(j)(2)(B)(iv) tests
+
+safe_harbor_amount:
+    - name: "No excess children"
+      period: 2021-01
+      inputs:
+        safe_harbor_base_amount: 2000
+        excess_children: 0
+      expect: 0
+
+    - name: "One excess child"
+      period: 2021-01
+      inputs:
+        safe_harbor_base_amount: 2000
+        excess_children: 1
+      expect: 2000
+
+    - name: "Three excess children"
+      period: 2021-01
+      inputs:
+        safe_harbor_base_amount: 2000
+        excess_children: 3
+      expect: 6000

--- a/statute/26/24/j/2/B/iv/I.rac
+++ b/statute/26/24/j/2/B/iv/I.rac
@@ -1,0 +1,12 @@
+# 26 USC Section 24(j)(2)(B)(iv)(I) - Base amount
+
+"""
+(I) $2,000, multiplied by
+"""
+
+status: encoded
+
+safe_harbor_base_amount:
+    description: "Base amount per child for safe harbor calculation under advance CTC reconciliation"
+    unit: USD
+    from 2021-01-01: 2000

--- a/statute/26/24/j/2/B/iv/I.rac.test
+++ b/statute/26/24/j/2/B/iv/I.rac.test
@@ -1,0 +1,14 @@
+# 26 USC Section 24(j)(2)(B)(iv)(I) tests
+
+safe_harbor_base_amount:
+    - name: "Base amount for 2021"
+      period: 2021-01
+      expect: 2000
+
+    - name: "Base amount for 2024"
+      period: 2024-01
+      expect: 2000
+
+    - name: "Base amount for 2025"
+      period: 2025-01
+      expect: 2000

--- a/statute/26/24/j/2/B/iv/II.rac
+++ b/statute/26/24/j/2/B/iv/II.rac
@@ -1,0 +1,23 @@
+# 26 USC Section 24(j)(2)(B)(iv)(II) - Excess children
+
+"""
+(II) the excess (if any) of the number of qualified children taken into
+account in determining the annual advance amount with respect to the
+taxpayer under section 7527A with respect to months beginning in such
+taxable year, over the number of qualified children taken into account
+in determining the credit allowed under this section for such taxable year.
+"""
+
+status: encoded
+
+excess_children:
+    imports:
+        - 26/7527A#advance_qualified_children
+        - 26/24#credit_qualified_children
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    label: "Excess children"
+    description: "Excess of qualified children used for advance payments over those used for actual credit per 26 USC 24(j)(2)(B)(iv)(II)"
+    from 2021-01-01:
+        max(0, advance_qualified_children - credit_qualified_children)

--- a/statute/26/24/j/2/B/iv/II.rac.test
+++ b/statute/26/24/j/2/B/iv/II.rac.test
@@ -1,0 +1,37 @@
+# 26 USC Section 24(j)(2)(B)(iv)(II) tests
+
+excess_children:
+    - name: "No excess - same number of children"
+      period: 2021-01
+      inputs:
+        advance_qualified_children: 2
+        credit_qualified_children: 2
+      expect: 0
+
+    - name: "Excess children - advance exceeds credit"
+      period: 2021-01
+      inputs:
+        advance_qualified_children: 3
+        credit_qualified_children: 1
+      expect: 2
+
+    - name: "No excess - credit exceeds advance"
+      period: 2021-01
+      inputs:
+        advance_qualified_children: 1
+        credit_qualified_children: 3
+      expect: 0
+
+    - name: "Zero advance children"
+      period: 2021-01
+      inputs:
+        advance_qualified_children: 0
+        credit_qualified_children: 2
+      expect: 0
+
+    - name: "Zero both"
+      period: 2021-01
+      inputs:
+        advance_qualified_children: 0
+        credit_qualified_children: 0
+      expect: 0

--- a/statute/26/3101/3101.rac
+++ b/statute/26/3101/3101.rac
@@ -1,0 +1,96 @@
+# 26 USC 3101
+
+"""
+§ 3101. Rate of tax
+(a) Old-age, survivors, and disability insurance.-- In addition to other
+taxes, there is hereby imposed on the income of every individual a tax equal
+to 6.2 percent of the wages (as defined in section 3121(a)) received by the
+individual with respect to employment (as defined in section 3121(b)).
+
+(b) Hospital insurance.--
+(1) In general.-- In addition to the tax imposed by the preceding
+subsection, there is hereby imposed on the income of every individual a tax
+equal to 1.45 percent of the wages (as defined in section 3121(a)) received
+by him with respect to employment (as defined in section 3121(b)).
+
+(2) Additional tax.-- In addition to the tax imposed by paragraph (1) and
+the preceding subsection, there is hereby imposed on every taxpayer (other
+than a corporation, estate, or trust) a tax equal to 0.9 percent of wages
+which are received with respect to employment (as defined in section 3121(b))
+during any taxable year beginning after December 31, 2012, and which are in
+excess of--
+  (A) in the case of a joint return, $250,000,
+  (B) in the case of a married taxpayer (as defined in section 7703) filing
+      a separate return, 1/2 of the dollar amount determined under
+      subparagraph (A), and
+  (C) in any other case, $200,000.
+
+(c) Relief from taxes in cases covered by certain international agreements.--
+During any period in which there is in effect an agreement entered into
+pursuant to section 233 of the Social Security Act with any foreign country,
+wages received by or paid to an individual shall be exempt from the taxes
+imposed by this section to the extent that such wages are subject under such
+agreement exclusively to the laws applicable to the social security system of
+such foreign country.
+"""
+
+status: encoded
+
+# (a) OASDI rate
+oasdi_rate:
+    description: "Old-age, survivors, and disability insurance tax rate per 26 USC 3101(a)"
+    unit: rate
+    from 2014-01-01: 0.062
+
+# (b)(1) HI rate
+hi_rate:
+    description: "Hospital insurance tax rate per 26 USC 3101(b)(1)"
+    unit: rate
+    from 2010-01-01: 0.0145
+
+# (b)(2) Additional Medicare tax rate
+additional_medicare_tax_rate:
+    description: "Additional hospital insurance tax rate per 26 USC 3101(b)(2)"
+    unit: rate
+    from 2013-01-01: 0.009
+
+# (b)(2)(A) Threshold for joint return
+additional_medicare_tax_threshold_joint:
+    description: "Wage threshold for additional Medicare tax on a joint return per 26 USC 3101(b)(2)(A)"
+    unit: USD
+    from 2013-01-01: 250000
+
+# (b)(2)(B) Threshold for married filing separately (half of joint)
+additional_medicare_tax_threshold_separate:
+    description: "Wage threshold for additional Medicare tax for married filing separately per 26 USC 3101(b)(2)(B)"
+    unit: USD
+    from 2013-01-01: 125000
+
+# (b)(2)(C) Threshold for all other filers
+additional_medicare_tax_threshold_other:
+    description: "Wage threshold for additional Medicare tax for filers other than joint or married separate per 26 USC 3101(b)(2)(C)"
+    unit: USD
+    from 2013-01-01: 200000
+
+fica_employee_tax:
+    imports:
+        - 26/3121/a#wages_under_3121a
+        - 26/7703/a#is_joint_return
+        - 26/7703/a#is_married
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "FICA employee tax"
+    description: "Total employee portion of FICA taxes imposed by 26 USC 3101: OASDI tax (subsection a) plus hospital insurance tax (subsection b(1)) plus additional Medicare tax (subsection b(2))"
+    from 2013-01-01:
+        oasdi_tax = oasdi_rate * wages_under_3121a
+        hi_tax = hi_rate * wages_under_3121a
+        additional_medicare_threshold = (
+            if is_joint_return: additional_medicare_tax_threshold_joint
+            elif is_married: additional_medicare_tax_threshold_separate
+            else: additional_medicare_tax_threshold_other
+        )
+        excess_wages = max(wages_under_3121a - additional_medicare_threshold, 0)
+        additional_medicare_tax = additional_medicare_tax_rate * excess_wages
+        oasdi_tax + hi_tax + additional_medicare_tax

--- a/statute/26/3201/a.rac
+++ b/statute/26/3201/a.rac
@@ -1,0 +1,22 @@
+# 26 USC 3201(a)
+
+"""
+§ 3201. Rate of tax
+(a) Tier 1 tax.-- In addition to other taxes, there is hereby imposed on
+the income of each employee a tax equal to the applicable percentage of the
+compensation received during any calendar year by such employee for services
+rendered by such employee. For purposes of the preceding sentence, the term
+"applicable percentage" means the percentage equal to the sum of the rates of
+tax in effect under subsections (a) and (b) of section 3101 for the calendar
+year.
+"""
+
+status: stub
+
+railroad_retirement_tier1_tax:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Railroad retirement tier 1 employee tax"
+    description: "Tax imposed on railroad employee compensation equal to the sum of rates under 26 USC 3101(a) (OASDI) and 3101(b) (HI), applied to compensation as defined in 26 USC 3231(e)"

--- a/statute/26/3211/a.rac
+++ b/statute/26/3211/a.rac
@@ -1,0 +1,23 @@
+# 26 USC 3211(a)
+
+"""
+§ 3211. Rate of tax
+(a) Tier 1 tax.-- In addition to other taxes, there is hereby imposed on
+the income of each employee representative a tax equal to the applicable
+percentage of the compensation received during any calendar year by such
+employee representative for services rendered by such employee representative.
+For purposes of the preceding sentence, the term "applicable percentage" means
+the percentage equal to the sum of the rates of tax in effect under subsections
+(a) and (b) of section 3101 and subsections (a) and (b) of section 3201 for
+the calendar year.
+"""
+
+status: stub
+
+railroad_employee_representative_tax:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    unit: USD
+    label: "Railroad retirement tier 1 employee representative tax"
+    description: "Tax imposed on railroad employee representative compensation equal to the sum of rates under 26 USC 3101(a)-(b) and 3201(a)-(b), applied to compensation as defined in 26 USC 3231(e)"

--- a/statute/26/6413/c.rac
+++ b/statute/26/6413/c.rac
@@ -1,0 +1,25 @@
+# 26 USC 6413(c)
+
+"""
+(c) Special refunds.--
+(1) In general.-- If by reason of an employee receiving wages from
+more than one employer during a calendar year the wages received by
+him during such year exceed the contribution and benefit base (as
+determined under section 230 of the Social Security Act) which is
+effective with respect to such year, the employee shall be entitled
+to a credit or refund of any amount of tax imposed by section
+3101(a) or section 3201(a) with respect to such wages which is
+deducted and withheld (whether or not paid to the Secretary) from
+the excess. The term "wages" as used in this paragraph shall, for
+purposes of this paragraph, include "compensation" as defined in
+section 3231(e).
+"""
+
+status: stub
+
+special_refund_of_social_security_taxes:
+    entity: TaxUnit
+    period: Year
+    dtype: Money
+    label: "Special refund of social security taxes"
+    description: "Credit or refund of social security tax (section 3101(a) or 3201(a)) withheld on wages exceeding the contribution and benefit base, when an employee receives wages from more than one employer during a calendar year, per 26 USC 6413(c)(1)"

--- a/statute/26/7527A/7527A.rac
+++ b/statute/26/7527A/7527A.rac
@@ -1,0 +1,43 @@
+# 26 USC 7527A - Advance payment of child tax credit
+
+"""
+§ 7527A. Advance payment of child tax credit
+(a) In general.-- The Secretary shall establish a program for making periodic
+payments to taxpayers which, in the aggregate during any calendar year, equal
+the annual advance amount determined with respect to such taxpayer for such
+calendar year.
+
+(b) Annual advance amount.-- For purposes of this section—
+(1) In general.-- The term "annual advance amount" means, with respect to any
+taxpayer for any calendar year, the amount (if any) which is estimated by the
+Secretary as being equal to 50 percent of the amount which would be treated as
+allowed under subpart C of part IV of subchapter A of chapter 1 by reason of
+section 24(i)(1) for the taxpayer's taxable year beginning in such calendar
+year if—
+  (A) the status of the taxpayer as a taxpayer described in section 24(i)(1) is
+  determined with respect to the reference taxable year,
+  (B) the taxpayer's modified adjusted gross income for such taxable year is
+  equal to the taxpayer's modified adjusted gross income for the reference
+  taxable year,
+  (C) the only children of such taxpayer for such taxable year are qualifying
+  children properly claimed on the taxpayer's return of tax for the reference
+  taxable year, and
+  (D) the ages of such children (and the status of such children as qualifying
+  children) are determined for such taxable year by taking into account the
+  passage of time since the reference taxable year.
+"""
+
+status: stub
+
+# The number of qualifying children used by the Secretary to determine
+# advance CTC payments per 26 USC 7527A(b)(1)(C). This is an
+# administrative determination based on the taxpayer's reference year
+# return, not directly computable from a single formula.
+advance_qualified_children:
+    entity: TaxUnit
+    period: Year
+    dtype: Integer
+    status: input
+    label: "Advance qualifying children"
+    description: "Number of qualifying children used by the Secretary in determining advance child tax credit payments per 26 USC 7527A(b)(1)(C), based on children properly claimed on the taxpayer's return for the reference taxable year"
+    default: 0

--- a/statute/26/7703/a.rac
+++ b/statute/26/7703/a.rac
@@ -19,3 +19,21 @@ marital_status_under_7703a:
     dtype: Boolean
     label: "Married under 7703(a)"
     description: "Whether the individual is considered married under 26 USC 7703(a) - determined as of close of taxable year (or time of spouse's death if spouse died during year), excluding individuals legally separated under a decree of divorce or separate maintenance"
+
+is_married:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    status: input
+    label: "Is married"
+    description: "Whether the individual is married as of the close of the taxable year per 26 USC 7703(a)(1), excluding individuals legally separated under a decree of divorce or separate maintenance per 7703(a)(2)"
+    default: false
+
+is_joint_return:
+    entity: TaxUnit
+    period: Year
+    dtype: Boolean
+    status: input
+    label: "Files a joint return"
+    description: "Whether the individual files a joint return with their spouse for the taxable year"
+    default: false


### PR DESCRIPTION
## Summary

- Full autorac CLI encoding of 26 USC 24 (Child Tax Credit)
- 53 `.rac` files covering subsections (a) through (j)
- 46 `.rac.test` companion test files
- Auto-generated stubs for external dependencies (FICA, self-employment tax, railroad retirement, etc.)

## Known issues

- 11/14 stub generations failed — `_extract_rac_content()` couldn't parse LLM responses. Tracked for improvement.
- "atlas not installed" warnings during stub generation — atlas path discovery needs to be configurable.

## Test plan

- [ ] Spot-check CTC amounts in test files ($2,000 base, $2,200 OBBBA)
- [ ] Verify refundable portion calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)