### PR TITLE
Encode 26 USC 225 qualified overtime deduction

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/225.json
+++ b/.axiom/encoding-manifests/statutes/26/225.json
@@ -1,0 +1,39 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/225.yaml",
+      "sha256": "97eaea8552cf557eb9b19bbb0f1bc9a117851018c307ac00ea8305d8c0860f24"
+    },
+    {
+      "path": "statutes/26/225.test.yaml",
+      "sha256": "bf3cf39d0820bcf47c84a0577d2e9bc80af3e1b552e1459a27461a263e82fbc2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7927b3a5aaeee4a78ef2ea0c5edccc3506b33e8f",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+  },
+  "axiom_encode_version": "0.2.68",
+  "backend": "openai",
+  "citation": "26 USC 225",
+  "context_manifest_file": "/tmp/axiom-encode-26-225-qualified-overtime-openai/_eval_workspaces/openai-gpt-5.5/26-USC-225/workspace/context-manifest.json",
+  "context_manifest_sha256": "58384a22aa515a029c4e87dfbba6fb4170be8f029b54381295efc361e4aebf31",
+  "generated_at": "2026-05-15T11:06:03.228427+00:00",
+  "generated_output_file": "/tmp/axiom-encode-26-225-qualified-overtime-openai/openai-gpt-5.5/statutes/26/225.yaml",
+  "generated_output_root": "/tmp/axiom-encode-26-225-qualified-overtime-openai",
+  "generated_output_sha256": "97eaea8552cf557eb9b19bbb0f1bc9a117851018c307ac00ea8305d8c0860f24",
+  "generation_prompt_sha256": "ee7f755f20ca92876752d19b412c7a614a4af2352251a7af4ce293da976192b4",
+  "model": "gpt-5.5",
+  "run_id": "26dd2d09",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c91745f3d5fb99d081a4b4f34400c735cfbb2c5b8be6ad698d5a84b6b209e5ce"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-26-225-qualified-overtime-openai/traces/openai-gpt-5.5/26-USC-225.json",
+  "trace_sha256": "7650795c250467cb510c606e61068f592edd87231d6ce8d3124c42baff853083"
+}

--- a/statutes/26/225.test.yaml
+++ b/statutes/26/225.test.yaml
@@ -1,0 +1,101 @@
+- name: single_taxpayer_overtime_below_phaseout
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/225#input.filing_status: 0
+    us:statutes/26/225#input.adjusted_gross_income: 140000
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_933: 0
+    ? us:statutes/26/225#input.overtime_compensation_required_under_flsa_section_7_in_excess_of_regular_rate_included_on_statements
+    : 8000
+    us:statutes/26/225#input.qualified_tips_included_in_overtime_compensation: 0
+    us:statutes/26/225#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/225#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/225#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/225#qualified_overtime_deduction_cap_other: 12500
+    us:statutes/26/225#qualified_overtime_deduction_cap_joint: 25000
+    us:statutes/26/225#qualified_overtime_phaseout_reduction: 100
+    us:statutes/26/225#qualified_overtime_phaseout_increment: 1000
+    us:statutes/26/225#qualified_overtime_phaseout_threshold_other: 150000
+    us:statutes/26/225#qualified_overtime_phaseout_threshold_joint: 300000
+    us:statutes/26/225#qualified_overtime_compensation: 8000
+    us:statutes/26/225#qualified_overtime_modified_adjusted_gross_income: 140000
+    us:statutes/26/225#qualified_overtime_deduction_cap: 12500
+    us:statutes/26/225#qualified_overtime_phaseout_threshold: 150000
+    us:statutes/26/225#qualified_overtime_deduction_before_phaseout: 8000
+    us:statutes/26/225#qualified_overtime_phaseout_amount: 0
+    us:statutes/26/225#qualified_overtime_deduction_eligibility: holds
+    us:statutes/26/225#qualified_overtime_deduction: 8000
+- name: joint_taxpayer_overtime_capped_and_partially_phased_out
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/225#input.filing_status: 1
+    us:statutes/26/225#input.adjusted_gross_income: 302500
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_933: 0
+    ? us:statutes/26/225#input.overtime_compensation_required_under_flsa_section_7_in_excess_of_regular_rate_included_on_statements
+    : 30000
+    us:statutes/26/225#input.qualified_tips_included_in_overtime_compensation: 0
+    us:statutes/26/225#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/225#input.taxpayer_is_married_individual_within_section_7703: true
+    us:statutes/26/225#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/225#qualified_overtime_compensation: 30000
+    us:statutes/26/225#qualified_overtime_modified_adjusted_gross_income: 302500
+    us:statutes/26/225#qualified_overtime_deduction_cap: 25000
+    us:statutes/26/225#qualified_overtime_phaseout_threshold: 300000
+    us:statutes/26/225#qualified_overtime_deduction_before_phaseout: 25000
+    us:statutes/26/225#qualified_overtime_phaseout_amount: 200
+    us:statutes/26/225#qualified_overtime_deduction_eligibility: holds
+    us:statutes/26/225#qualified_overtime_deduction: 24800
+- name: qualified_tips_excluded_from_overtime_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/225#input.filing_status: 0
+    us:statutes/26/225#input.adjusted_gross_income: 90000
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_933: 0
+    ? us:statutes/26/225#input.overtime_compensation_required_under_flsa_section_7_in_excess_of_regular_rate_included_on_statements
+    : 10000
+    us:statutes/26/225#input.qualified_tips_included_in_overtime_compensation: 3000
+    us:statutes/26/225#input.taxpayer_social_security_number_included_on_return: true
+    us:statutes/26/225#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/225#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/225#qualified_overtime_compensation: 7000
+    us:statutes/26/225#qualified_overtime_deduction_before_phaseout: 7000
+    us:statutes/26/225#qualified_overtime_phaseout_amount: 0
+    us:statutes/26/225#qualified_overtime_deduction_eligibility: holds
+    us:statutes/26/225#qualified_overtime_deduction: 7000
+- name: missing_ssn_disallows_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/225#input.filing_status: 0
+    us:statutes/26/225#input.adjusted_gross_income: 90000
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/225#input.amount_excluded_from_gross_income_under_section_933: 0
+    ? us:statutes/26/225#input.overtime_compensation_required_under_flsa_section_7_in_excess_of_regular_rate_included_on_statements
+    : 8000
+    us:statutes/26/225#input.qualified_tips_included_in_overtime_compensation: 0
+    us:statutes/26/225#input.taxpayer_social_security_number_included_on_return: false
+    us:statutes/26/225#input.taxpayer_is_married_individual_within_section_7703: false
+    us:statutes/26/225#input.taxable_year_begins_after_december_31_2028: false
+  output:
+    us:statutes/26/225#qualified_overtime_deduction_eligibility: not_holds
+    us:statutes/26/225#qualified_overtime_deduction: 0

--- a/statutes/26/225.yaml
+++ b/statutes/26/225.yaml
@@ -1,0 +1,367 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/225
+  summary: |-
+    (a) In general There shall be allowed as a deduction an amount equal to the qualified overtime compensation received during the taxable year and included on statements furnished to the individual pursuant to section 6041(d)(4) or 6051(a)(19).
+
+    (b) Limitation (1) In general The amount allowed as a deduction under this section for any taxable year shall not exceed $12,500 ($25,000 in the case of a joint return). (2) Limitation based on adjusted gross income (A) In general The amount allowable as a deduction under subsection (a) (after application of paragraph (1)) shall be reduced (but not below zero) by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return). (B) Modified adjusted gross income For purposes of this paragraph, the term “modified adjusted gross income” means the adjusted gross income of the taxpayer for the taxable year increased by any amount excluded from gross income under section 911, 931, or 933.
+
+    (c) Qualified overtime compensation (1) In general For purposes of this section, the term “qualified overtime compensation” means overtime compensation paid to an individual required under section 7 of the Fair Labor Standards Act of 1938 that is in excess of the regular rate (as used in such section) at which such individual is employed. (2) Exclusions Such term shall not include any qualified tip (as defined in section 224(d)).
+
+    (d) Social security number required (1) In general No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number. (2) Social security number defined For purposes of paragraph (1), the term “social security number” shall have the meaning given such term in section 24(h)(7).
+
+    (e) Married individuals If the taxpayer is a married individual (within the meaning of section 7703), this section shall apply only if the taxpayer and the taxpayer’s spouse file a joint return for the taxable year.
+
+    (f) Regulations The Secretary shall issue such regulations or other guidance as may be necessary or appropriate to carry out the purposes of this section, including regulations or other guidance to prevent abuse of the deduction allowed by this section.
+
+    (g) Termination No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+rules:
+  - name: qualified_overtime_deduction_cap_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $12,500 ($25,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          12500
+
+  - name: qualified_overtime_deduction_cap_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $12,500 ($25,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          25000
+
+  - name: qualified_overtime_phaseout_reduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: shall be reduced (but not below zero) by $100 for each $1,000
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          100
+
+  - name: qualified_overtime_phaseout_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          1000
+
+  - name: qualified_overtime_phaseout_threshold_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          150000
+
+  - name: qualified_overtime_phaseout_threshold_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          300000
+
+  - name: qualified_overtime_compensation
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(a), (c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: qualified overtime compensation received during the taxable year and included on statements furnished to the individual pursuant to section 6041(d)(4) or 6051(a)(19).
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: the term “qualified overtime compensation” means overtime compensation paid to an individual required under section 7 of the Fair Labor Standards Act of 1938 that is in excess of the regular rate (as used in such section) at which such individual is employed.
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: Such term shall not include any qualified tip (as defined in section 224(d)).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          max(
+              0,
+              overtime_compensation_required_under_flsa_section_7_in_excess_of_regular_rate_included_on_statements
+              - qualified_tips_included_in_overtime_compensation
+          )
+
+  - name: qualified_overtime_modified_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(b)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: modified adjusted gross income means the adjusted gross income of the taxpayer for the taxable year increased by any amount excluded from gross income under section 911, 931, or 933.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          adjusted_gross_income
+          + amount_excluded_from_gross_income_under_section_911
+          + amount_excluded_from_gross_income_under_section_931
+          + amount_excluded_from_gross_income_under_section_933
+
+  - name: qualified_overtime_deduction_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $12,500 ($25,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          match filing_status:
+              1 => qualified_overtime_deduction_cap_joint
+              0 => qualified_overtime_deduction_cap_other
+              2 => qualified_overtime_deduction_cap_other
+              3 => qualified_overtime_deduction_cap_other
+              4 => qualified_overtime_deduction_cap_other
+
+  - name: qualified_overtime_phaseout_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          match filing_status:
+              1 => qualified_overtime_phaseout_threshold_joint
+              0 => qualified_overtime_phaseout_threshold_other
+              2 => qualified_overtime_phaseout_threshold_other
+              3 => qualified_overtime_phaseout_threshold_other
+              4 => qualified_overtime_phaseout_threshold_other
+
+  - name: qualified_overtime_deduction_before_phaseout
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(a), (b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: There shall be allowed as a deduction an amount equal to the qualified overtime compensation received during the taxable year and included on statements furnished to the individual pursuant to section 6041(d)(4) or 6051(a)(19).
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: The amount allowed as a deduction under this section for any taxable year shall not exceed $12,500 ($25,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          min(
+              qualified_overtime_compensation,
+              qualified_overtime_deduction_cap
+          )
+
+  - name: qualified_overtime_phaseout_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: shall be reduced (but not below zero) by $100 for each $1,000 by which the taxpayer’s modified adjusted gross income exceeds $150,000 ($300,000 in the case of a joint return).
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          floor(
+              max(
+                  0,
+                  qualified_overtime_modified_adjusted_gross_income
+                  - qualified_overtime_phaseout_threshold
+              )
+              / qualified_overtime_phaseout_increment
+          )
+          * qualified_overtime_phaseout_reduction
+
+  - name: qualified_overtime_deduction_eligibility
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 225(d), (e), (g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number.
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: If the taxpayer is a married individual (within the meaning of section 7703), this section shall apply only if the taxpayer and the taxpayer’s spouse file a joint return for the taxable year.
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          taxpayer_social_security_number_included_on_return
+          and (
+              not taxpayer_is_married_individual_within_section_7703
+              or filing_status == 1
+          )
+          and not taxable_year_begins_after_december_31_2028
+
+  - name: qualified_overtime_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 225(a), (b), (d), (e), (g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: There shall be allowed as a deduction an amount equal to the qualified overtime compensation received during the taxable year and included on statements furnished to the individual pursuant to section 6041(d)(4) or 6051(a)(19).
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: No deduction shall be allowed under this section unless the taxpayer includes on the return of tax for the taxable year such individual’s social security number.
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: If the taxpayer is a married individual (within the meaning of section 7703), this section shall apply only if the taxpayer and the taxpayer’s spouse file a joint return for the taxable year.
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/225
+              text: No deduction shall be allowed under this section for any taxable year beginning after December 31, 2028.
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if qualified_overtime_deduction_eligibility:
+              max(
+                  0,
+                  qualified_overtime_deduction_before_phaseout
+                  - qualified_overtime_phaseout_amount
+              )
+          else:
+              0


### PR DESCRIPTION
## Summary
- encode 26 USC 225 qualified overtime deduction as generated RuleSpec
- add companion tests for cap, phaseout, qualified-tip exclusion, SSN disallowance
- include signed axiom-encode apply manifest

## Tests
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/225.test.yaml
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/225.yaml
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/225.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref main --head-ref HEAD
- uv run axiom-encode validate --json /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/225.yaml
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 40 --fail-on-unmapped --fail-on-untested-comparable