### PR TITLE
Stress test: SNAP allotment (7 USC 2017)

### DIFF
--- a/encode_snap_allotment.py
+++ b/encode_snap_allotment.py
@@ -1,0 +1,24 @@
+"""Stress test: encode SNAP allotment (7 USC 2017)."""
+
+import asyncio
+from pathlib import Path
+
+from autorac.harness.orchestrator import Orchestrator
+
+CITATION = "7 USC 2017"
+OUTPUT = Path(__file__).parent / "statute" / "7" / "2017"
+STATUTE_TEXT = Path("/tmp/7_usc_2017.txt").read_text()
+
+orchestrator = Orchestrator(backend="cli")
+run = asyncio.run(
+    orchestrator.encode(
+        CITATION,
+        output_path=OUTPUT,
+        statute_text=STATUTE_TEXT,
+    )
+)
+
+print(orchestrator.print_report(run))
+print(f"\nFiles created: {len(run.files_created)}")
+for f in run.files_created:
+    print(f"  {f}")

--- a/statute/7/2017/2017.rac
+++ b/statute/7/2017/2017.rac
@@ -1,0 +1,37 @@
+# 7 USC Section 2017 - Value of allotment
+
+"""
+Sec. 2017. Value of allotment.
+
+(a) Calculation.-- The value of the allotment authorized for eligible
+households equals the thrifty food plan cost reduced by 30 percent of
+household income, with a minimum allotment for 1-2 person households.
+
+(c) Initial month proration and combined allotment.-- The initial month
+allotment is prorated by remaining days. States may combine initial and
+following month allotments for applications after the 15th.
+
+(d) Reduction of public assistance benefits.-- When household benefits
+are reduced under a means-tested program for failure to perform a
+required action, the allotment may not increase from the resulting income
+decrease, and the State may reduce the allotment by up to 25 percent.
+"""
+
+status: encoded
+
+snap_allotment_under_2017:
+    imports:
+        - 7/2017/c/1#snap_prorated_allotment
+        - 7/2017/d/1#pa_benefit_reduction_applies
+        - 7/2017/d/1#snap_allotment_after_pa_reduction
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP allotment under 7 USC 2017"
+    description: "Value of the allotment per 7 USC 2017, incorporating base calculation (a), initial month proration (c), and public assistance benefit reduction (d)"
+    from 1977-10-01:
+        if pa_benefit_reduction_applies:
+            snap_allotment_after_pa_reduction
+        else:
+            snap_prorated_allotment

--- a/statute/7/2017/a.rac
+++ b/statute/7/2017/a.rac
@@ -1,0 +1,106 @@
+# 7 USC Section 2017(a) - Calculation
+
+"""
+(a) Calculation.-- The value of the allotment which State agencies shall be
+authorized to issue to any households certified as eligible to participate in
+the supplemental nutrition assistance program shall be equal to the cost to
+such households of the thrifty food plan reduced by an amount equal to 30 per
+centum of the household's income, as determined in accordance with section
+2014(d) and (e) of this title, rounded to the nearest lower whole dollar:
+Provided, That for households of one and two persons the minimum allotment
+shall be 8 percent of the cost of the thrifty food plan for a household
+containing 1 member, as determined by the Secretary under section 2012 of
+this title, rounded to the nearest whole dollar increment.
+"""
+
+status: encoded
+
+contribution_rate:
+    description: "Household contribution as share of net income per 7 USC 2017(a)"
+    unit: rate
+    from 1977-10-01: 0.30
+
+minimum_allotment_rate:
+    description: "Minimum allotment as share of 1-member thrifty food plan cost per 7 USC 2017(a)"
+    unit: rate
+    from 1977-10-01: 0.08
+
+minimum_allotment_household_size_threshold:
+    description: "Maximum household size eligible for minimum allotment per 7 USC 2017(a)"
+    from 1977-10-01: 2
+
+snap_eligible:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "SNAP eligible"
+    description: "Whether household is certified as eligible to participate per 7 USC 2014"
+    default: false
+
+household_size:
+    entity: Household
+    period: Month
+    dtype: Integer
+    label: "Household size"
+    description: "Number of persons in the SNAP household"
+    default: 1
+
+snap_net_income:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP net income"
+    description: "Household income determined under 7 USC 2014(d) and (e)"
+    default: 0
+
+thrifty_food_plan_cost:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Thrifty food plan cost"
+    description: "Cost of the thrifty food plan for the household as determined under 7 USC 2012"
+    default: 0
+
+thrifty_food_plan_cost_1_member:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Thrifty food plan cost for 1-member household"
+    description: "Cost of the thrifty food plan for a household containing 1 member per 7 USC 2012"
+    default: 0
+
+snap_calculated_allotment:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP calculated allotment"
+    description: "Thrifty food plan cost reduced by 30% of household income, rounded to nearest lower whole dollar"
+    from 1977-10-01:
+        floor(thrifty_food_plan_cost - contribution_rate * snap_net_income)
+
+snap_minimum_allotment:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP minimum allotment"
+    description: "Minimum allotment for 1-2 person households: 8% of 1-member thrifty food plan cost, rounded to nearest whole dollar"
+    from 1977-10-01:
+        round(minimum_allotment_rate * thrifty_food_plan_cost_1_member, 0)
+
+snap_allotment:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP allotment"
+    description: "Value of allotment per 7 USC 2017(a)"
+    from 1977-10-01:
+        if not snap_eligible: 0
+        elif household_size <= minimum_allotment_household_size_threshold:
+            max(snap_minimum_allotment, snap_calculated_allotment)
+        else: max(0, snap_calculated_allotment)

--- a/statute/7/2017/a.rac.test
+++ b/statute/7/2017/a.rac.test
@@ -1,0 +1,52 @@
+# 7 USC Section 2017(a) tests
+
+snap_allotment:
+    - name: "Ineligible household receives zero"
+      period: 2024-10
+      inputs:
+        snap_eligible: false
+        household_size: 1
+        snap_net_income: 0
+        thrifty_food_plan_cost: 291
+        thrifty_food_plan_cost_1_member: 291
+      expect: 0
+
+    - name: "1-person household with zero income gets full allotment"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 1
+        snap_net_income: 0
+        thrifty_food_plan_cost: 291
+        thrifty_food_plan_cost_1_member: 291
+      expect: 291
+
+    - name: "1-person household with high income gets minimum allotment"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 1
+        snap_net_income: 900
+        thrifty_food_plan_cost: 291
+        thrifty_food_plan_cost_1_member: 291
+      expect: 23
+
+    - name: "4-person household with income, floor rounding applied"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 4
+        snap_net_income: 101
+        thrifty_food_plan_cost: 200
+        thrifty_food_plan_cost_1_member: 291
+      expect: 169
+
+    - name: "2-person household eligible for minimum allotment"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 2
+        snap_net_income: 1200
+        thrifty_food_plan_cost: 380
+        thrifty_food_plan_cost_1_member: 291
+      expect: 23

--- a/statute/7/2017/c/1.rac
+++ b/statute/7/2017/c/1.rac
@@ -1,0 +1,63 @@
+# 7 USC Section 2017(c)(1) - Proration formula
+
+"""
+(1) The value of the allotment issued to any eligible household for the initial
+month or other initial period for which an allotment is issued shall have a value
+which bears the same ratio to the value of the allotment for a full month or other
+initial period for which the allotment is issued as the number of days (from the
+date of application) remaining in the month or other initial period for which the
+allotment is issued bears to the total number of days in the month or other initial
+period for which the allotment is issued, except that no allotment may be issued to
+a household for the initial month or period if the value of the allotment which such
+household would otherwise be eligible to receive under this subsection is less than
+$10. Households shall receive full months' allotments for all months within a
+certification period, except as provided in the first sentence of this paragraph
+with respect to an initial month.
+"""
+
+status: encoded
+
+minimum_initial_month_allotment:
+    description: "Minimum prorated allotment required to issue for initial month per 7 USC 2017(c)(1)"
+    unit: USD
+    from 1977-10-01: 10
+
+is_initial_snap_month:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "Initial SNAP month"
+    description: "Whether this is the initial month for which an allotment is issued per 7 USC 2017(c)(2)"
+    default: false
+
+initial_month_days_remaining:
+    entity: Household
+    period: Month
+    dtype: Integer
+    label: "Days remaining in initial month"
+    description: "Number of days from date of application remaining in the initial month or period"
+    default: 0
+
+initial_month_total_days:
+    entity: Household
+    period: Month
+    dtype: Integer
+    label: "Total days in initial month"
+    description: "Total number of days in the initial month or period"
+    default: 0
+
+snap_prorated_allotment:
+    imports:
+        - 7/2017/a#snap_allotment
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP prorated allotment"
+    description: "Allotment value after initial month proration per 7 USC 2017(c)(1)"
+    from 1977-10-01:
+        if not is_initial_snap_month: snap_allotment
+        else:
+            prorated = floor(snap_allotment * initial_month_days_remaining / initial_month_total_days)
+            if prorated < minimum_initial_month_allotment: 0
+            else: prorated

--- a/statute/7/2017/c/1.rac.test
+++ b/statute/7/2017/c/1.rac.test
@@ -1,0 +1,47 @@
+# 7 USC Section 2017(c)(1) tests
+
+snap_prorated_allotment:
+    - name: "Non-initial month receives full allotment"
+      period: 2024-10
+      inputs:
+        snap_allotment: 291
+        is_initial_snap_month: false
+        initial_month_days_remaining: 0
+        initial_month_total_days: 0
+      expect: 291
+
+    - name: "Initial month prorated - applied on day 1 of 31-day month"
+      period: 2024-10
+      inputs:
+        snap_allotment: 291
+        is_initial_snap_month: true
+        initial_month_days_remaining: 31
+        initial_month_total_days: 31
+      expect: 291
+
+    - name: "Initial month prorated - applied mid-month (15 of 30 days remaining)"
+      period: 2024-10
+      inputs:
+        snap_allotment: 291
+        is_initial_snap_month: true
+        initial_month_days_remaining: 15
+        initial_month_total_days: 30
+      expect: 145
+
+    - name: "Initial month prorated below $10 threshold yields zero"
+      period: 2024-10
+      inputs:
+        snap_allotment: 100
+        is_initial_snap_month: true
+        initial_month_days_remaining: 2
+        initial_month_total_days: 31
+      expect: 0
+
+    - name: "Initial month prorated exactly at $10 threshold"
+      period: 2024-10
+      inputs:
+        snap_allotment: 310
+        is_initial_snap_month: true
+        initial_month_days_remaining: 1
+        initial_month_total_days: 31
+      expect: 10

--- a/statute/7/2017/c/3.rac
+++ b/statute/7/2017/c/3.rac
@@ -1,0 +1,51 @@
+# 7 USC Section 2017(c)(3) - Combined initial and following month allotment
+
+"""
+(3) A State agency may provide to an eligible household applying after the 15th
+day of a month, in lieu of the initial allotment of the household and the regular
+allotment of the household for the following month, an allotment that is equal to
+the total amount of the initial allotment and the first regular allotment. The
+allotment shall be provided in accordance with section 2020(e)(3) of this title
+in the case of a household that is not entitled to expedited service and in
+accordance with paragraphs (3) and (9) of section 2020(e) of this title in the
+case of a household that is entitled to expedited service.
+"""
+
+status: encoded
+
+combined_allotment_application_day_threshold:
+    description: "Day of month after which a State may provide combined initial and following month allotment per 7 USC 2017(c)(3)"
+    from 1977-10-01: 15
+
+state_provides_combined_allotment:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "State provides combined allotment"
+    description: "Whether the State agency exercises option to provide combined initial and following month allotment per 7 USC 2017(c)(3)"
+    default: false
+
+snap_application_day_of_month:
+    entity: Household
+    period: Month
+    dtype: Integer
+    label: "SNAP application day of month"
+    description: "Day of the month on which household applied for SNAP benefits"
+    default: 1
+
+snap_combined_allotment:
+    imports:
+        - 7/2017/c/1#snap_prorated_allotment
+        - 7/2017/c/1#is_initial_snap_month
+        - 7/2017/a#snap_allotment
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP combined allotment"
+    description: "Combined initial and following month allotment per 7 USC 2017(c)(3)"
+    from 1977-10-01:
+        if not is_initial_snap_month: 0
+        elif not state_provides_combined_allotment: 0
+        elif snap_application_day_of_month <= combined_allotment_application_day_threshold: 0
+        else: snap_prorated_allotment + snap_allotment

--- a/statute/7/2017/c/3.rac.test
+++ b/statute/7/2017/c/3.rac.test
@@ -1,0 +1,52 @@
+# 7 USC Section 2017(c)(3) tests
+
+snap_combined_allotment:
+    - name: "Combined allotment when applying after 15th day"
+      period: 2024-10
+      inputs:
+        is_initial_snap_month: true
+        state_provides_combined_allotment: true
+        snap_application_day_of_month: 20
+        snap_prorated_allotment: 100
+        snap_allotment: 300
+      expect: 400
+
+    - name: "No combined allotment when applying on or before 15th day"
+      period: 2024-10
+      inputs:
+        is_initial_snap_month: true
+        state_provides_combined_allotment: true
+        snap_application_day_of_month: 15
+        snap_prorated_allotment: 150
+        snap_allotment: 300
+      expect: 0
+
+    - name: "No combined allotment when state does not exercise option"
+      period: 2024-10
+      inputs:
+        is_initial_snap_month: true
+        state_provides_combined_allotment: false
+        snap_application_day_of_month: 20
+        snap_prorated_allotment: 100
+        snap_allotment: 300
+      expect: 0
+
+    - name: "No combined allotment when not initial month"
+      period: 2024-10
+      inputs:
+        is_initial_snap_month: false
+        state_provides_combined_allotment: true
+        snap_application_day_of_month: 20
+        snap_prorated_allotment: 0
+        snap_allotment: 300
+      expect: 0
+
+    - name: "Combined allotment on last day of month"
+      period: 2024-10
+      inputs:
+        is_initial_snap_month: true
+        state_provides_combined_allotment: true
+        snap_application_day_of_month: 31
+        snap_prorated_allotment: 10
+        snap_allotment: 300
+      expect: 310

--- a/statute/7/2017/d/1.rac
+++ b/statute/7/2017/d/1.rac
@@ -1,0 +1,85 @@
+# 7 USC Section 2017(d)(1) - Reduction of public assistance benefits - General rule
+
+"""
+(1) If the benefits of a household are reduced under a Federal, State, or
+local law relating to a means-tested public assistance program for the failure
+of a member of the household to perform an action required under the law or
+program, for the duration of the reduction—
+(A) the household may not receive an increased allotment as the result of a
+decrease in the income of the household to the extent that the decrease is the
+result of the reduction; and
+(B) the State agency may reduce the allotment of the household by not more
+than 25 percent.
+"""
+
+status: encoded
+
+max_pa_allotment_reduction_rate:
+    description: "Maximum rate by which state may reduce allotment per 7 USC 2017(d)(1)(B)"
+    unit: rate
+    from 1996-08-22: 0.25
+
+pa_benefit_reduction_applies:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "PA benefit reduction applies"
+    description: "Whether household benefits are reduced under a means-tested public assistance program for failure to perform a required action per 7 USC 2017(d)(1)"
+    default: false
+
+pa_income_decrease_from_reduction:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Income decrease from PA benefit reduction"
+    description: "Decrease in household income resulting from the public assistance benefit reduction per 7 USC 2017(d)(1)(A)"
+    default: 0
+
+state_applies_pa_allotment_reduction:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "State applies PA allotment reduction"
+    description: "Whether state agency reduces allotment per 7 USC 2017(d)(1)(B)"
+    default: false
+
+snap_allotment_pa_income_adjusted:
+    imports:
+        - 7/2017/a#snap_allotment
+        - 7/2017/a#snap_net_income
+        - 7/2017/a#thrifty_food_plan_cost
+        - 7/2017/a#contribution_rate
+        - 7/2017/a#household_size
+        - 7/2017/a#minimum_allotment_household_size_threshold
+        - 7/2017/a#snap_minimum_allotment
+        - 7/2017/a#snap_eligible
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP allotment adjusted for PA income reduction"
+    description: "Allotment capped at pre-reduction level per 7 USC 2017(d)(1)(A)"
+    from 1996-08-22:
+        if not pa_benefit_reduction_applies: snap_allotment
+        elif not snap_eligible: 0
+        else:
+            pre_reduction_income = snap_net_income + pa_income_decrease_from_reduction
+            pre_reduction_calculated = floor(thrifty_food_plan_cost - contribution_rate * pre_reduction_income)
+            if household_size <= minimum_allotment_household_size_threshold:
+                max(snap_minimum_allotment, pre_reduction_calculated)
+            else:
+                max(0, pre_reduction_calculated)
+
+snap_allotment_after_pa_reduction:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP allotment after PA reduction"
+    description: "Allotment after optional state reduction per 7 USC 2017(d)(1)(B)"
+    from 1996-08-22:
+        if pa_benefit_reduction_applies and state_applies_pa_allotment_reduction:
+            floor(snap_allotment_pa_income_adjusted * (1 - max_pa_allotment_reduction_rate))
+        else:
+            snap_allotment_pa_income_adjusted

--- a/statute/7/2017/d/1.rac.test
+++ b/statute/7/2017/d/1.rac.test
@@ -1,0 +1,67 @@
+# 7 USC Section 2017(d)(1) tests
+
+snap_allotment_after_pa_reduction:
+    - name: "PA reduction not active - allotment unchanged"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        pa_benefit_reduction_applies: false
+        pa_income_decrease_from_reduction: 0
+        state_applies_pa_allotment_reduction: false
+      expect: 590
+
+    - name: "PA reduction caps allotment at pre-reduction income level"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        pa_benefit_reduction_applies: true
+        pa_income_decrease_from_reduction: 200
+        state_applies_pa_allotment_reduction: false
+      expect: 530
+
+    - name: "PA reduction with state 25% allotment reduction"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        pa_benefit_reduction_applies: true
+        pa_income_decrease_from_reduction: 200
+        state_applies_pa_allotment_reduction: true
+      expect: 397
+
+    - name: "1-person household, min allotment with PA and state reduction"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 1
+        snap_net_income: 800
+        thrifty_food_plan_cost: 291
+        thrifty_food_plan_cost_1_member: 291
+        pa_benefit_reduction_applies: true
+        pa_income_decrease_from_reduction: 100
+        state_applies_pa_allotment_reduction: true
+      expect: 17
+
+    - name: "Ineligible household with PA reduction gets zero"
+      period: 2024-10
+      inputs:
+        snap_eligible: false
+        household_size: 1
+        snap_net_income: 0
+        thrifty_food_plan_cost: 291
+        thrifty_food_plan_cost_1_member: 291
+        pa_benefit_reduction_applies: true
+        pa_income_decrease_from_reduction: 100
+        state_applies_pa_allotment_reduction: true
+      expect: 0

--- a/statute/7/2017/d/1/A.rac
+++ b/statute/7/2017/d/1/A.rac
@@ -1,0 +1,41 @@
+# 7 USC Section 2017(d)(1)(A) - No increased allotment from decreased income
+
+"""
+(A) the household may not receive an increased allotment as the result of a
+decrease in the income of the household to the extent that the decrease is
+the result of the reduction; and
+"""
+
+status: encoded
+
+public_assistance_sanction_active:
+    entity: Household
+    period: Month
+    dtype: Boolean
+    label: "Public assistance sanction active"
+    description: "Whether household benefits are reduced under a means-tested public assistance program for failure to perform a required action per 7 USC 2017(d)(1)"
+    default: false
+
+income_decrease_from_sanction:
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "Income decrease from public assistance sanction"
+    description: "Amount of decrease in household income resulting from the public assistance benefit reduction per 7 USC 2017(d)(1)"
+    default: 0
+
+snap_net_income_after_sanction_adjustment:
+    imports:
+        - 7/2017/a#snap_net_income
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP net income adjusted for public assistance sanction"
+    description: "Net income with sanction-related decrease added back to prevent increased allotment per 7 USC 2017(d)(1)(A)"
+    from 1996-10-01:
+        if public_assistance_sanction_active:
+            snap_net_income + income_decrease_from_sanction
+        else:
+            snap_net_income

--- a/statute/7/2017/d/1/A.rac.test
+++ b/statute/7/2017/d/1/A.rac.test
@@ -1,0 +1,42 @@
+# 7 USC Section 2017(d)(1)(A) tests
+
+snap_net_income_after_sanction_adjustment:
+    - name: "No sanction - net income passes through unchanged"
+      period: 2024-10
+      inputs:
+        snap_net_income: 1000
+        public_assistance_sanction_active: false
+        income_decrease_from_sanction: 0
+      expect: 1000
+
+    - name: "Sanction active - income decrease added back"
+      period: 2024-10
+      inputs:
+        snap_net_income: 700
+        public_assistance_sanction_active: true
+        income_decrease_from_sanction: 300
+      expect: 1000
+
+    - name: "Sanction active but zero income decrease"
+      period: 2024-10
+      inputs:
+        snap_net_income: 1000
+        public_assistance_sanction_active: true
+        income_decrease_from_sanction: 0
+      expect: 1000
+
+    - name: "No sanction - income decrease input ignored"
+      period: 2024-10
+      inputs:
+        snap_net_income: 700
+        public_assistance_sanction_active: false
+        income_decrease_from_sanction: 300
+      expect: 700
+
+    - name: "Sanction active with large income decrease"
+      period: 2024-10
+      inputs:
+        snap_net_income: 200
+        public_assistance_sanction_active: true
+        income_decrease_from_sanction: 800
+      expect: 1000

--- a/statute/7/2017/d/1/B.rac
+++ b/statute/7/2017/d/1/B.rac
@@ -1,0 +1,34 @@
+# 7 USC Section 2017(d)(1)(B) - Maximum allotment reduction
+
+"""
+(B) the State agency may reduce the allotment of the household by not more
+than 25 percent.
+"""
+
+status: encoded
+
+snap_pa_sanction_max_allotment_reduction_rate:
+    description: "Maximum rate by which allotment may be reduced under a public assistance sanction per 7 USC 2017(d)(1)(B)"
+    unit: rate
+    from 1996-08-22: 0.25
+
+snap_pa_sanction_allotment_reduction_rate:
+    entity: Household
+    period: Month
+    dtype: Rate
+    label: "SNAP public assistance sanction allotment reduction rate"
+    description: "State-chosen allotment reduction rate for public assistance sanction (must not exceed 25%)"
+    default: 0
+
+snap_pa_sanction_allotment_reduction:
+    imports:
+        - 7/2017/a#snap_allotment
+    entity: Household
+    period: Month
+    dtype: Money
+    unit: USD
+    label: "SNAP allotment reduction for public assistance sanction"
+    description: "Allotment reduction capped at 25% per 7 USC 2017(d)(1)(B)"
+    from 1996-08-22:
+        capped_rate = min(snap_pa_sanction_allotment_reduction_rate, snap_pa_sanction_max_allotment_reduction_rate)
+        floor(snap_allotment * capped_rate)

--- a/statute/7/2017/d/1/B.rac.test
+++ b/statute/7/2017/d/1/B.rac.test
@@ -1,0 +1,57 @@
+# 7 USC Section 2017(d)(1)(B) tests
+
+snap_pa_sanction_allotment_reduction:
+    - name: "No sanction applied (zero reduction rate)"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        snap_pa_sanction_allotment_reduction_rate: 0
+      expect: 0
+
+    - name: "State applies maximum 25% reduction"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        snap_pa_sanction_allotment_reduction_rate: 0.25
+      expect: 147
+
+    - name: "State applies partial 10% reduction"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 2
+        snap_net_income: 400
+        thrifty_food_plan_cost: 535
+        thrifty_food_plan_cost_1_member: 291
+        snap_pa_sanction_allotment_reduction_rate: 0.10
+      expect: 41
+
+    - name: "Reduction rate exceeding 25% is capped at 25%"
+      period: 2024-10
+      inputs:
+        snap_eligible: true
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        snap_pa_sanction_allotment_reduction_rate: 0.50
+      expect: 147
+
+    - name: "Ineligible household has zero allotment so zero reduction"
+      period: 2024-10
+      inputs:
+        snap_eligible: false
+        household_size: 3
+        snap_net_income: 500
+        thrifty_food_plan_cost: 740
+        thrifty_food_plan_cost_1_member: 291
+        snap_pa_sanction_allotment_reduction_rate: 0.25
+      expect: 0


### PR DESCRIPTION
## Summary

Stress test encoding of SNAP allotment calculation — 7 USC 2017. Third stress test (after RI CCAP PR #21, MA EITC PR #23), targeting a **federal benefit program** in a completely different domain from tax (Household entity, monthly period).

## Results

**7 files, 4 waves, 29 minutes**

| File | Description |
|------|-------------|
| `2017.rac` | Root aggregator — combines proration and PA reduction |
| `a.rac` | Core formula: thrifty food plan - 30% of income, min allotment for 1-2 person HH |
| `c/1.rac` | Initial month proration (days remaining / total days, $10 minimum) |
| `c/3.rac` | Optional combined allotment for applications after the 15th |
| `d/1.rac` | PA benefit reduction — income adjustment + 25% cap |
| `d/1/A.rac` | No increased allotment from reduction-caused income decrease |
| `d/1/B.rac` | State may reduce allotment by up to 25% |

## What went well

- **Correct entity and period** — `entity: Household`, `period: Month` used throughout. Encoder correctly identified this is not a tax/TaxUnit program.
- **Core formula is solid** — `floor(thrifty_food_plan_cost - contribution_rate * snap_net_income)` with minimum allotment for 1-2 person households
- **Parameters properly extracted** — `contribution_rate: 0.30`, `minimum_allotment_rate: 0.08`, `minimum_initial_month_allotment: 10`
- **Cross-file imports** — `c/1.rac` imports `snap_allotment` from `a.rac`; `d/1.rac` imports 8 variables from `a.rac`
- **PE got 40% match on `a.rac`** — partial oracle validation on the core formula

## Issues found

1. **Skipped subsections (b), (e), (f)** — the analyzer did not encode benefits-not-income (b), treatment center allotments (e), or group facility procedures (f). Reasonable for (b) which is declaratory, but (e) and (f) contain allotment logic.

2. **Atlas can't fetch Title 7** — had to provide statute text manually via Python API (autorac issue #28).

## Encoding method

Statute text fetched from [law.cornell.edu/uscode/text/7/2017](https://www.law.cornell.edu/uscode/text/7/2017) and passed via `Orchestrator.encode(statute_text=...)` (see `encode_snap_allotment.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)