### PR TITLE
Use snap_excess_shelter_deduction_for_net_income in 7 USC 2014(e)(6)(A)

### DIFF
--- a/statutes/7/2014/e/6/A.test.yaml
+++ b/statutes/7/2014/e/6/A.test.yaml
@@ -8,7 +8,7 @@
     us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
     us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
     us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 204.5
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction_for_net_income: 204.5
   output:
     us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter: 591
     us:statutes/7/2014/e/6/A#snap_net_income: 386.5
@@ -22,7 +22,7 @@
     us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
     us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
     us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 50
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction_for_net_income: 50
   output:
     us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter: 0
     us:statutes/7/2014/e/6/A#snap_net_income: 0

--- a/statutes/7/2014/e/6/A.yaml
+++ b/statutes/7/2014/e/6/A.yaml
@@ -39,4 +39,4 @@ rules:
     source: 7 USC 2014(d) and (e)
     versions:
       - effective_from: '2008-10-01'
-        formula: max(0, snap_net_income_pre_shelter - snap_excess_shelter_deduction)
+        formula: max(0, snap_net_income_pre_shelter - snap_excess_shelter_deduction_for_net_income)


### PR DESCRIPTION
The `snap_net_income` formula in `statutes/7/2014/e/6/A.yaml` references `snap_excess_shelter_deduction`, but that name isn't defined anywhere in the federal or state corpus today. The shelter-deduction mechanic lives in `regulations/7-cfr/273/10.yaml` as `snap_excess_shelter_deduction_for_net_income`, following the same `_for_net_income` convention as its siblings:

- `snap_earned_income_deduction_for_net_income`
- `snap_excess_medical_deduction_for_net_income`
- `snap_homeless_shelter_deduction_for_net_income`
- `snap_excess_shelter_deduction_for_net_income`

This PR renames the reference in the statute so the formula resolves at compile time when both files are imported into the same top-level program (e.g. `rules-us-co`'s CO SNAP composition).

## Repro before this change

```
axiom-rules-engine compile --program rules-us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml --output /tmp/co-snap.json
# … artifact compiles OK …
axiom-rules-engine run-compiled --artifact /tmp/co-snap.json < household.json
# missing input `snap_excess_shelter_deduction` for entity `case-0::household` over 2026-01-01..2026-01-31
```

The engine treats unresolved name references as missing inputs.

## After this change

The reference resolves to the regulation's derived rule; the CO SNAP run produces values for `snap_eligible` and `snap_allotment` instead of erroring.

## Test plan

- [x] Updated `statutes/7/2014/e/6/A.test.yaml` to use the new input name; the statute's isolated unit test still treats the deduction as an external input.
- [x] Composed CO SNAP module compiles and runs end-to-end.
- [ ] Composed program produces matching SNAP values against PolicyEngine on Colorado ECPS households (downstream wiring is in TheAxiomFoundation/axiom-oracles#14).

## Found via

[TheAxiomFoundation/axiom-oracles#14](https://github.com/TheAxiomFoundation/axiom-oracles/pull/14) — wiring CO SNAP cross-engine validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)