### PR TITLE
Stress-test: RI CCAP (218-RICR-20-00-4) — state regulation encoding

### DIFF
--- a/encode_ri_ccap.py
+++ b/encode_ri_ccap.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from autorac.harness.orchestrator import Orchestrator
+from autorac.harness.orchestrator import Orchestrator, Phase
 
 CITATION = "RI RICR 218-20-00-4"
 OUTPUT_PATH = Path.cwd() / "statute" / "ri" / "218-RICR-20-00-4"

--- a/encode_ri_ccap.py
+++ b/encode_ri_ccap.py
@@ -1,0 +1,323 @@
+"""Stress-test: encode RI CCAP (218-RICR-20-00-4) with pre-fetched regulation text."""
+
+import asyncio
+from pathlib import Path
+from autorac.harness.orchestrator import Orchestrator
+
+CITATION = "RI RICR 218-20-00-4"
+OUTPUT_PATH = Path.cwd() / "statute" / "ri" / "218-RICR-20-00-4"
+
+# Full regulation text fetched from https://rules.sos.ri.gov/Regulations/part/218-20-00-4
+STATUTE_TEXT = """
+218-RICR-20-00-4: Child Care Assistance Program Rules and Regulations
+Title 218 - Rhode Island Department of Human Services
+
+Authority: R.I. Gen. Laws § 42-12-23
+
+4.1 General Provisions
+
+4.1.1 Introduction
+The Rhode Island Department of Human Services recognizes affordable child care access as critical for families transitioning from economic assistance to self-sufficiency. The Starting RIght Child Care Assistance Program (CCAP), adopted in 1998, ensures access to developmentally appropriate early childhood education and support services.
+
+4.1.2 Authority and Purpose
+Authority derives from R.I. Gen. Laws § 42-12-23, designating DHS as the principal state agency responsible for planning, coordination, and child care subsidy programs for Rhode Island Works Program (RIW) recipients and low to moderate-income eligible working families.
+
+4.2 Definitions
+
+"Allowable child care expense" - Total cost of CCAP authorized services paid by DHS to approved providers, minus family share.
+
+"Applicant child(ren)" - Dependent children in the financial unit for whom CCAP services are requested.
+
+"Authorized child care services" - Child care approved for a child based on assessed family need, categorized as full-time (FT), three-quarter time (3QT), half-time (HT), or quarter-time (QT).
+
+"Categorically eligible" - Eligibility conferred by state law or DHS policy based on receipt of/participation in particular public benefit.
+
+"Certification period" - Actual period eligible children obtain CCAP services, minimum twelve (12) months.
+
+"Child Care Assistance Program (CCAP)" - DHS-administered program consolidating subsidy programs for RIW recipients, income-eligible working families, families with parents in approved education/training, and youth services participants.
+
+"Dependent child" - Child under thirteen (13) years, or turning thirteen during the twelve-month certification period, or under nineteen if disabled with acceptable degree of relationship.
+
+"DHS authorized payment rate for providers" - Rate DHS pays approved providers: either actual provider rate reported in APRR or DHS CCAP Established Payment Rate, whichever is lower.
+
+"DHS CCAP established payment rate" - Maximum rate DHS pays providers per rate category, established from biennial Market Rate Survey.
+
+"Eligible child" - Dependent child meeting requirements to receive authorized CCAP services (excludes foster children eligible through DCYF).
+
+"Excluded income" - Certain money/goods/services not counted for eligibility determination:
+- USDA donated foods value
+- Relocation assistance under Title II
+- Educational grants/loans for undergraduates
+- Per capita Indian tribe payments
+- Title VII nutrition benefits
+- Volunteer service reimbursements
+- Child nutrition act benefits
+- Foster care payments (child not in assistance unit)
+- Food assistance value
+- Government rent/housing subsidies
+- Home energy assistance
+- College work study income
+- Dependent child earned income
+- Workforce Investment Act/WIOA stipends
+- Earned Income Tax Credit (EITC) refunds
+- Educational loans/scholarships
+- Federal PASS/IRWE program funds
+- Parent income (teen parent cases)
+- Section 8 utility payments
+- Veterans benefits
+- AmeriCorps/VISTA volunteer payments
+- Rhode Island Works cash assistance
+
+"Family child care home" - Provider's home-based program for four (4) to eight (8) unrelated children, requiring DCYF licensure.
+
+"Family share" - Amount families contribute as co-payments toward child care cost.
+
+"Financial unit" - Dependent children (applicant and non-applicant), parent(s), and legal spouse(s) living in same household; determines family size for income purposes.
+
+"Homeless individuals" - Individuals lacking fixed/regular/adequate nighttime residence.
+
+"Income" - Money, goods, or services available to the financial unit for CCAP eligibility calculation, including:
+- Wages, salary, commissions, work-based fees, stipends, tips, bonuses
+- Self-employment adjusted gross income
+- Social Security Benefits (RSDI)
+- Supplemental Security Income (SSI)
+- Dividends/interest
+- Estate/trust income
+- Rental income
+- Public assistance payments
+- Unemployment compensation
+- Temporary Disability Insurance (TDI)
+- Workers' compensation
+- Government/military retirement
+- Private pensions/annuities
+- Alimony
+- Child support payments
+- Regular household contributions
+- Foster care payments (child in assistance unit)
+
+"Income eligible" - CCAP eligibility determined on income basis for non-RIW recipients within state law limits.
+
+"Infant" - Child from one (1) week to eighteen (18) months old.
+"Toddler" - Child over eighteen (18) months, up to three (3) years old.
+"Pre-school age child" - Child age three (3) through first-grade entry.
+"School-age child" - Child through age twelve, or turning thirteen during eligibility period, enrolled in at least first grade.
+
+"Rhode Island Works Program (RIW)" - State program per R.I. Gen. Laws Chapter 40-5.1 providing cash assistance; beneficiaries categorically eligible for fully-subsidized CCAP.
+
+"Temporary change in status" - Temporary parent status change including:
+- Time-limited absence from work (family care, illness)
+- Seasonal worker interruption between industry seasons
+- Student holiday/break participation
+- Work/training/education hour reduction while still participating
+- Cessation not exceeding three (3) months
+
+4.3 Eligibility and Authorization of Services
+
+4.3.1 General Eligibility Requirements
+
+Families with incomes at or below one hundred eighty percent (180%) of Federal Poverty Level (FPL) meeting CCAP requirements qualify for full or partial child care expense payment through two avenues:
+
+1. Categorical Eligibility - RIW cash assistance recipients (including Youth Services participants) meeting need for services per § 4.5
+2. Income Eligibility - Working families and those with parents in approved education/training programs meeting requirements per § 4.6
+3. Temporary Higher Education Eligibility - October 1, 2021 through June 30, 2022, families where parent needs child care for enrollment in Rhode Island public institution of higher education, subject to available funding up to $200,000.
+
+General Requirements (all applicants):
+
+1. Age of applicant child(ren) - Child must be over one (1) week old, below thirteen (13) years, unless:
+   - Child is thirteen (13) to eighteen (18) with documented physical/mental disability making self-care impossible; or
+   - Child turns thirteen (13) during certification period, remaining eligible until redetermination
+
+2. Relationship - Applicant child must live in parent's home.
+
+3. Residency - Parent(s) and applicant children must be Rhode Island residents.
+
+4. Citizenship - Applicant child must be U.S. citizen or qualified immigrant (no five-year waiting period for qualified immigrants).
+
+5. Need for Services:
+   - RIW/Youth Services parents: Must be in approved education/training activity or work plan activity per § 4.5
+   - Income-eligible: Parents must be employed or participating in approved education/training program per § 4.6
+
+6. Cooperation with Office of Child Support Services - All families with absent parent(s) are referred to OCSS. Parent must cooperate in establishing paternity and child support orders, unless good cause exists.
+
+4.3.9 Limitations and Exclusions of Eligibility
+
+1. One CCAP Household per Applicant Child - CCAP services authorized for one household per applicant child during certification period.
+
+2. Self-Employment as Child Care Provider - Parent deriving sole self-employment income as child care provider ineligible for CCAP services.
+
+4.4 Applying for Child Care Assistance
+
+4.4.1 Application
+Application period: Thirty (30) days from application date.
+Homeless applicants have up to ninety (90) days providing required documentation.
+
+4.4.3 Reporting Requirements
+Families must report:
+- Income changes during twelve (12)-month certification period exceeding eighty-five percent (85%) State Median Income (SMI)
+- Non-temporary work/training/education cessation
+- Address changes
+
+4.4.4 Redetermination
+CCAP eligibility period: No less than twelve (12) months.
+
+4.5 Criteria for Categorical Eligibility
+
+4.5.1 General Requirements and Criteria
+
+RIW recipients fulfilling general § 4.3 requirements meet CCAP criteria by:
+
+1. RIW-eligible acceptable need includes:
+   a. Employment plan requirement: Parent(s) must have approved, signed, current employment plan on file.
+   b. RIW component activities: Must meet Rhode Island Works Program Rules § 2.11 employment plan component activity requirements.
+   c. Two-parent home requirement: Both parents must have signed, approved, current employment plans.
+
+2. Youth Services (YS) participants:
+   a. YS parents under twenty (20) years without high school diploma/equivalency, actively working with Youth Services Home Visiting Program, participating in approved education activity.
+
+4.5.2 Limitations
+Child care services not authorized for otherwise categorically eligible families when:
+1. One-parent home: Parent failed completing RIW employment plan
+2. Two-parent home: One parent lacks approved employment plan
+3. Two-parent home: One parent statutorily barred from RIW and not working
+4. Parent self-employed as child care provider requesting payment during employment hours
+5. Eligible child parent providing child care
+6. Same legal residence person providing child care
+7. Full family sanction in place per RIW Rules Part 2
+
+4.5.4 Co-payments
+1. RIW recipients: Zero ($0.00) co-payment.
+2. Loco-parentis applicants: Assessed co-payment based on Family Cost Sharing Requirement.
+3. Homeless families: Zero ($0.00) co-payment.
+
+4.6 Criteria for Income Eligibility
+
+4.6.1 General Requirements and Criteria
+
+1. Financial Determination:
+   a. Income limits: Financial unit countable income at or below one hundred eighty percent (180%) Federal Poverty Level (FPL) based on family size.
+
+   Transitional Child Care: Families currently child-care-eligible may continue receiving care after income exceeds 180% FPL, as long as income remains below two hundred twenty-five percent (225%) FPL.
+   - Above 225% FPL: No longer eligible
+   - New applicants exceeding 180% FPL ineligible for Transitional Child Care
+
+   b. Self-employment income calculation: Per RIW Rules § 2.15.4
+
+   c. Prospective budgeting: Weekly income converted to monthly using 4.3333 weeks/month conversion.
+
+B. Treatment of Resources
+   Liquid resources limit: one million dollars ($1,000,000.00). Exceeding this limit results in application denial.
+
+   Liquid resources include: Cash, bank accounts, certificates of deposit, stocks, bonds, mutual funds.
+   Excludes: Educational savings accounts, retirement accounts, joint accounts with non-household adult (documented).
+
+C. Family Cost Sharing Requirement
+
+1. Cost sharing: Eligible families with countable income above one hundred percent (100%) FPL pay service expense share.
+
+   Effective through December 31, 2021:
+   Level 0: ≤100% FPL - No Family Share
+   Level 1: >100% to ≤125% FPL - 2% of Countable Gross Income
+   Level 2: >125% to ≤150% FPL - 5% of Countable Gross Income
+   Level 3: >150% to ≤180% FPL - 8% of Countable Gross Income
+   Level 4: >180% to ≤200% FPL - 10% of Countable Gross Income
+   Level 5: >200% to ≤225% FPL - 14% of Countable Gross Income
+
+   Effective January 1, 2022:
+   Level 0: ≤100% FPL - No Family Share
+   Level 1: >100% to ≤125% FPL - 2% of Countable Gross Income
+   Level 2: >125% to ≤150% FPL - 5% of Countable Gross Income
+   Level 3: >150% to ≤225% FPL - 7% of Countable Gross Income
+
+   2021 Income Thresholds (through December 31, 2021):
+   Family Size 2: Level 0 <$17,420, Level 1 $21,775, Level 2 $26,130, Level 3 $31,356, Level 4 $34,840, Level 5 $39,195
+   Family Size 3: Level 0 <$21,960, Level 1 $27,450, Level 2 $32,940, Level 3 $39,528, Level 4 $43,920, Level 5 $49,410
+   Family Size 4: Level 0 <$26,500, Level 1 $33,125, Level 2 $39,750, Level 3 $47,700, Level 4 $53,000, Level 5 $59,625
+   Family Size 5: Level 0 <$31,040, Level 1 $38,800, Level 2 $46,560, Level 3 $55,872, Level 4 $62,080, Level 5 $69,840
+   Family Size 6: Level 0 <$35,580, Level 1 $44,475, Level 2 $53,370, Level 3 $64,044, Level 4 $71,160, Level 5 $80,055
+   Family Size 7: Level 0 <$40,120, Level 1 $50,150, Level 2 $60,180, Level 3 $72,216, Level 4 $80,240, Level 5 $90,270
+   Family Size 8: Level 0 <$44,660, Level 1 $55,825, Level 2 $66,990, Level 3 $80,388, Level 4 $89,320, Level 5 $100,485
+
+   2022 Income Thresholds (effective January 1, 2022):
+   Family Size 2: Level 0 <$17,420, Level 1 $21,775, Level 2 $26,130, Level 3 $39,195
+   Family Size 3: Level 0 <$21,960, Level 1 $27,450, Level 2 $32,940, Level 3 $49,410
+   Family Size 4: Level 0 <$26,500, Level 1 $33,125, Level 2 $39,750, Level 3 $59,625
+   Family Size 5: Level 0 <$31,040, Level 1 $38,800, Level 2 $46,560, Level 3 $69,840
+   Family Size 6: Level 0 <$35,580, Level 1 $44,475, Level 2 $53,370, Level 3 $80,055
+   Family Size 7: Level 0 <$40,120, Level 1 $50,150, Level 2 $60,180, Level 3 $90,270
+   Family Size 8: Level 0 <$44,660, Level 1 $55,825, Level 2 $66,990, Level 3 $100,485
+
+2. Family share distribution:
+   a. Determined without regard to eligible children enrollment number
+   b. Assigned to first (youngest) eligible child enrolled receiving highest-rate authorized services
+   c. Only distributed among providers when total family share exceeds first/youngest child rate
+
+4.6.2 Need for Services
+
+1. General Criteria - Income Eligible:
+   a. Two-parent home: Each parent minimum average twenty (20) hours/week per month employment. Each parent earns hourly average of greater of State or Federal minimum wage.
+   b. One-parent home: Parent minimum average twenty (20) hours/week per month employment, hourly average of greater of State or Federal minimum wage.
+
+2. Program-Specific Criteria - Non-RIW YS Participants:
+   a. YS parent under twenty (20) years, without high school degree/equivalent. Employed, attending school, or combination minimum twenty (20) hours/week. Authorization up to twelve (12) months.
+
+3. Program-Specific Criteria - Child Care for Training:
+   Beginning October 1, 2013, DHS provides child care to income-eligible families below 180% FPL in approved training programs.
+   a. Parent participating minimum twenty (20) hours/week average monthly. Authorization no less than twelve (12) months.
+
+4. Program-Specific Criteria - Child Care College:
+   Beginning October 1, 2021, for families below 180% FPL enrolled in RI public institution of higher education.
+   a. Parent enrolled minimum seven (7) credit hours per semester.
+   b. Seven-credit-hour student: twenty-one (21) school-activity hours, meeting minimum twenty (20) hours/week.
+
+4.6.3 Limitations
+CCAP not authorized for otherwise income-eligible children when:
+1. Parent self-employed as child care provider
+2. Parent providing child care
+3. Household-resident person providing child care
+4. Applicant parent's sole income from rental/room-board
+5. Applicant parent's need based wholly on volunteer work (unpaid work doesn't count toward minimum hours)
+
+4.6.4 Exceptions
+1. Parents with disabilities: May be exempt from minimum work hours/minimum wage requirements.
+2. Temporary Change in Status: Temporary changes not adversely affecting CCAP authorization.
+3. Non-Temporary Change in Status: Continue CCAP three (3) months for work-resumption or approved program attendance.
+
+4.7 Short Term Special Approval
+
+4.7.1 Criteria
+SSACC approved when documented serious health condition evidence indicates child or parent special need.
+- Child-based SSACC: Based on CEDARR finding
+- Parent-based SSACC: Health condition prohibits employment and routine child care
+
+4.7.2 Limitations
+1. Not authorized exceeding full-time in any 24-hour period
+2. Authorized up to three (3) months initially, additional three (3) months in any twelve (12)-month period
+
+4.8 Authorization of Child Care Services
+
+4.8.1 Authorization Levels
+Services authorized as:
+- Full-time (FT): 30+ hours per week
+- Three-quarter time (3QT): 20-29 hours per week
+- Half-time (HT): 10-19 hours per week
+- Quarter-time (QT): Under 10 hours per week
+"""
+
+
+async def main():
+    orchestrator = Orchestrator(backend="cli")
+    run = await orchestrator.encode(
+        citation=CITATION,
+        output_path=OUTPUT_PATH,
+        statute_text=STATUTE_TEXT,
+    )
+    print(f"\n{'='*60}")
+    print(f"Session: {run.session_id}")
+    print(f"Files created: {len(list(OUTPUT_PATH.rglob('*.rac')))}")
+    print(f"Agent runs: {len(run.agent_runs)}")
+    for ar in run.agent_runs:
+        print(f"  - {ar.agent_key} ({ar.phase}): {ar.duration_ms/1000:.1f}s")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/statute/ri/218-RICR-20-00-4/218-20-00-4.rac
+++ b/statute/ri/218-RICR-20-00-4/218-20-00-4.rac
@@ -1,0 +1,49 @@
+# 218 RICR 20-00-4 - Child Care Assistance Program Rules and Regulations
+
+"""
+218-RICR-20-00-4: Child Care Assistance Program Rules and Regulations
+Title 218 - Rhode Island Department of Human Services
+Authority: R.I. Gen. Laws § 42-12-23
+
+The Starting RIght Child Care Assistance Program (CCAP) ensures access to
+developmentally appropriate early childhood education for eligible families
+through two pathways:
+1. Categorical Eligibility (§ 4.5) - RIW cash assistance recipients and
+   Youth Services participants meeting need for services
+2. Income Eligibility (§ 4.6) - Working families with income at or below
+   180% FPL (225% FPL for transitional care)
+"""
+
+status: encoded
+
+ccap_eligible:
+    imports:
+        - ri/218-RICR-20-00-4/4/3/9#ccap_eligible_with_limitations
+        - ri/218-RICR-20-00-4/4/5/1#ccap_categorically_eligible
+        - ri/218-RICR-20-00-4/4/5/2#ccap_passes_categorical_limitations
+        - ri/218-RICR-20-00-4/4/6/1/1#ccap_income_eligible
+        - ri/218-RICR-20-00-4/4/6/1/B#ccap_resource_eligible
+        - ri/218-RICR-20-00-4/4/6/2#ccap_need_for_services
+        - ri/218-RICR-20-00-4/4/6/3#ccap_income_limitation_disqualified
+        - ri/218-RICR-20-00-4/4/6/4#ccap_exception_applies
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "CCAP eligible"
+    description: "Whether child is eligible for RI CCAP through categorical or income pathway per 218 RICR 20-00-4"
+    from 1998-01-01:
+        categorical = ccap_categorically_eligible and ccap_eligible_with_limitations and ccap_passes_categorical_limitations
+        income = ccap_eligible_with_limitations and ccap_income_eligible and ccap_resource_eligible and (ccap_need_for_services or ccap_exception_applies) and not ccap_income_limitation_disqualified
+        categorical or income
+
+ccap_copayment:
+    imports:
+        - ri/218-RICR-20-00-4/4/5/4#ccap_categorical_copayment
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "CCAP family co-payment"
+    description: "Family co-payment for child care services per 218 RICR 20-00-4"
+    from 1998-01-01:
+        ccap_categorical_copayment

--- a/statute/ri/218-RICR-20-00-4/4/1/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/1/1.rac
@@ -1,0 +1,12 @@
+# 218 RICR 20-00-4.1.1 - Introduction
+
+"""
+4.1.1 Introduction
+The Rhode Island Department of Human Services recognizes affordable child care
+access as critical for families transitioning from economic assistance to
+self-sufficiency. The Starting RIght Child Care Assistance Program (CCAP),
+adopted in 1998, ensures access to developmentally appropriate early childhood
+education and support services.
+"""
+
+status: boilerplate

--- a/statute/ri/218-RICR-20-00-4/4/1/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/1/2.rac
@@ -1,0 +1,11 @@
+# 218 RICR 20-00-4.1.2 - Authority and Purpose
+
+"""
+4.1.2 Authority and Purpose
+Authority derives from R.I. Gen. Laws Section 42-12-23, designating DHS as the
+principal state agency responsible for planning, coordination, and child care
+subsidy programs for Rhode Island Works Program (RIW) recipients and low to
+moderate-income eligible working families.
+"""
+
+status: boilerplate

--- a/statute/ri/218-RICR-20-00-4/4/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/2.rac
@@ -1,0 +1,156 @@
+# 218 RICR 20-00-4.2 - Definitions
+
+"""
+4.2 Definitions
+
+"Allowable child care expense" - Total cost of CCAP authorized services paid
+by DHS to approved providers, minus family share.
+
+"Applicant child(ren)" - Dependent children in the financial unit for whom
+CCAP services are requested.
+
+"Authorized child care services" - Child care approved for a child based on
+assessed family need, categorized as full-time (FT), three-quarter time (3QT),
+half-time (HT), or quarter-time (QT).
+
+"Categorically eligible" - Eligibility conferred by state law or DHS policy
+based on receipt of/participation in particular public benefit.
+
+"Certification period" - Actual period eligible children obtain CCAP services,
+minimum twelve (12) months.
+
+"Child Care Assistance Program (CCAP)" - DHS-administered program consolidating
+subsidy programs for RIW recipients, income-eligible working families, families
+with parents in approved education/training, and youth services participants.
+
+"Dependent child" - Child under thirteen (13) years, or turning thirteen during
+the twelve-month certification period, or under nineteen if disabled with
+acceptable degree of relationship.
+
+"DHS authorized payment rate for providers" - Rate DHS pays approved providers:
+either actual provider rate reported in APRR or DHS CCAP Established Payment
+Rate, whichever is lower.
+
+"DHS CCAP established payment rate" - Maximum rate DHS pays providers per rate
+category, established from biennial Market Rate Survey.
+
+"Eligible child" - Dependent child meeting requirements to receive authorized
+CCAP services (excludes foster children eligible through DCYF).
+
+"Excluded income" - Certain money/goods/services not counted for eligibility
+determination: USDA donated foods value; relocation assistance under Title II;
+educational grants/loans for undergraduates; per capita Indian tribe payments;
+Title VII nutrition benefits; volunteer service reimbursements; child nutrition
+act benefits; foster care payments (child not in assistance unit); food
+assistance value; government rent/housing subsidies; home energy assistance;
+college work study income; dependent child earned income; Workforce Investment
+Act/WIOA stipends; Earned Income Tax Credit (EITC) refunds; educational
+loans/scholarships; Federal PASS/IRWE program funds; parent income (teen parent
+cases); Section 8 utility payments; veterans benefits; AmeriCorps/VISTA
+volunteer payments; Rhode Island Works cash assistance.
+
+"Family child care home" - Provider's home-based program for four (4) to
+eight (8) unrelated children, requiring DCYF licensure.
+
+"Family share" - Amount families contribute as co-payments toward child care
+cost.
+
+"Financial unit" - Dependent children (applicant and non-applicant), parent(s),
+and legal spouse(s) living in same household; determines family size for income
+purposes.
+
+"Homeless individuals" - Individuals lacking fixed/regular/adequate nighttime
+residence.
+
+"Income" - Money, goods, or services available to the financial unit for CCAP
+eligibility calculation, including: wages, salary, commissions, work-based fees,
+stipends, tips, bonuses; self-employment adjusted gross income; Social Security
+Benefits (RSDI); Supplemental Security Income (SSI); dividends/interest;
+estate/trust income; rental income; public assistance payments; unemployment
+compensation; Temporary Disability Insurance (TDI); workers' compensation;
+government/military retirement; private pensions/annuities; alimony; child
+support payments; regular household contributions; foster care payments (child
+in assistance unit).
+
+"Income eligible" - CCAP eligibility determined on income basis for non-RIW
+recipients within state law limits.
+
+"Infant" - Child from one (1) week to eighteen (18) months old.
+
+"Toddler" - Child over eighteen (18) months, up to three (3) years old.
+
+"Pre-school age child" - Child age three (3) through first-grade entry.
+
+"School-age child" - Child through age twelve, or turning thirteen during
+eligibility period, enrolled in at least first grade.
+
+"Rhode Island Works Program (RIW)" - State program per R.I. Gen. Laws
+Chapter 40-5.1 providing cash assistance; beneficiaries categorically eligible
+for fully-subsidized CCAP.
+
+"Temporary change in status" - Temporary parent status change including:
+time-limited absence from work (family care, illness); seasonal worker
+interruption between industry seasons; student holiday/break participation;
+work/training/education hour reduction while still participating; cessation
+not exceeding three (3) months.
+"""
+
+status: encoded
+
+# --- Age classification thresholds ---
+
+ccap_dependent_child_max_age:
+    description: "Maximum age for a dependent child under CCAP"
+    unit: years
+    from 1998-01-01: 13
+
+ccap_disabled_child_max_age:
+    description: "Maximum age for a disabled dependent child under CCAP"
+    unit: years
+    from 1998-01-01: 19
+
+ccap_infant_min_age_weeks:
+    description: "Minimum age in weeks for infant classification"
+    unit: weeks
+    from 1998-01-01: 1
+
+ccap_infant_max_age_months:
+    description: "Maximum age in months for infant classification"
+    unit: months
+    from 1998-01-01: 18
+
+ccap_toddler_max_age_years:
+    description: "Maximum age in years for toddler classification"
+    unit: years
+    from 1998-01-01: 3
+
+ccap_school_age_max_years:
+    description: "Maximum age in years for school-age child classification"
+    unit: years
+    from 1998-01-01: 12
+
+# --- Certification period ---
+
+ccap_certification_min_months:
+    description: "Minimum certification period for CCAP services"
+    unit: months
+    from 1998-01-01: 12
+
+# --- Family child care home ---
+
+ccap_family_child_care_min_children:
+    description: "Minimum number of unrelated children for family child care home"
+    unit: Integer
+    from 1998-01-01: 4
+
+ccap_family_child_care_max_children:
+    description: "Maximum number of unrelated children for family child care home"
+    unit: Integer
+    from 1998-01-01: 8
+
+# --- Temporary change in status ---
+
+ccap_temporary_cessation_max_months:
+    description: "Maximum months of cessation qualifying as temporary change in status"
+    unit: months
+    from 1998-01-01: 3

--- a/statute/ri/218-RICR-20-00-4/4/2.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/2.rac.test
@@ -1,0 +1,31 @@
+# 218 RICR 20-00-4.2 - Definitions tests
+
+ccap_dependent_child_max_age:
+    - name: "Dependent child max age is 13 years"
+      period: 2024-01
+      inputs: {}
+      expect: 13
+
+ccap_disabled_child_max_age:
+    - name: "Disabled child max age is 19 years"
+      period: 2024-01
+      inputs: {}
+      expect: 19
+
+ccap_certification_min_months:
+    - name: "Minimum certification period is 12 months"
+      period: 2024-01
+      inputs: {}
+      expect: 12
+
+ccap_infant_max_age_months:
+    - name: "Infant max age is 18 months"
+      period: 2024-01
+      inputs: {}
+      expect: 18
+
+ccap_family_child_care_max_children:
+    - name: "Family child care home max is 8 children"
+      period: 2024-01
+      inputs: {}
+      expect: 8

--- a/statute/ri/218-RICR-20-00-4/4/3/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/3/1.rac
@@ -1,0 +1,176 @@
+# 218 RICR 20-00-4.3.1 - General Eligibility Requirements
+
+"""
+4.3.1 General Eligibility Requirements
+
+Families with incomes at or below one hundred eighty percent (180%) of Federal
+Poverty Level (FPL) meeting CCAP requirements qualify for full or partial child
+care expense payment through two avenues:
+
+1. Categorical Eligibility - RIW cash assistance recipients (including Youth
+   Services participants) meeting need for services per Section 4.5
+2. Income Eligibility - Working families and those with parents in approved
+   education/training programs meeting requirements per Section 4.6
+3. Temporary Higher Education Eligibility - October 1, 2021 through June 30,
+   2022, families where parent needs child care for enrollment in Rhode Island
+   public institution of higher education, subject to available funding up to
+   $200,000.
+
+General Requirements (all applicants):
+
+1. Age of applicant child(ren) - Child must be over one (1) week old, below
+   thirteen (13) years, unless:
+   - Child is thirteen (13) to eighteen (18) with documented physical/mental
+     disability making self-care impossible; or
+   - Child turns thirteen (13) during certification period, remaining eligible
+     until redetermination
+
+2. Relationship - Applicant child must live in parent's home.
+
+3. Residency - Parent(s) and applicant children must be Rhode Island residents.
+
+4. Citizenship - Applicant child must be U.S. citizen or qualified immigrant
+   (no five-year waiting period for qualified immigrants).
+
+5. Need for Services:
+   - RIW/Youth Services parents: Must be in approved education/training
+     activity or work plan activity per Section 4.5
+   - Income-eligible: Parents must be employed or participating in approved
+     education/training program per Section 4.6
+
+6. Cooperation with Office of Child Support Services - All families with
+   absent parent(s) are referred to OCSS. Parent must cooperate in establishing
+   paternity and child support orders, unless good cause exists.
+"""
+
+status: encoded
+
+# --- Parameters ---
+
+ccap_fpl_eligibility_threshold:
+    description: "Maximum income as percentage of FPL for CCAP eligibility"
+    unit: rate
+    from 1998-01-01: 1.80
+
+ccap_child_min_age_weeks:
+    description: "Minimum age in weeks for applicant child"
+    unit: weeks
+    from 1998-01-01: 1
+
+ccap_child_max_age:
+    description: "Maximum age in years for non-disabled applicant child"
+    unit: years
+    from 1998-01-01: 13
+
+ccap_disabled_child_min_age:
+    description: "Minimum age in years for disabled child extended eligibility"
+    unit: years
+    from 1998-01-01: 13
+
+ccap_disabled_child_max_age:
+    description: "Maximum age in years for disabled child extended eligibility"
+    unit: years
+    from 1998-01-01: 18
+
+# --- Inputs ---
+
+ccap_child_age_years:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Child age in years"
+    description: "Age of applicant child in years"
+    default: 0
+
+ccap_child_age_weeks:
+    entity: Person
+    period: Month
+    dtype: Integer
+    label: "Child age in weeks"
+    description: "Age of applicant child in weeks"
+    default: 0
+
+ccap_child_is_disabled:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child is disabled"
+    description: "Whether child has documented physical/mental disability making self-care impossible"
+    default: false
+
+ccap_child_turns_thirteen_during_cert:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child turns thirteen during certification period"
+    description: "Whether child turns 13 during the current certification period"
+    default: false
+
+ccap_child_lives_with_parent:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child lives with parent"
+    description: "Whether applicant child lives in parent's home"
+    default: false
+
+ccap_is_ri_resident:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Rhode Island resident"
+    description: "Whether parent(s) and applicant children are Rhode Island residents"
+    default: false
+
+ccap_is_us_citizen_or_qualified_immigrant:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "US citizen or qualified immigrant"
+    description: "Whether applicant child is US citizen or qualified immigrant"
+    default: false
+
+ccap_meets_need_for_services:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Meets need for services"
+    description: "Whether parent meets need for services per Section 4.5 (categorical) or Section 4.6 (income-eligible)"
+    default: false
+
+ccap_cooperates_with_ocss:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Cooperates with OCSS"
+    description: "Whether parent cooperates with Office of Child Support Services or no absent parent exists"
+    default: true
+
+# --- Computed ---
+
+ccap_age_eligible:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "CCAP age eligible"
+    description: "Whether child meets age requirements per 218 RICR 20-00-4.3.1"
+    from 1998-01-01:
+        if ccap_child_age_weeks < ccap_child_min_age_weeks:
+            false
+        elif ccap_child_age_years < ccap_child_max_age:
+            true
+        elif ccap_child_is_disabled and ccap_child_age_years >= ccap_disabled_child_min_age and ccap_child_age_years <= ccap_disabled_child_max_age:
+            true
+        elif ccap_child_turns_thirteen_during_cert:
+            true
+        else:
+            false
+
+ccap_general_eligible:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "CCAP general eligibility"
+    description: "Whether child meets all general eligibility requirements per 218 RICR 20-00-4.3.1"
+    from 1998-01-01:
+        ccap_age_eligible and ccap_child_lives_with_parent and ccap_is_ri_resident and ccap_is_us_citizen_or_qualified_immigrant and ccap_meets_need_for_services and ccap_cooperates_with_ocss

--- a/statute/ri/218-RICR-20-00-4/4/3/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/3/1.rac.test
@@ -1,0 +1,136 @@
+# 218 RICR 20-00-4.3.1 - General Eligibility Requirements tests
+
+ccap_age_eligible:
+    - name: "Child under 13 and over 1 week - age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+      expect: true
+
+    - name: "Newborn under 1 week - not age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 0
+          ccap_child_age_weeks: 0
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+      expect: false
+
+    - name: "Child exactly 13 not disabled - not age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 13
+          ccap_child_age_weeks: 676
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+      expect: false
+
+    - name: "Disabled child age 15 - age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 15
+          ccap_child_age_weeks: 780
+          ccap_child_is_disabled: true
+          ccap_child_turns_thirteen_during_cert: false
+      expect: true
+
+    - name: "Disabled child age 18 - age eligible (inclusive upper bound)"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 18
+          ccap_child_age_weeks: 936
+          ccap_child_is_disabled: true
+          ccap_child_turns_thirteen_during_cert: false
+      expect: true
+
+    - name: "Disabled child age 19 - not age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 19
+          ccap_child_age_weeks: 988
+          ccap_child_is_disabled: true
+          ccap_child_turns_thirteen_during_cert: false
+      expect: false
+
+    - name: "Child turns 13 during cert period - age eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 13
+          ccap_child_age_weeks: 676
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: true
+      expect: true
+
+ccap_general_eligible:
+    - name: "Child meets all general requirements - eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+      expect: true
+
+    - name: "Child not RI resident - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: false
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+      expect: false
+
+    - name: "Child does not live with parent - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: false
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+      expect: false
+
+    - name: "Age ineligible child (too young) - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 0
+          ccap_child_age_weeks: 0
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+      expect: false
+
+    - name: "Parent does not meet need for services - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: false
+          ccap_cooperates_with_ocss: true
+      expect: false

--- a/statute/ri/218-RICR-20-00-4/4/3/9.rac
+++ b/statute/ri/218-RICR-20-00-4/4/3/9.rac
@@ -1,0 +1,51 @@
+# 218 RICR 20-00-4.3.9 - Limitations and Exclusions of Eligibility
+
+"""
+4.3.9 Limitations and Exclusions of Eligibility
+1. One CCAP Household per Applicant Child - CCAP services authorized for one
+   household per applicant child during certification period.
+2. Self-Employment as Child Care Provider - Parent deriving sole self-employment
+   income as child care provider ineligible for CCAP services.
+"""
+
+status: encoded
+
+# --- Inputs ---
+
+ccap_child_receives_ccap_other_household:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Child already receives CCAP in another household"
+    description: "Whether applicant child already receives CCAP services in another household during the certification period"
+    default: false
+
+ccap_parent_sole_self_employment_is_childcare:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Parent sole self-employment is child care"
+    description: "Whether parent derives sole self-employment income as a child care provider"
+    default: false
+
+# --- Computed ---
+
+ccap_meets_limitation_requirements:
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "Meets CCAP limitation requirements"
+    description: "Whether applicant passes limitations and exclusions per 218 RICR 20-00-4.3.9"
+    from 1998-01-01:
+        not ccap_child_receives_ccap_other_household and not ccap_parent_sole_self_employment_is_childcare
+
+ccap_eligible_with_limitations:
+    imports:
+        - ri/218-RICR-20-00-4/4/3/1#ccap_general_eligible
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "CCAP eligible after limitations"
+    description: "Whether child meets general eligibility (4.3.1) and is not excluded by limitations (4.3.9)"
+    from 1998-01-01:
+        ccap_general_eligible and ccap_meets_limitation_requirements

--- a/statute/ri/218-RICR-20-00-4/4/3/9.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/3/9.rac.test
@@ -1,0 +1,79 @@
+# 218 RICR 20-00-4.3.9 - Limitations and Exclusions of Eligibility tests
+
+ccap_meets_limitation_requirements:
+    - name: "No exclusions apply - meets limitations"
+      period: 2024-01
+      inputs:
+          ccap_child_receives_ccap_other_household: false
+          ccap_parent_sole_self_employment_is_childcare: false
+      expect: true
+
+    - name: "Child already receives CCAP in another household - excluded"
+      period: 2024-01
+      inputs:
+          ccap_child_receives_ccap_other_household: true
+          ccap_parent_sole_self_employment_is_childcare: false
+      expect: false
+
+    - name: "Parent sole self-employment is child care provider - excluded"
+      period: 2024-01
+      inputs:
+          ccap_child_receives_ccap_other_household: false
+          ccap_parent_sole_self_employment_is_childcare: true
+      expect: false
+
+    - name: "Both exclusions apply - excluded"
+      period: 2024-01
+      inputs:
+          ccap_child_receives_ccap_other_household: true
+          ccap_parent_sole_self_employment_is_childcare: true
+      expect: false
+
+ccap_eligible_with_limitations:
+    - name: "General eligible and no exclusions - eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+          ccap_child_receives_ccap_other_household: false
+          ccap_parent_sole_self_employment_is_childcare: false
+      expect: true
+
+    - name: "General eligible but child receives CCAP elsewhere - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: true
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+          ccap_child_receives_ccap_other_household: true
+          ccap_parent_sole_self_employment_is_childcare: false
+      expect: false
+
+    - name: "Not general eligible (not RI resident) and no exclusions - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_child_age_years: 5
+          ccap_child_age_weeks: 260
+          ccap_child_is_disabled: false
+          ccap_child_turns_thirteen_during_cert: false
+          ccap_child_lives_with_parent: true
+          ccap_is_ri_resident: false
+          ccap_is_us_citizen_or_qualified_immigrant: true
+          ccap_meets_need_for_services: true
+          ccap_cooperates_with_ocss: true
+          ccap_child_receives_ccap_other_household: false
+          ccap_parent_sole_self_employment_is_childcare: false
+      expect: false

--- a/statute/ri/218-RICR-20-00-4/4/4/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/4/1.rac
@@ -1,0 +1,19 @@
+# 218 RICR 20-00-4.4.1 - Application
+
+"""
+4.4.1 Application
+Application period: Thirty (30) days from application date.
+Homeless applicants have up to ninety (90) days providing required documentation.
+"""
+
+status: encoded
+
+ccap_application_period_days:
+    description: "Standard number of days to complete CCAP application"
+    unit: days
+    from 1998-01-01: 30
+
+ccap_homeless_application_period_days:
+    description: "Extended number of days for homeless applicants to complete CCAP application"
+    unit: days
+    from 1998-01-01: 90

--- a/statute/ri/218-RICR-20-00-4/4/4/3.rac
+++ b/statute/ri/218-RICR-20-00-4/4/4/3.rac
@@ -1,0 +1,12 @@
+# 218 RICR 20-00-4.4.3 - Reporting Requirements
+
+"""
+4.4.3 Reporting Requirements
+Families must report:
+- Income changes during twelve (12)-month certification period exceeding
+  eighty-five percent (85%) State Median Income (SMI)
+- Non-temporary work/training/education cessation
+- Address changes
+"""
+
+status: stub

--- a/statute/ri/218-RICR-20-00-4/4/4/4.rac
+++ b/statute/ri/218-RICR-20-00-4/4/4/4.rac
@@ -1,0 +1,13 @@
+# 218 RICR 20-00-4.4.4 - Redetermination
+
+"""
+4.4.4 Redetermination
+CCAP eligibility period: No less than twelve (12) months.
+"""
+
+status: encoded
+
+ccap_min_eligibility_period_months:
+    description: "Minimum CCAP eligibility period before redetermination"
+    unit: months
+    from 1998-01-01: 12

--- a/statute/ri/218-RICR-20-00-4/4/5/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/5/1.rac
@@ -1,0 +1,145 @@
+# 218 RICR 20-00-4.5.1 - General Requirements and Criteria (Categorical)
+
+"""
+4.5.1 General Requirements and Criteria
+
+RIW recipients fulfilling general Section 4.3 requirements meet CCAP criteria by:
+
+1. RIW-eligible acceptable need includes:
+   a. Employment plan requirement: Parent(s) must have approved, signed,
+      current employment plan on file.
+   b. RIW component activities: Must meet Rhode Island Works Program Rules
+      Section 2.11 employment plan component activity requirements.
+   c. Two-parent home requirement: Both parents must have signed, approved,
+      current employment plans.
+
+2. Youth Services (YS) participants:
+   a. YS parents under twenty (20) years without high school diploma/equivalency,
+      actively working with Youth Services Home Visiting Program, participating
+      in approved education activity.
+"""
+
+status: encoded
+
+# --- Parameters ---
+
+ccap_ys_max_parent_age:
+    description: "Maximum parent age for Youth Services categorical eligibility"
+    unit: years
+    from 1998-01-01: 20
+
+# --- Inputs ---
+
+ccap_has_employment_plan:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Has approved employment plan"
+    description: "Whether parent has approved, signed, current employment plan on file"
+    default: false
+
+ccap_meets_riw_component_activities:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Meets RIW component activities"
+    description: "Whether family meets RIW Program Rules Section 2.11 employment plan component activity requirements"
+    default: false
+
+ccap_is_two_parent_home:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Two-parent home"
+    description: "Whether family is a two-parent home"
+    default: false
+
+ccap_both_parents_have_employment_plan:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Both parents have employment plans"
+    description: "Whether both parents have signed, approved, current employment plans in a two-parent home"
+    default: false
+
+ccap_is_ys_participant:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Youth Services participant"
+    description: "Whether parent is a Youth Services participant"
+    default: false
+
+ccap_ys_parent_age:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "YS parent age"
+    description: "Age of Youth Services participant parent in years"
+    default: 0
+
+ccap_ys_parent_has_hs_diploma:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "YS parent has HS diploma"
+    description: "Whether Youth Services parent has high school diploma or equivalency"
+    default: false
+
+ccap_ys_parent_in_home_visiting:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "In YS Home Visiting Program"
+    description: "Whether parent actively works with Youth Services Home Visiting Program"
+    default: false
+
+ccap_ys_parent_in_approved_education:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "In approved education activity"
+    description: "Whether parent participates in approved education activity"
+    default: false
+
+# --- Computed ---
+
+ccap_riw_need_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "RIW need for services met"
+    description: "Whether RIW recipient meets need for services per 218 RICR 20-00-4.5.1(1)"
+    from 1998-01-01:
+        if ccap_is_two_parent_home:
+            ccap_both_parents_have_employment_plan and ccap_meets_riw_component_activities
+        else:
+            ccap_has_employment_plan and ccap_meets_riw_component_activities
+
+ccap_ys_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Youth Services eligible"
+    description: "Whether family meets Youth Services eligibility per 218 RICR 20-00-4.5.1(2)"
+    from 1998-01-01:
+        ccap_is_ys_participant and ccap_ys_parent_age < ccap_ys_max_parent_age and not ccap_ys_parent_has_hs_diploma and ccap_ys_parent_in_home_visiting and ccap_ys_parent_in_approved_education
+
+ccap_categorically_eligible:
+    imports:
+        - ri/218-RICR-20-00-4/4/3/1#ccap_general_eligible
+        - ri/218-RICR-20-00-4/4/5/4#ccap_is_riw_recipient
+    entity: Person
+    period: Month
+    dtype: Boolean
+    label: "CCAP categorically eligible"
+    description: "Whether child is categorically eligible for CCAP per 218 RICR 20-00-4.5.1"
+    from 1998-01-01:
+        if not ccap_general_eligible:
+            false
+        elif ccap_is_riw_recipient and ccap_riw_need_met:
+            true
+        elif ccap_ys_eligible:
+            true
+        else:
+            false

--- a/statute/ri/218-RICR-20-00-4/4/5/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/5/1.rac.test
@@ -1,0 +1,160 @@
+# 218 RICR 20-00-4.5.1 - General Requirements and Criteria (Categorical) tests
+
+ccap_riw_need_met:
+    - name: "One-parent home with employment plan and activities - need met"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: true
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+      expect: true
+
+    - name: "One-parent home without employment plan - need not met"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: false
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+      expect: false
+
+    - name: "Two-parent home with both plans and activities - need met"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: true
+          ccap_has_employment_plan: true
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: true
+      expect: true
+
+    - name: "Two-parent home without both plans - need not met"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: true
+          ccap_has_employment_plan: true
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+      expect: false
+
+ccap_ys_eligible:
+    - name: "YS participant under 20 meeting all criteria - eligible"
+      period: 2024-01
+      inputs:
+          ccap_is_ys_participant: true
+          ccap_ys_parent_age: 18
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: true
+          ccap_ys_parent_in_approved_education: true
+      expect: true
+
+    - name: "YS participant age 20 - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_is_ys_participant: true
+          ccap_ys_parent_age: 20
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: true
+          ccap_ys_parent_in_approved_education: true
+      expect: false
+
+    - name: "YS participant with HS diploma - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_is_ys_participant: true
+          ccap_ys_parent_age: 19
+          ccap_ys_parent_has_hs_diploma: true
+          ccap_ys_parent_in_home_visiting: true
+          ccap_ys_parent_in_approved_education: true
+      expect: false
+
+    - name: "Not a YS participant - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_is_ys_participant: false
+          ccap_ys_parent_age: 18
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: true
+          ccap_ys_parent_in_approved_education: true
+      expect: false
+
+ccap_categorically_eligible:
+    - name: "RIW recipient meeting general and need requirements - eligible"
+      period: 2024-01
+      inputs:
+          ccap_general_eligible: true
+          ccap_is_riw_recipient: true
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: true
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+          ccap_is_ys_participant: false
+          ccap_ys_parent_age: 0
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: false
+          ccap_ys_parent_in_approved_education: false
+      expect: true
+
+    - name: "Not general eligible - not categorically eligible"
+      period: 2024-01
+      inputs:
+          ccap_general_eligible: false
+          ccap_is_riw_recipient: true
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: true
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+          ccap_is_ys_participant: false
+          ccap_ys_parent_age: 0
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: false
+          ccap_ys_parent_in_approved_education: false
+      expect: false
+
+    - name: "YS participant meeting all criteria - categorically eligible"
+      period: 2024-01
+      inputs:
+          ccap_general_eligible: true
+          ccap_is_riw_recipient: false
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: false
+          ccap_meets_riw_component_activities: false
+          ccap_both_parents_have_employment_plan: false
+          ccap_is_ys_participant: true
+          ccap_ys_parent_age: 18
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: true
+          ccap_ys_parent_in_approved_education: true
+      expect: true
+
+    - name: "RIW recipient without employment plan - not eligible"
+      period: 2024-01
+      inputs:
+          ccap_general_eligible: true
+          ccap_is_riw_recipient: true
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: false
+          ccap_meets_riw_component_activities: true
+          ccap_both_parents_have_employment_plan: false
+          ccap_is_ys_participant: false
+          ccap_ys_parent_age: 0
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: false
+          ccap_ys_parent_in_approved_education: false
+      expect: false
+
+    - name: "Neither RIW nor YS - not categorically eligible"
+      period: 2024-01
+      inputs:
+          ccap_general_eligible: true
+          ccap_is_riw_recipient: false
+          ccap_is_two_parent_home: false
+          ccap_has_employment_plan: false
+          ccap_meets_riw_component_activities: false
+          ccap_both_parents_have_employment_plan: false
+          ccap_is_ys_participant: false
+          ccap_ys_parent_age: 0
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_in_home_visiting: false
+          ccap_ys_parent_in_approved_education: false
+      expect: false

--- a/statute/ri/218-RICR-20-00-4/4/5/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/5/2.rac
@@ -1,0 +1,103 @@
+# 218 RICR 20-00-4.5.2 - Limitations (Categorical)
+
+"""
+4.5.2 Limitations
+Child care services not authorized for otherwise categorically eligible
+families when:
+1. One-parent home: Parent failed completing RIW employment plan
+2. Two-parent home: One parent lacks approved employment plan
+3. Two-parent home: One parent statutorily barred from RIW and not working
+4. Parent self-employed as child care provider requesting payment during
+   employment hours
+5. Eligible child parent providing child care
+6. Same legal residence person providing child care
+7. Full family sanction in place per RIW Rules Part 2
+"""
+
+status: encoded
+
+# --- Inputs ---
+
+ccap_parent_failed_employment_plan:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Parent failed RIW employment plan"
+    description: "Whether parent failed completing RIW employment plan (one-parent home)"
+    default: false
+
+ccap_one_parent_lacks_employment_plan:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "One parent lacks employment plan"
+    description: "Whether one parent in a two-parent home lacks an approved employment plan"
+    default: false
+
+ccap_one_parent_barred_from_riw_not_working:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "One parent barred from RIW and not working"
+    description: "Whether one parent in a two-parent home is statutorily barred from RIW and not working"
+    default: false
+
+ccap_parent_self_employed_childcare_requesting_payment:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Self-employed childcare parent requesting payment"
+    description: "Whether parent is self-employed as child care provider and requesting payment during employment hours"
+    default: false
+
+ccap_eligible_child_parent_provides_care:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Eligible child's parent provides care"
+    description: "Whether the eligible child's parent is providing the child care"
+    default: false
+
+ccap_same_residence_person_provides_care:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Same residence person provides care"
+    description: "Whether a person in the same legal residence is providing the child care"
+    default: false
+
+ccap_full_family_sanction:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Full family sanction in place"
+    description: "Whether a full family sanction is in place per RIW Rules Part 2"
+    default: false
+
+# --- Computed ---
+
+ccap_passes_categorical_limitations:
+    imports:
+        - ri/218-RICR-20-00-4/4/5/1#ccap_is_two_parent_home
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Passes categorical CCAP limitations"
+    description: "Whether family is not barred by any limitation per 218 RICR 20-00-4.5.2"
+    from 1998-01-01:
+        if not ccap_is_two_parent_home and ccap_parent_failed_employment_plan:
+            false
+        elif ccap_is_two_parent_home and ccap_one_parent_lacks_employment_plan:
+            false
+        elif ccap_is_two_parent_home and ccap_one_parent_barred_from_riw_not_working:
+            false
+        elif ccap_parent_self_employed_childcare_requesting_payment:
+            false
+        elif ccap_eligible_child_parent_provides_care:
+            false
+        elif ccap_same_residence_person_provides_care:
+            false
+        elif ccap_full_family_sanction:
+            false
+        else:
+            true

--- a/statute/ri/218-RICR-20-00-4/4/5/2.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/5/2.rac.test
@@ -1,0 +1,67 @@
+# 218 RICR 20-00-4.5.2 - Limitations (Categorical) tests
+
+ccap_passes_categorical_limitations:
+    - name: "No limitations apply - family passes"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_parent_failed_employment_plan: false
+          ccap_one_parent_lacks_employment_plan: false
+          ccap_one_parent_barred_from_riw_not_working: false
+          ccap_parent_self_employed_childcare_requesting_payment: false
+          ccap_eligible_child_parent_provides_care: false
+          ccap_same_residence_person_provides_care: false
+          ccap_full_family_sanction: false
+      expect: true
+
+    - name: "One-parent home - parent failed employment plan"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_parent_failed_employment_plan: true
+          ccap_one_parent_lacks_employment_plan: false
+          ccap_one_parent_barred_from_riw_not_working: false
+          ccap_parent_self_employed_childcare_requesting_payment: false
+          ccap_eligible_child_parent_provides_care: false
+          ccap_same_residence_person_provides_care: false
+          ccap_full_family_sanction: false
+      expect: false
+
+    - name: "Two-parent home - one parent lacks employment plan"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: true
+          ccap_parent_failed_employment_plan: false
+          ccap_one_parent_lacks_employment_plan: true
+          ccap_one_parent_barred_from_riw_not_working: false
+          ccap_parent_self_employed_childcare_requesting_payment: false
+          ccap_eligible_child_parent_provides_care: false
+          ccap_same_residence_person_provides_care: false
+          ccap_full_family_sanction: false
+      expect: false
+
+    - name: "Full family sanction bars authorization"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_parent_failed_employment_plan: false
+          ccap_one_parent_lacks_employment_plan: false
+          ccap_one_parent_barred_from_riw_not_working: false
+          ccap_parent_self_employed_childcare_requesting_payment: false
+          ccap_eligible_child_parent_provides_care: false
+          ccap_same_residence_person_provides_care: false
+          ccap_full_family_sanction: true
+      expect: false
+
+    - name: "Two-parent home - failed employment plan does not trigger one-parent limitation"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: true
+          ccap_parent_failed_employment_plan: true
+          ccap_one_parent_lacks_employment_plan: false
+          ccap_one_parent_barred_from_riw_not_working: false
+          ccap_parent_self_employed_childcare_requesting_payment: false
+          ccap_eligible_child_parent_provides_care: false
+          ccap_same_residence_person_provides_care: false
+          ccap_full_family_sanction: false
+      expect: true

--- a/statute/ri/218-RICR-20-00-4/4/5/4.rac
+++ b/statute/ri/218-RICR-20-00-4/4/5/4.rac
@@ -1,0 +1,55 @@
+# 218 RICR 20-00-4.5.4 - Co-payments (Categorical Eligibility)
+
+"""
+4.5.4 Co-payments
+1. RIW recipients: Zero ($0.00) co-payment.
+2. Loco-parentis applicants: Assessed co-payment based on Family Cost
+   Sharing Requirement.
+3. Homeless families: Zero ($0.00) co-payment.
+"""
+
+status: encoded
+
+ccap_riw_copayment:
+    description: "Co-payment amount for RIW recipients"
+    unit: USD
+    from 1998-01-01: 0
+
+ccap_homeless_copayment:
+    description: "Co-payment amount for homeless families"
+    unit: USD
+    from 1998-01-01: 0
+
+# Inputs
+ccap_is_riw_recipient:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "RIW recipient"
+    description: "Whether family receives Rhode Island Works cash assistance"
+    default: false
+
+ccap_is_homeless:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Homeless family"
+    description: "Whether family meets definition of homeless individuals"
+    default: false
+
+ccap_categorical_copayment:
+    imports:
+        - ri/218-RICR-20-00-4/4/6/1/C#ccap_family_share
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "CCAP categorical co-payment"
+    description: "Co-payment for categorically eligible families per 218 RICR 20-00-4.5.4"
+    from 1998-01-01:
+        if ccap_is_riw_recipient:
+            ccap_riw_copayment
+        elif ccap_is_homeless:
+            ccap_homeless_copayment
+        else:
+            ccap_family_share

--- a/statute/ri/218-RICR-20-00-4/4/5/4.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/5/4.rac.test
@@ -1,0 +1,34 @@
+# 218 RICR 20-00-4.5.4 - Co-payments tests
+
+ccap_categorical_copayment:
+    - name: "RIW recipient - zero co-payment"
+      period: 2024-01
+      inputs:
+          ccap_is_riw_recipient: true
+          ccap_is_homeless: false
+          ccap_family_share: 200
+      expect: 0
+
+    - name: "Homeless family - zero co-payment"
+      period: 2024-01
+      inputs:
+          ccap_is_riw_recipient: false
+          ccap_is_homeless: true
+          ccap_family_share: 150
+      expect: 0
+
+    - name: "Loco-parentis - assessed family share"
+      period: 2024-01
+      inputs:
+          ccap_is_riw_recipient: false
+          ccap_is_homeless: false
+          ccap_family_share: 250
+      expect: 250
+
+    - name: "RIW takes priority over homeless"
+      period: 2024-01
+      inputs:
+          ccap_is_riw_recipient: true
+          ccap_is_homeless: true
+          ccap_family_share: 100
+      expect: 0

--- a/statute/ri/218-RICR-20-00-4/4/6/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1.rac
@@ -1,0 +1,25 @@
+# 218 RICR 20-00-4.6.1 - General Requirements and Criteria (Income Eligibility)
+
+"""
+4.6.1 General Requirements and Criteria
+
+1. Financial Determination (A): Income limits at 180% FPL, with transitional
+   care up to 225% FPL for current recipients.
+B. Treatment of Resources: Liquid resources limit of $1,000,000.
+C. Family Cost Sharing Requirement: Graduated cost sharing based on income
+   as percentage of FPL.
+"""
+
+status: encoded
+
+ccap_income_and_resource_eligible:
+    imports:
+        - ri/218-RICR-20-00-4/4/6/1/A#ccap_income_eligible
+        - ri/218-RICR-20-00-4/4/6/1/B#ccap_resource_eligible
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP income and resource eligible"
+    description: "Whether family meets both income and resource eligibility per 218 RICR 20-00-4.6.1"
+    from 1998-01-01:
+        ccap_income_eligible and ccap_resource_eligible

--- a/statute/ri/218-RICR-20-00-4/4/6/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1.rac.test
@@ -1,0 +1,30 @@
+# 218 RICR 20-00-4.6.1 - Income Eligibility tests
+
+ccap_income_and_resource_eligible:
+    - name: "Income and resources within limits"
+      period: 2024-01
+      inputs:
+          ccap_income_eligible: true
+          ccap_resource_eligible: true
+      expect: true
+
+    - name: "Income eligible but resources over limit"
+      period: 2024-01
+      inputs:
+          ccap_income_eligible: true
+          ccap_resource_eligible: false
+      expect: false
+
+    - name: "Resources eligible but income over limit"
+      period: 2024-01
+      inputs:
+          ccap_income_eligible: false
+          ccap_resource_eligible: true
+      expect: false
+
+    - name: "Both ineligible"
+      period: 2024-01
+      inputs:
+          ccap_income_eligible: false
+          ccap_resource_eligible: false
+      expect: false

--- a/statute/ri/218-RICR-20-00-4/4/6/1/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/1.rac
@@ -1,0 +1,92 @@
+# 218 RICR 20-00-4.6.1.1 - Financial Determination
+
+"""
+4.6.1 General Requirements and Criteria
+
+1. Financial Determination:
+   a. Income limits: Financial unit countable income at or below one hundred
+      eighty percent (180%) Federal Poverty Level (FPL) based on family size.
+
+      Transitional Child Care: Families currently child-care-eligible may
+      continue receiving care after income exceeds 180% FPL, as long as income
+      remains below two hundred twenty-five percent (225%) FPL.
+      - Above 225% FPL: No longer eligible
+      - New applicants exceeding 180% FPL ineligible for Transitional Child Care
+
+   b. Self-employment income calculation: Per RIW Rules Section 2.15.4
+
+   c. Prospective budgeting: Weekly income converted to monthly using 4.3333
+      weeks/month conversion.
+"""
+
+status: encoded
+
+# --- Parameters ---
+
+ccap_initial_fpl_threshold:
+    description: "Maximum income as percentage of FPL for initial CCAP eligibility"
+    unit: rate
+    from 1998-01-01: 1.80
+
+ccap_transitional_fpl_threshold:
+    description: "Maximum income as percentage of FPL for transitional child care"
+    unit: rate
+    from 1998-01-01: 2.25
+
+ccap_weekly_to_monthly_conversion:
+    description: "Factor to convert weekly income to monthly (weeks per month)"
+    unit: rate
+    from 1998-01-01: 4.3333
+
+# --- Inputs ---
+
+ccap_income_as_pct_fpl:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Income as percentage of FPL"
+    description: "Financial unit countable income expressed as ratio of Federal Poverty Level"
+    default: 0
+
+ccap_is_currently_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Currently CCAP eligible"
+    description: "Whether family is currently receiving CCAP services (for transitional care)"
+    default: false
+
+ccap_weekly_income:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Weekly income"
+    description: "Financial unit weekly countable income"
+    default: 0
+
+# --- Computed ---
+
+ccap_monthly_income:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Monthly income (from weekly)"
+    description: "Weekly income converted to monthly per 218 RICR 20-00-4.6.1.1(c)"
+    from 1998-01-01:
+        ccap_weekly_income * ccap_weekly_to_monthly_conversion
+
+ccap_income_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP income eligible"
+    description: "Whether family meets income eligibility for CCAP per 218 RICR 20-00-4.6.1.1(a)"
+    from 1998-01-01:
+        if ccap_income_as_pct_fpl <= ccap_initial_fpl_threshold:
+            true
+        elif ccap_is_currently_eligible and ccap_income_as_pct_fpl <= ccap_transitional_fpl_threshold:
+            true
+        else:
+            false

--- a/statute/ri/218-RICR-20-00-4/4/6/1/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/1.rac.test
@@ -1,0 +1,44 @@
+# 218 RICR 20-00-4.6.1.1 - Financial Determination tests
+
+ccap_income_eligible:
+    - name: "Income below 180% FPL - eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.50
+          ccap_is_currently_eligible: false
+      expect: true
+
+    - name: "Income at exactly 180% FPL - eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.80
+          ccap_is_currently_eligible: false
+      expect: true
+
+    - name: "New applicant above 180% FPL - ineligible (no transitional care)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.90
+          ccap_is_currently_eligible: false
+      expect: false
+
+    - name: "Current recipient at 200% FPL - eligible (transitional)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_is_currently_eligible: true
+      expect: true
+
+    - name: "Current recipient above 225% FPL - ineligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.30
+          ccap_is_currently_eligible: true
+      expect: false
+
+ccap_monthly_income:
+    - name: "Weekly income converted to monthly"
+      period: 2024-01
+      inputs:
+          ccap_weekly_income: 500
+      expect: 2166.65

--- a/statute/ri/218-RICR-20-00-4/4/6/1/A.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/A.rac
@@ -1,0 +1,68 @@
+# 218 RICR 20-00-4.6.1.A - Financial Determination
+
+"""
+4.6.1.A Financial Determination
+
+a. Income limits: Financial unit countable income at or below one hundred
+   eighty percent (180%) Federal Poverty Level (FPL) based on family size.
+
+   Transitional Child Care: Families currently child-care-eligible may
+   continue receiving care after income exceeds 180% FPL, as long as income
+   remains below two hundred twenty-five percent (225%) FPL.
+   - Above 225% FPL: No longer eligible
+   - New applicants exceeding 180% FPL ineligible for Transitional Child Care
+
+b. Self-employment income calculation: Per RIW Rules Section 2.15.4
+
+c. Prospective budgeting: Weekly income converted to monthly using 4.3333
+   weeks/month conversion.
+"""
+
+status: encoded
+
+ccap_initial_fpl_threshold:
+    description: "Maximum income as percentage of FPL for initial CCAP eligibility"
+    unit: rate
+    from 1998-01-01: 1.80
+
+ccap_transitional_fpl_threshold:
+    description: "Maximum income as percentage of FPL for transitional child care"
+    unit: rate
+    from 1998-01-01: 2.25
+
+ccap_weekly_to_monthly_conversion:
+    description: "Factor to convert weekly income to monthly (weeks per month)"
+    unit: rate
+    from 1998-01-01: 4.3333
+
+# Inputs
+ccap_income_as_pct_fpl:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Income as percentage of FPL"
+    description: "Financial unit countable income expressed as ratio of Federal Poverty Level"
+    default: 0
+
+ccap_is_currently_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Currently CCAP eligible"
+    description: "Whether family is currently receiving CCAP services (for transitional care)"
+    default: false
+
+# Computed
+ccap_income_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP income eligible"
+    description: "Whether family meets income eligibility for CCAP per 218 RICR 20-00-4.6.1.A"
+    from 1998-01-01:
+        if ccap_income_as_pct_fpl <= ccap_initial_fpl_threshold:
+            true
+        elif ccap_is_currently_eligible and ccap_income_as_pct_fpl <= ccap_transitional_fpl_threshold:
+            true
+        else:
+            false

--- a/statute/ri/218-RICR-20-00-4/4/6/1/A.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/A.rac.test
@@ -1,0 +1,44 @@
+# 218 RICR 20-00-4.6.1.A - Financial Determination tests
+
+ccap_income_eligible:
+    - name: "Income below 180% FPL - new applicant eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.50
+          ccap_is_currently_eligible: false
+      expect: true
+
+    - name: "Income at exactly 180% FPL - eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.80
+          ccap_is_currently_eligible: false
+      expect: true
+
+    - name: "New applicant above 180% FPL - ineligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_is_currently_eligible: false
+      expect: false
+
+    - name: "Current recipient at 200% FPL - transitional eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_is_currently_eligible: true
+      expect: true
+
+    - name: "Current recipient above 225% FPL - ineligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.30
+          ccap_is_currently_eligible: true
+      expect: false
+
+    - name: "Current recipient at exactly 225% FPL - transitional eligible"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.25
+          ccap_is_currently_eligible: true
+      expect: true

--- a/statute/ri/218-RICR-20-00-4/4/6/1/B.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/B.rac
@@ -1,0 +1,37 @@
+# 218 RICR 20-00-4.6.1.B - Treatment of Resources
+
+"""
+4.6.1.B Treatment of Resources
+Liquid resources limit: one million dollars ($1,000,000.00). Exceeding this
+limit results in application denial.
+
+Liquid resources include: Cash, bank accounts, certificates of deposit, stocks,
+bonds, mutual funds.
+Excludes: Educational savings accounts, retirement accounts, joint accounts
+with non-household adult (documented).
+"""
+
+status: encoded
+
+ccap_liquid_resources_limit:
+    description: "Maximum liquid resources for CCAP eligibility"
+    unit: USD
+    from 1998-01-01: 1000000
+
+ccap_liquid_resources:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Liquid resources"
+    description: "Total liquid resources of the financial unit"
+    default: 0
+
+ccap_resource_eligible:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP resource eligible"
+    description: "Whether family's liquid resources are within CCAP limit per 218 RICR 20-00-4.6.1.B"
+    from 1998-01-01:
+        ccap_liquid_resources <= ccap_liquid_resources_limit

--- a/statute/ri/218-RICR-20-00-4/4/6/1/B.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/B.rac.test
@@ -1,0 +1,26 @@
+# 218 RICR 20-00-4.6.1.B - Treatment of Resources tests
+
+ccap_resource_eligible:
+    - name: "Zero resources - eligible"
+      period: 2024-01
+      inputs:
+          ccap_liquid_resources: 0
+      expect: true
+
+    - name: "Below limit - eligible"
+      period: 2024-01
+      inputs:
+          ccap_liquid_resources: 500000
+      expect: true
+
+    - name: "At limit - eligible"
+      period: 2024-01
+      inputs:
+          ccap_liquid_resources: 1000000
+      expect: true
+
+    - name: "Above limit - ineligible"
+      period: 2024-01
+      inputs:
+          ccap_liquid_resources: 1000001
+      expect: false

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C.rac
@@ -1,0 +1,146 @@
+# 218 RICR 20-00-4.6.1.C - Family Cost Sharing Requirement
+
+"""
+4.6.1.C Family Cost Sharing Requirement
+
+1. Cost sharing: Eligible families with countable income above one hundred
+   percent (100%) FPL pay service expense share.
+
+   Effective through December 31, 2021:
+   Level 0: <=100% FPL - No Family Share
+   Level 1: >100% to <=125% FPL - 2% of Countable Gross Income
+   Level 2: >125% to <=150% FPL - 5% of Countable Gross Income
+   Level 3: >150% to <=180% FPL - 8% of Countable Gross Income
+   Level 4: >180% to <=200% FPL - 10% of Countable Gross Income
+   Level 5: >200% to <=225% FPL - 14% of Countable Gross Income
+
+   Effective January 1, 2022:
+   Level 0: <=100% FPL - No Family Share
+   Level 1: >100% to <=125% FPL - 2% of Countable Gross Income
+   Level 2: >125% to <=150% FPL - 5% of Countable Gross Income
+   Level 3: >150% to <=225% FPL - 7% of Countable Gross Income
+
+2. Family share distribution:
+   a. Determined without regard to eligible children enrollment number
+   b. Assigned to first (youngest) eligible child enrolled receiving
+      highest-rate authorized services
+   c. Only distributed among providers when total family share exceeds
+      first/youngest child rate
+"""
+
+status: encoded
+
+# FPL percentage thresholds used for cost sharing brackets
+ccap_fpl_threshold_100:
+    description: "FPL percentage threshold for Level 0 upper bound"
+    unit: rate
+    from 1998-01-01: 1.00
+
+ccap_fpl_threshold_125:
+    description: "FPL percentage threshold for Level 1 upper bound"
+    unit: rate
+    from 1998-01-01: 1.25
+
+ccap_fpl_threshold_150:
+    description: "FPL percentage threshold for Level 2 upper bound"
+    unit: rate
+    from 1998-01-01: 1.50
+
+ccap_fpl_threshold_180:
+    description: "FPL percentage threshold for Level 3 upper bound (pre-2022)"
+    unit: rate
+    from 1998-01-01: 1.80
+
+ccap_fpl_threshold_200:
+    description: "FPL percentage threshold for Level 4 upper bound (pre-2022)"
+    unit: rate
+    from 1998-01-01: 2.00
+
+# Cost sharing rates by bracket
+ccap_cost_sharing_rate_level_1:
+    description: "Cost sharing rate for income >100% to <=125% FPL"
+    unit: rate
+    from 1998-01-01: 0.02
+
+ccap_cost_sharing_rate_level_2:
+    description: "Cost sharing rate for income >125% to <=150% FPL"
+    unit: rate
+    from 1998-01-01: 0.05
+
+ccap_cost_sharing_rate_level_3_pre2022:
+    description: "Cost sharing rate for income >150% to <=180% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.08
+
+ccap_cost_sharing_rate_level_4:
+    description: "Cost sharing rate for income >180% to <=200% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.10
+
+ccap_cost_sharing_rate_level_5:
+    description: "Cost sharing rate for income >200% to <=225% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.14
+
+ccap_cost_sharing_rate_level_3_post2022:
+    description: "Cost sharing rate for income >150% to <=225% FPL (from 2022)"
+    unit: rate
+    from 2022-01-01: 0.07
+
+# Inputs
+ccap_income_as_pct_fpl:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Income as percentage of FPL"
+    description: "Financial unit countable income expressed as ratio of Federal Poverty Level"
+    default: 0
+
+ccap_countable_gross_monthly_income:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Countable gross monthly income"
+    description: "Financial unit countable gross income per month"
+    default: 0
+
+# Computed family share
+ccap_family_share_rate:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "CCAP family cost sharing rate"
+    description: "Cost sharing rate applied to gross income per 218 RICR 20-00-4.6.1.C"
+    from 1998-01-01:
+        if ccap_income_as_pct_fpl <= ccap_fpl_threshold_100:
+            0
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_125:
+            ccap_cost_sharing_rate_level_1
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_150:
+            ccap_cost_sharing_rate_level_2
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_180:
+            ccap_cost_sharing_rate_level_3_pre2022
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_200:
+            ccap_cost_sharing_rate_level_4
+        else:
+            ccap_cost_sharing_rate_level_5
+    from 2022-01-01:
+        if ccap_income_as_pct_fpl <= ccap_fpl_threshold_100:
+            0
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_125:
+            ccap_cost_sharing_rate_level_1
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_150:
+            ccap_cost_sharing_rate_level_2
+        else:
+            ccap_cost_sharing_rate_level_3_post2022
+
+ccap_family_share:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "CCAP family share"
+    description: "Monthly family co-payment for child care per 218 RICR 20-00-4.6.1.C"
+    from 1998-01-01:
+        ccap_family_share_rate * ccap_countable_gross_monthly_income

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C.rac.test
@@ -1,0 +1,91 @@
+# 218 RICR 20-00-4.6.1.C - Family Cost Sharing tests
+
+ccap_family_share_rate:
+    - name: "Level 0: income at 80% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 0.80
+      expect: 0
+
+    - name: "Level 1: income at 110% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.10
+      expect: 0.02
+
+    - name: "Level 2: income at 140% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.40
+      expect: 0.05
+
+    - name: "Level 3: income at 170% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.70
+      expect: 0.08
+
+    - name: "Level 4: income at 190% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.90
+      expect: 0.10
+
+    - name: "Level 5: income at 210% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 2.10
+      expect: 0.14
+
+    - name: "Level 0: income at 100% FPL exactly (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.00
+      expect: 0
+
+    - name: "Level 1: income at 115% FPL (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.15
+      expect: 0.02
+
+    - name: "Level 2: income at 140% FPL (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.40
+      expect: 0.05
+
+    - name: "Level 3: income at 200% FPL (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+      expect: 0.07
+
+ccap_family_share:
+    - name: "No family share at 80% FPL"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 0.80
+          ccap_countable_gross_monthly_income: 2000
+      expect: 0
+
+    - name: "2% share at 115% FPL with $3000 monthly income"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.15
+          ccap_countable_gross_monthly_income: 3000
+      expect: 60
+
+    - name: "5% share at 140% FPL with $4000 monthly income"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.40
+          ccap_countable_gross_monthly_income: 4000
+      expect: 200
+
+    - name: "7% share at 200% FPL with $5000 monthly income"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_countable_gross_monthly_income: 5000
+      expect: 350

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C/1.rac
@@ -1,0 +1,143 @@
+# 218 RICR 20-00-4.6.1.C.1 - Cost Sharing Schedule
+
+"""
+4.6.1.C.1 Cost Sharing Schedule
+
+Cost sharing: Eligible families with countable income above one hundred
+percent (100%) FPL pay service expense share.
+
+Effective through December 31, 2021:
+Level 0: <=100% FPL - No Family Share
+Level 1: >100% to <=125% FPL - 2% of Countable Gross Income
+Level 2: >125% to <=150% FPL - 5% of Countable Gross Income
+Level 3: >150% to <=180% FPL - 8% of Countable Gross Income
+Level 4: >180% to <=200% FPL - 10% of Countable Gross Income
+Level 5: >200% to <=225% FPL - 14% of Countable Gross Income
+
+Effective January 1, 2022:
+Level 0: <=100% FPL - No Family Share
+Level 1: >100% to <=125% FPL - 2% of Countable Gross Income
+Level 2: >125% to <=150% FPL - 5% of Countable Gross Income
+Level 3: >150% to <=225% FPL - 7% of Countable Gross Income
+"""
+
+status: encoded
+
+# --- FPL Percentage Thresholds ---
+
+ccap_fpl_threshold_100:
+    description: "FPL percentage threshold for Level 0 upper bound"
+    unit: rate
+    from 1998-01-01: 1.00
+
+ccap_fpl_threshold_125:
+    description: "FPL percentage threshold for Level 1 upper bound"
+    unit: rate
+    from 1998-01-01: 1.25
+
+ccap_fpl_threshold_150:
+    description: "FPL percentage threshold for Level 2 upper bound"
+    unit: rate
+    from 1998-01-01: 1.50
+
+ccap_fpl_threshold_180:
+    description: "FPL percentage threshold for Level 3 upper bound (pre-2022)"
+    unit: rate
+    from 1998-01-01: 1.80
+
+ccap_fpl_threshold_200:
+    description: "FPL percentage threshold for Level 4 upper bound (pre-2022)"
+    unit: rate
+    from 1998-01-01: 2.00
+
+# --- Cost Sharing Rates ---
+
+ccap_cost_sharing_rate_level_1:
+    description: "Cost sharing rate for income >100% to <=125% FPL"
+    unit: rate
+    from 1998-01-01: 0.02
+
+ccap_cost_sharing_rate_level_2:
+    description: "Cost sharing rate for income >125% to <=150% FPL"
+    unit: rate
+    from 1998-01-01: 0.05
+
+ccap_cost_sharing_rate_level_3_pre2022:
+    description: "Cost sharing rate for income >150% to <=180% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.08
+
+ccap_cost_sharing_rate_level_4:
+    description: "Cost sharing rate for income >180% to <=200% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.10
+
+ccap_cost_sharing_rate_level_5:
+    description: "Cost sharing rate for income >200% to <=225% FPL (through 2021)"
+    unit: rate
+    from 1998-01-01: 0.14
+
+ccap_cost_sharing_rate_level_3_post2022:
+    description: "Cost sharing rate for income >150% to <=225% FPL (from 2022)"
+    unit: rate
+    from 2022-01-01: 0.07
+
+# --- Inputs ---
+
+ccap_income_as_pct_fpl:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "Income as percentage of FPL"
+    description: "Financial unit countable income expressed as ratio of Federal Poverty Level"
+    default: 0
+
+ccap_countable_gross_monthly_income:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Countable gross monthly income"
+    description: "Financial unit countable gross income per month"
+    default: 0
+
+# --- Computed ---
+
+ccap_family_share_rate:
+    entity: Family
+    period: Month
+    dtype: Rate
+    label: "CCAP family cost sharing rate"
+    description: "Cost sharing rate applied to gross income per 218 RICR 20-00-4.6.1.C.1"
+    from 1998-01-01:
+        if ccap_income_as_pct_fpl <= ccap_fpl_threshold_100:
+            0
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_125:
+            ccap_cost_sharing_rate_level_1
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_150:
+            ccap_cost_sharing_rate_level_2
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_180:
+            ccap_cost_sharing_rate_level_3_pre2022
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_200:
+            ccap_cost_sharing_rate_level_4
+        else:
+            ccap_cost_sharing_rate_level_5
+    from 2022-01-01:
+        if ccap_income_as_pct_fpl <= ccap_fpl_threshold_100:
+            0
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_125:
+            ccap_cost_sharing_rate_level_1
+        elif ccap_income_as_pct_fpl <= ccap_fpl_threshold_150:
+            ccap_cost_sharing_rate_level_2
+        else:
+            ccap_cost_sharing_rate_level_3_post2022
+
+ccap_family_share:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "CCAP family share"
+    description: "Monthly family co-payment for child care per 218 RICR 20-00-4.6.1.C.1"
+    from 1998-01-01:
+        ccap_family_share_rate * ccap_countable_gross_monthly_income

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C/1.rac.test
@@ -1,0 +1,86 @@
+# 218 RICR 20-00-4.6.1.C.1 - Cost Sharing Schedule tests
+
+ccap_family_share_rate:
+    - name: "Level 0: income at 80% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 0.80
+      expect: 0
+
+    - name: "Level 1: income at 110% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.10
+      expect: 0.02
+
+    - name: "Level 3: income at 170% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.70
+      expect: 0.08
+
+    - name: "Level 4: income at 190% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.90
+      expect: 0.10
+
+    - name: "Level 5: income at 210% FPL (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 2.10
+      expect: 0.14
+
+    - name: "Level 0: income at 100% FPL exactly (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.00
+      expect: 0
+
+    - name: "Level 2: income at 140% FPL (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.40
+      expect: 0.05
+
+    - name: "Level 3: income at 200% FPL (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+      expect: 0.07
+
+ccap_family_share:
+    - name: "No family share at 80% FPL"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 0.80
+          ccap_countable_gross_monthly_income: 2000
+      expect: 0
+
+    - name: "2% share at 115% FPL with $3000 monthly income"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.15
+          ccap_countable_gross_monthly_income: 3000
+      expect: 60
+
+    - name: "7% share at 200% FPL with $5000 monthly income"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_countable_gross_monthly_income: 5000
+      expect: 350
+
+    - name: "8% share at 170% FPL with $4000 monthly income (pre-2022)"
+      period: 2021-06
+      inputs:
+          ccap_income_as_pct_fpl: 1.70
+          ccap_countable_gross_monthly_income: 4000
+      expect: 320
+
+    - name: "Boundary: exactly 125% FPL stays Level 1 (post-2022)"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.25
+          ccap_countable_gross_monthly_income: 3500
+      expect: 70

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C/2.rac
@@ -1,0 +1,50 @@
+# 218 RICR 20-00-4.6.1.C.2 - Family Share Distribution
+
+"""
+4.6.1.C.2 Family Share Distribution
+
+a. Determined without regard to eligible children enrollment number
+b. Assigned to first (youngest) eligible child enrolled receiving
+   highest-rate authorized services
+c. Only distributed among providers when total family share exceeds
+   first/youngest child rate
+"""
+
+status: encoded
+
+# --- Inputs ---
+
+ccap_first_child_provider_rate:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "First child provider rate"
+    description: "DHS authorized payment rate for the first (youngest) eligible child enrolled receiving highest-rate authorized services"
+    default: 0
+
+# --- Computed ---
+
+ccap_family_share_first_child:
+    imports:
+        - ri/218-RICR-20-00-4/4/6/1/C/1#ccap_family_share
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Family share assigned to first child"
+    description: "Family share amount assigned to youngest eligible child's provider per 218 RICR 20-00-4.6.1.C.2(b)"
+    from 1998-01-01:
+        min(ccap_family_share, ccap_first_child_provider_rate)
+
+ccap_family_share_excess:
+    imports:
+        - ri/218-RICR-20-00-4/4/6/1/C/1#ccap_family_share
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Family share excess for other providers"
+    description: "Family share amount distributed among other providers per 218 RICR 20-00-4.6.1.C.2(c)"
+    from 1998-01-01:
+        max(0, ccap_family_share - ccap_first_child_provider_rate)

--- a/statute/ri/218-RICR-20-00-4/4/6/1/C/2.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/1/C/2.rac.test
@@ -1,0 +1,57 @@
+# 218 RICR 20-00-4.6.1.C.2 - Family Share Distribution tests
+
+ccap_family_share_first_child:
+    - name: "Family share fully covered by first child rate"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.15
+          ccap_countable_gross_monthly_income: 3000
+          ccap_first_child_provider_rate: 1200
+      # family_share = 0.02 * 3000 = 60; min(60, 1200) = 60
+      expect: 60
+
+    - name: "Family share exceeds first child rate"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_countable_gross_monthly_income: 5000
+          ccap_first_child_provider_rate: 200
+      # family_share = 0.07 * 5000 = 350; min(350, 200) = 200
+      expect: 200
+
+    - name: "Zero income yields zero family share to first child"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 0.80
+          ccap_countable_gross_monthly_income: 2000
+          ccap_first_child_provider_rate: 1000
+      # family_share = 0 * 2000 = 0; min(0, 1000) = 0
+      expect: 0
+
+ccap_family_share_excess:
+    - name: "No excess when family share below first child rate"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.15
+          ccap_countable_gross_monthly_income: 3000
+          ccap_first_child_provider_rate: 1200
+      # family_share = 60; max(0, 60 - 1200) = 0
+      expect: 0
+
+    - name: "Excess when family share exceeds first child rate"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 2.00
+          ccap_countable_gross_monthly_income: 5000
+          ccap_first_child_provider_rate: 200
+      # family_share = 350; max(0, 350 - 200) = 150
+      expect: 150
+
+    - name: "Excess equals family share when first child rate is zero"
+      period: 2024-01
+      inputs:
+          ccap_income_as_pct_fpl: 1.40
+          ccap_countable_gross_monthly_income: 4000
+          ccap_first_child_provider_rate: 0
+      # family_share = 0.05 * 4000 = 200; max(0, 200 - 0) = 200
+      expect: 200

--- a/statute/ri/218-RICR-20-00-4/4/6/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/2.rac
@@ -1,0 +1,267 @@
+# 218 RICR 20-00-4.6.2 - Need for Services
+
+"""
+4.6.2 Need for Services
+
+1. General Criteria - Income Eligible:
+   a. Two-parent home: Each parent minimum average twenty (20) hours/week per
+      month employment. Each parent earns hourly average of greater of State or
+      Federal minimum wage.
+   b. One-parent home: Parent minimum average twenty (20) hours/week per month
+      employment, hourly average of greater of State or Federal minimum wage.
+
+2. Program-Specific Criteria - Non-RIW YS Participants:
+   a. YS parent under twenty (20) years, without high school degree/equivalent.
+      Employed, attending school, or combination minimum twenty (20) hours/week.
+      Authorization up to twelve (12) months.
+
+3. Program-Specific Criteria - Child Care for Training:
+   Beginning October 1, 2013, DHS provides child care to income-eligible
+   families below 180% FPL in approved training programs.
+   a. Parent participating minimum twenty (20) hours/week average monthly.
+      Authorization no less than twelve (12) months.
+
+4. Program-Specific Criteria - Child Care College:
+   Beginning October 1, 2021, for families below 180% FPL enrolled in RI
+   public institution of higher education.
+   a. Parent enrolled minimum seven (7) credit hours per semester.
+   b. Seven-credit-hour student: twenty-one (21) school-activity hours,
+      meeting minimum twenty (20) hours/week.
+"""
+
+status: encoded
+
+# --- Parameters ---
+
+ccap_min_weekly_work_hours:
+    description: "Minimum average weekly hours of employment required for CCAP eligibility"
+    unit: hours
+    from 1998-01-01: 20
+
+ccap_ys_max_parent_age:
+    description: "Maximum age for Youth Services parent eligibility"
+    unit: years
+    from 1998-01-01: 20
+
+ccap_ys_max_authorization_months:
+    description: "Maximum authorization period for YS participants"
+    unit: months
+    from 1998-01-01: 12
+
+ccap_training_min_authorization_months:
+    description: "Minimum authorization period for training program participants"
+    unit: months
+    from 2013-10-01: 12
+
+ccap_min_credit_hours_per_semester:
+    description: "Minimum credit hours per semester for college child care eligibility"
+    unit: Integer
+    from 2021-10-01: 7
+
+ccap_school_activity_hours_per_credit:
+    description: "School-activity hours counted per credit hour enrolled"
+    unit: Integer
+    from 2021-10-01: 3
+
+# --- Inputs ---
+
+ccap_is_two_parent_home:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Two-parent home"
+    description: "Whether family is a two-parent home"
+    default: false
+
+ccap_parent1_avg_weekly_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Parent 1 average weekly work hours"
+    description: "Average weekly hours of employment for parent 1"
+    default: 0
+
+ccap_parent1_hourly_wage:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Parent 1 hourly wage"
+    description: "Average hourly wage earned by parent 1"
+    default: 0
+
+ccap_parent2_avg_weekly_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Parent 2 average weekly work hours"
+    description: "Average weekly hours of employment for parent 2 in two-parent home"
+    default: 0
+
+ccap_parent2_hourly_wage:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Parent 2 hourly wage"
+    description: "Average hourly wage earned by parent 2 in two-parent home"
+    default: 0
+
+ccap_state_minimum_wage:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "State minimum wage"
+    description: "Rhode Island state minimum hourly wage"
+    default: 0
+
+ccap_federal_minimum_wage:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Federal minimum wage"
+    description: "Federal minimum hourly wage"
+    default: 0
+
+ccap_is_ys_participant:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Youth Services participant"
+    description: "Whether parent is a non-RIW Youth Services participant"
+    default: false
+
+ccap_ys_parent_age:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "YS parent age"
+    description: "Age of Youth Services participant parent in years"
+    default: 0
+
+ccap_ys_parent_has_hs_diploma:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "YS parent has HS diploma/equivalent"
+    description: "Whether Youth Services parent has high school diploma or equivalency"
+    default: false
+
+ccap_ys_parent_weekly_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "YS parent weekly activity hours"
+    description: "Weekly hours of employment, school, or combination for YS parent"
+    default: 0
+
+ccap_in_approved_training:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "In approved training program"
+    description: "Whether parent is in a DHS-approved training program"
+    default: false
+
+ccap_training_weekly_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Training weekly hours"
+    description: "Average weekly hours of participation in approved training program"
+    default: 0
+
+ccap_enrolled_ri_public_higher_ed:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Enrolled in RI public higher education"
+    description: "Whether parent is enrolled in a Rhode Island public institution of higher education"
+    default: false
+
+ccap_credit_hours_enrolled:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Credit hours enrolled"
+    description: "Number of credit hours enrolled per semester"
+    default: 0
+
+# --- Computed ---
+
+ccap_applicable_minimum_wage:
+    entity: Family
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Applicable minimum wage"
+    description: "Greater of State or Federal minimum wage per 218 RICR 20-00-4.6.2(1)"
+    from 1998-01-01:
+        max(ccap_state_minimum_wage, ccap_federal_minimum_wage)
+
+ccap_employment_need_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Employment need for services met"
+    description: "Whether parent(s) meet employment criteria per 218 RICR 20-00-4.6.2(1)"
+    from 1998-01-01:
+        p1_hours = ccap_parent1_avg_weekly_hours >= ccap_min_weekly_work_hours
+        p1_wage = ccap_parent1_hourly_wage >= ccap_applicable_minimum_wage
+        p2_hours = ccap_parent2_avg_weekly_hours >= ccap_min_weekly_work_hours
+        p2_wage = ccap_parent2_hourly_wage >= ccap_applicable_minimum_wage
+        if ccap_is_two_parent_home:
+            p1_hours and p1_wage and p2_hours and p2_wage
+        else:
+            p1_hours and p1_wage
+
+ccap_ys_need_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "YS need for services met"
+    description: "Whether non-RIW YS participant meets need criteria per 218 RICR 20-00-4.6.2(2)"
+    from 1998-01-01:
+        ccap_is_ys_participant and ccap_ys_parent_age < ccap_ys_max_parent_age and not ccap_ys_parent_has_hs_diploma and ccap_ys_parent_weekly_hours >= ccap_min_weekly_work_hours
+
+ccap_training_need_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Training need for services met"
+    description: "Whether parent meets training program criteria per 218 RICR 20-00-4.6.2(3)"
+    from 2013-10-01:
+        ccap_in_approved_training and ccap_training_weekly_hours >= ccap_min_weekly_work_hours
+
+ccap_college_school_activity_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "College school-activity hours"
+    description: "Total weekly school-activity hours based on credit hours enrolled per 218 RICR 20-00-4.6.2(4)(b)"
+    from 2021-10-01:
+        ccap_credit_hours_enrolled * ccap_school_activity_hours_per_credit
+
+ccap_college_need_met:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "College need for services met"
+    description: "Whether parent meets college program criteria per 218 RICR 20-00-4.6.2(4)"
+    from 2021-10-01:
+        ccap_enrolled_ri_public_higher_ed and ccap_credit_hours_enrolled >= ccap_min_credit_hours_per_semester and ccap_college_school_activity_hours >= ccap_min_weekly_work_hours
+
+ccap_need_for_services:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP need for services"
+    description: "Whether family meets need for services requirement per 218 RICR 20-00-4.6.2"
+    from 1998-01-01:
+        ccap_employment_need_met or ccap_ys_need_met
+    from 2013-10-01:
+        ccap_employment_need_met or ccap_ys_need_met or ccap_training_need_met
+    from 2021-10-01:
+        ccap_employment_need_met or ccap_ys_need_met or ccap_training_need_met or ccap_college_need_met

--- a/statute/ri/218-RICR-20-00-4/4/6/2.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/2.rac.test
@@ -1,0 +1,51 @@
+# 218 RICR 20-00-4.6.2 - Need for Services tests
+
+ccap_employment_need_met:
+    - name: "Single parent meets employment criteria"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_parent1_avg_weekly_hours: 25
+          ccap_parent1_hourly_wage: 15
+          ccap_state_minimum_wage: 13
+          ccap_federal_minimum_wage: 7.25
+      expect: true
+
+    - name: "Single parent below minimum wage"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: false
+          ccap_parent1_avg_weekly_hours: 25
+          ccap_parent1_hourly_wage: 6
+          ccap_state_minimum_wage: 13
+          ccap_federal_minimum_wage: 7.25
+      expect: false
+
+    - name: "Two-parent home, second parent insufficient hours"
+      period: 2024-01
+      inputs:
+          ccap_is_two_parent_home: true
+          ccap_parent1_avg_weekly_hours: 25
+          ccap_parent1_hourly_wage: 15
+          ccap_parent2_avg_weekly_hours: 10
+          ccap_parent2_hourly_wage: 15
+          ccap_state_minimum_wage: 13
+          ccap_federal_minimum_wage: 7.25
+      expect: false
+
+ccap_need_for_services:
+    - name: "YS participant meets need criteria"
+      period: 2024-01
+      inputs:
+          ccap_is_ys_participant: true
+          ccap_ys_parent_age: 18
+          ccap_ys_parent_has_hs_diploma: false
+          ccap_ys_parent_weekly_hours: 20
+      expect: true
+
+    - name: "College student meets need criteria"
+      period: 2024-01
+      inputs:
+          ccap_enrolled_ri_public_higher_ed: true
+          ccap_credit_hours_enrolled: 7
+      expect: true

--- a/statute/ri/218-RICR-20-00-4/4/6/3.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/3.rac
@@ -1,0 +1,67 @@
+# 218 RICR 20-00-4.6.3 - Limitations (Income Eligibility)
+
+"""
+4.6.3 Limitations
+CCAP not authorized for otherwise income-eligible children when:
+1. Parent self-employed as child care provider
+2. Parent providing child care
+3. Household-resident person providing child care
+4. Applicant parent's sole income from rental/room-board
+5. Applicant parent's need based wholly on volunteer work (unpaid work doesn't
+   count toward minimum hours)
+"""
+
+status: encoded
+
+# --- Inputs ---
+
+ccap_parent_selfemployed_child_care_provider:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Parent self-employed as child care provider"
+    description: "Whether parent derives self-employment income as a child care provider"
+    default: false
+
+ccap_parent_providing_child_care:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Parent providing child care"
+    description: "Whether the applicant parent provides child care for the eligible child"
+    default: false
+
+ccap_household_resident_providing_care:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Household resident providing child care"
+    description: "Whether a person residing in the same household provides child care"
+    default: false
+
+ccap_sole_income_from_rental:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Sole income from rental/room-board"
+    description: "Whether applicant parent's sole income is from rental or room and board"
+    default: false
+
+ccap_need_based_wholly_on_volunteer_work:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Need based wholly on volunteer work"
+    description: "Whether applicant parent's need is based wholly on volunteer work (unpaid work does not count toward minimum hours)"
+    default: false
+
+# --- Computed ---
+
+ccap_income_limitation_disqualified:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP income limitation disqualified"
+    description: "Whether family is disqualified under income eligibility limitations per 218 RICR 20-00-4.6.3"
+    from 1998-01-01:
+        ccap_parent_selfemployed_child_care_provider or ccap_parent_providing_child_care or ccap_household_resident_providing_care or ccap_sole_income_from_rental or ccap_need_based_wholly_on_volunteer_work

--- a/statute/ri/218-RICR-20-00-4/4/6/3.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/3.rac.test
@@ -1,0 +1,52 @@
+# 218 RICR 20-00-4.6.3 - Limitations (Income Eligibility) tests
+
+ccap_income_limitation_disqualified:
+    - name: "No disqualifying conditions - not disqualified"
+      period: 2024-01
+      inputs:
+          ccap_parent_selfemployed_child_care_provider: false
+          ccap_parent_providing_child_care: false
+          ccap_household_resident_providing_care: false
+          ccap_sole_income_from_rental: false
+          ccap_need_based_wholly_on_volunteer_work: false
+      expect: false
+
+    - name: "Parent self-employed as child care provider - disqualified"
+      period: 2024-01
+      inputs:
+          ccap_parent_selfemployed_child_care_provider: true
+          ccap_parent_providing_child_care: false
+          ccap_household_resident_providing_care: false
+          ccap_sole_income_from_rental: false
+          ccap_need_based_wholly_on_volunteer_work: false
+      expect: true
+
+    - name: "Household resident providing care - disqualified"
+      period: 2024-01
+      inputs:
+          ccap_parent_selfemployed_child_care_provider: false
+          ccap_parent_providing_child_care: false
+          ccap_household_resident_providing_care: true
+          ccap_sole_income_from_rental: false
+          ccap_need_based_wholly_on_volunteer_work: false
+      expect: true
+
+    - name: "Sole income from rental - disqualified"
+      period: 2024-01
+      inputs:
+          ccap_parent_selfemployed_child_care_provider: false
+          ccap_parent_providing_child_care: false
+          ccap_household_resident_providing_care: false
+          ccap_sole_income_from_rental: true
+          ccap_need_based_wholly_on_volunteer_work: false
+      expect: true
+
+    - name: "Need based wholly on volunteer work - disqualified"
+      period: 2024-01
+      inputs:
+          ccap_parent_selfemployed_child_care_provider: false
+          ccap_parent_providing_child_care: false
+          ccap_household_resident_providing_care: false
+          ccap_sole_income_from_rental: false
+          ccap_need_based_wholly_on_volunteer_work: true
+      expect: true

--- a/statute/ri/218-RICR-20-00-4/4/6/4.rac
+++ b/statute/ri/218-RICR-20-00-4/4/6/4.rac
@@ -1,0 +1,92 @@
+# 218 RICR 20-00-4.6.4 - Exceptions
+
+"""
+4.6.4 Exceptions
+1. Parents with disabilities: May be exempt from minimum work hours/minimum
+   wage requirements.
+2. Temporary Change in Status: Temporary changes not adversely affecting
+   CCAP authorization.
+3. Non-Temporary Change in Status: Continue CCAP three (3) months for
+   work-resumption or approved program attendance.
+"""
+
+status: encoded
+
+# --- Parameters ---
+
+ccap_non_temporary_continuation_months:
+    description: "Months CCAP continues after non-temporary change in status"
+    unit: months
+    from 1998-01-01: 3
+
+# --- Inputs ---
+
+ccap_parent_has_disability:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Parent has qualifying disability"
+    description: "Whether parent has a disability exempting them from minimum work hours/wage requirements per 218 RICR 20-00-4.6.4(1)"
+    default: false
+
+ccap_has_temporary_status_change:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Temporary change in status"
+    description: "Whether parent has a temporary change in status (time-limited absence, seasonal interruption, holiday/break, hour reduction, or cessation under 3 months)"
+    default: false
+
+ccap_has_non_temporary_status_change:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Non-temporary change in status"
+    description: "Whether parent has experienced a non-temporary change in work/training/education status"
+    default: false
+
+ccap_months_since_non_temporary_change:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Months since non-temporary status change"
+    description: "Number of months elapsed since non-temporary change in status"
+    default: 0
+
+# --- Computed ---
+
+ccap_disability_exception_applies:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Disability exception applies"
+    description: "Whether parent with disability is exempt from minimum work hours/wage requirements per 218 RICR 20-00-4.6.4(1)"
+    from 1998-01-01:
+        ccap_parent_has_disability
+
+ccap_temporary_change_exception_applies:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Temporary change exception applies"
+    description: "Whether temporary change in status allows continued CCAP authorization per 218 RICR 20-00-4.6.4(2)"
+    from 1998-01-01:
+        ccap_has_temporary_status_change
+
+ccap_non_temporary_change_exception_applies:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "Non-temporary change exception applies"
+    description: "Whether CCAP continues during non-temporary change period (up to 3 months) per 218 RICR 20-00-4.6.4(3)"
+    from 1998-01-01:
+        ccap_has_non_temporary_status_change and ccap_months_since_non_temporary_change <= ccap_non_temporary_continuation_months
+
+ccap_exception_applies:
+    entity: Family
+    period: Month
+    dtype: Boolean
+    label: "CCAP exception applies"
+    description: "Whether any exception to normal need-for-services requirements applies per 218 RICR 20-00-4.6.4"
+    from 1998-01-01:
+        ccap_disability_exception_applies or ccap_temporary_change_exception_applies or ccap_non_temporary_change_exception_applies

--- a/statute/ri/218-RICR-20-00-4/4/6/4.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/6/4.rac.test
@@ -1,0 +1,53 @@
+# 218 RICR 20-00-4.6.4 - Exceptions tests
+
+ccap_disability_exception_applies:
+    - name: "Parent with disability - exception applies"
+      period: 2024-01
+      inputs:
+          ccap_parent_has_disability: true
+      expect: true
+
+    - name: "Parent without disability - no exception"
+      period: 2024-01
+      inputs:
+          ccap_parent_has_disability: false
+      expect: false
+
+ccap_non_temporary_change_exception_applies:
+    - name: "Non-temporary change within 3-month window"
+      period: 2024-01
+      inputs:
+          ccap_has_non_temporary_status_change: true
+          ccap_months_since_non_temporary_change: 2
+      expect: true
+
+    - name: "Non-temporary change at 3-month boundary"
+      period: 2024-01
+      inputs:
+          ccap_has_non_temporary_status_change: true
+          ccap_months_since_non_temporary_change: 3
+      expect: true
+
+    - name: "Non-temporary change beyond 3-month window"
+      period: 2024-01
+      inputs:
+          ccap_has_non_temporary_status_change: true
+          ccap_months_since_non_temporary_change: 4
+      expect: false
+
+ccap_exception_applies:
+    - name: "No exceptions - not applicable"
+      period: 2024-01
+      inputs:
+          ccap_parent_has_disability: false
+          ccap_has_temporary_status_change: false
+          ccap_has_non_temporary_status_change: false
+      expect: false
+
+    - name: "Temporary status change - exception applies"
+      period: 2024-01
+      inputs:
+          ccap_parent_has_disability: false
+          ccap_has_temporary_status_change: true
+          ccap_has_non_temporary_status_change: false
+      expect: true

--- a/statute/ri/218-RICR-20-00-4/4/7/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/7/1.rac
@@ -1,0 +1,12 @@
+# 218 RICR 20-00-4.7.1 - Short Term Special Approval Criteria
+
+"""
+4.7.1 Criteria
+SSACC approved when documented serious health condition evidence indicates
+child or parent special need.
+- Child-based SSACC: Based on CEDARR finding
+- Parent-based SSACC: Health condition prohibits employment and routine
+  child care
+"""
+
+status: stub

--- a/statute/ri/218-RICR-20-00-4/4/7/2.rac
+++ b/statute/ri/218-RICR-20-00-4/4/7/2.rac
@@ -1,0 +1,25 @@
+# 218 RICR 20-00-4.7.2 - SSACC Limitations
+
+"""
+4.7.2 Limitations
+1. Not authorized exceeding full-time in any 24-hour period
+2. Authorized up to three (3) months initially, additional three (3) months
+   in any twelve (12)-month period
+"""
+
+status: encoded
+
+ccap_ssacc_initial_months:
+    description: "Initial SSACC authorization period in months"
+    unit: months
+    from 1998-01-01: 3
+
+ccap_ssacc_extension_months:
+    description: "Additional SSACC authorization period in months"
+    unit: months
+    from 1998-01-01: 3
+
+ccap_ssacc_review_period_months:
+    description: "Rolling period in months within which SSACC extensions are measured"
+    unit: months
+    from 1998-01-01: 12

--- a/statute/ri/218-RICR-20-00-4/4/7/2.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/7/2.rac.test
@@ -1,0 +1,19 @@
+# 218 RICR 20-00-4.7.2 - SSACC Limitations tests
+
+ccap_ssacc_initial_months:
+    - name: "Initial authorization is 3 months"
+      period: 2024-01
+      inputs: {}
+      expect: 3
+
+ccap_ssacc_extension_months:
+    - name: "Extension authorization is 3 months"
+      period: 2024-01
+      inputs: {}
+      expect: 3
+
+ccap_ssacc_review_period_months:
+    - name: "Review period is 12 months"
+      period: 2024-01
+      inputs: {}
+      expect: 12

--- a/statute/ri/218-RICR-20-00-4/4/8/1.rac
+++ b/statute/ri/218-RICR-20-00-4/4/8/1.rac
@@ -1,0 +1,58 @@
+# 218 RICR 20-00-4.8.1 - Authorization Levels
+
+"""
+4.8.1 Authorization Levels
+Services authorized as:
+- Full-time (FT): 30+ hours per week
+- Three-quarter time (3QT): 20-29 hours per week
+- Half-time (HT): 10-19 hours per week
+- Quarter-time (QT): Under 10 hours per week
+"""
+
+status: encoded
+
+enum CcapAuthorizationLevel:
+    values:
+        - FULL_TIME
+        - THREE_QUARTER_TIME
+        - HALF_TIME
+        - QUARTER_TIME
+
+ccap_full_time_min_hours:
+    description: "Minimum weekly hours for full-time authorization"
+    unit: hours
+    from 1998-01-01: 30
+
+ccap_three_quarter_time_min_hours:
+    description: "Minimum weekly hours for three-quarter time authorization"
+    unit: hours
+    from 1998-01-01: 20
+
+ccap_half_time_min_hours:
+    description: "Minimum weekly hours for half-time authorization"
+    unit: hours
+    from 1998-01-01: 10
+
+ccap_weekly_child_care_hours:
+    entity: Family
+    period: Month
+    dtype: Integer
+    label: "Weekly child care hours"
+    description: "Weekly hours of child care needed"
+    default: 0
+
+ccap_authorization_level:
+    entity: Family
+    period: Month
+    dtype: Enum[CcapAuthorizationLevel]
+    label: "CCAP authorization level"
+    description: "Child care authorization level based on weekly hours per 218 RICR 20-00-4.8.1"
+    from 1998-01-01:
+        if ccap_weekly_child_care_hours >= ccap_full_time_min_hours:
+            CcapAuthorizationLevel.FULL_TIME
+        elif ccap_weekly_child_care_hours >= ccap_three_quarter_time_min_hours:
+            CcapAuthorizationLevel.THREE_QUARTER_TIME
+        elif ccap_weekly_child_care_hours >= ccap_half_time_min_hours:
+            CcapAuthorizationLevel.HALF_TIME
+        else:
+            CcapAuthorizationLevel.QUARTER_TIME

--- a/statute/ri/218-RICR-20-00-4/4/8/1.rac.test
+++ b/statute/ri/218-RICR-20-00-4/4/8/1.rac.test
@@ -1,0 +1,68 @@
+# 218 RICR 20-00-4.8.1 - Authorization Levels tests
+
+ccap_authorization_level:
+    - name: "Full-time: 35 hours per week"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 35
+      expect: FULL_TIME
+
+    - name: "Full-time: exactly 30 hours"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 30
+      expect: FULL_TIME
+
+    - name: "Three-quarter time: 25 hours"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 25
+      expect: THREE_QUARTER_TIME
+
+    - name: "Half-time: 15 hours"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 15
+      expect: HALF_TIME
+
+    - name: "Boundary: 29 hours is three-quarter time (not full-time)"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 29
+      expect: THREE_QUARTER_TIME
+
+    - name: "Boundary: exactly 20 hours is three-quarter time"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 20
+      expect: THREE_QUARTER_TIME
+
+    - name: "Boundary: 19 hours is half-time (not three-quarter)"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 19
+      expect: HALF_TIME
+
+    - name: "Boundary: exactly 10 hours is half-time"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 10
+      expect: HALF_TIME
+
+    - name: "Boundary: 9 hours is quarter-time"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 9
+      expect: QUARTER_TIME
+
+    - name: "Quarter-time: 5 hours"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 5
+      expect: QUARTER_TIME
+
+    - name: "Zero hours defaults to quarter-time"
+      period: 2024-01
+      inputs:
+          ccap_weekly_child_care_hours: 0
+      expect: QUARTER_TIME


### PR DESCRIPTION
## Summary
- Stress-test encoding of **RI CCAP (218-RICR-20-00-4)** — Rhode Island Child Care Assistance Program
- First **state regulation** (not federal USC statute) encoded through autorac pipeline
- **25 .rac files** + 18 test files covering eligibility, income limits, copayments, work requirements
- Required **4 local autorac fixes** to handle non-USC citation format

## What this tests
| Dimension | Challenge |
|-----------|-----------|
| Citation format | `218-RICR-20-00-4` instead of `XX USC YYY` |
| Statute text source | Not in atlas (federal-only DB) — text pre-fetched from `rules.sos.ri.gov` |
| Program type | Childcare subsidy (eligibility + copayment tiers) |
| Entity model | Family (not TaxUnit) |
| Income tables | Multi-tier FPL brackets with copayment rates (0%/2%/5%/7-14%) across family sizes 2-15 |
| Eligibility pathways | Dual: categorical (RIW recipients) + income-based |
| Rule types | $1M resource limit, 20 hr/week work requirement, 12-month certification period |

## Coverage
| Section | Files | Description |
|---------|-------|-------------|
| `218-20-00-4.rac` | 1 | Root aggregator |
| `4/1/` | 2 | General provisions (intro, authority) |
| `4/2` | 1 | Definitions (age thresholds, income types, authorization categories) |
| `4/3/` | 2 | General eligibility + limitations |
| `4/4/` | 3 | Application, reporting, redetermination |
| `4/5/` | 3 | Categorical eligibility (RIW), limitations, co-payments |
| `4/6/` | 13 | Income eligibility (financial determination, resources, cost sharing, need for services, limitations, exceptions) |
| `4/7/` | 2 | Short-term special approval |
| `4/8/` | 1 | Authorization levels (FT/3QT/HT/QT) |

## Attempt log

### Attempt 1: `autorac encode` CLI (failed)
```
autorac encode "RI RICR 218-20-00-4" --output statute/ri/218-RICR-20-00-4 --backend cli
```
- Atlas: `Cannot parse citation: RI RICR 218-20-00-4` — atlas only handles USC citations
- Analyzer: no subsections parsed, fallback single encoder produced 0 files
- Duration: ~93s
- **Bug found**: Citation parser strips "USC" and splits — breaks on non-USC citations
- **Bug found**: `--output` path mangled — citation components appended even with explicit `--output`, producing `statute/ri/218-RICR-20-00-4/RI/RICR`

### Attempt 2: Python script with pre-fetched text (failed)
```python
orchestrator.encode(citation=CITATION, output_path=OUTPUT_PATH, statute_text=STATUTE_TEXT)
```
- Pre-fetched regulation text from https://rules.sos.ri.gov/Regulations/part/218-20-00-4
- Analyzer ran 161.6s (had text to work with) but still produced 0 files
- `_parse_analyzer_output` couldn't extract subsections — **Bug found**: regex `\|\s*\((\w+)\)\s*\|` only matches single-word IDs like `(a)`, not dot-notation `(4.3)` since `.` isn't `\w`
- No encoding, validation, or review phases triggered

### Attempt 3: Debug run to inspect analyzer output (success — analysis only)
- Added debug print to capture raw `analysis.result`
- Analyzer returned well-structured output with 13 ENCODE subsections using IDs like `4.2`, `4.3.1`, `4.6.1.A`
- After fixing regex to `[\w./]+`, parser correctly extracted all 13 tasks
- Confirmed the LLM analysis was fine — only the parser was broken

### Attempt 4: Full pipeline with regex fix (failed — 0 files)
- All 3 parser bugs fixed (citation, output path, regex)
- Pipeline ran to completion: analysis → 5 encoding waves (20 agents) → oracle → 4 reviewers
- **24 agent runs, ~40 minutes total — but 0 files created**
- Root cause: orchestrator's `_run_via_cli` was missing `--permission-mode acceptEdits`
- The `ClaudeCodeBackend` class had it (line 191 of backends.py), but the orchestrator has its own separate CLI runner that didn't
- **Bug found**: All encoder agents ran but couldn't write files

### Attempt 5: Full pipeline with `--permission-mode acceptEdits` globally (failed — timeout)
- Added `--permission-mode acceptEdits` to orchestrator's `_run_via_cli`
- Analysis phase timed out at exactly 600.0s (the subprocess timeout limit)
- With write permission, the analysis agent tried to create files during what should be a read-only step, burning through the timeout
- Fell back to single encoder which also produced nothing useful
- **Bug found**: `--permission-mode acceptEdits` should only apply to encoding phases, not analysis/review

### Attempt 6: Phase-aware permissions (success!)
- Only grant `--permission-mode acceptEdits` for `Phase.ENCODING`, not analysis/review
- Analysis completed in 272s, parsed subsections successfully
- 5 encoding waves + root aggregator, all completed
- **25 .rac files + 18 .rac.test files created**
- Oracle: PE=0%, TAXSIM=0% (expected — no CCAP validators)
- All 4 LLM reviewers completed
- Duration: ~45 min total, $0 API cost (Max subscription)

## Autorac bugs found (4 total, all fixed locally)

### 1. Citation parser can't handle non-USC formats
**File**: `autorac/src/autorac/cli.py` and `orchestrator.py`
**Fix**: Check for "USC" in citation; non-USC citations skip path derivation and use `--output` as-is

### 2. `--output` path gets mangled
**File**: `autorac/src/autorac/cli.py`
**Fix**: Non-USC citations don't append parsed citation components to `--output`

### 3. Subsection ID parser hardcoded for USC format
**File**: `autorac/src/autorac/harness/orchestrator.py`
**Fix**: Changed regex from `\((\w+)\)` to `\(([\w./]+)\)` to accept dot-notation like `4.3`, `4.6.1`

### 4. Orchestrator `_run_via_cli` missing `--permission-mode acceptEdits`
**File**: `autorac/src/autorac/harness/orchestrator.py`
**Fix**: Added `accept_edits` parameter to `_run_via_cli`, only enabled for `Phase.ENCODING`

## Test plan
- [ ] Review .rac files for correctness against regulation text
- [ ] Validate schema: `python -m rac.validate schema statute/ri/218-RICR-20-00-4/`
- [ ] Check imports resolve: `python -m rac.validate imports statute/ri/218-RICR-20-00-4/`
- [ ] Run inline tests: `python -m rac.test_runner statute/ri/218-RICR-20-00-4/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)