### PR TITLE
Encode 42 USC 607 (TANF work requirements): 52 .rac files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Write",
+      "Edit",
+      "Bash(mkdir:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "WebFetch"
+    ]
+  }
+}

--- a/statute/42/607/607.rac
+++ b/statute/42/607/607.rac
@@ -1,0 +1,55 @@
+# 42 USC Section 607 - Mandatory work requirements
+
+"""
+Sec. 607. Mandatory work requirements.
+
+(a) Participation rate requirements.-- States must achieve minimum
+participation rates for all families and 2-parent families receiving
+TANF assistance.
+
+(b) Calculation of participation rates.-- Participation rates are
+calculated as average monthly rates, with adjustments for caseload
+reductions.
+
+(c) Engaged in work.-- Defines what constitutes being engaged in work,
+including minimum hours and special rules.
+
+(d) Work activities.-- Enumerates 12 approved work activities.
+
+(e) Penalties against individuals.-- Provides for reduction or
+termination of assistance for refusal to engage in work, with
+exception for inability to obtain child care.
+
+(f) Nondisplacement.-- Prohibits using TANF participants to displace
+regular workers.
+"""
+
+status: encoded
+
+tanf_all_families_requirement_met:
+    imports:
+        - 42/607/a/1#min_participation_rate_all_families
+        - 42/607/b/1/A#tanf_annual_participation_rate_all_families
+        - 42/607/b/3/A#caseload_reduction_credit
+    entity: Family
+    period: Year
+    dtype: Boolean
+    label: "State meets all-families participation rate requirement"
+    description: "Whether the State's annual participation rate for all families meets the applicable minimum after caseload reduction credit per 42 USC 607(a)(1) and (b)(3)(A)"
+    from 1996-10-01:
+        effective_min_rate = max(0, min_participation_rate_all_families - caseload_reduction_credit)
+        tanf_annual_participation_rate_all_families >= effective_min_rate
+
+tanf_two_parent_requirement_met:
+    imports:
+        - 42/607/a/2#two_parent_min_participation_rate
+        - 42/607/b/2/A#tanf_annual_participation_rate_two_parent_families
+        - 42/607/b/3/A#caseload_reduction_credit
+    entity: Family
+    period: Year
+    dtype: Boolean
+    label: "State meets 2-parent families participation rate requirement"
+    description: "Whether the State's annual participation rate for 2-parent families meets the applicable minimum after caseload reduction credit per 42 USC 607(a)(2) and (b)(3)(A)"
+    from 1996-10-01:
+        effective_min_rate = max(0, two_parent_min_participation_rate - caseload_reduction_credit)
+        tanf_annual_participation_rate_two_parent_families >= effective_min_rate

--- a/statute/42/607/a/1.rac
+++ b/statute/42/607/a/1.rac
@@ -1,0 +1,30 @@
+# 42 USC Section 607(a)(1) - All families
+
+"""
+(1) All families.-- A State to which a grant is made under section 603
+of this title for a fiscal year shall achieve the minimum participation
+rate specified in the following table for the fiscal year with respect to
+all families receiving assistance under the State program funded under
+this part or any other State program funded with qualified State
+expenditures (as defined in section 609(a)(7)(B)(i) of this title):
+
+If the fiscal year is:    The minimum participation rate is:
+1997                      25
+1998                      30
+1999                      35
+2000                      40
+2001                      45
+2002 or thereafter        50
+"""
+
+status: encoded
+
+min_participation_rate_all_families:
+    description: "Minimum participation rate for all families per 42 USC 607(a)(1)"
+    unit: rate
+    from 1996-10-01: 0.25
+    from 1997-10-01: 0.30
+    from 1998-10-01: 0.35
+    from 1999-10-01: 0.40
+    from 2000-10-01: 0.45
+    from 2001-10-01: 0.50

--- a/statute/42/607/a/1.rac.test
+++ b/statute/42/607/a/1.rac.test
@@ -1,0 +1,27 @@
+# 42 USC Section 607(a)(1) - All families tests
+
+min_participation_rate_all_families:
+    - name: "FY1997 - minimum participation rate is 25%"
+      period: 1997-01
+      inputs: {}
+      expect: 0.25
+
+    - name: "FY1999 - minimum participation rate is 35%"
+      period: 1999-01
+      inputs: {}
+      expect: 0.35
+
+    - name: "FY2001 - minimum participation rate is 45%"
+      period: 2001-01
+      inputs: {}
+      expect: 0.45
+
+    - name: "FY2002 - minimum participation rate is 50%"
+      period: 2002-01
+      inputs: {}
+      expect: 0.50
+
+    - name: "FY2024 - minimum participation rate is still 50% (2002 or thereafter)"
+      period: 2024-01
+      inputs: {}
+      expect: 0.50

--- a/statute/42/607/a/2.rac
+++ b/statute/42/607/a/2.rac
@@ -1,0 +1,23 @@
+# 42 USC Section 607(a)(2) - 2-parent families
+
+"""
+(2) 2-parent families.-- A State to which a grant is made under section
+603 of this title for a fiscal year shall achieve the minimum participation
+rate specified in the following table for the fiscal year with respect to
+2-parent families receiving assistance under the State program funded under
+this part or any other State program funded with qualified State expenditures
+(as defined in section 609(a)(7)(B)(i) of this title):
+
+If the fiscal year is:  The minimum participation rate is:
+1997                     75
+1998                     75
+1999 or thereafter       90
+"""
+
+status: encoded
+
+two_parent_min_participation_rate:
+    description: "Minimum participation rate for 2-parent families per 42 USC 607(a)(2)"
+    unit: rate
+    from 1996-10-01: 0.75
+    from 1998-10-01: 0.90

--- a/statute/42/607/a/2.rac.test
+++ b/statute/42/607/a/2.rac.test
@@ -1,0 +1,18 @@
+# 42 USC Section 607(a)(2) tests
+
+two_parent_min_participation_rate:
+    - name: "FY1997 - first year rate"
+      period: 1997-01
+      expect: 0.75
+
+    - name: "FY1998 - same rate as FY1997"
+      period: 1998-01
+      expect: 0.75
+
+    - name: "FY1999 - rate increases to 90%"
+      period: 1999-01
+      expect: 0.90
+
+    - name: "FY2024 - rate unchanged since 1999"
+      period: 2024-01
+      expect: 0.90

--- a/statute/42/607/b/1/A.rac
+++ b/statute/42/607/b/1/A.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(b)(1)(A) - Average monthly rate - all families
+
+"""
+(A) Average monthly rate.-- For purposes of subsection (a)(1), the
+participation rate for all families of a State for a fiscal year is
+the average of the participation rates for all families of the State
+for each month in the fiscal year.
+"""
+
+status: encoded
+
+months_in_fiscal_year:
+    description: "Number of months in a federal fiscal year"
+    unit: Month
+    from 1997-07-01: 12
+
+sum_monthly_participation_rates_all_families:
+    entity: Family
+    period: Year
+    dtype: Rate
+    label: "Sum of monthly participation rates for all families"
+    description: "Sum of the monthly TANF work participation rates for all families of the State across each month in the fiscal year, per 42 USC 607(b)(1)(A)"
+    default: 0
+
+tanf_annual_participation_rate_all_families:
+    imports:
+        - ./B#tanf_monthly_participation_rate_all_families
+    entity: Family
+    period: Year
+    dtype: Rate
+    label: "Annual TANF work participation rate - all families"
+    description: "The participation rate for all families of a State for a fiscal year, computed as the average of the monthly participation rates per 42 USC 607(b)(1)(A)"
+    from 1997-07-01:
+        sum_monthly_participation_rates_all_families / months_in_fiscal_year

--- a/statute/42/607/b/1/A.rac.test
+++ b/statute/42/607/b/1/A.rac.test
@@ -1,0 +1,31 @@
+# 42 USC Section 607(b)(1)(A) tests
+
+tanf_annual_participation_rate_all_families:
+    - name: "Average of monthly rates across fiscal year"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_all_families: 6.0
+      expect: 0.50
+
+    - name: "Zero sum returns zero rate"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_all_families: 0
+      expect: 0
+
+    - name: "Full participation every month"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_all_families: 12.0
+      expect: 1.0
+
+    - name: "Partial participation across months"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_all_families: 3.0
+      expect: 0.25
+
+    - name: "Default inputs return zero"
+      period: 2024-01
+      inputs: {}
+      expect: 0

--- a/statute/42/607/b/1/B.rac
+++ b/statute/42/607/b/1/B.rac
@@ -1,0 +1,48 @@
+# 42 USC Section 607(b)(1)(B) - Monthly participation rates - all families
+
+"""
+(B) Monthly participation rates.-- The participation rate of a State
+for all families of the State for a month, expressed as a percentage,
+is--
+(i) the number of families receiving assistance under the State program
+funded under this part or any other State program funded with qualified
+State expenditures (as defined in section 609(a)(7)(B)(i) of this title)
+that include an adult or a minor child head of household who is engaged
+in work for the month; divided by
+(ii) the amount by which--
+(I) the number of families receiving such assistance during the month
+that include an adult or a minor child head of household receiving such
+assistance; exceeds
+(II) the number of families receiving such assistance that are subject
+in such month to a penalty described in subsection (e)(1) but have not
+been subject to such penalty for more than 3 months within the preceding
+12-month period (whether or not consecutive).
+"""
+
+status: encoded
+
+tanf_families_in_numerator:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Number of families in participation rate numerator"
+    description: "State-level count of families counted in the numerator per 42 USC 607(b)(1)(B)(i): families receiving TANF assistance that include an adult or minor child head of household engaged in work"
+    default: 0
+
+tanf_families_in_denominator:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Number of families in participation rate denominator"
+    description: "State-level count of families counted in the denominator per 42 USC 607(b)(1)(B)(ii): total denominator families (clause I) minus penalty-excluded families (clause II)"
+    default: 0
+
+tanf_monthly_participation_rate_all_families:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Monthly TANF work participation rate - all families"
+    description: "The participation rate of a State for all families for a month, expressed as a percentage (stored as a rate), per 42 USC 607(b)(1)(B): numerator (clause i) divided by denominator (clause ii)"
+    from 1996-10-01:
+        if tanf_families_in_denominator == 0: 0
+        else: tanf_families_in_numerator / tanf_families_in_denominator

--- a/statute/42/607/b/1/B.rac.test
+++ b/statute/42/607/b/1/B.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(1)(B) tests
+
+tanf_monthly_participation_rate_all_families:
+    - name: "50 percent participation rate"
+      period: 2024-01
+      inputs:
+        tanf_families_in_numerator: 500
+        tanf_families_in_denominator: 1000
+      expect: 0.50
+
+    - name: "Zero denominator returns zero rate"
+      period: 2024-01
+      inputs:
+        tanf_families_in_numerator: 100
+        tanf_families_in_denominator: 0
+      expect: 0
+
+    - name: "100 percent participation rate"
+      period: 2024-01
+      inputs:
+        tanf_families_in_numerator: 1000
+        tanf_families_in_denominator: 1000
+      expect: 1.0
+
+    - name: "Zero numerator returns zero rate"
+      period: 2024-01
+      inputs:
+        tanf_families_in_numerator: 0
+        tanf_families_in_denominator: 500
+      expect: 0
+
+    - name: "Default inputs return zero"
+      period: 2024-01
+      inputs: {}
+      expect: 0

--- a/statute/42/607/b/1/B/i.rac
+++ b/statute/42/607/b/1/B/i.rac
@@ -1,0 +1,36 @@
+# 42 USC Section 607(b)(1)(B)(i) - Monthly rate numerator - families with working adult
+
+"""
+(i) the number of families receiving assistance under the State program
+funded under this part or any other State program funded with qualified
+State expenditures (as defined in section 609(a)(7)(B)(i) of this title)
+that include an adult or a minor child head of household who is engaged
+in work for the month;
+"""
+
+status: encoded
+
+is_receiving_tanf_assistance:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Receiving TANF assistance"
+    description: "Whether the family is receiving assistance under the State TANF program or any other State program funded with qualified State expenditures as defined in 42 USC 609(a)(7)(B)(i)"
+    default: false
+
+includes_working_adult_or_minor_hoh:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Includes working adult or minor child head of household"
+    description: "Whether the family includes an adult or a minor child head of household who is engaged in work for the month"
+    default: false
+
+tanf_work_participation_numerator_family:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family counted in TANF work participation rate numerator"
+    description: "Whether this family is counted in the numerator of the monthly participation rate per 42 USC 607(b)(1)(B)(i): a family receiving TANF assistance that includes an adult or minor child head of household engaged in work"
+    from 1996-10-01:
+        is_receiving_tanf_assistance and includes_working_adult_or_minor_hoh

--- a/statute/42/607/b/1/B/i.rac.test
+++ b/statute/42/607/b/1/B/i.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(1)(B)(i) tests
+
+tanf_work_participation_numerator_family:
+    - name: "Family receiving assistance with working adult counts in numerator"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: true
+        includes_working_adult_or_minor_hoh: true
+      expect: true
+
+    - name: "Family receiving assistance without working adult does not count"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: true
+        includes_working_adult_or_minor_hoh: false
+      expect: false
+
+    - name: "Family not receiving assistance with working adult does not count"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: false
+        includes_working_adult_or_minor_hoh: true
+      expect: false
+
+    - name: "Family not receiving assistance without working adult does not count"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: false
+        includes_working_adult_or_minor_hoh: false
+      expect: false
+
+    - name: "Default inputs - no assistance, no working adult"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/b/1/B/ii.rac
+++ b/statute/42/607/b/1/B/ii.rac
@@ -1,0 +1,26 @@
+# 42 USC Section 607(b)(1)(B)(ii) - Monthly rate denominator
+
+"""
+(ii) the amount by which--
+(I) the number of families receiving such assistance during the
+month that include an adult or a minor child head of household
+receiving such assistance; exceeds
+(II) the number of families receiving such assistance that are subject
+in such month to a penalty described in subsection (e)(1) but have not
+been subject to such penalty for more than 3 months within the
+preceding 12-month period (whether or not consecutive).
+"""
+
+status: encoded
+
+tanf_work_participation_denominator_family:
+    imports:
+        - ./I#is_tanf_denominator_family
+        - ./II#is_penalty_exclusion_family
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family counted in TANF work participation rate denominator"
+    description: "Whether this family is counted in the denominator of the monthly participation rate per 42 USC 607(b)(1)(B)(ii): a family in the total denominator pool (clause I) that is not excluded due to a recent penalty (clause II)"
+    from 1996-10-01:
+        is_tanf_denominator_family and not is_penalty_exclusion_family

--- a/statute/42/607/b/1/B/ii.rac.test
+++ b/statute/42/607/b/1/B/ii.rac.test
@@ -1,0 +1,37 @@
+# 42 USC Section 607(b)(1)(B)(ii) tests
+
+tanf_work_participation_denominator_family:
+    - name: "Family in denominator pool and not penalty-excluded"
+      period: 2024-01
+      inputs:
+        is_tanf_denominator_family: true
+        is_penalty_exclusion_family: false
+      expect: true
+
+    - name: "Family in denominator pool but penalty-excluded"
+      period: 2024-01
+      inputs:
+        is_tanf_denominator_family: true
+        is_penalty_exclusion_family: true
+      expect: false
+
+    - name: "Family not in denominator pool and not penalty-excluded"
+      period: 2024-01
+      inputs:
+        is_tanf_denominator_family: false
+        is_penalty_exclusion_family: false
+      expect: false
+
+    - name: "Family not in denominator pool but penalty-excluded"
+      period: 2024-01
+      inputs:
+        is_tanf_denominator_family: false
+        is_penalty_exclusion_family: true
+      expect: false
+
+    - name: "Family in denominator pool, effective date 1997"
+      period: 1997-10
+      inputs:
+        is_tanf_denominator_family: true
+        is_penalty_exclusion_family: false
+      expect: true

--- a/statute/42/607/b/1/B/ii/I.rac
+++ b/statute/42/607/b/1/B/ii/I.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(b)(1)(B)(ii)(I) - Total families in denominator
+
+"""
+(I) the number of families receiving such assistance during the
+month that include an adult or a minor child head of household
+receiving such assistance;
+"""
+
+status: encoded
+
+is_receiving_tanf_assistance:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Receiving TANF assistance"
+    description: "Whether the family is receiving assistance under the State TANF program or any other State program funded with qualified State expenditures"
+    default: false
+
+has_adult_or_minor_child_hoh:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Includes adult or minor child head of household"
+    description: "Whether the family includes an adult or a minor child head of household receiving such assistance"
+    default: false
+
+is_tanf_denominator_family:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family counted in participation rate denominator total"
+    description: "Whether the family is counted in the total families for the monthly participation rate denominator per 42 USC 607(b)(1)(B)(ii)(I)"
+    from 1996-10-01:
+        is_receiving_tanf_assistance and has_adult_or_minor_child_hoh

--- a/statute/42/607/b/1/B/ii/I.rac.test
+++ b/statute/42/607/b/1/B/ii/I.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(1)(B)(ii)(I) tests
+
+is_tanf_denominator_family:
+    - name: "Family not receiving TANF is not counted"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: false
+        has_adult_or_minor_child_hoh: true
+      expect: false
+
+    - name: "TANF family without adult or minor child HOH is not counted"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: true
+        has_adult_or_minor_child_hoh: false
+      expect: false
+
+    - name: "TANF family with adult or minor child HOH is counted"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: true
+        has_adult_or_minor_child_hoh: true
+      expect: true
+
+    - name: "Default inputs - not counted"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Both conditions false - not counted"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: false
+        has_adult_or_minor_child_hoh: false
+      expect: false

--- a/statute/42/607/b/1/B/ii/II.rac
+++ b/statute/42/607/b/1/B/ii/II.rac
@@ -1,0 +1,39 @@
+# 42 USC Section 607(b)(1)(B)(ii)(II) - Monthly rate denominator - penalty exclusion
+
+"""
+(II) the number of families receiving such assistance that are subject
+in such month to a penalty described in subsection (e)(1) but have not
+been subject to such penalty for more than 3 months within the
+preceding 12-month period (whether or not consecutive).
+"""
+
+status: encoded
+
+penalty_exclusion_max_months:
+    description: "Maximum months subject to e(1) penalty in lookback period for denominator exclusion"
+    from 1996-10-01: 3
+
+penalty_exclusion_lookback_months:
+    description: "Preceding period in months over which penalty months are counted"
+    from 1996-10-01: 12
+
+months_subject_to_e1_penalty_in_lookback:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Months subject to e(1) penalty in preceding period"
+    description: "Number of months the family has been subject to a penalty under 42 USC 607(e)(1) within the preceding 12-month period (whether or not consecutive)"
+    default: 0
+
+is_penalty_exclusion_family:
+    imports:
+        - 42/607/e/1#work_refusal_penalty
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family excluded from denominator due to recent penalty"
+    description: "Whether the family qualifies for exclusion from the participation rate denominator per 42 USC 607(b)(1)(B)(ii)(II) - subject to e(1) penalty this month but not for more than 3 months in the preceding 12"
+    from 1996-10-01:
+        is_subject_this_month = work_refusal_penalty > 0
+        within_exclusion_limit = months_subject_to_e1_penalty_in_lookback <= penalty_exclusion_max_months
+        is_subject_this_month and within_exclusion_limit

--- a/statute/42/607/b/1/B/ii/II.rac.test
+++ b/statute/42/607/b/1/B/ii/II.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(1)(B)(ii)(II) tests
+
+is_penalty_exclusion_family:
+    - name: "Family with penalty this month and 0 prior months - excluded"
+      period: 2024-01
+      inputs:
+        work_refusal_penalty: 200
+        months_subject_to_e1_penalty_in_lookback: 0
+      expect: true
+
+    - name: "Family with penalty this month and 3 prior months - excluded (at limit)"
+      period: 2024-01
+      inputs:
+        work_refusal_penalty: 200
+        months_subject_to_e1_penalty_in_lookback: 3
+      expect: true
+
+    - name: "Family with penalty this month and 4 prior months - not excluded (exceeds limit)"
+      period: 2024-01
+      inputs:
+        work_refusal_penalty: 200
+        months_subject_to_e1_penalty_in_lookback: 4
+      expect: false
+
+    - name: "Family with no penalty this month - not excluded"
+      period: 2024-01
+      inputs:
+        work_refusal_penalty: 0
+        months_subject_to_e1_penalty_in_lookback: 1
+      expect: false
+
+    - name: "Default inputs - not excluded"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/b/2/A.rac
+++ b/statute/42/607/b/2/A.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(b)(2)(A) - Average monthly rate - 2-parent families
+
+"""
+(A) Average monthly rate.-- For purposes of subsection (a)(2), the
+participation rate for 2-parent families of a State for a fiscal year is
+the average of the participation rates for 2-parent families of the State
+for each month in the fiscal year.
+"""
+
+status: encoded
+
+months_in_fiscal_year:
+    description: "Number of months in a federal fiscal year"
+    unit: Month
+    from 1997-07-01: 12
+
+sum_monthly_participation_rates_two_parent_families:
+    entity: Family
+    period: Year
+    dtype: Rate
+    label: "Sum of monthly participation rates for 2-parent families"
+    description: "Sum of the monthly TANF work participation rates for 2-parent families of the State across each month in the fiscal year, per 42 USC 607(b)(2)(A)"
+    default: 0
+
+tanf_annual_participation_rate_two_parent_families:
+    imports:
+        - ./B#tanf_monthly_participation_rate_two_parent_families
+    entity: Family
+    period: Year
+    dtype: Rate
+    label: "Annual TANF work participation rate - 2-parent families"
+    description: "The participation rate for 2-parent families of a State for a fiscal year, computed as the average of the monthly participation rates per 42 USC 607(b)(2)(A)"
+    from 1997-07-01:
+        sum_monthly_participation_rates_two_parent_families / months_in_fiscal_year

--- a/statute/42/607/b/2/A.rac.test
+++ b/statute/42/607/b/2/A.rac.test
@@ -1,0 +1,31 @@
+# 42 USC Section 607(b)(2)(A) tests
+
+tanf_annual_participation_rate_two_parent_families:
+    - name: "Average of monthly rates across fiscal year"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_two_parent_families: 6.0
+      expect: 0.50
+
+    - name: "Zero sum returns zero rate"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_two_parent_families: 0
+      expect: 0
+
+    - name: "Full participation every month"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_two_parent_families: 12.0
+      expect: 1.0
+
+    - name: "Partial participation across months"
+      period: 2024-01
+      inputs:
+        sum_monthly_participation_rates_two_parent_families: 3.0
+      expect: 0.25
+
+    - name: "Default inputs return zero"
+      period: 2024-01
+      inputs: {}
+      expect: 0

--- a/statute/42/607/b/2/B.rac
+++ b/statute/42/607/b/2/B.rac
@@ -1,0 +1,37 @@
+# 42 USC Section 607(b)(2)(B) - Monthly participation rates - 2-parent families
+
+"""
+(B) Monthly participation rates.-- The participation rate of a State
+for 2-parent families of the State for a month shall be calculated by
+use of the formula set forth in paragraph (1)(B), except that in the
+formula the term "number of 2-parent families" shall be substituted
+for the term "number of families" each place such latter term appears.
+"""
+
+status: encoded
+
+tanf_two_parent_families_in_numerator:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Number of 2-parent families in participation rate numerator"
+    description: "State-level count of 2-parent families counted in the numerator per 42 USC 607(b)(2)(B): 2-parent families receiving TANF assistance that include an adult engaged in work, using the formula from paragraph (1)(B) with '2-parent families' substituted for 'families'"
+    default: 0
+
+tanf_two_parent_families_in_denominator:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Number of 2-parent families in participation rate denominator"
+    description: "State-level count of 2-parent families counted in the denominator per 42 USC 607(b)(2)(B): total denominator 2-parent families minus penalty-excluded 2-parent families, using the formula from paragraph (1)(B) with '2-parent families' substituted for 'families'"
+    default: 0
+
+tanf_monthly_participation_rate_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Monthly TANF work participation rate - 2-parent families"
+    description: "The participation rate of a State for 2-parent families for a month, calculated using the formula set forth in paragraph (1)(B) with '2-parent families' substituted for 'families' per 42 USC 607(b)(2)(B)"
+    from 1996-10-01:
+        if tanf_two_parent_families_in_denominator == 0: 0
+        else: tanf_two_parent_families_in_numerator / tanf_two_parent_families_in_denominator

--- a/statute/42/607/b/2/B.rac.test
+++ b/statute/42/607/b/2/B.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(2)(B) tests
+
+tanf_monthly_participation_rate_two_parent_families:
+    - name: "90 percent participation rate for 2-parent families"
+      period: 2024-01
+      inputs:
+        tanf_two_parent_families_in_numerator: 900
+        tanf_two_parent_families_in_denominator: 1000
+      expect: 0.90
+
+    - name: "Zero denominator returns zero rate"
+      period: 2024-01
+      inputs:
+        tanf_two_parent_families_in_numerator: 50
+        tanf_two_parent_families_in_denominator: 0
+      expect: 0
+
+    - name: "100 percent participation rate"
+      period: 2024-01
+      inputs:
+        tanf_two_parent_families_in_numerator: 200
+        tanf_two_parent_families_in_denominator: 200
+      expect: 1.0
+
+    - name: "Zero numerator returns zero rate"
+      period: 2024-01
+      inputs:
+        tanf_two_parent_families_in_numerator: 0
+        tanf_two_parent_families_in_denominator: 300
+      expect: 0
+
+    - name: "Default inputs return zero"
+      period: 2024-01
+      inputs: {}
+      expect: 0

--- a/statute/42/607/b/2/C.rac
+++ b/statute/42/607/b/2/C.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(b)(2)(C) - Family with a disabled parent not treated as a 2-parent family
+
+"""
+(C) Family with a disabled parent not treated as a 2-parent family.--
+A family that includes a disabled parent shall not be considered a
+2-parent family for purposes of subsections (a) and (b) of this section.
+"""
+
+status: encoded
+
+has_disabled_parent:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family includes a disabled parent"
+    description: "Whether the family includes a parent who is disabled"
+    default: false
+
+is_two_parent_family:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family has two parents"
+    description: "Whether the family has two parents present in the household"
+    default: false
+
+is_two_parent_family_for_participation:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Treated as 2-parent family for participation rates"
+    description: "A family that includes a disabled parent shall not be considered a 2-parent family for purposes of participation rate requirements per 42 USC 607(b)(2)(C)"
+    from 1997-07-01:
+        is_two_parent_family and not has_disabled_parent

--- a/statute/42/607/b/2/C.rac.test
+++ b/statute/42/607/b/2/C.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(2)(C) tests
+
+is_two_parent_family_for_participation:
+    - name: "Two-parent family with no disabled parent is treated as 2-parent"
+      period: 2024-01
+      inputs:
+        is_two_parent_family: true
+        has_disabled_parent: false
+      expect: true
+
+    - name: "Two-parent family with disabled parent is NOT treated as 2-parent"
+      period: 2024-01
+      inputs:
+        is_two_parent_family: true
+        has_disabled_parent: true
+      expect: false
+
+    - name: "Single-parent family is not treated as 2-parent"
+      period: 2024-01
+      inputs:
+        is_two_parent_family: false
+        has_disabled_parent: false
+      expect: false
+
+    - name: "Single-parent family with disabled parent is not treated as 2-parent"
+      period: 2024-01
+      inputs:
+        is_two_parent_family: false
+        has_disabled_parent: true
+      expect: false
+
+    - name: "Defaults - no parents flagged"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/b/3/A.rac
+++ b/statute/42/607/b/3/A.rac
@@ -1,0 +1,53 @@
+# 42 USC Section 607(b)(3)(A) - Caseload reduction credit - in general
+
+"""
+(A) In general.-- The Secretary shall prescribe regulations for reducing
+the minimum participation rate otherwise required by this section for a
+fiscal year by the number of percentage points equal to the number of
+percentage points (if any) by which--
+
+(i) the average monthly number of families receiving assistance during
+the immediately preceding fiscal year under the State program funded under
+this part or any other State program funded with qualified State
+expenditures (as defined in section 609(a)(7)(B)(i) of this title)
+is less than
+
+(ii) the average monthly number of families that received assistance
+under any State program referred to in clause (i) during fiscal year 2015.
+
+The minimum participation rate shall not be reduced to the extent that
+the Secretary determines that the reduction in the number of families
+receiving such assistance is required by Federal law.
+"""
+
+status: encoded
+
+preceding_fy_avg_monthly_caseload:
+    entity: Family
+    period: Year
+    dtype: Integer
+    label: "Preceding fiscal year average monthly caseload"
+    description: "The average monthly number of families receiving assistance during the immediately preceding fiscal year under the State TANF program or any other State program funded with qualified State expenditures, per 42 USC 607(b)(3)(A)(i). State-level aggregate provided as exogenous data."
+    default: 0
+
+caseload_reduction_required_by_federal_law:
+    entity: Family
+    period: Year
+    dtype: Integer
+    label: "Caseload reduction required by Federal law"
+    description: "The number of families whose reduction from the caseload is determined by the Secretary to be required by Federal law, per the proviso in 42 USC 607(b)(3)(A). State-level aggregate provided as exogenous data."
+    default: 0
+
+caseload_reduction_credit:
+    imports:
+        - 42/607/b/3/A/ii#baseline_avg_monthly_caseload
+    entity: Family
+    period: Year
+    dtype: Rate
+    label: "Caseload reduction credit"
+    description: "Pro rata reduction of the minimum participation rate due to caseload reductions not required by Federal law and not resulting from changes in State eligibility criteria, per 42 USC 607(b)(3)(A). Expressed as a rate (e.g. 0.20 = 20 percentage points)."
+    from 1996-10-01:
+        if baseline_avg_monthly_caseload == 0: 0
+        total_decline = max(0, baseline_avg_monthly_caseload - preceding_fy_avg_monthly_caseload)
+        eligible_decline = max(0, total_decline - caseload_reduction_required_by_federal_law)
+        eligible_decline / baseline_avg_monthly_caseload

--- a/statute/42/607/b/3/A.rac.test
+++ b/statute/42/607/b/3/A.rac.test
@@ -1,0 +1,61 @@
+# 42 USC Section 607(b)(3)(A) tests
+
+caseload_reduction_credit:
+    - name: "No caseload decline - preceding equals baseline"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 10000
+        baseline_avg_monthly_caseload: 10000
+      expect: 0
+
+    - name: "No caseload decline - preceding exceeds baseline"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 12000
+        baseline_avg_monthly_caseload: 10000
+      expect: 0
+
+    - name: "20 percent caseload decline"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 8000
+        baseline_avg_monthly_caseload: 10000
+      expect: 0.20
+
+    - name: "Full caseload decline - preceding is zero"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 0
+        baseline_avg_monthly_caseload: 10000
+      expect: 1.0
+
+    - name: "Zero baseline caseload returns zero"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 5000
+        baseline_avg_monthly_caseload: 0
+      expect: 0
+
+    - name: "Decline partially offset by federally required reduction"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 7000
+        baseline_avg_monthly_caseload: 10000
+        caseload_reduction_required_by_federal_law: 1000
+      expect: 0.20
+
+    - name: "Decline fully offset by federally required reduction"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 8000
+        baseline_avg_monthly_caseload: 10000
+        caseload_reduction_required_by_federal_law: 2000
+      expect: 0
+
+    - name: "Federally required reduction exceeds total decline"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 9000
+        baseline_avg_monthly_caseload: 10000
+        caseload_reduction_required_by_federal_law: 5000
+      expect: 0

--- a/statute/42/607/b/3/A/i.rac
+++ b/statute/42/607/b/3/A/i.rac
@@ -1,0 +1,28 @@
+# 42 USC Section 607(b)(3)(A)(i) - Current year average monthly caseload
+
+"""
+(i) the average monthly number of families receiving assistance during
+the immediately preceding fiscal year under the State program funded
+under this part or any other State program funded with qualified State
+expenditures (as defined in section 609(a)(7)(B)(i) of this title)
+is less than
+"""
+
+status: encoded
+
+is_receiving_tanf_assistance:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Receiving TANF assistance"
+    description: "Whether the family is receiving assistance under the State TANF program or any other State program funded with qualified State expenditures as defined in 42 USC 609(a)(7)(B)(i)"
+    default: false
+
+is_caseload_family_preceding_fy:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family counted in preceding fiscal year caseload"
+    description: "Whether this family is counted toward the average monthly caseload for the immediately preceding fiscal year for purposes of the caseload reduction credit per 42 USC 607(b)(3)(A)(i)"
+    from 1996-10-01:
+        is_receiving_tanf_assistance

--- a/statute/42/607/b/3/A/i.rac.test
+++ b/statute/42/607/b/3/A/i.rac.test
@@ -1,0 +1,31 @@
+# 42 USC Section 607(b)(3)(A)(i) tests
+
+is_caseload_family_preceding_fy:
+    - name: "Family receiving TANF assistance is counted in caseload"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: true
+      expect: true
+
+    - name: "Family not receiving TANF assistance is not counted"
+      period: 2024-01
+      inputs:
+        is_receiving_tanf_assistance: false
+      expect: false
+
+    - name: "Default - family not counted (default is false)"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Family receiving assistance in FY1997"
+      period: 1997-01
+      inputs:
+        is_receiving_tanf_assistance: true
+      expect: true
+
+    - name: "Family not receiving assistance before effective date"
+      period: 1996-09
+      inputs:
+        is_receiving_tanf_assistance: true
+      expect: null

--- a/statute/42/607/b/3/A/ii.rac
+++ b/statute/42/607/b/3/A/ii.rac
@@ -1,0 +1,21 @@
+# 42 USC Section 607(b)(3)(A)(ii) - Baseline year (FY2015) average monthly caseload
+
+"""
+(ii) the average monthly number of families that received assistance
+under any State program referred to in clause (i) during fiscal year
+2015.
+"""
+
+status: encoded
+
+baseline_fiscal_year:
+    description: "Baseline fiscal year for caseload reduction comparison per 42 USC 607(b)(3)(A)(ii), as amended by BBA 2018"
+    from 2015-10-01: 2015
+
+baseline_avg_monthly_caseload:
+    entity: Family
+    period: Year
+    dtype: Integer
+    label: "Baseline FY2015 average monthly caseload"
+    description: "The average monthly number of families that received assistance under the State TANF program or any other State program funded with qualified State expenditures during fiscal year 2015, per 42 USC 607(b)(3)(A)(ii). State-level aggregate provided as exogenous data."
+    default: 0

--- a/statute/42/607/b/3/A/ii.rac.test
+++ b/statute/42/607/b/3/A/ii.rac.test
@@ -1,0 +1,31 @@
+# 42 USC Section 607(b)(3)(A)(ii) tests
+
+baseline_avg_monthly_caseload:
+    - name: "Default baseline caseload is zero"
+      period: 2024
+      inputs: {}
+      expect: 0
+
+    - name: "Typical state baseline caseload"
+      period: 2024
+      inputs:
+        baseline_avg_monthly_caseload: 15000
+      expect: 15000
+
+    - name: "Small state baseline caseload"
+      period: 2024
+      inputs:
+        baseline_avg_monthly_caseload: 500
+      expect: 500
+
+    - name: "Explicit zero caseload"
+      period: 2024
+      inputs:
+        baseline_avg_monthly_caseload: 0
+      expect: 0
+
+    - name: "Large state baseline caseload"
+      period: 2024
+      inputs:
+        baseline_avg_monthly_caseload: 150000
+      expect: 150000

--- a/statute/42/607/b/3/B.rac
+++ b/statute/42/607/b/3/B.rac
@@ -1,0 +1,37 @@
+# 42 USC Section 607(b)(3)(B) - Eligibility changes not counted
+
+"""
+(B) Eligibility changes not counted.-- The regulations required by
+subparagraph (A) shall not take into account families that are diverted
+from a State program funded under this part as a result of differences
+in eligibility criteria under a State program funded under this part and
+the eligibility criteria in effect during fiscal year 2005. Such
+regulations shall place the burden on the Secretary to prove that such
+families were diverted as a direct result of differences in such
+eligibility criteria.
+"""
+
+status: encoded
+
+eligibility_criteria_baseline_fiscal_year:
+    description: "Baseline fiscal year for eligibility criteria comparison per 42 USC 607(b)(3)(B)"
+    from 2006-02-08: 2005
+
+families_diverted_by_eligibility_changes:
+    entity: Family
+    period: Year
+    dtype: Integer
+    label: "Families diverted by eligibility changes"
+    description: "The number of families diverted from the State TANF program as a direct result of differences between current eligibility criteria and those in effect during FY2005, as determined by the Secretary per 42 USC 607(b)(3)(B). State-level aggregate provided as exogenous data."
+    default: 0
+
+eligibility_change_caseload_adjustment:
+    imports:
+        - 42/607/b/3/A#preceding_fy_avg_monthly_caseload
+    entity: Family
+    period: Year
+    dtype: Integer
+    label: "Caseload adjusted for eligibility changes"
+    description: "Adjusted preceding FY average monthly caseload, adding back families diverted due to eligibility criteria changes since FY2005 per 42 USC 607(b)(3)(B). This adjusted count should be used in place of the raw preceding FY caseload when computing the caseload reduction credit under 42 USC 607(b)(3)(A)."
+    from 2006-02-08:
+        preceding_fy_avg_monthly_caseload + families_diverted_by_eligibility_changes

--- a/statute/42/607/b/3/B.rac.test
+++ b/statute/42/607/b/3/B.rac.test
@@ -1,0 +1,37 @@
+# 42 USC Section 607(b)(3)(B) tests
+
+eligibility_change_caseload_adjustment:
+    - name: "No families diverted - caseload unchanged"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 8000
+        families_diverted_by_eligibility_changes: 0
+      expect: 8000
+
+    - name: "500 families diverted - caseload adjusted upward"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 7500
+        families_diverted_by_eligibility_changes: 500
+      expect: 8000
+
+    - name: "Zero preceding caseload with diversions"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 0
+        families_diverted_by_eligibility_changes: 200
+      expect: 200
+
+    - name: "Both inputs zero"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 0
+        families_diverted_by_eligibility_changes: 0
+      expect: 0
+
+    - name: "Large diversion relative to caseload"
+      period: 2024
+      inputs:
+        preceding_fy_avg_monthly_caseload: 3000
+        families_diverted_by_eligibility_changes: 2000
+      expect: 5000

--- a/statute/42/607/b/4.rac
+++ b/statute/42/607/b/4.rac
@@ -1,0 +1,37 @@
+# 42 USC Section 607(b)(4) - State option to include individuals receiving assistance under a tribal family assistance plan or tribal work program
+
+"""
+(4) State option to include individuals receiving assistance under
+a tribal family assistance plan or tribal work program.-- For purposes
+of paragraphs (1)(B) and (2)(B), a State may, at its option, include
+families in the State that are receiving assistance under a tribal
+family assistance plan approved under section 612 of this title or
+under a tribal work program to which funds are provided under this part.
+"""
+
+status: encoded
+
+state_elects_tribal_family_inclusion:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "State elects tribal family inclusion"
+    description: "Whether the State has elected to include families receiving assistance under a tribal family assistance plan approved under 42 USC 612 or a tribal work program in participation rate calculations per 42 USC 607(b)(4)"
+    default: false
+
+is_receiving_tribal_assistance:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Receiving tribal family assistance or tribal work program assistance"
+    description: "Whether the family is receiving assistance under a tribal family assistance plan approved under 42 USC 612 or under a tribal work program to which funds are provided under part A of title IV"
+    default: false
+
+tribal_family_included_in_participation_rate:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Tribal family included in TANF participation rate"
+    description: "Whether a family receiving tribal assistance is included in the State participation rate calculations for purposes of 42 USC 607(b)(1)(B) and (b)(2)(B), per State election under 42 USC 607(b)(4)"
+    from 1997-07-01:
+        state_elects_tribal_family_inclusion and is_receiving_tribal_assistance

--- a/statute/42/607/b/4.rac.test
+++ b/statute/42/607/b/4.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(4) tests
+
+tribal_family_included_in_participation_rate:
+    - name: "Tribal family included when state elects and family receives tribal assistance"
+      period: 2024-01
+      inputs:
+        state_elects_tribal_family_inclusion: true
+        is_receiving_tribal_assistance: true
+      expect: true
+
+    - name: "Tribal family NOT included when state does not elect even if receiving tribal assistance"
+      period: 2024-01
+      inputs:
+        state_elects_tribal_family_inclusion: false
+        is_receiving_tribal_assistance: true
+      expect: false
+
+    - name: "Non-tribal family NOT included even when state elects"
+      period: 2024-01
+      inputs:
+        state_elects_tribal_family_inclusion: true
+        is_receiving_tribal_assistance: false
+      expect: false
+
+    - name: "Neither election nor tribal assistance"
+      period: 2024-01
+      inputs:
+        state_elects_tribal_family_inclusion: false
+        is_receiving_tribal_assistance: false
+      expect: false
+
+    - name: "Defaults - no election, no tribal assistance"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/b/5.rac
+++ b/statute/42/607/b/5.rac
@@ -1,0 +1,54 @@
+# 42 USC Section 607(b)(5) - State option - infant care exemption
+
+"""
+(5) For any fiscal year, a State may, at its option, not require an
+individual who is a single custodial parent caring for a child who has
+not attained 12 months of age to engage in work, and may disregard such
+an individual in determining the participation rates under subsection (a)
+for not more than 12 months.
+"""
+
+status: encoded
+
+infant_age_threshold_months:
+    description: "Maximum age in months below which a child qualifies the custodial parent for the infant care exemption"
+    unit: Month
+    from 1997-07-01: 12
+
+max_infant_care_disregard_months:
+    description: "Maximum months a State may disregard an individual under the infant care exemption in participation rate calculations"
+    unit: Month
+    from 1997-07-01: 12
+
+state_elects_infant_care_exemption:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "State elects infant care exemption"
+    description: "Whether the State has elected the option under 42 USC 607(b)(5) to exempt single custodial parents caring for infants from work requirements"
+    default: false
+
+is_single_custodial_parent:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Single custodial parent"
+    description: "Whether the family includes an individual who is a single custodial parent"
+    default: false
+
+youngest_child_age_months:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Age of youngest child in months"
+    description: "Age in months of the youngest child in the care of the custodial parent"
+    default: 0
+
+infant_care_exempt:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Infant care exemption applies"
+    description: "Whether the family is exempt from work requirements and may be disregarded in participation rate calculations as a single custodial parent caring for a child under 12 months of age, per State election under 42 USC 607(b)(5)"
+    from 1997-07-01:
+        state_elects_infant_care_exemption and is_single_custodial_parent and youngest_child_age_months < infant_age_threshold_months

--- a/statute/42/607/b/5.rac.test
+++ b/statute/42/607/b/5.rac.test
@@ -1,0 +1,39 @@
+# 42 USC Section 607(b)(5) tests
+
+infant_care_exempt:
+    - name: "Single custodial parent with infant when state elects exemption"
+      period: 2024-01
+      inputs:
+        state_elects_infant_care_exemption: true
+        is_single_custodial_parent: true
+        youngest_child_age_months: 6
+      expect: true
+
+    - name: "State does not elect exemption"
+      period: 2024-01
+      inputs:
+        state_elects_infant_care_exemption: false
+        is_single_custodial_parent: true
+        youngest_child_age_months: 6
+      expect: false
+
+    - name: "Not a single custodial parent"
+      period: 2024-01
+      inputs:
+        state_elects_infant_care_exemption: true
+        is_single_custodial_parent: false
+        youngest_child_age_months: 6
+      expect: false
+
+    - name: "Child at exactly 12 months - not eligible"
+      period: 2024-01
+      inputs:
+        state_elects_infant_care_exemption: true
+        is_single_custodial_parent: true
+        youngest_child_age_months: 12
+      expect: false
+
+    - name: "Defaults - no conditions met"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/b/6.rac
+++ b/statute/42/607/b/6.rac
@@ -1,0 +1,41 @@
+# 42 USC Section 607(b)(6) - De minimis threshold
+
+"""
+(6) The Secretary shall determine participation rates under this section
+without regard to any individual engaged in work in a family that
+receives no assistance under this part and less than $35 in assistance
+funded with qualified State expenditures (as defined in section
+609(a)(7)(B)(i) of this title).
+"""
+
+status: encoded
+
+de_minimis_assistance_threshold:
+    description: "De minimis threshold for qualified State expenditure assistance below which families are excluded from participation rate calculations per 42 USC 607(b)(6)"
+    unit: USD
+    from 2025-10-01: 35
+
+tanf_part_a_assistance_amount:
+    entity: Family
+    period: Month
+    dtype: Money
+    label: "TANF Part A assistance amount"
+    description: "Amount of assistance received by the family under Part A of Title IV (TANF)"
+    default: 0
+
+qualified_state_expenditure_assistance_amount:
+    entity: Family
+    period: Month
+    dtype: Money
+    label: "Qualified State expenditure assistance amount"
+    description: "Amount of assistance received by the family funded with qualified State expenditures as defined in 42 USC 609(a)(7)(B)(i)"
+    default: 0
+
+excluded_from_participation_rate_de_minimis:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Excluded from participation rate under de minimis threshold"
+    description: "Whether the family is excluded from participation rate calculations because it receives no TANF Part A assistance and less than $35 in qualified State expenditure assistance per 42 USC 607(b)(6)"
+    from 2025-10-01:
+        tanf_part_a_assistance_amount == 0 and qualified_state_expenditure_assistance_amount < de_minimis_assistance_threshold

--- a/statute/42/607/b/6.rac.test
+++ b/statute/42/607/b/6.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(b)(6) tests
+
+excluded_from_participation_rate_de_minimis:
+    - name: "No Part A assistance and QSE below threshold - excluded"
+      period: 2026-01
+      inputs:
+        tanf_part_a_assistance_amount: 0
+        qualified_state_expenditure_assistance_amount: 20
+      expect: true
+
+    - name: "No Part A assistance and zero QSE - excluded"
+      period: 2026-01
+      inputs:
+        tanf_part_a_assistance_amount: 0
+        qualified_state_expenditure_assistance_amount: 0
+      expect: true
+
+    - name: "No Part A assistance but QSE at threshold - not excluded"
+      period: 2026-01
+      inputs:
+        tanf_part_a_assistance_amount: 0
+        qualified_state_expenditure_assistance_amount: 35
+      expect: false
+
+    - name: "Receives Part A assistance with low QSE - not excluded"
+      period: 2026-01
+      inputs:
+        tanf_part_a_assistance_amount: 100
+        qualified_state_expenditure_assistance_amount: 10
+      expect: false
+
+    - name: "Default inputs - no assistance at all - excluded"
+      period: 2026-01
+      inputs: {}
+      expect: true

--- a/statute/42/607/c/1/A.rac
+++ b/statute/42/607/c/1/A.rac
@@ -1,0 +1,56 @@
+# 42 USC Section 607(c)(1)(A) - Engaged in work: all families
+
+"""
+(A) In general.-- For purposes of subsection (b)(1)(B)(i), a recipient
+is engaged in work for a month in a fiscal year if the recipient is
+participating in work activities for at least the minimum average number
+of hours per week specified in the following table during the month, not
+fewer than 20 hours per week of which are attributable to an activity
+described in paragraph (1), (2), (3), (4), (5), (6), (7), (8), or (12)
+of subsection (d), subject to this subsection:
+
+If the fiscal year is:    The minimum participation hours are:
+1997                      20
+1998                      20
+1999                      25
+2000 or thereafter        30
+"""
+
+status: encoded
+
+minimum_weekly_hours_all_families:
+    description: "Minimum average hours per week of participation in work activities required for a recipient to be considered engaged in work for all-families rate per 42 USC 607(c)(1)(A)"
+    unit: hours/week
+    from 1996-10-01: 20
+    from 1998-10-01: 25
+    from 1999-10-01: 30
+
+minimum_core_activity_hours_per_week:
+    description: "Minimum hours per week that must be attributable to core work activities described in 42 USC 607(d)(1)-(8) and (d)(12) per 42 USC 607(c)(1)(A)"
+    unit: hours/week
+    from 1996-10-01: 20
+
+total_work_activity_hours_per_week:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Total work activity hours per week"
+    description: "Average hours per week the recipient participates in any work activities described in 42 USC 607(d)"
+    default: 0
+
+core_work_activity_hours_per_week:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Core work activity hours per week"
+    description: "Average hours per week attributable to core work activities described in 42 USC 607(d)(1), (2), (3), (4), (5), (6), (7), (8), or (12)"
+    default: 0
+
+is_engaged_in_work_all_families:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in work for all-families participation rate"
+    description: "Whether a recipient meets the work participation requirements for all families per 42 USC 607(c)(1)(A): participates in work activities for at least the minimum hours per week, with not fewer than the core activity minimum in core activities"
+    from 1996-10-01:
+        total_work_activity_hours_per_week >= minimum_weekly_hours_all_families and core_work_activity_hours_per_week >= minimum_core_activity_hours_per_week

--- a/statute/42/607/c/1/A.rac.test
+++ b/statute/42/607/c/1/A.rac.test
@@ -1,0 +1,51 @@
+# 42 USC Section 607(c)(1)(A) tests
+
+is_engaged_in_work_all_families:
+    - name: "FY1997 - meets both minimums (20 total, 20 core)"
+      period: 1997-01
+      inputs:
+          total_work_activity_hours_per_week: 20
+          core_work_activity_hours_per_week: 20
+      expect: true
+
+    - name: "FY1997 - total hours met but core hours not met"
+      period: 1997-01
+      inputs:
+          total_work_activity_hours_per_week: 20
+          core_work_activity_hours_per_week: 15
+      expect: false
+
+    - name: "FY1999 - needs 25 total, has only 20"
+      period: 1999-01
+      inputs:
+          total_work_activity_hours_per_week: 20
+          core_work_activity_hours_per_week: 20
+      expect: false
+
+    - name: "FY1999 - meets 25 total and 20 core"
+      period: 1999-01
+      inputs:
+          total_work_activity_hours_per_week: 25
+          core_work_activity_hours_per_week: 20
+      expect: true
+
+    - name: "FY2000+ - needs 30 total, has 30 total and 20 core"
+      period: 2000-01
+      inputs:
+          total_work_activity_hours_per_week: 30
+          core_work_activity_hours_per_week: 20
+      expect: true
+
+    - name: "FY2000+ - has 30 total but only 19 core"
+      period: 2000-01
+      inputs:
+          total_work_activity_hours_per_week: 30
+          core_work_activity_hours_per_week: 19
+      expect: false
+
+    - name: "Zero hours - not engaged"
+      period: 2024-01
+      inputs:
+          total_work_activity_hours_per_week: 0
+          core_work_activity_hours_per_week: 0
+      expect: false

--- a/statute/42/607/c/1/B/i.rac
+++ b/statute/42/607/c/1/B/i.rac
@@ -1,0 +1,46 @@
+# 42 USC Section 607(c)(1)(B)(i) - 2-parent families: 35hr total / 30hr core
+
+"""
+(i) the individual and the other parent in the family are participating
+in work activities for a total of at least 35 hours per week during the
+month, not fewer than 30 hours per week of which are attributable to an
+activity described in paragraph (1), (2), (3), (4), (5), (6), (7), (8),
+or (12) of subsection (d), subject to this subsection; and
+"""
+
+status: encoded
+
+two_parent_standard_total_hours_per_week:
+    description: "Minimum total weekly work hours for both parents in a 2-parent family per 42 USC 607(c)(1)(B)(i)"
+    unit: hours_per_week
+    from 1996-10-01: 35
+
+two_parent_standard_core_hours_per_week:
+    description: "Minimum core activity weekly work hours for both parents in a 2-parent family per 42 USC 607(c)(1)(B)(i)"
+    unit: hours_per_week
+    from 1996-10-01: 30
+
+two_parent_total_weekly_work_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Total weekly work hours for both parents"
+    description: "Average weekly hours that the individual and the other parent are participating in work activities during the month"
+    default: 0
+
+two_parent_core_weekly_work_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Core activity weekly work hours for both parents"
+    description: "Average weekly hours that the individual and the other parent participate in core work activities (d)(1)-(8),(12) during the month"
+    default: 0
+
+two_parent_standard_work_requirement_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "2-parent family standard work requirement met"
+    description: "Whether the 2-parent family meets the standard work participation requirement of 42 USC 607(c)(1)(B)(i): at least 35 total hours and 30 core hours per week"
+    from 1996-10-01:
+        two_parent_total_weekly_work_hours >= two_parent_standard_total_hours_per_week and two_parent_core_weekly_work_hours >= two_parent_standard_core_hours_per_week

--- a/statute/42/607/c/1/B/i.rac.test
+++ b/statute/42/607/c/1/B/i.rac.test
@@ -1,0 +1,37 @@
+# 42 USC Section 607(c)(1)(B)(i) tests
+
+two_parent_standard_work_requirement_met:
+    - name: "Both thresholds met exactly"
+      period: 2024-01
+      inputs:
+        two_parent_total_weekly_work_hours: 35
+        two_parent_core_weekly_work_hours: 30
+      expect: true
+
+    - name: "Total hours below minimum"
+      period: 2024-01
+      inputs:
+        two_parent_total_weekly_work_hours: 34
+        two_parent_core_weekly_work_hours: 30
+      expect: false
+
+    - name: "Core hours below minimum"
+      period: 2024-01
+      inputs:
+        two_parent_total_weekly_work_hours: 35
+        two_parent_core_weekly_work_hours: 29
+      expect: false
+
+    - name: "Zero hours - no participation"
+      period: 2024-01
+      inputs:
+        two_parent_total_weekly_work_hours: 0
+        two_parent_core_weekly_work_hours: 0
+      expect: false
+
+    - name: "Exceeds both thresholds"
+      period: 2024-01
+      inputs:
+        two_parent_total_weekly_work_hours: 40
+        two_parent_core_weekly_work_hours: 35
+      expect: true

--- a/statute/42/607/c/1/B/ii.rac
+++ b/statute/42/607/c/1/B/ii.rac
@@ -1,0 +1,66 @@
+# 42 USC Section 607(c)(1)(B)(ii) - 2-parent families with child care: enhanced work requirement
+
+"""
+(ii) if the family of the individual receives federally-funded child care
+assistance and an adult in the family is not disabled or caring for a
+severely disabled child, the individual and the other parent in the family
+are participating in work activities for a total of at least 55 hours per
+week during the month, not fewer than 50 hours per week of which are
+attributable to an activity described in paragraph (1), (2), (3), (4), (5),
+(6), (7), (8), or (12) of subsection (d).
+"""
+
+status: encoded
+
+two_parent_child_care_total_hours_per_week:
+    description: "Minimum total weekly work hours for 2-parent families receiving federally-funded child care per 42 USC 607(c)(1)(B)(ii)"
+    unit: hours_per_week
+    from 1996-10-01: 55
+
+two_parent_child_care_core_hours_per_week:
+    description: "Minimum core activity weekly work hours for 2-parent families receiving federally-funded child care per 42 USC 607(c)(1)(B)(ii)"
+    unit: hours_per_week
+    from 1996-10-01: 50
+
+receives_federally_funded_child_care:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Receives federally-funded child care assistance"
+    description: "Whether the family receives federally-funded child care assistance per 42 USC 607(c)(1)(B)(ii)"
+    default: false
+
+has_disabled_adult_or_caring_for_severely_disabled_child:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Family has disabled adult or adult caring for severely disabled child"
+    description: "Whether an adult in the family is disabled or caring for a severely disabled child per 42 USC 607(c)(1)(B)(ii)"
+    default: false
+
+two_parent_total_weekly_work_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Total weekly work hours for both parents"
+    description: "Average weekly hours that the individual and the other parent are participating in work activities during the month"
+    default: 0
+
+two_parent_core_weekly_work_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Core activity weekly work hours for both parents"
+    description: "Average weekly hours that the individual and the other parent participate in core work activities (d)(1)-(8),(12) during the month"
+    default: 0
+
+two_parent_child_care_work_requirement_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "2-parent child care enhanced work requirement met"
+    description: "Whether the 2-parent family meets the enhanced work participation requirement of 42 USC 607(c)(1)(B)(ii): 55 total hours and 50 core hours per week, applicable only when the family receives federally-funded child care and no adult is disabled or caring for a severely disabled child"
+    from 1996-10-01:
+        if not receives_federally_funded_child_care: true
+        elif has_disabled_adult_or_caring_for_severely_disabled_child: true
+        else: two_parent_total_weekly_work_hours >= two_parent_child_care_total_hours_per_week and two_parent_core_weekly_work_hours >= two_parent_child_care_core_hours_per_week

--- a/statute/42/607/c/1/B/ii.rac.test
+++ b/statute/42/607/c/1/B/ii.rac.test
@@ -1,0 +1,46 @@
+# 42 USC Section 607(c)(1)(B)(ii) tests
+
+two_parent_child_care_work_requirement_met:
+    - name: "No child care - requirement automatically met"
+      period: 2024-01
+      inputs:
+        receives_federally_funded_child_care: false
+        two_parent_total_weekly_work_hours: 0
+        two_parent_core_weekly_work_hours: 0
+      expect: true
+
+    - name: "Child care with disabled adult exemption - requirement met"
+      period: 2024-01
+      inputs:
+        receives_federally_funded_child_care: true
+        has_disabled_adult_or_caring_for_severely_disabled_child: true
+        two_parent_total_weekly_work_hours: 0
+        two_parent_core_weekly_work_hours: 0
+      expect: true
+
+    - name: "Child care with sufficient hours - requirement met"
+      period: 2024-01
+      inputs:
+        receives_federally_funded_child_care: true
+        has_disabled_adult_or_caring_for_severely_disabled_child: false
+        two_parent_total_weekly_work_hours: 55
+        two_parent_core_weekly_work_hours: 50
+      expect: true
+
+    - name: "Child care with insufficient total hours - requirement not met"
+      period: 2024-01
+      inputs:
+        receives_federally_funded_child_care: true
+        has_disabled_adult_or_caring_for_severely_disabled_child: false
+        two_parent_total_weekly_work_hours: 54
+        two_parent_core_weekly_work_hours: 50
+      expect: false
+
+    - name: "Child care with insufficient core hours - requirement not met"
+      period: 2024-01
+      inputs:
+        receives_federally_funded_child_care: true
+        has_disabled_adult_or_caring_for_severely_disabled_child: false
+        two_parent_total_weekly_work_hours: 55
+        two_parent_core_weekly_work_hours: 49
+      expect: false

--- a/statute/42/607/c/2/A/i.rac
+++ b/statute/42/607/c/2/A/i.rac
@@ -1,0 +1,116 @@
+# 42 USC Section 607(c)(2)(A)(i) - Job search week limit
+
+"""
+(i) Notwithstanding paragraph (1) of this subsection, an individual shall
+not be considered to be engaged in work by virtue of participation in an
+activity described in subsection (d)(6) of a State program funded under
+this part or any other State program funded with qualified State
+expenditures (as defined in section 609(a)(7)(B)(i) of this title), after
+the individual has participated in such an activity for 6 weeks (or, if
+the unemployment rate of the State is at least 50 percent greater than the
+unemployment rate of the United States or the State is a needy State
+(within the meaning of section 603(b)(5) of this title), 12 weeks), or if
+the participation is for a week that immediately follows 4 consecutive
+weeks of such participation.
+"""
+
+status: encoded
+
+# Parameters
+
+job_search_annual_week_limit:
+    description: "Maximum weeks per fiscal year that job search (d)(6) may count as work activity, general rule per 42 USC 607(c)(2)(A)(i)"
+    unit: weeks
+    from 1996-10-01: 6
+
+job_search_annual_week_limit_extended:
+    description: "Maximum weeks per fiscal year that job search (d)(6) may count as work activity for high-unemployment or needy states per 42 USC 607(c)(2)(A)(i)"
+    unit: weeks
+    from 1996-10-01: 12
+
+unemployment_rate_excess_threshold:
+    description: "Minimum excess by which state unemployment rate must exceed US unemployment rate to qualify for extended job search limit per 42 USC 607(c)(2)(A)(i); 0.50 means at least 50 percent greater"
+    unit: rate
+    from 1996-10-01: 0.50
+
+job_search_max_consecutive_weeks:
+    description: "Maximum consecutive weeks of job search participation before the activity ceases to count; participation for a week immediately following this many consecutive weeks does not count per 42 USC 607(c)(2)(A)(i)"
+    unit: weeks
+    from 1996-10-01: 4
+
+# Inputs
+
+state_unemployment_rate:
+    entity: Person
+    period: Year
+    dtype: Rate
+    label: "State unemployment rate"
+    description: "Unemployment rate of the State in which the individual resides"
+    default: 0
+
+us_unemployment_rate:
+    entity: Person
+    period: Year
+    dtype: Rate
+    label: "US unemployment rate"
+    description: "Unemployment rate of the United States"
+    default: 0
+
+is_needy_state:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "State is a needy state"
+    description: "Whether the State is a needy State within the meaning of 42 USC 603(b)(5)"
+    default: false
+
+job_search_weeks_used_in_fiscal_year:
+    entity: Person
+    period: Year
+    dtype: Integer
+    label: "Job search weeks used in fiscal year"
+    description: "Number of weeks the individual has already participated in job search activity (d)(6) during the current fiscal year"
+    default: 0
+
+consecutive_job_search_weeks_prior:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Consecutive prior weeks of job search"
+    description: "Number of consecutive weeks of job search participation immediately preceding the current week"
+    default: 0
+
+# Computed values
+
+qualifies_for_extended_job_search_limit:
+    entity: Person
+    period: Year
+    dtype: Boolean
+    label: "Qualifies for extended 12-week job search limit"
+    description: "Whether the state qualifies for the extended 12-week job search limit because its unemployment rate is at least 50 percent greater than the US rate or it is a needy State per 42 USC 607(c)(2)(A)(i)"
+    from 1996-10-01:
+        state_unemployment_rate >= us_unemployment_rate * (1 + unemployment_rate_excess_threshold) or is_needy_state
+
+applicable_job_search_week_limit:
+    entity: Person
+    period: Year
+    dtype: Integer
+    label: "Applicable job search week limit"
+    description: "The applicable maximum weeks of job search activity that count as work: 12 for high-unemployment or needy states, 6 otherwise per 42 USC 607(c)(2)(A)(i)"
+    from 1996-10-01:
+        if qualifies_for_extended_job_search_limit: job_search_annual_week_limit_extended
+        else: job_search_annual_week_limit
+
+job_search_counts_as_engaged_in_work:
+    imports:
+        - 42/607/d/6#is_engaged_in_job_search_and_job_readiness
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Job search counts as engaged in work"
+    description: "Whether an individual's participation in job search (d)(6) can count toward being engaged in work, subject to the annual week limit and 4-consecutive-week limit per 42 USC 607(c)(2)(A)(i)"
+    from 1996-10-01:
+        if not is_engaged_in_job_search_and_job_readiness: false
+        elif job_search_weeks_used_in_fiscal_year >= applicable_job_search_week_limit: false
+        elif consecutive_job_search_weeks_prior >= job_search_max_consecutive_weeks: false
+        else: true

--- a/statute/42/607/c/2/A/i.rac.test
+++ b/statute/42/607/c/2/A/i.rac.test
@@ -1,0 +1,73 @@
+# 42 USC Section 607(c)(2)(A)(i) tests
+
+job_search_counts_as_engaged_in_work:
+    - name: "Not participating in job search - does not count"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: false
+          job_search_weeks_used_in_fiscal_year: 0
+          consecutive_job_search_weeks_prior: 0
+      expect: false
+
+    - name: "Participating, under 6-week limit - counts"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 5
+          consecutive_job_search_weeks_prior: 2
+      expect: true
+
+    - name: "Participating, at 6-week limit - does not count"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 6
+          consecutive_job_search_weeks_prior: 0
+      expect: false
+
+    - name: "Participating, at 4 consecutive weeks - does not count"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 0
+          consecutive_job_search_weeks_prior: 4
+      expect: false
+
+    - name: "High-unemployment state, under 12-week extended limit - counts"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 10
+          consecutive_job_search_weeks_prior: 2
+          state_unemployment_rate: 0.09
+          us_unemployment_rate: 0.05
+      expect: true
+
+    - name: "High-unemployment state, at 12-week extended limit - does not count"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 12
+          consecutive_job_search_weeks_prior: 0
+          state_unemployment_rate: 0.09
+          us_unemployment_rate: 0.05
+      expect: false
+
+    - name: "Needy state, under 12-week extended limit - counts"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 8
+          consecutive_job_search_weeks_prior: 3
+          is_needy_state: true
+      expect: true
+
+    - name: "Normal state, over 6-week limit but under 12 - does not count"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+          job_search_weeks_used_in_fiscal_year: 8
+          consecutive_job_search_weeks_prior: 0
+          state_unemployment_rate: 0.05
+          us_unemployment_rate: 0.05
+      expect: false

--- a/statute/42/607/c/2/A/ii.rac
+++ b/statute/42/607/c/2/A/ii.rac
@@ -1,0 +1,60 @@
+# 42 USC Section 607(c)(2)(A)(ii) - Job search partial week counting
+
+"""
+(ii) Limited authority to count less than full week of participation.--
+For purposes of clause (i) of this subparagraph, on not more than 1
+occasion per individual, the State shall consider participation of the
+individual in an activity described in subsection (d)(6) for 3 or 4 days
+during a week as a week of participation in the activity by the
+individual.
+"""
+
+status: encoded
+
+# Parameters
+
+partial_week_max_occasions:
+    description: "Maximum number of occasions per individual that a partial week of job search may be counted as a full week per 42 USC 607(c)(2)(A)(ii)"
+    unit: count
+    from 1996-10-01: 1
+
+partial_week_min_days:
+    description: "Minimum number of days of participation in a week for the partial week to count as a full week per 42 USC 607(c)(2)(A)(ii)"
+    unit: days
+    from 1996-10-01: 3
+
+partial_week_max_days:
+    description: "Maximum number of days of participation in a week below a full week that still qualifies for partial week counting per 42 USC 607(c)(2)(A)(ii)"
+    unit: days
+    from 1996-10-01: 4
+
+# Inputs
+
+job_search_days_in_week:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Job search days in current week"
+    description: "Number of days of participation in job search activity (d)(6) during the current week"
+    default: 0
+
+partial_week_occasions_used:
+    entity: Person
+    period: Year
+    dtype: Integer
+    label: "Partial week occasions already used"
+    description: "Number of times the individual has already had a partial week counted as a full week of job search participation"
+    default: 0
+
+# Computed values
+
+partial_week_counts_as_full_week:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Partial week counts as full week of job search"
+    description: "Whether the individual's partial week of job search participation (3 or 4 days) counts as a full week for purposes of 42 USC 607(c)(2)(A)(i), limited to 1 occasion per individual per 42 USC 607(c)(2)(A)(ii)"
+    from 1996-10-01:
+        if partial_week_occasions_used >= partial_week_max_occasions: false
+        elif job_search_days_in_week >= partial_week_min_days and job_search_days_in_week <= partial_week_max_days: true
+        else: false

--- a/statute/42/607/c/2/A/ii.rac.test
+++ b/statute/42/607/c/2/A/ii.rac.test
@@ -1,0 +1,37 @@
+# 42 USC Section 607(c)(2)(A)(ii) tests
+
+partial_week_counts_as_full_week:
+    - name: "3 days in a week, no prior occasions used - counts"
+      period: 2024-01
+      inputs:
+          job_search_days_in_week: 3
+          partial_week_occasions_used: 0
+      expect: true
+
+    - name: "4 days in a week, no prior occasions used - counts"
+      period: 2024-01
+      inputs:
+          job_search_days_in_week: 4
+          partial_week_occasions_used: 0
+      expect: true
+
+    - name: "3 days in a week, occasion already used - does not count"
+      period: 2024-01
+      inputs:
+          job_search_days_in_week: 3
+          partial_week_occasions_used: 1
+      expect: false
+
+    - name: "2 days in a week - too few days, does not count"
+      period: 2024-01
+      inputs:
+          job_search_days_in_week: 2
+          partial_week_occasions_used: 0
+      expect: false
+
+    - name: "5 days in a week - full week, partial rule not applicable"
+      period: 2024-01
+      inputs:
+          job_search_days_in_week: 5
+          partial_week_occasions_used: 0
+      expect: false

--- a/statute/42/607/c/2/B.rac
+++ b/statute/42/607/c/2/B.rac
@@ -1,0 +1,49 @@
+# 42 USC Section 607(c)(2)(B) - Single parent or relative with child under 6
+
+"""
+(B) Single parent or relative with child under age 6.-- For purposes of
+determining monthly participation rates under subsection (b)(1)(B)(i), a
+recipient who is the only parent or caretaker relative in the family of a
+child who has not attained 6 years of age is deemed to be engaged in work
+for a month if the recipient is engaged in work for an average of at least
+20 hours per week during the month.
+"""
+
+status: encoded
+
+child_age_threshold_single_parent_deeming:
+    description: "Age that the child must not have attained for the single parent/caretaker relative reduced work hour deeming rule per 42 USC 607(c)(2)(B)"
+    unit: years
+    from 1996-10-01: 6
+
+minimum_weekly_hours_single_parent_child_under_6:
+    description: "Minimum average hours per week a single parent or caretaker relative with a child under age 6 must work to be deemed engaged in work per 42 USC 607(c)(2)(B)"
+    unit: hours/week
+    from 1996-10-01: 20
+
+is_only_parent_or_caretaker_relative:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Only parent or caretaker relative in family"
+    description: "Whether the recipient is the only parent or caretaker relative in the family per 42 USC 607(c)(2)(B)"
+    default: false
+
+youngest_child_age_in_family:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Age of youngest child in family"
+    description: "Age in years of the youngest child in the recipient's family"
+    default: 0
+
+is_deemed_engaged_in_work_single_parent_child_under_6:
+    imports:
+        - 42/607/c/1/A#total_work_activity_hours_per_week
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Deemed engaged in work as single parent with child under 6"
+    description: "Whether a single parent or caretaker relative in a family with a child under age 6 is deemed engaged in work per 42 USC 607(c)(2)(B), for purposes of monthly participation rates under 42 USC 607(b)(1)(B)(i)"
+    from 1996-10-01:
+        is_only_parent_or_caretaker_relative and youngest_child_age_in_family < child_age_threshold_single_parent_deeming and total_work_activity_hours_per_week >= minimum_weekly_hours_single_parent_child_under_6

--- a/statute/42/607/c/2/B.rac.test
+++ b/statute/42/607/c/2/B.rac.test
@@ -1,0 +1,42 @@
+# 42 USC Section 607(c)(2)(B) tests
+
+is_deemed_engaged_in_work_single_parent_child_under_6:
+    - name: "Single parent, child under 6, works 20 hours - deemed engaged"
+      period: 2024-01
+      inputs:
+          is_only_parent_or_caretaker_relative: true
+          youngest_child_age_in_family: 3
+          total_work_activity_hours_per_week: 20
+      expect: true
+
+    - name: "Single parent, child under 6, works 19 hours - not deemed"
+      period: 2024-01
+      inputs:
+          is_only_parent_or_caretaker_relative: true
+          youngest_child_age_in_family: 3
+          total_work_activity_hours_per_week: 19
+      expect: false
+
+    - name: "Single parent, child exactly 6 - not eligible for deeming"
+      period: 2024-01
+      inputs:
+          is_only_parent_or_caretaker_relative: true
+          youngest_child_age_in_family: 6
+          total_work_activity_hours_per_week: 25
+      expect: false
+
+    - name: "Not only parent in family - not eligible for deeming"
+      period: 2024-01
+      inputs:
+          is_only_parent_or_caretaker_relative: false
+          youngest_child_age_in_family: 3
+          total_work_activity_hours_per_week: 25
+      expect: false
+
+    - name: "Zero work hours - not deemed engaged"
+      period: 2024-01
+      inputs:
+          is_only_parent_or_caretaker_relative: true
+          youngest_child_age_in_family: 2
+          total_work_activity_hours_per_week: 0
+      expect: false

--- a/statute/42/607/c/2/C/i.rac
+++ b/statute/42/607/c/2/C/i.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(c)(2)(C)(i) - Teen head of household - school attendance
+
+"""
+(i) maintains satisfactory attendance at secondary school or the
+equivalent during the month;
+"""
+
+status: encoded
+
+maintains_satisfactory_secondary_school_attendance:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Maintains satisfactory secondary school attendance"
+    description: "Whether the recipient maintains satisfactory attendance at secondary school or the equivalent during the month per 42 USC 607(c)(2)(C)(i)"
+    default: false
+
+teen_hoh_meets_school_attendance:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Meets teen head of household school attendance requirement"
+    description: "Whether the recipient satisfies the school attendance condition for being deemed engaged in work per 42 USC 607(c)(2)(C)(i): maintains satisfactory attendance at secondary school or the equivalent during the month"
+    from 1996-10-01:
+        maintains_satisfactory_secondary_school_attendance

--- a/statute/42/607/c/2/C/i.rac.test
+++ b/statute/42/607/c/2/C/i.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(c)(2)(C)(i) tests
+
+teen_hoh_meets_school_attendance:
+    - name: "Maintains satisfactory secondary school attendance"
+      period: 2024-01
+      inputs:
+          maintains_satisfactory_secondary_school_attendance: true
+      expect: true
+
+    - name: "Does not maintain satisfactory school attendance"
+      period: 2024-01
+      inputs:
+          maintains_satisfactory_secondary_school_attendance: false
+      expect: false
+
+    - name: "Default - no attendance declared"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Effective date - FY1997 with attendance"
+      period: 1997-01
+      inputs:
+          maintains_satisfactory_secondary_school_attendance: true
+      expect: true

--- a/statute/42/607/c/2/C/ii.rac
+++ b/statute/42/607/c/2/C/ii.rac
@@ -1,0 +1,30 @@
+# 42 USC Section 607(c)(2)(C)(ii) - Teen head of household: employment education pathway
+
+"""
+(ii) participates in education directly related to employment for an
+average of at least 20 hours per week during the month.
+"""
+
+status: encoded
+
+teen_employment_education_min_hours_per_week:
+    description: "Minimum average hours per week of participation in education directly related to employment for teen head of household deemed engagement per 42 USC 607(c)(2)(C)(ii)"
+    unit: hours_per_week
+    from 1996-10-01: 20
+
+employment_education_hours_per_week:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Employment education hours per week"
+    description: "Average hours per week the recipient participates in education directly related to employment during the month"
+    default: 0
+
+teen_hoh_employment_education_met:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Teen head of household employment education requirement met"
+    description: "Whether the teen head of household or married teen meets the deemed engagement pathway by participating in education directly related to employment for at least 20 hours per week per 42 USC 607(c)(2)(C)(ii)"
+    from 1996-10-01:
+        employment_education_hours_per_week >= teen_employment_education_min_hours_per_week

--- a/statute/42/607/c/2/C/ii.rac.test
+++ b/statute/42/607/c/2/C/ii.rac.test
@@ -1,0 +1,32 @@
+# 42 USC Section 607(c)(2)(C)(ii) tests
+
+teen_hoh_employment_education_met:
+    - name: "Meets minimum: exactly 20 hours"
+      period: 2024-01
+      inputs:
+        employment_education_hours_per_week: 20
+      expect: true
+
+    - name: "Exceeds minimum: 25 hours"
+      period: 2024-01
+      inputs:
+        employment_education_hours_per_week: 25
+      expect: true
+
+    - name: "Below minimum: 19 hours"
+      period: 2024-01
+      inputs:
+        employment_education_hours_per_week: 19
+      expect: false
+
+    - name: "Zero hours: no participation"
+      period: 2024-01
+      inputs:
+        employment_education_hours_per_week: 0
+      expect: false
+
+    - name: "Minimal participation: 1 hour"
+      period: 2024-01
+      inputs:
+        employment_education_hours_per_week: 1
+      expect: false

--- a/statute/42/607/c/2/D.rac
+++ b/statute/42/607/c/2/D.rac
@@ -1,0 +1,154 @@
+# 42 USC Section 607(c)(2)(D) - 30% cap on educational activities
+
+"""
+(D) Limitation on number of persons who may be treated as engaged in
+work by reason of participation in educational activities.-- For
+purposes of determining monthly participation rates under paragraphs
+(1)(B)(i) and (2)(B) of subsection (b), not more than 30 percent of
+the number of individuals in all families and in 2-parent families,
+respectively, in a State who are treated as engaged in work for a
+month may consist of individuals who are determined to be engaged in
+work for the month by reason of participation in vocational
+educational training, or (if the month is in fiscal year 2000 or
+thereafter) deemed to be engaged in work for the month by reason of
+subparagraph (C) of this paragraph.
+"""
+
+status: encoded
+
+# Parameters
+
+educational_activity_cap_rate:
+    description: "Maximum share of individuals treated as engaged in work who may be counted by reason of vocational educational training or teen head of household deeming (subparagraph C) per 42 USC 607(c)(2)(D)"
+    unit: rate
+    from 1996-10-01: 0.30
+
+educational_activity_cap_teen_deeming_start_fiscal_year:
+    description: "Fiscal year from which the educational activity cap also applies to individuals deemed engaged in work under subparagraph (C) per 42 USC 607(c)(2)(D)"
+    unit: fiscal_year
+    from 1996-10-01: 2000
+
+# Inputs
+
+individuals_engaged_in_work_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Total individuals treated as engaged in work - all families"
+    description: "State-level count of individuals in all families who are treated as engaged in work for the month per 42 USC 607(b)(1)(B)(i)"
+    default: 0
+
+individuals_engaged_via_vocational_training_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Individuals engaged via vocational training - all families"
+    description: "State-level count of individuals in all families determined to be engaged in work by reason of participation in vocational educational training per 42 USC 607(d)(8)"
+    default: 0
+
+individuals_engaged_via_teen_deeming_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Individuals engaged via teen head of household deeming - all families"
+    description: "State-level count of individuals in all families deemed engaged in work by reason of subparagraph (C) of 42 USC 607(c)(2)"
+    default: 0
+
+individuals_engaged_in_work_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Total individuals treated as engaged in work - 2-parent families"
+    description: "State-level count of individuals in 2-parent families who are treated as engaged in work for the month per 42 USC 607(b)(2)(B)"
+    default: 0
+
+individuals_engaged_via_vocational_training_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Individuals engaged via vocational training - 2-parent families"
+    description: "State-level count of individuals in 2-parent families determined to be engaged in work by reason of participation in vocational educational training per 42 USC 607(d)(8)"
+    default: 0
+
+individuals_engaged_via_teen_deeming_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Individuals engaged via teen head of household deeming - 2-parent families"
+    description: "State-level count of individuals in 2-parent families deemed engaged in work by reason of subparagraph (C) of 42 USC 607(c)(2)"
+    default: 0
+
+fiscal_year:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Fiscal year"
+    description: "Federal fiscal year applicable to the month"
+    default: 0
+
+# Computed values
+
+teen_deeming_included_in_cap:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Teen deeming included in educational activity cap"
+    description: "Whether individuals deemed engaged in work under subparagraph (C) are included in the 30% cap, which applies from fiscal year 2000 onward per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        fiscal_year >= educational_activity_cap_teen_deeming_start_fiscal_year
+
+educational_activity_count_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Educational activity count subject to cap - all families"
+    description: "Number of individuals in all families counted as engaged in work by reason of vocational educational training (and if applicable, teen deeming) per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        if teen_deeming_included_in_cap: individuals_engaged_via_vocational_training_all_families + individuals_engaged_via_teen_deeming_all_families
+        else: individuals_engaged_via_vocational_training_all_families
+
+educational_activity_cap_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Maximum individuals countable via educational activities - all families"
+    description: "30% cap on the number of individuals in all families who may be treated as engaged in work by reason of educational activities per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        floor(individuals_engaged_in_work_all_families * educational_activity_cap_rate)
+
+educational_activity_count_within_cap_all_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Educational activity count within cap - all families"
+    description: "Actual number of individuals in all families countable via educational activities, limited by the 30% cap per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        min(educational_activity_count_all_families, educational_activity_cap_all_families)
+
+educational_activity_count_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Educational activity count subject to cap - 2-parent families"
+    description: "Number of individuals in 2-parent families counted as engaged in work by reason of vocational educational training (and if applicable, teen deeming) per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        if teen_deeming_included_in_cap: individuals_engaged_via_vocational_training_two_parent_families + individuals_engaged_via_teen_deeming_two_parent_families
+        else: individuals_engaged_via_vocational_training_two_parent_families
+
+educational_activity_cap_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Maximum individuals countable via educational activities - 2-parent families"
+    description: "30% cap on the number of individuals in 2-parent families who may be treated as engaged in work by reason of educational activities per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        floor(individuals_engaged_in_work_two_parent_families * educational_activity_cap_rate)
+
+educational_activity_count_within_cap_two_parent_families:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Educational activity count within cap - 2-parent families"
+    description: "Actual number of individuals in 2-parent families countable via educational activities, limited by the 30% cap per 42 USC 607(c)(2)(D)"
+    from 1996-10-01:
+        min(educational_activity_count_two_parent_families, educational_activity_cap_two_parent_families)

--- a/statute/42/607/c/2/D.rac.test
+++ b/statute/42/607/c/2/D.rac.test
@@ -1,0 +1,97 @@
+# 42 USC Section 607(c)(2)(D) tests
+
+teen_deeming_included_in_cap:
+    - name: "Before FY2000 - teen deeming not included"
+      period: 1999-01
+      inputs:
+          fiscal_year: 1999
+      expect: false
+
+    - name: "FY2000 onward - teen deeming included"
+      period: 2000-10
+      inputs:
+          fiscal_year: 2000
+      expect: true
+
+educational_activity_count_all_families:
+    - name: "Before FY2000 - only vocational training counts"
+      period: 1999-01
+      inputs:
+          fiscal_year: 1999
+          individuals_engaged_via_vocational_training_all_families: 15
+          individuals_engaged_via_teen_deeming_all_families: 5
+      expect: 15
+
+    - name: "FY2000 onward - vocational training plus teen deeming"
+      period: 2001-01
+      inputs:
+          fiscal_year: 2001
+          individuals_engaged_via_vocational_training_all_families: 15
+          individuals_engaged_via_teen_deeming_all_families: 5
+      expect: 20
+
+educational_activity_cap_all_families:
+    - name: "30% of 100 engaged individuals"
+      period: 2024-01
+      inputs:
+          individuals_engaged_in_work_all_families: 100
+      expect: 30
+
+    - name: "30% of 0 engaged individuals"
+      period: 2024-01
+      inputs:
+          individuals_engaged_in_work_all_families: 0
+      expect: 0
+
+    - name: "30% of 50 - floors to 15"
+      period: 2024-01
+      inputs:
+          individuals_engaged_in_work_all_families: 50
+      expect: 15
+
+educational_activity_count_within_cap_all_families:
+    - name: "Under cap - all educational count allowed"
+      period: 2024-01
+      inputs:
+          fiscal_year: 2024
+          individuals_engaged_in_work_all_families: 100
+          individuals_engaged_via_vocational_training_all_families: 10
+          individuals_engaged_via_teen_deeming_all_families: 5
+      expect: 15
+
+    - name: "Over cap - limited to 30%"
+      period: 2024-01
+      inputs:
+          fiscal_year: 2024
+          individuals_engaged_in_work_all_families: 100
+          individuals_engaged_via_vocational_training_all_families: 25
+          individuals_engaged_via_teen_deeming_all_families: 10
+      expect: 30
+
+    - name: "Zero engaged in work - cap is zero"
+      period: 2024-01
+      inputs:
+          fiscal_year: 2024
+          individuals_engaged_in_work_all_families: 0
+          individuals_engaged_via_vocational_training_all_families: 5
+          individuals_engaged_via_teen_deeming_all_families: 0
+      expect: 0
+
+educational_activity_count_within_cap_two_parent_families:
+    - name: "2-parent families under cap"
+      period: 2024-01
+      inputs:
+          fiscal_year: 2024
+          individuals_engaged_in_work_two_parent_families: 40
+          individuals_engaged_via_vocational_training_two_parent_families: 8
+          individuals_engaged_via_teen_deeming_two_parent_families: 2
+      expect: 10
+
+    - name: "2-parent families over cap - limited to 30%"
+      period: 2024-01
+      inputs:
+          fiscal_year: 2024
+          individuals_engaged_in_work_two_parent_families: 40
+          individuals_engaged_via_vocational_training_two_parent_families: 10
+          individuals_engaged_via_teen_deeming_two_parent_families: 8
+      expect: 12

--- a/statute/42/607/d/1.rac
+++ b/statute/42/607/d/1.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(1) - Unsubsidized employment
+
+"""
+(1) unsubsidized employment;
+"""
+
+status: encoded
+
+is_engaged_in_unsubsidized_employment:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in unsubsidized employment"
+    description: "Whether the individual is engaged in unsubsidized employment per 42 USC 607(d)(1)"
+    default: false
+
+unsubsidized_employment_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Unsubsidized employment counts as work activity"
+    description: "Unsubsidized employment qualifies as a work activity per 42 USC 607(d)(1)"
+    from 1996-10-01:
+        is_engaged_in_unsubsidized_employment

--- a/statute/42/607/d/1.rac.test
+++ b/statute/42/607/d/1.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(1) tests
+
+unsubsidized_employment_is_work_activity:
+    - name: "Engaged in unsubsidized employment - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_unsubsidized_employment: true
+      expect: true
+
+    - name: "Not engaged in unsubsidized employment - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_unsubsidized_employment: false
+      expect: false
+
+    - name: "Engaged in unsubsidized employment in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_unsubsidized_employment: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/10.rac
+++ b/statute/42/607/d/10.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(d)(10) - Education directly related to employment
+
+"""
+(10) education directly related to employment, in the case of a
+recipient who has not received a high school diploma or a certificate
+of high school equivalency;
+"""
+
+status: encoded
+
+is_engaged_in_education_related_to_employment:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in education directly related to employment"
+    description: "Whether the individual is engaged in education directly related to employment per 42 USC 607(d)(10)"
+    default: false
+
+has_high_school_diploma_or_equivalency:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Has high school diploma or equivalency certificate"
+    description: "Whether the individual has received a high school diploma or a certificate of high school equivalency per 42 USC 607(d)(10)"
+    default: false
+
+education_related_to_employment_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Education related to employment counts as work activity"
+    description: "Education directly related to employment qualifies as a work activity only for recipients who have not received a high school diploma or equivalency certificate per 42 USC 607(d)(10)"
+    from 1996-10-01:
+        is_engaged_in_education_related_to_employment and not has_high_school_diploma_or_equivalency

--- a/statute/42/607/d/10.rac.test
+++ b/statute/42/607/d/10.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(d)(10) tests
+
+education_related_to_employment_is_work_activity:
+    - name: "Engaged in education, no diploma - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_education_related_to_employment: true
+          has_high_school_diploma_or_equivalency: false
+      expect: true
+
+    - name: "Engaged in education, has diploma - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_education_related_to_employment: true
+          has_high_school_diploma_or_equivalency: true
+      expect: false
+
+    - name: "Not engaged in education, no diploma - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_education_related_to_employment: false
+          has_high_school_diploma_or_equivalency: false
+      expect: false
+
+    - name: "Not engaged in education, has diploma - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_education_related_to_employment: false
+          has_high_school_diploma_or_equivalency: true
+      expect: false
+
+    - name: "Default inputs - not engaged, no diploma (both default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/11.rac
+++ b/statute/42/607/d/11.rac
@@ -1,0 +1,35 @@
+# 42 USC Section 607(d)(11) - Secondary school attendance
+
+"""
+(11) satisfactory attendance at secondary school or in a course of
+study leading to a certificate of general equivalence, in the case of
+a recipient who has not completed secondary school or received such a
+certificate;
+"""
+
+status: encoded
+
+is_attending_secondary_school_or_equivalent:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Attending secondary school or GED program"
+    description: "Whether the individual is satisfactorily attending secondary school or a course of study leading to a certificate of general equivalence per 42 USC 607(d)(11)"
+    default: false
+
+has_completed_secondary_school_or_equivalent:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Has completed secondary school or received GED"
+    description: "Whether the individual has completed secondary school or received a certificate of general equivalence per 42 USC 607(d)(11)"
+    default: false
+
+secondary_school_attendance_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Secondary school attendance counts as work activity"
+    description: "Secondary school attendance qualifies as a work activity only for recipients who have not completed secondary school or received a GED, per 42 USC 607(d)(11)"
+    from 1996-10-01:
+        is_attending_secondary_school_or_equivalent and not has_completed_secondary_school_or_equivalent

--- a/statute/42/607/d/11.rac.test
+++ b/statute/42/607/d/11.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(d)(11) tests
+
+secondary_school_attendance_is_work_activity:
+    - name: "Attending and has not completed secondary school - qualifies"
+      period: 2024-01
+      inputs:
+          is_attending_secondary_school_or_equivalent: true
+          has_completed_secondary_school_or_equivalent: false
+      expect: true
+
+    - name: "Attending but has already completed secondary school - does not qualify"
+      period: 2024-01
+      inputs:
+          is_attending_secondary_school_or_equivalent: true
+          has_completed_secondary_school_or_equivalent: true
+      expect: false
+
+    - name: "Not attending and has not completed - does not qualify"
+      period: 2024-01
+      inputs:
+          is_attending_secondary_school_or_equivalent: false
+          has_completed_secondary_school_or_equivalent: false
+      expect: false
+
+    - name: "Default inputs - not attending (defaults to false)"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Attending in FY1997, has not completed - qualifies"
+      period: 1997-01
+      inputs:
+          is_attending_secondary_school_or_equivalent: true
+          has_completed_secondary_school_or_equivalent: false
+      expect: true

--- a/statute/42/607/d/12.rac
+++ b/statute/42/607/d/12.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(12) - Child care for community service participant
+
+"""
+(12) the provision of child care services to an individual who is
+participating in a community service program.
+"""
+
+status: encoded
+
+is_providing_child_care_to_community_service_participant:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Providing child care to a community service participant"
+    description: "Whether the individual is providing child care services to an individual who is participating in a community service program per 42 USC 607(d)(12)"
+    default: false
+
+child_care_for_community_service_participant_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child care for community service participant counts as work activity"
+    description: "Provision of child care services to an individual participating in a community service program qualifies as a work activity per 42 USC 607(d)(12)"
+    from 1996-10-01:
+        is_providing_child_care_to_community_service_participant

--- a/statute/42/607/d/12.rac.test
+++ b/statute/42/607/d/12.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(12) tests
+
+child_care_for_community_service_participant_is_work_activity:
+    - name: "Providing child care to community service participant - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_providing_child_care_to_community_service_participant: true
+      expect: true
+
+    - name: "Not providing child care to community service participant - does not qualify"
+      period: 2024-01
+      inputs:
+          is_providing_child_care_to_community_service_participant: false
+      expect: false
+
+    - name: "Providing child care in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_providing_child_care_to_community_service_participant: true
+      expect: true
+
+    - name: "Default - not providing child care (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/2.rac
+++ b/statute/42/607/d/2.rac
@@ -1,0 +1,15 @@
+# 42 USC Section 607(d)(2) - Subsidized private sector employment
+
+"""
+(2) subsidized private sector employment;
+"""
+
+status: encoded
+
+is_engaged_in_subsidized_private_sector_employment:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in subsidized private sector employment"
+    description: "Whether the individual is engaged in subsidized private sector employment, a qualifying work activity per 42 USC 607(d)(2)"
+    default: false

--- a/statute/42/607/d/2.rac.test
+++ b/statute/42/607/d/2.rac.test
@@ -1,0 +1,19 @@
+# 42 USC Section 607(d)(2) - Subsidized private sector employment tests
+
+is_engaged_in_subsidized_private_sector_employment:
+    - name: "Default - not engaged in subsidized private sector employment"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Engaged in subsidized private sector employment"
+      period: 2024-01
+      inputs:
+        is_engaged_in_subsidized_private_sector_employment: true
+      expect: true
+
+    - name: "Not engaged in subsidized private sector employment"
+      period: 2024-01
+      inputs:
+        is_engaged_in_subsidized_private_sector_employment: false
+      expect: false

--- a/statute/42/607/d/3.rac
+++ b/statute/42/607/d/3.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(3) - Subsidized public sector employment
+
+"""
+(3) subsidized public sector employment;
+"""
+
+status: encoded
+
+is_engaged_in_subsidized_public_sector_employment:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in subsidized public sector employment"
+    description: "Whether the individual is engaged in subsidized public sector employment per 42 USC 607(d)(3)"
+    default: false
+
+subsidized_public_sector_employment_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Subsidized public sector employment counts as work activity"
+    description: "Subsidized public sector employment qualifies as a work activity per 42 USC 607(d)(3)"
+    from 1996-10-01:
+        is_engaged_in_subsidized_public_sector_employment

--- a/statute/42/607/d/3.rac.test
+++ b/statute/42/607/d/3.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(3) tests
+
+subsidized_public_sector_employment_is_work_activity:
+    - name: "Engaged in subsidized public sector employment - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_subsidized_public_sector_employment: true
+      expect: true
+
+    - name: "Not engaged in subsidized public sector employment - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_subsidized_public_sector_employment: false
+      expect: false
+
+    - name: "Engaged in subsidized public sector employment in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_subsidized_public_sector_employment: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/4.rac
+++ b/statute/42/607/d/4.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(d)(4) - Work experience
+
+"""
+(4) work experience (including work associated with the refurbishing
+of publicly assisted housing) if sufficient private sector employment
+is not available;
+"""
+
+status: encoded
+
+is_engaged_in_work_experience:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in work experience"
+    description: "Whether the individual is engaged in work experience (including work associated with the refurbishing of publicly assisted housing) per 42 USC 607(d)(4)"
+    default: false
+
+sufficient_private_sector_employment_available:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Sufficient private sector employment available"
+    description: "Whether sufficient private sector employment is available per 42 USC 607(d)(4)"
+    default: false
+
+work_experience_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Work experience counts as work activity"
+    description: "Work experience qualifies as a work activity only if sufficient private sector employment is not available, per 42 USC 607(d)(4)"
+    from 1996-10-01:
+        is_engaged_in_work_experience and not sufficient_private_sector_employment_available

--- a/statute/42/607/d/4.rac.test
+++ b/statute/42/607/d/4.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(d)(4) tests
+
+work_experience_is_work_activity:
+    - name: "Engaged in work experience, no private sector employment available - qualifies"
+      period: 2024-01
+      inputs:
+          is_engaged_in_work_experience: true
+          sufficient_private_sector_employment_available: false
+      expect: true
+
+    - name: "Engaged in work experience but sufficient private sector employment available - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_work_experience: true
+          sufficient_private_sector_employment_available: true
+      expect: false
+
+    - name: "Not engaged in work experience - does not qualify regardless"
+      period: 2024-01
+      inputs:
+          is_engaged_in_work_experience: false
+          sufficient_private_sector_employment_available: false
+      expect: false
+
+    - name: "Default inputs - not engaged (defaults to false)"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Engaged in work experience in FY1997, no private sector available - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_work_experience: true
+          sufficient_private_sector_employment_available: false
+      expect: true

--- a/statute/42/607/d/5.rac
+++ b/statute/42/607/d/5.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(5) - On-the-job training
+
+"""
+(5) on-the-job training;
+"""
+
+status: encoded
+
+is_engaged_in_on_the_job_training:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in on-the-job training"
+    description: "Whether the individual is engaged in on-the-job training per 42 USC 607(d)(5)"
+    default: false
+
+on_the_job_training_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "On-the-job training counts as work activity"
+    description: "On-the-job training qualifies as a work activity per 42 USC 607(d)(5)"
+    from 1996-10-01:
+        is_engaged_in_on_the_job_training

--- a/statute/42/607/d/5.rac.test
+++ b/statute/42/607/d/5.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(5) tests
+
+on_the_job_training_is_work_activity:
+    - name: "Engaged in on-the-job training - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_on_the_job_training: true
+      expect: true
+
+    - name: "Not engaged in on-the-job training - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_on_the_job_training: false
+      expect: false
+
+    - name: "Engaged in on-the-job training in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_on_the_job_training: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/6.rac
+++ b/statute/42/607/d/6.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(6) - Job search and job readiness assistance
+
+"""
+(6) job search and job readiness assistance;
+"""
+
+status: encoded
+
+is_engaged_in_job_search_and_job_readiness:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in job search and job readiness assistance"
+    description: "Whether the individual is engaged in job search and job readiness assistance per 42 USC 607(d)(6)"
+    default: false
+
+job_search_and_job_readiness_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Job search and job readiness assistance counts as work activity"
+    description: "Job search and job readiness assistance qualifies as a work activity per 42 USC 607(d)(6)"
+    from 1996-10-01:
+        is_engaged_in_job_search_and_job_readiness

--- a/statute/42/607/d/6.rac.test
+++ b/statute/42/607/d/6.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(6) tests
+
+job_search_and_job_readiness_is_work_activity:
+    - name: "Engaged in job search and job readiness - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+      expect: true
+
+    - name: "Not engaged in job search and job readiness - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: false
+      expect: false
+
+    - name: "Engaged in job search and job readiness in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_job_search_and_job_readiness: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/7.rac
+++ b/statute/42/607/d/7.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(7) - Community service programs
+
+"""
+(7) community service programs;
+"""
+
+status: encoded
+
+is_engaged_in_community_service_program:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in community service program"
+    description: "Whether the individual is engaged in a community service program per 42 USC 607(d)(7)"
+    default: false
+
+community_service_program_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Community service program counts as work activity"
+    description: "Participation in a community service program qualifies as a work activity per 42 USC 607(d)(7)"
+    from 1996-10-01:
+        is_engaged_in_community_service_program

--- a/statute/42/607/d/7.rac.test
+++ b/statute/42/607/d/7.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(7) tests
+
+community_service_program_is_work_activity:
+    - name: "Engaged in community service program - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_community_service_program: true
+      expect: true
+
+    - name: "Not engaged in community service program - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_community_service_program: false
+      expect: false
+
+    - name: "Engaged in community service program in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_community_service_program: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/d/8.rac
+++ b/statute/42/607/d/8.rac
@@ -1,0 +1,38 @@
+# 42 USC Section 607(d)(8) - Vocational educational training (12-month limit)
+
+"""
+(8) vocational educational training (not to exceed 12 months with
+respect to any individual);
+"""
+
+status: encoded
+
+vocational_educational_training_month_limit:
+    description: "Maximum months of vocational educational training that count as a work activity per 42 USC 607(d)(8)"
+    unit: months
+    from 1996-10-01: 12
+
+is_engaged_in_vocational_educational_training:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in vocational educational training"
+    description: "Whether the individual is engaged in vocational educational training per 42 USC 607(d)(8)"
+    default: false
+
+vocational_educational_training_months_used:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Months of vocational educational training used"
+    description: "Cumulative months of vocational educational training already counted as a work activity for this individual per 42 USC 607(d)(8)"
+    default: 0
+
+vocational_educational_training_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Vocational educational training counts as work activity"
+    description: "Vocational educational training qualifies as a work activity only if the individual has not exceeded 12 months, per 42 USC 607(d)(8)"
+    from 1996-10-01:
+        is_engaged_in_vocational_educational_training and vocational_educational_training_months_used < vocational_educational_training_month_limit

--- a/statute/42/607/d/8.rac.test
+++ b/statute/42/607/d/8.rac.test
@@ -1,0 +1,37 @@
+# 42 USC Section 607(d)(8) tests
+
+vocational_educational_training_is_work_activity:
+    - name: "Engaged with no prior months - qualifies"
+      period: 2024-01
+      inputs:
+        is_engaged_in_vocational_educational_training: true
+        vocational_educational_training_months_used: 0
+      expect: true
+
+    - name: "Engaged with 11 months used - still qualifies"
+      period: 2024-01
+      inputs:
+        is_engaged_in_vocational_educational_training: true
+        vocational_educational_training_months_used: 11
+      expect: true
+
+    - name: "Engaged with 12 months used - exceeds limit"
+      period: 2024-01
+      inputs:
+        is_engaged_in_vocational_educational_training: true
+        vocational_educational_training_months_used: 12
+      expect: false
+
+    - name: "Not engaged - does not qualify regardless of months"
+      period: 2024-01
+      inputs:
+        is_engaged_in_vocational_educational_training: false
+        vocational_educational_training_months_used: 0
+      expect: false
+
+    - name: "Not engaged with months used - does not qualify"
+      period: 2024-01
+      inputs:
+        is_engaged_in_vocational_educational_training: false
+        vocational_educational_training_months_used: 6
+      expect: false

--- a/statute/42/607/d/9.rac
+++ b/statute/42/607/d/9.rac
@@ -1,0 +1,24 @@
+# 42 USC Section 607(d)(9) - Job skills training directly related to employment
+
+"""
+(9) job skills training directly related to employment;
+"""
+
+status: encoded
+
+is_engaged_in_job_skills_training:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Engaged in job skills training directly related to employment"
+    description: "Whether the individual is engaged in job skills training directly related to employment per 42 USC 607(d)(9)"
+    default: false
+
+job_skills_training_is_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Job skills training counts as work activity"
+    description: "Job skills training directly related to employment qualifies as a work activity per 42 USC 607(d)(9)"
+    from 1996-10-01:
+        is_engaged_in_job_skills_training

--- a/statute/42/607/d/9.rac.test
+++ b/statute/42/607/d/9.rac.test
@@ -1,0 +1,25 @@
+# 42 USC Section 607(d)(9) tests
+
+job_skills_training_is_work_activity:
+    - name: "Engaged in job skills training - qualifies as work activity"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_skills_training: true
+      expect: true
+
+    - name: "Not engaged in job skills training - does not qualify"
+      period: 2024-01
+      inputs:
+          is_engaged_in_job_skills_training: false
+      expect: false
+
+    - name: "Engaged in job skills training in FY1997 - qualifies"
+      period: 1997-01
+      inputs:
+          is_engaged_in_job_skills_training: true
+      expect: true
+
+    - name: "Default - not engaged (default false)"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/e/1.rac
+++ b/statute/42/607/e/1.rac
@@ -1,0 +1,44 @@
+# 42 USC Section 607(e)(1) - Penalties against individuals, in general
+
+"""
+(1) In general.-- Except as provided in paragraph (2), if an individual in a
+family receiving assistance under the State program funded under this part or
+any other State program funded with qualified State expenditures (as defined
+in section 609(a)(7)(B)(i) of this title) refuses to engage in work required
+in accordance with this section, the State shall--
+(A) reduce the amount of assistance otherwise payable to the family pro rata
+(or more, at the option of the State) with respect to any period during a
+month in which the individual so refuses; or
+(B) terminate such assistance,
+subject to such good cause and other exceptions as the State may establish.
+"""
+
+status: encoded
+
+paragraph_2_exception_applies:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Paragraph (2) child care exception applies"
+    description: "Whether the exception in 42 USC 607(e)(2) applies (single custodial parent with child under 6 unable to obtain needed child care)"
+    default: false
+
+work_refusal_penalty:
+    imports:
+        - 42/607/e/1/A#pro_rata_assistance_reduction
+        - 42/607/e/1/A#tanf_monthly_assistance_otherwise_payable
+        - 42/607/e/1/B#assistance_terminated_for_work_refusal
+        - 42/607/e/1/B#refuses_to_engage_in_work
+        - 42/607/e/1/B#has_good_cause_exception
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Work refusal penalty"
+    description: "Amount by which family's assistance is reduced due to work refusal per 42 USC 607(e)(1)"
+    from 1996-10-01:
+        if paragraph_2_exception_applies: 0
+        elif not refuses_to_engage_in_work: 0
+        elif has_good_cause_exception: 0
+        elif assistance_terminated_for_work_refusal: tanf_monthly_assistance_otherwise_payable
+        else: pro_rata_assistance_reduction

--- a/statute/42/607/e/1.rac.test
+++ b/statute/42/607/e/1.rac.test
@@ -1,0 +1,62 @@
+# 42 USC Section 607(e)(1) tests
+
+work_refusal_penalty:
+    - name: "Paragraph (2) child care exception overrides - no penalty"
+      period: 2024-01
+      inputs:
+        paragraph_2_exception_applies: true
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: false
+        state_elects_assistance_termination: false
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 15
+        days_in_month: 30
+      expect: 0
+
+    - name: "No work refusal - no penalty"
+      period: 2024-01
+      inputs:
+        paragraph_2_exception_applies: false
+        refuses_to_engage_in_work: false
+        has_good_cause_exception: false
+        state_elects_assistance_termination: false
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 0
+        days_in_month: 30
+      expect: 0
+
+    - name: "Good cause exception - no penalty"
+      period: 2024-01
+      inputs:
+        paragraph_2_exception_applies: false
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: true
+        state_elects_assistance_termination: false
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 30
+        days_in_month: 30
+      expect: 0
+
+    - name: "State elects termination - full assistance is penalty"
+      period: 2024-01
+      inputs:
+        paragraph_2_exception_applies: false
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: false
+        state_elects_assistance_termination: true
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 30
+        days_in_month: 30
+      expect: 500
+
+    - name: "Pro rata reduction - half month refusal"
+      period: 2024-01
+      inputs:
+        paragraph_2_exception_applies: false
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: false
+        state_elects_assistance_termination: false
+        tanf_monthly_assistance_otherwise_payable: 600
+        days_of_work_refusal_in_month: 15
+        days_in_month: 30
+      expect: 300

--- a/statute/42/607/e/1/A.rac
+++ b/statute/42/607/e/1/A.rac
@@ -1,0 +1,45 @@
+# 42 USC Section 607(e)(1)(A) - Pro rata reduction of assistance
+
+"""
+(A) reduce the amount of assistance otherwise payable to the family
+pro rata (or more, at the option of the State) with respect to any
+period during a month in which the individual so refuses; or
+"""
+
+status: encoded
+
+tanf_monthly_assistance_otherwise_payable:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "TANF monthly assistance otherwise payable"
+    description: "Amount of assistance otherwise payable to the family per 42 USC 607(e)(1)(A)"
+    default: 0
+
+days_of_work_refusal_in_month:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Days of work refusal in month"
+    description: "Number of days during the month in which the individual refuses to engage in required work per 42 USC 607(e)(1)(A)"
+    default: 0
+
+days_in_month:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Days in month"
+    description: "Total number of days in the month"
+    default: 0
+
+pro_rata_assistance_reduction:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Pro rata assistance reduction"
+    description: "Minimum pro rata reduction in assistance due to work refusal per 42 USC 607(e)(1)(A)"
+    from 1996-10-01:
+        if days_in_month == 0: 0
+        else: tanf_monthly_assistance_otherwise_payable * days_of_work_refusal_in_month / days_in_month

--- a/statute/42/607/e/1/A.rac.test
+++ b/statute/42/607/e/1/A.rac.test
@@ -1,0 +1,42 @@
+# 42 USC Section 607(e)(1)(A) tests
+
+pro_rata_assistance_reduction:
+    - name: "Full month refusal reduces entire benefit"
+      period: 2024-01
+      inputs:
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 30
+        days_in_month: 30
+      expect: 500
+
+    - name: "Half month refusal reduces benefit by half"
+      period: 2024-01
+      inputs:
+        tanf_monthly_assistance_otherwise_payable: 600
+        days_of_work_refusal_in_month: 15
+        days_in_month: 30
+      expect: 300
+
+    - name: "No refusal means no reduction"
+      period: 2024-01
+      inputs:
+        tanf_monthly_assistance_otherwise_payable: 500
+        days_of_work_refusal_in_month: 0
+        days_in_month: 30
+      expect: 0
+
+    - name: "One day refusal in 31-day month"
+      period: 2024-01
+      inputs:
+        tanf_monthly_assistance_otherwise_payable: 620
+        days_of_work_refusal_in_month: 1
+        days_in_month: 31
+      expect: 20
+
+    - name: "Zero assistance yields zero reduction"
+      period: 2024-01
+      inputs:
+        tanf_monthly_assistance_otherwise_payable: 0
+        days_of_work_refusal_in_month: 15
+        days_in_month: 30
+      expect: 0

--- a/statute/42/607/e/1/B.rac
+++ b/statute/42/607/e/1/B.rac
@@ -1,0 +1,42 @@
+# 42 USC Section 607(e)(1)(B) - Termination of assistance
+
+"""
+(B) terminate such assistance,
+
+subject to such good cause and other exceptions as the State may establish.
+"""
+
+status: encoded
+
+state_elects_assistance_termination:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "State elects termination for work refusal"
+    description: "Whether the State elects to terminate assistance rather than reduce it pro rata per 42 USC 607(e)(1)(B)"
+    default: false
+
+refuses_to_engage_in_work:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Refuses to engage in required work"
+    description: "Whether the individual refuses to engage in work required in accordance with 42 USC 607"
+    default: false
+
+has_good_cause_exception:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Has good cause exception"
+    description: "Whether the individual has a good cause or other exception as established by the State per 42 USC 607(e)(1)"
+    default: false
+
+assistance_terminated_for_work_refusal:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Assistance terminated for work refusal"
+    description: "Whether assistance is terminated because individual refused to engage in required work per 42 USC 607(e)(1)(B)"
+    from 1996-10-01:
+        state_elects_assistance_termination and refuses_to_engage_in_work and not has_good_cause_exception

--- a/statute/42/607/e/1/B.rac.test
+++ b/statute/42/607/e/1/B.rac.test
@@ -1,0 +1,42 @@
+# 42 USC Section 607(e)(1)(B) tests
+
+assistance_terminated_for_work_refusal:
+    - name: "Assistance terminated when state elects termination and individual refuses work"
+      period: 2024-01
+      inputs:
+        state_elects_assistance_termination: true
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: false
+      expect: true
+
+    - name: "No termination when individual does not refuse work"
+      period: 2024-01
+      inputs:
+        state_elects_assistance_termination: true
+        refuses_to_engage_in_work: false
+        has_good_cause_exception: false
+      expect: false
+
+    - name: "No termination when state elects reduction instead"
+      period: 2024-01
+      inputs:
+        state_elects_assistance_termination: false
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: false
+      expect: false
+
+    - name: "No termination when good cause exception applies"
+      period: 2024-01
+      inputs:
+        state_elects_assistance_termination: true
+        refuses_to_engage_in_work: true
+        has_good_cause_exception: true
+      expect: false
+
+    - name: "No termination when all inputs are false"
+      period: 2024-01
+      inputs:
+        state_elects_assistance_termination: false
+        refuses_to_engage_in_work: false
+        has_good_cause_exception: false
+      expect: false

--- a/statute/42/607/e/2.rac
+++ b/statute/42/607/e/2.rac
@@ -1,0 +1,64 @@
+# 42 USC Section 607(e)(2) - Child care inability exception
+
+"""
+(2) Exception.-- A State may not reduce or terminate assistance under
+the State program funded under this part or any other State program
+funded with qualified State expenditures (as defined in section
+609(a)(7)(B)(i) of this title) of a single custodial parent caring
+for a child who has not attained 6 years of age based on the refusal
+of the individual to engage in work required in accordance with this
+section if the individual proves (to the satisfaction of the State)
+that the individual has a demonstrated inability to obtain needed
+child care, for 1 or more of the following reasons:
+(A) Unavailability of appropriate child care within a reasonable
+distance from the individual's home or work site.
+(B) Unavailability or unsuitability of informal child care by a
+relative or under other arrangements.
+(C) Unavailability of appropriate and affordable formal child care
+arrangements.
+"""
+
+status: encoded
+
+child_care_exception_child_age_threshold:
+    description: "Age threshold below which the child care exception applies"
+    unit: years
+    from 1997-07-01: 6
+
+is_single_custodial_parent:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Is a single custodial parent"
+    description: "Whether the individual is a single custodial parent per 42 USC 607(e)(2)"
+    default: false
+
+is_caring_for_child_under_threshold_age:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Caring for a child under threshold age"
+    description: "Whether the individual is caring for a child who has not attained the age threshold (6 years) per 42 USC 607(e)(2)"
+    default: false
+
+child_care_inability_demonstrated:
+    imports:
+        - ./2/A#child_care_distance_exception_applies
+        - ./2/B#informal_child_care_exception_applies
+        - ./2/C#formal_child_care_exception_applies
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Demonstrated inability to obtain needed child care"
+    description: "Whether the individual has demonstrated inability to obtain needed child care for 1 or more of the reasons in subparagraphs (A), (B), or (C) per 42 USC 607(e)(2)"
+    from 1997-07-01:
+        child_care_distance_exception_applies or informal_child_care_exception_applies or formal_child_care_exception_applies
+
+child_care_inability_exception_applies:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child care inability exception applies"
+    description: "Whether the child care inability exception prevents the State from reducing or terminating assistance per 42 USC 607(e)(2)"
+    from 1997-07-01:
+        is_single_custodial_parent and is_caring_for_child_under_threshold_age and child_care_inability_demonstrated

--- a/statute/42/607/e/2.rac.test
+++ b/statute/42/607/e/2.rac.test
@@ -1,0 +1,69 @@
+# 42 USC Section 607(e)(2) tests
+
+child_care_inability_demonstrated:
+    - name: "Demonstrated when distance exception applies"
+      period: 2024-01
+      inputs:
+        child_care_distance_exception_applies: true
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: true
+
+    - name: "Not demonstrated when no reasons apply"
+      period: 2024-01
+      inputs:
+        child_care_distance_exception_applies: false
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: false
+
+child_care_inability_exception_applies:
+    - name: "Exception applies - single custodial parent with child under 6 and demonstrated inability"
+      period: 2024-01
+      inputs:
+        is_single_custodial_parent: true
+        is_caring_for_child_under_threshold_age: true
+        child_care_distance_exception_applies: true
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: true
+
+    - name: "Exception does not apply - not a single custodial parent"
+      period: 2024-01
+      inputs:
+        is_single_custodial_parent: false
+        is_caring_for_child_under_threshold_age: true
+        child_care_distance_exception_applies: true
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: false
+
+    - name: "Exception does not apply - child is above age threshold"
+      period: 2024-01
+      inputs:
+        is_single_custodial_parent: true
+        is_caring_for_child_under_threshold_age: false
+        child_care_distance_exception_applies: true
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: false
+
+    - name: "Exception does not apply - no child care inability demonstrated"
+      period: 2024-01
+      inputs:
+        is_single_custodial_parent: true
+        is_caring_for_child_under_threshold_age: true
+        child_care_distance_exception_applies: false
+        informal_child_care_exception_applies: false
+        formal_child_care_exception_applies: false
+      expect: false
+
+    - name: "Exception applies with multiple child care reasons"
+      period: 2024-01
+      inputs:
+        is_single_custodial_parent: true
+        is_caring_for_child_under_threshold_age: true
+        child_care_distance_exception_applies: true
+        informal_child_care_exception_applies: true
+        formal_child_care_exception_applies: true
+      expect: true

--- a/statute/42/607/e/2/A.rac
+++ b/statute/42/607/e/2/A.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(e)(2)(A) - Unavailability of appropriate child care within reasonable distance
+
+"""
+(A) Unavailability of appropriate child care within a reasonable
+distance from the individual's home or work site.
+"""
+
+status: encoded
+
+appropriate_child_care_unavailable_within_reasonable_distance:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Appropriate child care unavailable within reasonable distance"
+    description: "Whether appropriate child care is unavailable within a reasonable distance from the individual's home or work site per 42 USC 607(e)(2)(A)"
+    default: false
+
+child_care_distance_exception_applies:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child care distance/unavailability exception applies"
+    description: "The work penalty exception applies due to unavailability of appropriate child care within a reasonable distance from home or work site per 42 USC 607(e)(2)(A)"
+    from 1997-07-01:
+        appropriate_child_care_unavailable_within_reasonable_distance

--- a/statute/42/607/e/2/A.rac.test
+++ b/statute/42/607/e/2/A.rac.test
@@ -1,0 +1,19 @@
+# 42 USC Section 607(e)(2)(A) tests
+
+child_care_distance_exception_applies:
+    - name: "Exception applies when appropriate child care is unavailable within reasonable distance"
+      period: 2024-01
+      inputs:
+        appropriate_child_care_unavailable_within_reasonable_distance: true
+      expect: true
+
+    - name: "Exception does not apply when appropriate child care is available"
+      period: 2024-01
+      inputs:
+        appropriate_child_care_unavailable_within_reasonable_distance: false
+      expect: false
+
+    - name: "Default is false when no input provided"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/e/2/B.rac
+++ b/statute/42/607/e/2/B.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(e)(2)(B) - Unavailability or unsuitability of informal child care
+
+"""
+(B) Unavailability or unsuitability of informal child care by a
+relative or under other arrangements.
+"""
+
+status: encoded
+
+informal_child_care_unavailable_or_unsuitable:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Informal child care unavailable or unsuitable"
+    description: "Whether informal child care by a relative or under other arrangements is unavailable or unsuitable per 42 USC 607(e)(2)(B)"
+    default: false
+
+informal_child_care_exception_applies:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Informal child care exception applies"
+    description: "The work penalty exception applies due to unavailability or unsuitability of informal child care by a relative or under other arrangements per 42 USC 607(e)(2)(B)"
+    from 1997-07-01:
+        informal_child_care_unavailable_or_unsuitable

--- a/statute/42/607/e/2/B.rac.test
+++ b/statute/42/607/e/2/B.rac.test
@@ -1,0 +1,19 @@
+# 42 USC Section 607(e)(2)(B) tests
+
+informal_child_care_exception_applies:
+    - name: "Exception applies when informal child care is unavailable or unsuitable"
+      period: 2024-01
+      inputs:
+        informal_child_care_unavailable_or_unsuitable: true
+      expect: true
+
+    - name: "Exception does not apply when informal child care is available and suitable"
+      period: 2024-01
+      inputs:
+        informal_child_care_unavailable_or_unsuitable: false
+      expect: false
+
+    - name: "Default is false when no input provided"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/e/2/C.rac
+++ b/statute/42/607/e/2/C.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(e)(2)(C) - Unavailability of appropriate and affordable formal child care
+
+"""
+(C) Unavailability of appropriate and affordable formal child care
+arrangements.
+"""
+
+status: encoded
+
+appropriate_and_affordable_formal_child_care_unavailable:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Appropriate and affordable formal child care unavailable"
+    description: "Whether appropriate and affordable formal child care arrangements are unavailable per 42 USC 607(e)(2)(C)"
+    default: false
+
+formal_child_care_exception_applies:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Formal child care exception applies"
+    description: "The work penalty exception applies due to unavailability of appropriate and affordable formal child care arrangements per 42 USC 607(e)(2)(C)"
+    from 1997-07-01:
+        appropriate_and_affordable_formal_child_care_unavailable

--- a/statute/42/607/e/2/C.rac.test
+++ b/statute/42/607/e/2/C.rac.test
@@ -1,0 +1,31 @@
+# 42 USC Section 607(e)(2)(C) tests
+
+formal_child_care_exception_applies:
+    - name: "Exception applies when formal child care is unavailable"
+      period: 2024-01
+      inputs:
+        appropriate_and_affordable_formal_child_care_unavailable: true
+      expect: true
+
+    - name: "Exception does not apply when formal child care is available"
+      period: 2024-01
+      inputs:
+        appropriate_and_affordable_formal_child_care_unavailable: false
+      expect: false
+
+    - name: "Default is false when no input provided"
+      period: 2024-01
+      inputs: {}
+      expect: false
+
+    - name: "Exception applies in recent fiscal year"
+      period: 2025-10
+      inputs:
+        appropriate_and_affordable_formal_child_care_unavailable: true
+      expect: true
+
+    - name: "Exception does not apply before effective date"
+      period: 1996-01
+      inputs:
+        appropriate_and_affordable_formal_child_care_unavailable: true
+      expect: 0

--- a/statute/42/607/f/1.rac
+++ b/statute/42/607/f/1.rac
@@ -1,0 +1,51 @@
+# 42 USC Section 607(f)(1) - Vacant position rule
+
+"""
+(1) In general.-- Subject to paragraph (2), an adult in a family receiving
+assistance under a State program funded under this part attributable to funds
+provided by the Federal Government may fill a vacant employment position in
+order to engage in a work activity described in subsection (d).
+"""
+
+status: encoded
+
+is_tanf_adult_receiving_federal_assistance:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Adult in TANF family receiving federally funded assistance"
+    description: "Whether the individual is an adult in a family receiving assistance under a State TANF program attributable to funds provided by the Federal Government per 42 USC 607(f)(1)"
+    default: false
+
+is_position_vacant:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Position is a vacant employment position"
+    description: "Whether the employment position is a vacant position per 42 USC 607(f)(1)"
+    default: false
+
+is_for_work_activity_described_in_d:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Work activity described in subsection (d)"
+    description: "Whether the work activity is one described in 42 USC 607(d) per 42 USC 607(f)(1)"
+    default: false
+
+is_nondisplacement_compliant:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Compliant with nondisplacement restrictions"
+    description: "Whether the placement meets the nondisplacement restrictions of 42 USC 607(f)(2), as referenced by 'subject to paragraph (2)'"
+    default: true
+
+may_fill_vacant_employment_position:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "May fill vacant employment position"
+    description: "Whether an adult in a TANF family may fill a vacant employment position to engage in a work activity described in subsection (d), subject to nondisplacement restrictions per 42 USC 607(f)(1)"
+    from 1996-10-01:
+        is_tanf_adult_receiving_federal_assistance and is_position_vacant and is_for_work_activity_described_in_d and is_nondisplacement_compliant

--- a/statute/42/607/f/1.rac.test
+++ b/statute/42/607/f/1.rac.test
@@ -1,0 +1,47 @@
+# 42 USC Section 607(f)(1) tests
+
+may_fill_vacant_employment_position:
+    - name: "All conditions met - may fill vacant position"
+      period: 2024-01
+      inputs:
+          is_tanf_adult_receiving_federal_assistance: true
+          is_position_vacant: true
+          is_for_work_activity_described_in_d: true
+          is_nondisplacement_compliant: true
+      expect: true
+
+    - name: "Not a TANF adult - may not fill"
+      period: 2024-01
+      inputs:
+          is_tanf_adult_receiving_federal_assistance: false
+          is_position_vacant: true
+          is_for_work_activity_described_in_d: true
+          is_nondisplacement_compliant: true
+      expect: false
+
+    - name: "Position not vacant - may not fill"
+      period: 2024-01
+      inputs:
+          is_tanf_adult_receiving_federal_assistance: true
+          is_position_vacant: false
+          is_for_work_activity_described_in_d: true
+          is_nondisplacement_compliant: true
+      expect: false
+
+    - name: "Not for work activity in subsection (d) - may not fill"
+      period: 2024-01
+      inputs:
+          is_tanf_adult_receiving_federal_assistance: true
+          is_position_vacant: true
+          is_for_work_activity_described_in_d: false
+          is_nondisplacement_compliant: true
+      expect: false
+
+    - name: "Nondisplacement violation under (f)(2) - may not fill"
+      period: 2024-01
+      inputs:
+          is_tanf_adult_receiving_federal_assistance: true
+          is_position_vacant: true
+          is_for_work_activity_described_in_d: true
+          is_nondisplacement_compliant: false
+      expect: false

--- a/statute/42/607/f/2.rac
+++ b/statute/42/607/f/2.rac
@@ -1,0 +1,44 @@
+# 42 USC Section 607(f)(2) - No filling certain vacancies
+
+"""
+(2) No adult in a work activity described in subsection (d) which is
+funded, in whole or in part, by funds provided by the Federal Government
+shall be employed or assigned--
+(A) when any other individual is on layoff from the same or any
+substantially equivalent job; or
+(B) if the employer has terminated the employment of any regular employee
+or otherwise caused an involuntary reduction of its workforce in order
+to fill the vacancy so created with an adult described in paragraph (1).
+"""
+
+status: encoded
+
+is_work_activity_federally_funded:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Work activity is federally funded"
+    description: "Whether the work activity described in 42 USC 607(d) is funded, in whole or in part, by funds provided by the Federal Government per 42 USC 607(f)(2)"
+    default: false
+
+is_employed_or_assigned_in_work_activity:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Employed or assigned in work activity"
+    description: "Whether the adult is employed or assigned in a work activity described in subsection (d) per 42 USC 607(f)(2)"
+    default: false
+
+no_filling_certain_vacancies:
+    imports:
+        - ./2/A#violates_layoff_restriction
+        - ./2/B#violates_workforce_reduction_restriction
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Prohibited from filling vacancy"
+    description: "Whether the adult is prohibited from being employed or assigned in the position because of nondisplacement protections per 42 USC 607(f)(2)"
+    from 1996-10-01:
+        if not is_work_activity_federally_funded: false
+        elif not is_employed_or_assigned_in_work_activity: false
+        else: violates_layoff_restriction or violates_workforce_reduction_restriction

--- a/statute/42/607/f/2.rac.test
+++ b/statute/42/607/f/2.rac.test
@@ -1,0 +1,47 @@
+# 42 USC Section 607(f)(2) tests
+
+no_filling_certain_vacancies:
+    - name: "Federally funded activity with layoff violation - prohibited"
+      period: 2024-01
+      inputs:
+          is_work_activity_federally_funded: true
+          is_employed_or_assigned_in_work_activity: true
+          violates_layoff_restriction: true
+          violates_workforce_reduction_restriction: false
+      expect: true
+
+    - name: "Federally funded activity with workforce reduction violation - prohibited"
+      period: 2024-01
+      inputs:
+          is_work_activity_federally_funded: true
+          is_employed_or_assigned_in_work_activity: true
+          violates_layoff_restriction: false
+          violates_workforce_reduction_restriction: true
+      expect: true
+
+    - name: "Federally funded activity with both violations - prohibited"
+      period: 2024-01
+      inputs:
+          is_work_activity_federally_funded: true
+          is_employed_or_assigned_in_work_activity: true
+          violates_layoff_restriction: true
+          violates_workforce_reduction_restriction: true
+      expect: true
+
+    - name: "Federally funded activity with no violations - not prohibited"
+      period: 2024-01
+      inputs:
+          is_work_activity_federally_funded: true
+          is_employed_or_assigned_in_work_activity: true
+          violates_layoff_restriction: false
+          violates_workforce_reduction_restriction: false
+      expect: false
+
+    - name: "Not federally funded - not prohibited even with violations"
+      period: 2024-01
+      inputs:
+          is_work_activity_federally_funded: false
+          is_employed_or_assigned_in_work_activity: true
+          violates_layoff_restriction: true
+          violates_workforce_reduction_restriction: true
+      expect: false

--- a/statute/42/607/f/2/A.rac
+++ b/statute/42/607/f/2/A.rac
@@ -1,0 +1,25 @@
+# 42 USC Section 607(f)(2)(A) - Layoff restriction
+
+"""
+(A) when any other individual is on layoff from the same or any
+substantially equivalent position; or
+"""
+
+status: encoded
+
+is_other_individual_on_layoff_from_same_or_equivalent_position:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Other individual on layoff from same or equivalent position"
+    description: "Whether any other individual is on layoff from the same or any substantially equivalent position per 42 USC 607(f)(2)(A)"
+    default: false
+
+violates_layoff_restriction:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Violates layoff restriction"
+    description: "Whether the layoff restriction condition of 42 USC 607(f)(2)(A) is triggered because another individual is on layoff from the same or substantially equivalent position"
+    from 1996-10-01:
+        is_other_individual_on_layoff_from_same_or_equivalent_position

--- a/statute/42/607/f/2/A.rac.test
+++ b/statute/42/607/f/2/A.rac.test
@@ -1,0 +1,19 @@
+# 42 USC Section 607(f)(2)(A) tests
+
+violates_layoff_restriction:
+    - name: "Other individual on layoff - violates restriction"
+      period: 2024-01
+      inputs:
+          is_other_individual_on_layoff_from_same_or_equivalent_position: true
+      expect: true
+
+    - name: "No individual on layoff - no violation"
+      period: 2024-01
+      inputs:
+          is_other_individual_on_layoff_from_same_or_equivalent_position: false
+      expect: false
+
+    - name: "Default - no layoff, no violation"
+      period: 2024-01
+      inputs: {}
+      expect: false

--- a/statute/42/607/f/2/B.rac
+++ b/statute/42/607/f/2/B.rac
@@ -1,0 +1,34 @@
+# 42 USC Section 607(f)(2)(B) - Workforce reduction restriction
+
+"""
+(B) the employer has terminated the employment of any regular employee
+or otherwise caused an involuntary reduction of its workforce in order
+to fill the vacancy so created with an adult described in paragraph (1).
+"""
+
+status: encoded
+
+has_employer_terminated_regular_employee_to_create_vacancy:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Employer terminated regular employee to create vacancy"
+    description: "Whether the employer has terminated the employment of any regular employee in order to fill the vacancy so created with a TANF adult per 42 USC 607(f)(2)(B)"
+    default: false
+
+has_employer_caused_involuntary_workforce_reduction_to_create_vacancy:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Employer caused involuntary workforce reduction to create vacancy"
+    description: "Whether the employer has otherwise caused an involuntary reduction of its workforce in order to fill the vacancy so created with a TANF adult per 42 USC 607(f)(2)(B)"
+    default: false
+
+violates_workforce_reduction_restriction:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Violates workforce reduction restriction"
+    description: "Whether the workforce reduction restriction of 42 USC 607(f)(2)(B) is triggered because the employer terminated a regular employee or caused an involuntary workforce reduction to create the vacancy"
+    from 1996-10-01:
+        has_employer_terminated_regular_employee_to_create_vacancy or has_employer_caused_involuntary_workforce_reduction_to_create_vacancy

--- a/statute/42/607/f/2/B.rac.test
+++ b/statute/42/607/f/2/B.rac.test
@@ -1,0 +1,35 @@
+# 42 USC Section 607(f)(2)(B) tests
+
+violates_workforce_reduction_restriction:
+    - name: "Employer terminated regular employee to create vacancy - violates restriction"
+      period: 2024-01
+      inputs:
+          has_employer_terminated_regular_employee_to_create_vacancy: true
+          has_employer_caused_involuntary_workforce_reduction_to_create_vacancy: false
+      expect: true
+
+    - name: "Employer caused involuntary workforce reduction - violates restriction"
+      period: 2024-01
+      inputs:
+          has_employer_terminated_regular_employee_to_create_vacancy: false
+          has_employer_caused_involuntary_workforce_reduction_to_create_vacancy: true
+      expect: true
+
+    - name: "Both termination and involuntary reduction - violates restriction"
+      period: 2024-01
+      inputs:
+          has_employer_terminated_regular_employee_to_create_vacancy: true
+          has_employer_caused_involuntary_workforce_reduction_to_create_vacancy: true
+      expect: true
+
+    - name: "Neither termination nor involuntary reduction - no violation"
+      period: 2024-01
+      inputs:
+          has_employer_terminated_regular_employee_to_create_vacancy: false
+          has_employer_caused_involuntary_workforce_reduction_to_create_vacancy: false
+      expect: false
+
+    - name: "Default - no violation"
+      period: 2024-01
+      inputs: {}
+      expect: false


### PR DESCRIPTION
## Summary
- Stress-test encoding of **42 USC § 607 — Mandatory Work Requirements** (TANF) using autorac CLI backend
- First non-tax (Title 42) statute encoded in rac-us
- **52 .rac files** + 50 test files covering all major subsections

## Coverage
| Section | Files | Description |
|---------|-------|-------------|
| `607.rac` | 1 | Root aggregator |
| `a/` | 2 | Participation rate requirements (all families + 2-parent) |
| `b/` | 15 | Rate calculations (numerator/denominator, caseload reduction, exemptions) |
| `c/` | 9 | "Engaged in work" definitions (hour thresholds by year, special rules) |
| `d/` | 12 | All 12 work activity definitions |
| `e/` | 6 | Penalties (pro rata reduction, termination, childcare exceptions) |
| `f/` | 4 | Nondisplacement rules and grievance procedures |

## Stress-test findings
- **Atlas setup required**: Title 42 not pre-loaded; needed `arch download 42` + `arch ingest` before encoding
- **Permission fix needed**: CLI backend's `claude --print` lacked `--permission-mode acceptEdits`, causing 0 files on first two attempts
- **No subsection parsing without text**: Without statute text, analyzer fell back to single encoder and produced nothing
- **Oracle validation N/A**: PE and TAXSIM have no TANF validators, both reported 0% match
- **Entity type**: Uses `Family` (not `TaxUnit`) — appropriate for TANF
- **Duration**: ~50 min total on CLI backend, $0 API cost (Max subscription)
- **Misplaced file**: One encoder wrote to `statute/I/` instead of `statute/42/607/b/1/B/ii/I` (excluded from commit)

## Test plan
- [ ] Review .rac files for correctness against statute text
- [ ] Validate schema: `python -m rac.validate schema statute/42/607/`
- [ ] Check imports resolve: `python -m rac.validate imports statute/42/607/`
- [ ] Run inline tests: `python -m rac.test_runner statute/42/607/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)