### PR TITLE
Encode 26 USC 170(p) nonitemizer charitable deduction

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/170/p.json
+++ b/.axiom/encoding-manifests/statutes/26/170/p.json
@@ -1,0 +1,39 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/170/p.yaml",
+      "sha256": "e460a0d2e5275870e1b47b657a9755bf7d2f4028cfe3fae538be03dc7d77d791"
+    },
+    {
+      "path": "statutes/26/170/p.test.yaml",
+      "sha256": "fe65e70259729249e2087dae58b61995c028fb631f66be341706830064109fac"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2cabcedee852bc8346e093ed0c989a4fef9c98f0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+  },
+  "axiom_encode_version": "0.2.68",
+  "backend": "openai",
+  "citation": "26 USC 170(p)",
+  "context_manifest_file": "/tmp/axiom-encode-26-170-p-charitable-deduction-openai-7/_eval_workspaces/openai-gpt-5.5/26-USC-170-p/workspace/context-manifest.json",
+  "context_manifest_sha256": "29c70691cc9f10f65accb0d925e8588d11d0d678887eeea2e20254372601d584",
+  "generated_at": "2026-05-15T12:01:38.578649+00:00",
+  "generated_output_file": "/tmp/axiom-encode-26-170-p-charitable-deduction-openai-7/openai-gpt-5.5/statutes/26/170/p.yaml",
+  "generated_output_root": "/tmp/axiom-encode-26-170-p-charitable-deduction-openai-7",
+  "generated_output_sha256": "e460a0d2e5275870e1b47b657a9755bf7d2f4028cfe3fae538be03dc7d77d791",
+  "generation_prompt_sha256": "43e3975b7ddd118c7b9ecb4dd24e5105e51d651da5175ff4d9c104c5db2e450c",
+  "model": "gpt-5.5",
+  "run_id": "4bcd8378",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2f851bb6efe563a22d9023d9fb22f90660e3c5fcdb624561c48878d3d825828f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-26-170-p-charitable-deduction-openai-7/traces/openai-gpt-5.5/26-USC-170-p.json",
+  "trace_sha256": "1fefaba7f11a5055af85d9b8c7140e9c264d5d7dd39de604bc88e31c2ef5d1f8"
+}

--- a/statutes/26/170/p.test.yaml
+++ b/statutes/26/170/p.test.yaml
@@ -1,0 +1,81 @@
+- name: qualifying_cash_contribution_is_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.payment_amount: 600
+    us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: false
+    us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: false
+  output:
+    us:statutes/26/170/p#nonitemizer_charitable_deduction_individual_cap: 1000
+    us:statutes/26/170/p#nonitemizer_charitable_deduction_joint_cap: 2000
+    us:statutes/26/170/p#nonitemizer_cash_contribution_taken_into_account: holds
+    us:statutes/26/170/p#nonitemizer_cash_contribution_amount_taken_into_account: 600
+- name: section_509_a_3_organization_contribution_not_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.payment_amount: 600
+    us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: true
+    us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: false
+  output:
+    us:statutes/26/170/p#nonitemizer_cash_contribution_taken_into_account: not_holds
+    us:statutes/26/170/p#nonitemizer_cash_contribution_amount_taken_into_account: 0
+- name: donor_advised_fund_contribution_not_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.payment_amount: 600
+    us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: true
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: false
+    us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: true
+  output:
+    us:statutes/26/170/p#nonitemizer_cash_contribution_taken_into_account: not_holds
+    us:statutes/26/170/p#nonitemizer_cash_contribution_amount_taken_into_account: 0
+- name: joint_nonitemizer_deduction_capped_at_joint_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.filing_status: 1
+    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: true
+    us:statutes/26/170/p#relation.charitable_contribution_of_tax_unit:
+    - us:statutes/26/170/p#input.payment_amount: 1500
+      us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: true
+      us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: true
+      us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: false
+      us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: false
+    - us:statutes/26/170/p#input.payment_amount: 900
+      us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: true
+      us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: true
+      us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: false
+      us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: false
+  output:
+    us:statutes/26/170/p#nonitemizer_charitable_deduction_cap: 2000
+    us:statutes/26/170/p#nonitemizer_charitable_deduction: 2000
+- name: itemizer_zero_nonitemizer_charitable_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2: false
+    us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: false
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_170_b_1_A: false
+    us:statutes/26/170/p#input.contribution_to_organization_described_in_section_509_a_3: false
+    us:statutes/26/170/p#input.filing_status: 0
+    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: false
+    us:statutes/26/170/p#input.payment_amount: 0
+  output:
+    us:statutes/26/170/p#nonitemizer_charitable_deduction: 0

--- a/statutes/26/170/p.yaml
+++ b/statutes/26/170/p.yaml
@@ -1,0 +1,174 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/170
+  summary: |-
+    (p) Special rule for taxpayers who do not elect to itemize deductions In the case of any taxable year, if the individual does not elect to itemize deductions for such taxable year, the deduction under this section shall be equal to the deduction, not in excess of 1,000 ($2,000 in the case of a joint return), which would be determined under this section if the only charitable contributions taken into account in determining such deduction were contributions made in cash during such taxable year (determined without regard to subsections (b)(1)(G)(ii), (b)(1)(I), and (d)(1)) to an organization described in section 170(b)(1)(A) and not— (1) to an organization described in section 509(a)(3), or (2) for the establishment of a new, or maintenance of an existing, donor advised fund (as defined in section 4966(d)(2)).
+rules:
+  - name: charitable_contribution_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: charitable_contribution_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Payment
+
+  - name: nonitemizer_charitable_deduction_individual_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: not in excess of 1,000 ($2,000 in the case of a joint return)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1000
+
+  - name: nonitemizer_charitable_deduction_joint_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: not in excess of 1,000 ($2,000 in the case of a joint return)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2000
+
+  - name: nonitemizer_cash_contribution_taken_into_account
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: contributions made in cash during such taxable year ... to an organization described in section 170(b)(1)(A)
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: and not— (1) to an organization described in section 509(a)(3), or (2) for the establishment of a new, or maintenance of an existing, donor advised fund
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          contribution_made_in_cash_during_taxable_year
+          and contribution_to_organization_described_in_section_170_b_1_A
+          and
+          not contribution_to_organization_described_in_section_509_a_3
+          and
+          not contribution_for_establishment_or_maintenance_of_donor_advised_fund_defined_in_section_4966_d_2
+
+  - name: nonitemizer_cash_contribution_amount_taken_into_account
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: if the only charitable contributions taken into account in determining such deduction were contributions made in cash during such taxable year
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/170
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if nonitemizer_cash_contribution_taken_into_account: payment_amount else: 0
+
+  - name: nonitemizer_charitable_deduction_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: not in excess of 1,000 ($2,000 in the case of a joint return)
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/170
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => nonitemizer_charitable_deduction_joint_cap
+              0 => nonitemizer_charitable_deduction_individual_cap
+              2 => nonitemizer_charitable_deduction_individual_cap
+              3 => nonitemizer_charitable_deduction_individual_cap
+              4 => nonitemizer_charitable_deduction_individual_cap
+
+  - name: nonitemizer_charitable_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 170(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: if the individual does not elect to itemize deductions for such taxable year, the deduction under this section shall be equal to the deduction, not in excess of 1,000 ($2,000 in the case of a joint return)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/170
+              text: if the only charitable contributions taken into account in determining such deduction were contributions made in cash during such taxable year ... to an organization described in section 170(b)(1)(A) and not—
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/170
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_does_not_elect_to_itemize_deductions_for_taxable_year:
+              min(
+                  nonitemizer_charitable_deduction_cap,
+                  sum_where(
+                      charitable_contribution_of_tax_unit,
+                      nonitemizer_cash_contribution_amount_taken_into_account,
+                      nonitemizer_cash_contribution_taken_into_account
+                  )
+              )
+          else:
+              0


### PR DESCRIPTION
## Summary
- add encoder-applied RuleSpec for 26 USC 170(p), the nonitemizer charitable deduction
- add companion tests for qualifying contributions, excluded contributions, the joint cap, and the itemizer zero branch
- include the signed encoder apply manifest for the generated files

## Validation
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/170/p.test.yaml --root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/170/p.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/170/p.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/170/p.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 50 --fail-on-unmapped --fail-on-untested-comparable