### PR TITLE
Encode 26 USC 224 qualified tips deduction

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/224.json
+++ b/.axiom/encoding-manifests/statutes/26/224.json
@@ -1,0 +1,39 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/224.yaml",
+      "sha256": "64270edf3fb15d56920304f7223f172ddd1f10af6419b05c2b7ff27cda21fcf1"
+    },
+    {
+      "path": "statutes/26/224.test.yaml",
+      "sha256": "68d8cdc6351ee5570ae71e826e0bd4dc31d701b43ef60624c3e5bd0875cb172d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "348fc0ab9f2c07af57b89545b8568b9702267b55",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+  },
+  "axiom_encode_version": "0.2.68",
+  "backend": "openai",
+  "citation": "26 USC 224",
+  "context_manifest_file": "/tmp/axiom-encode-26-224-qualified-tips-openai/_eval_workspaces/openai-gpt-5.5/26-USC-224/workspace/context-manifest.json",
+  "context_manifest_sha256": "5ffd54f72f219e79e3e0db755efcecc94b6dee159174d4379b4b2fce7aa948dc",
+  "generated_at": "2026-05-15T01:42:32.397391+00:00",
+  "generated_output_file": "/tmp/axiom-encode-26-224-qualified-tips-openai/openai-gpt-5.5/statutes/26/224.yaml",
+  "generated_output_root": "/tmp/axiom-encode-26-224-qualified-tips-openai",
+  "generated_output_sha256": "64270edf3fb15d56920304f7223f172ddd1f10af6419b05c2b7ff27cda21fcf1",
+  "generation_prompt_sha256": "5bcdba0db4e1a0eef245422e533d214c7309c87a1e022bc7e053476477298e3f",
+  "model": "gpt-5.5",
+  "run_id": "b04d132e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ab1195a2738bd6b6ad0087e1a0dad475361bbe02f4892c9336e5fe44f8b01838"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-26-224-qualified-tips-openai/traces/openai-gpt-5.5/26-USC-224.json",
+  "trace_sha256": "42b2be11b2a12f00bde79493b1527ca6805c9ee4d039991f87edd1456c297a49"
+}

--- a/statutes/26/224.test.yaml
+++ b/statutes/26/224.test.yaml
@@ -1,0 +1,109 @@
+- name: single_taxpayer_employee_tips_below_phaseout
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/224#input.filing_status: 0
+    us:statutes/26/224#input.adjusted_gross_income: 140000
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/224#input.employee_qualified_tips_included_on_statements_or_form_4137: 12000
+    us:statutes/26/224#input.nonemployee_trade_or_business_qualified_tips_included_on_statements_or_form_4137: 0
+    us:statutes/26/224#input.gross_income_from_nonemployee_trade_or_business_including_qualified_tips: 0
+    us:statutes/26/224#input.deductions_allocable_to_nonemployee_trade_or_business_other_than_section_224: 0
+    us:statutes/26/224#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/224#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/224#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/224#qualified_tips_deduction_cap: 25000
+    us:statutes/26/224#qualified_tips_phaseout_reduction: 100
+    us:statutes/26/224#qualified_tips_phaseout_increment: 1000
+    us:statutes/26/224#qualified_tips_phaseout_threshold_other: 150000
+    us:statutes/26/224#qualified_tips_phaseout_threshold_joint: 300000
+    us:statutes/26/224#qualified_tips_modified_adjusted_gross_income: 140000
+    us:statutes/26/224#qualified_tips_phaseout_threshold: 150000
+    us:statutes/26/224#nonemployee_trade_or_business_qualified_tips_taken_into_account: 0
+    us:statutes/26/224#qualified_tips_taken_into_account_before_cap: 12000
+    us:statutes/26/224#qualified_tips_deduction_before_phaseout: 12000
+    us:statutes/26/224#qualified_tips_phaseout_amount: 0
+    us:statutes/26/224#qualified_tips_deduction_eligibility: holds
+    us:statutes/26/224#qualified_tips_deduction: 12000
+- name: joint_taxpayer_tips_capped_and_partially_phased_out
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/224#input.filing_status: 1
+    us:statutes/26/224#input.adjusted_gross_income: 302500
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/224#input.employee_qualified_tips_included_on_statements_or_form_4137: 30000
+    us:statutes/26/224#input.nonemployee_trade_or_business_qualified_tips_included_on_statements_or_form_4137: 0
+    us:statutes/26/224#input.gross_income_from_nonemployee_trade_or_business_including_qualified_tips: 0
+    us:statutes/26/224#input.deductions_allocable_to_nonemployee_trade_or_business_other_than_section_224: 0
+    us:statutes/26/224#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/224#input.taxpayer_is_married_individual_within_section_7703: true
+    us:statutes/26/224#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/224#qualified_tips_modified_adjusted_gross_income: 302500
+    us:statutes/26/224#qualified_tips_phaseout_threshold: 300000
+    us:statutes/26/224#qualified_tips_taken_into_account_before_cap: 30000
+    us:statutes/26/224#qualified_tips_deduction_before_phaseout: 25000
+    us:statutes/26/224#qualified_tips_phaseout_amount: 200
+    us:statutes/26/224#qualified_tips_deduction_eligibility: holds
+    us:statutes/26/224#qualified_tips_deduction: 24800
+- name: nonemployee_trade_or_business_tips_limited_by_net_business_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/224#input.filing_status: 0
+    us:statutes/26/224#input.adjusted_gross_income: 100000
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/224#input.employee_qualified_tips_included_on_statements_or_form_4137: 5000
+    us:statutes/26/224#input.nonemployee_trade_or_business_qualified_tips_included_on_statements_or_form_4137: 10000
+    us:statutes/26/224#input.gross_income_from_nonemployee_trade_or_business_including_qualified_tips: 18000
+    us:statutes/26/224#input.deductions_allocable_to_nonemployee_trade_or_business_other_than_section_224: 12000
+    us:statutes/26/224#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/224#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/224#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/224#qualified_tips_modified_adjusted_gross_income: 100000
+    us:statutes/26/224#nonemployee_trade_or_business_qualified_tips_taken_into_account: 6000
+    us:statutes/26/224#qualified_tips_taken_into_account_before_cap: 11000
+    us:statutes/26/224#qualified_tips_deduction_before_phaseout: 11000
+    us:statutes/26/224#qualified_tips_phaseout_amount: 0
+    us:statutes/26/224#qualified_tips_deduction_eligibility: holds
+    us:statutes/26/224#qualified_tips_deduction: 11000
+- name: missing_ssn_disallows_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/224#input.filing_status: 0
+    us:statutes/26/224#input.adjusted_gross_income: 90000
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/224#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/224#input.employee_qualified_tips_included_on_statements_or_form_4137: 8000
+    us:statutes/26/224#input.nonemployee_trade_or_business_qualified_tips_included_on_statements_or_form_4137: 0
+    us:statutes/26/224#input.gross_income_from_nonemployee_trade_or_business_including_qualified_tips: 0
+    us:statutes/26/224#input.deductions_allocable_to_nonemployee_trade_or_business_other_than_section_224: 0
+    us:statutes/26/224#input.taxpayer_social_security_number_included_on_return: false
+    us:statutes/26/224#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/224#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/224#qualified_tips_modified_adjusted_gross_income: 90000
+    us:statutes/26/224#qualified_tips_taken_into_account_before_cap: 8000
+    us:statutes/26/224#qualified_tips_deduction_before_phaseout: 8000
+    us:statutes/26/224#qualified_tips_phaseout_amount: 0
+    us:statutes/26/224#qualified_tips_deduction_eligibility: not_holds
+    us:statutes/26/224#qualified_tips_deduction: 0

--- a/statutes/26/224.yaml
+++ b/statutes/26/224.yaml
@@ -1,0 +1,343 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/224
+  summary: |-
+    (a) In general There shall be allowed as a deduction an amount equal to the qualified tips received during the taxable year that are included on statements furnished to the individual pursuant to section 6041(d)(3), 6041A(e)(3), 6050W(f)(2), or 6051(a)(18), or reported by the taxpayer on Form 4137 (or successor).
+
+    (b) Limitation (1) In general The amount allowed as a deduction under this section for any taxable year shall not exceed $25,000. (2) Limitation based on adjusted gross income (A) In general The amount allowable as a deduction under subsection (a) (after application of paragraph (1)) shall be reduced (but not below zero) by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return). (B) Modified adjusted gross income For purposes of this paragraph, the term “modified adjusted gross income” means the adjusted gross income of the taxpayer for the taxable year increased by any amount excluded from gross income under section 911, 931, or 933.
+
+    (c) Tips received in course of trade or business In the case of qualified tips received by an individual during any taxable year in the course of a trade or business (other than the trade or business of performing services as an employee) of such individual, such qualified tips shall be taken into account under subsection (a) only to the extent that the gross income for the taxpayer from such trade or business for such taxable year (including such qualified tips) exceeds the sum of the deductions (other than the deduction allowed under this section) allocable to the trade or business in which such qualified tips are received by the individual for such taxable year.
+
+    (d) Qualified tips For purposes of this section— (1) In general The term “qualified tips” means cash tips received by an individual in an occupation which customarily and regularly received tips on or before December 31, 2024, as provided by the Secretary. (2) Exclusions Such term shall not include any amount received by an individual unless— (A) such amount is paid voluntarily without any consequence in the event of nonpayment, is not the subject of negotiation, and is determined by the payor, (B) the trade or business in the course of which the individual receives such amount is not a specified service trade or business (as defined in section 199A(d)(2)), and (C) such other requirements as may be established by the Secretary in regulations or other guidance are satisfied. For purposes of subparagraph (B), in the case of an individual receiving tips in the trade or business of performing services as an employee, such individual shall be treated as receiving tips in the course of a trade or business which is a specified service trade or business if the trade or business of the employer is a specified service trade or business. (3) Cash tips For purposes of paragraph (1), the term “cash tips” includes tips received from customers that are paid in cash or charged and, in the case of an employee, tips received under any tip-sharing arrangement.
+
+    (e) Social security number required (1) In general No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number. (2) Social security number defined For purposes of paragraph (1), the term “social security number” shall have the meaning given such term in section 24(h)(7).
+
+    (f) Married individuals If the taxpayer is a married individual (within the meaning of section 7703), this section shall apply only if the taxpayer and the taxpayer’s spouse file a joint return for the taxable year.
+
+    (h) Termination No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+rules:
+  - name: qualified_tips_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 224(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $25,000.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          25000
+
+  - name: qualified_tips_phaseout_reduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: shall be reduced (but not below zero) by $100 for each $1,000
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          100
+
+  - name: qualified_tips_phaseout_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          1000
+
+  - name: qualified_tips_phaseout_threshold_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: exceeds $150,000 ($300,000 in the case of a joint return)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          150000
+
+  - name: qualified_tips_phaseout_threshold_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: exceeds $150,000 ($300,000 in the case of a joint return)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          300000
+
+  - name: qualified_tips_modified_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(b)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: modified adjusted gross income means the adjusted gross income of the taxpayer for the taxable year increased by any amount excluded from gross income under section 911, 931, or 933.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          adjusted_gross_income
+          + amount_excluded_from_gross_income_under_section_911
+          + amount_excluded_from_gross_income_under_section_931
+          + amount_excluded_from_gross_income_under_section_933
+
+  - name: qualified_tips_phaseout_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: $150,000 ($300,000 in the case of a joint return)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          match filing_status:
+              1 => qualified_tips_phaseout_threshold_joint
+              4 => qualified_tips_phaseout_threshold_joint
+              0 => qualified_tips_phaseout_threshold_other
+              2 => qualified_tips_phaseout_threshold_other
+              3 => qualified_tips_phaseout_threshold_other
+
+  - name: nonemployee_trade_or_business_qualified_tips_taken_into_account
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: such qualified tips shall be taken into account under subsection (a) only to the extent that the gross income for the taxpayer from such trade or business for such taxable year (including such qualified tips) exceeds the sum of the deductions (other than the deduction allowed under this section) allocable to the trade or business
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          min(
+              nonemployee_trade_or_business_qualified_tips_included_on_statements_or_form_4137,
+              max(
+                  0,
+                  gross_income_from_nonemployee_trade_or_business_including_qualified_tips
+                  - deductions_allocable_to_nonemployee_trade_or_business_other_than_section_224
+              )
+          )
+
+  - name: qualified_tips_taken_into_account_before_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(a), (c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: an amount equal to the qualified tips received during the taxable year that are included on statements furnished to the individual pursuant to section 6041(d)(3), 6041A(e)(3), 6050W(f)(2), or 6051(a)(18), or reported by the taxpayer on Form 4137 (or successor).
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: In the case of qualified tips received by an individual during any taxable year in the course of a trade or business (other than the trade or business of performing services as an employee) ... only to the extent that the gross income ... exceeds the sum of the deductions
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          employee_qualified_tips_included_on_statements_or_form_4137
+          + nonemployee_trade_or_business_qualified_tips_taken_into_account
+
+  - name: qualified_tips_deduction_before_phaseout
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $25,000.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          min(
+              qualified_tips_taken_into_account_before_cap,
+              qualified_tips_deduction_cap
+          )
+
+  - name: qualified_tips_phaseout_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: shall be reduced (but not below zero) by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          floor(
+              max(
+                  0,
+                  qualified_tips_modified_adjusted_gross_income
+                  - qualified_tips_phaseout_threshold
+              )
+              / qualified_tips_phaseout_increment
+          )
+          * qualified_tips_phaseout_reduction
+
+  - name: qualified_tips_deduction_eligibility
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 224(e), (f), (h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number.
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: If the taxpayer is a married individual (within the meaning of section 7703), this section shall apply only if the taxpayer and the taxpayer’s spouse file a joint return for the taxable year.
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          taxpayer_social_security_number_included_on_return
+          and (
+              not taxpayer_is_married_individual_within_section_7703
+              or filing_status == 1
+          )
+          and not taxable_year_begins_after_december_31_2028
+
+  - name: qualified_tips_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 224(a)-(c), (e), (f), (h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: There shall be allowed as a deduction an amount equal to the qualified tips received during the taxable year
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: shall not exceed $25,000
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: shall be reduced (but not below zero) by $100 for each $1,000
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number.
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/224
+              text: No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if qualified_tips_deduction_eligibility:
+              max(
+                  0,
+                  qualified_tips_deduction_before_phaseout
+                  - qualified_tips_phaseout_amount
+              )
+          else:
+              0


### PR DESCRIPTION
## Summary
- encode 26 USC 224 qualified tips deduction from the corpus-backed statute source
- add companion RuleSpec tests for cap, phaseout, nonemployee business limitation, and SSN eligibility
- include signed axiom-encode apply manifest generated by axiom-encode 0.2.68

## Verification
- `uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/224.test.yaml`
- `uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/224.yaml`
- `uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/224.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref main --head-ref HEAD`
- `uv run axiom-encode validate --json /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/224.yaml` -> `all_passed=true`

## Notes
- PolicyEngine oracle coverage reports the new 26 USC 224 outputs as unmapped; no PolicyEngine mapping/classification was added in this PR.