### PR TITLE
CI: corpus resolution check (gate against naming desyncs)

### DIFF
--- a/.github/workflows/corpus-resolution.yml
+++ b/.github/workflows/corpus-resolution.yml
@@ -1,0 +1,48 @@
+name: Corpus resolution check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout rulespec-us
+        uses: actions/checkout@v6.0.2
+
+      - name: Checkout axiom-rules-engine
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          path: _axiom/axiom-rules-engine
+
+      - name: Set up Rust
+        run: |
+          if ! command -v rustup &> /dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
+              --location --silent --show-error --fail https://sh.rustup.rs \
+              | sh -s -- --default-toolchain stable -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+
+      - name: Build axiom-rules-engine
+        run: |
+          cd _axiom/axiom-rules-engine
+          cargo build --release --quiet
+
+      - name: Run SNAP composition resolution check
+        env:
+          AXIOM_RULES_ENGINE_BINARY: ${{ github.workspace }}/_axiom/axiom-rules-engine/target/release/axiom-rules-engine
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}/..
+        run: |
+          # The engine expects to find the corpus under a directory named
+          # `rulespec-us` for `us:` imports. Set up a sibling symlink so the
+          # resolver can find this repo.
+          ln -sfn "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/../rulespec-us"
+          python3 scripts/check_corpus_resolution.py snap

--- a/scripts/check_corpus_resolution.py
+++ b/scripts/check_corpus_resolution.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Detect producer/consumer naming desyncs in a rulespec-us program domain.
+
+Per-file CI catches per-file errors. It does NOT catch the case where two
+modules in different files use different names for the same legal concept,
+because the engine treats unresolved name references as external inputs by
+default. This script composes a domain (e.g. SNAP) into one synthetic
+top-level program, compiles it, then walks the lowered expression tree for
+``Input { name }`` references that don't have a matching producer.
+
+Most unresolved references are legitimate external inputs (per-household
+facts the runtime provides). The script applies a heuristic to flag the
+suspicious ones: names that start with the domain prefix (e.g. ``snap_``)
+are expected to resolve to producer rules within the corpus; if they don't,
+that's almost certainly a producer/consumer naming desync.
+
+Usage::
+
+    python scripts/check_corpus_resolution.py snap
+
+Domains supported today:
+- ``snap``: composes statutes/7, regulations/7-cfr/273, policies/usda/snap
+
+Add new domains by editing ``DOMAIN_ROOTS`` below.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+
+
+# Per-domain composition roots. Each entry is a list of corpus subdirectories
+# that compose together cleanly (no cross-domain rule-name collisions).
+DOMAIN_ROOTS: dict[str, list[str]] = {
+    "snap": [
+        "statutes/7",
+        "regulations/7-cfr/273",
+        "policies/usda/snap",
+    ],
+}
+
+# Names with these prefixes are expected to be producer rules from within the
+# domain, not external inputs. Unresolved references with these prefixes are
+# treated as bugs.
+DOMAIN_PRODUCER_PREFIXES: dict[str, tuple[str, ...]] = {
+    "snap": ("snap_",),
+}
+
+
+def find_modules(corpus: Path, roots: list[str]) -> list[str]:
+    citations = []
+    for relative in roots:
+        root = corpus / relative
+        if not root.exists():
+            continue
+        for yaml_path in sorted(root.rglob("*.yaml")):
+            if yaml_path.name.endswith(".test.yaml"):
+                continue
+            rel = yaml_path.relative_to(corpus).with_suffix("")
+            citations.append(f"us:{rel}")
+    return citations
+
+
+def synthesize_top_module(citations: list[str], output: Path, domain: str) -> None:
+    imports = "\n".join(f"  - {c}" for c in citations)
+    output.write_text(
+        f"format: rulespec/v1\n"
+        f"module:\n"
+        f"  summary: |-\n"
+        f"    Auto-generated {domain} composition for resolution audit.\n"
+        f"imports:\n{imports}\n"
+        f"rules: []\n"
+    )
+
+
+def resolve_repo_roots(corpus: Path) -> str:
+    """AXIOM_RULESPEC_REPO_ROOTS env value: parent of the corpus."""
+    return str(corpus.parent)
+
+
+def compile_program(engine: Path, program: Path, output: Path, repo_roots: str) -> str:
+    env = os.environ.copy()
+    env["AXIOM_RULESPEC_REPO_ROOTS"] = repo_roots
+    result = subprocess.run(
+        [str(engine), "compile", "--program", str(program), "--output", str(output)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        sys.exit(f"compile failed (exit {result.returncode})")
+    return result.stdout
+
+
+def collect_input_references(expr, accumulator: set[str]) -> None:
+    if not isinstance(expr, dict):
+        return
+    kind = expr.get("kind")
+    if kind in {"input", "input_or_else"}:
+        name = expr.get("name")
+        if name:
+            accumulator.add(name)
+    if kind == "parameter_lookup":
+        collect_input_references(expr.get("index"), accumulator)
+    for key in (
+        "expr", "condition", "then_expr", "else_expr",
+        "left", "right", "value", "item",
+        "date", "days", "from", "to",
+        "where_clause", "where", "index",
+    ):
+        if key in expr:
+            collect_input_references(expr[key], accumulator)
+    for key in ("items",):
+        for child in expr.get(key, []) or []:
+            collect_input_references(child, accumulator)
+
+
+def find_unresolved(artifact: dict, prefixes: tuple[str, ...]) -> dict[str, list[str]]:
+    program = artifact.get("program", artifact)
+    derived = program.get("derived", [])
+    parameters = program.get("parameters", [])
+
+    defined = {r["name"] for r in derived}
+    defined.update({p["name"] for p in parameters})
+
+    refs_by_name: dict[str, list[str]] = defaultdict(list)
+    for rule in derived:
+        refs: set[str] = set()
+        collect_input_references(rule.get("expr") or rule.get("semantics"), refs)
+        for name in refs:
+            refs_by_name[name].append(rule["name"])
+
+    suspicious = {}
+    for name, consumers in refs_by_name.items():
+        if name in defined:
+            continue
+        if not name.startswith(prefixes):
+            continue
+        suspicious[name] = sorted(set(consumers))
+    return suspicious
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "domain",
+        choices=sorted(DOMAIN_ROOTS.keys()),
+        help="Program domain to audit.",
+    )
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Path to the rulespec-us corpus root.",
+    )
+    parser.add_argument(
+        "--engine",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "AXIOM_RULES_ENGINE_BINARY",
+                Path.home() / "axiom-rules" / "target" / "release" / "axiom-rules-engine",
+            )
+        ),
+        help="Path to axiom-rules-engine binary.",
+    )
+    args = parser.parse_args()
+
+    corpus = args.corpus.expanduser().resolve()
+    if not corpus.exists():
+        sys.exit(f"corpus not found: {corpus}")
+    if not args.engine.exists():
+        sys.exit(f"engine not found: {args.engine}")
+
+    citations = find_modules(corpus, DOMAIN_ROOTS[args.domain])
+    print(f"[{args.domain}] {len(citations)} modules in composition")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        program = tmp / "compose.yaml"
+        compiled = tmp / "compose.compiled.json"
+        synthesize_top_module(citations, program, args.domain)
+        compile_program(args.engine, program, compiled, resolve_repo_roots(corpus))
+        artifact = json.loads(compiled.read_text())
+
+    suspicious = find_unresolved(artifact, DOMAIN_PRODUCER_PREFIXES[args.domain])
+    if not suspicious:
+        print(f"[{args.domain}] no unresolved producer references — corpus is clean.")
+        return 0
+
+    print(
+        f"\n[{args.domain}] {len(suspicious)} unresolved producer references "
+        f"(probable naming desyncs):\n"
+    )
+    for name in sorted(suspicious):
+        consumers = suspicious[name]
+        print(f"  {name}")
+        for c in consumers[:3]:
+            print(f"    consumed by: {c}")
+        if len(consumers) > 3:
+            print(f"    ... and {len(consumers) - 3} more")
+
+    print(
+        f"\nFix by either renaming the consumer to match an existing producer, "
+        f"or adding a producer with the expected name. References that are "
+        f"genuinely external inputs should not start with `{DOMAIN_PRODUCER_PREFIXES[args.domain][0]}` "
+        f"— rename them to a domain-neutral name."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #31.

Adds a CI job that composes a program domain (SNAP today) into one synthetic top-level module, compiles it, and walks the lowered expression tree for ${'`'}Input { name }${'`'} references that don't resolve to a defined rule. Heuristic: names with the domain producer prefix (e.g. ${'`'}snap_${'`'}) are expected to be derived rules within the corpus. References that fall through to Input are flagged as naming desyncs.

## Why

Per-file CI catches per-file errors. It doesn't catch the case where two modules use different names for the same legal concept, because the engine treats unresolved name references as external inputs by default. The bug shows up at downstream runtime when something tries to compose the modules together — the first downstream consumer today is [axiom-oracles](https://github.com/TheAxiomFoundation/axiom-oracles/pull/14).

## Current findings

The check currently flags **19 references** in the SNAP composition that look like producer/consumer naming desyncs. Two are already-filed (#28 ${'`'}snap_gross_monthly_income${'`'}, #29 ${'`'}snap_excess_shelter_deduction${'`'}). The other 17 are new finds, including:

- ${'`'}snap_monthly_household_income${'`'}, ${'`'}snap_gross_monthly_earned_income${'`'}, ${'`'}snap_total_monthly_unearned_income${'`'} — same conceptual sibling of #28
- ${'`'}snap_total_allowable_shelter_expenses${'`'}, ${'`'}snap_total_medical_expenses${'`'}, ${'`'}snap_claimed_homeless_shelter_deduction${'`'} — same pattern
- ${'`'}snap_countable_earned_income${'`'}, ${'`'}snap_countable_financial_resources${'`'} — references that look like derived rules but fall through to Input
- ${'`'}snap_eligible${'`'} — federal-level rule absent; only defined at the state level today

A few may turn out to be legitimate external inputs that happen to share the ${'`'}snap_${'`'} prefix; those should be renamed to a domain-neutral identifier so the heuristic doesn't false-positive.

## How to extend

Add new domains in ${'`'}DOMAIN_ROOTS${'`'} and ${'`'}DOMAIN_PRODUCER_PREFIXES${'`'} at the top of ${'`'}scripts/check_corpus_resolution.py${'`'}. Federal income tax should be next.

## Test plan

- [x] Script runs locally against current main and surfaces 19 references.
- [ ] CI workflow builds the engine + runs the check. CI will be RED on this PR (by design) until the flagged references are reconciled. Merging this PR ${'\\\\'}\\*requires${'\\\\'}\\* either fixing the 19 flagged references in the same PR or accepting an initial red CI as the marker for the cleanup backlog.

## Related

- Encoder-side fix: TheAxiomFoundation/axiom-encode#38 (prevents new instances)
- Engine flag for direct strict-resolution: TheAxiomFoundation/axiom-rules-engine#38 (not strictly required — this script walks the existing compiled JSON)