### PR TITLE
Encode 26 USC 151 personal exemptions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/151.json
+++ b/.axiom/encoding-manifests/statutes/26/151.json
@@ -1,0 +1,39 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/151.yaml",
+      "sha256": "db47b3e58db9e596745abd57de0d7fbf6e404db52813c7928d6e4dd5a3548afb"
+    },
+    {
+      "path": "statutes/26/151.test.yaml",
+      "sha256": "d5f653fa7e2d1216f8b3ffaa8d416c81043da592234ab6e601d9fb07fb89bb61"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d14aa8894c66b955a3f540c7095b8fde0bacec01",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+  },
+  "axiom_encode_version": "0.2.68",
+  "backend": "openai",
+  "citation": "26 USC 151",
+  "context_manifest_file": "/tmp/axiom-encode-26-151-personal-exemptions-openai-2/_eval_workspaces/openai-gpt-5.5/26-USC-151/workspace/context-manifest.json",
+  "context_manifest_sha256": "5cd7555b167c836f9fe8f58841d286575fbeed759badba697fbe939433c2e27e",
+  "generated_at": "2026-05-15T12:28:01.313435+00:00",
+  "generated_output_file": "/tmp/axiom-encode-26-151-personal-exemptions-openai-2/openai-gpt-5.5/statutes/26/151.yaml",
+  "generated_output_root": "/tmp/axiom-encode-26-151-personal-exemptions-openai-2",
+  "generated_output_sha256": "db47b3e58db9e596745abd57de0d7fbf6e404db52813c7928d6e4dd5a3548afb",
+  "generation_prompt_sha256": "0b346eda0ea6ccaf125221b0db498f3f02e4b7db068ab312bb02d4e3f545e8ca",
+  "model": "gpt-5.5",
+  "run_id": "df550f29",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0417054587a90d809ce44d4d0c5d623a4d7b2976fc8d33806a9764f6f5f114c7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-26-151-personal-exemptions-openai-2/traces/openai-gpt-5.5/26-USC-151.json",
+  "trace_sha256": "53956eae12596f3d3bbc98643c47d3afff422be98d3816e1f0de70e80b4b0027"
+}

--- a/statutes/26/151.test.yaml
+++ b/statutes/26/151.test.yaml
@@ -1,0 +1,150 @@
+- name: person_level_taxpayer_age_65_with_ssn_is_senior_qualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/151#input.age: 65
+    us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+    us:statutes/26/151#input.is_taxpayer: true
+    us:statutes/26/151#input.is_spouse_of_taxpayer: false
+    us:statutes/26/151#input.filing_status: 0
+    us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+    us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+    us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: false
+    us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+    us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+  output:
+    us:statutes/26/151#senior_deduction_age_threshold: 65
+    us:statutes/26/151#senior_deduction_qualified_individual: holds
+    us:statutes/26/151#exemption_individual_eligible: holds
+- name: person_level_missing_ssn_prevents_senior_qualified_status
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/151#input.age: 65
+    us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: false
+    us:statutes/26/151#input.is_taxpayer: true
+    us:statutes/26/151#input.is_spouse_of_taxpayer: false
+    us:statutes/26/151#input.filing_status: 0
+    us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+    us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+    us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: false
+    us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+    us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+  output:
+    us:statutes/26/151#senior_deduction_qualified_individual: not_holds
+    us:statutes/26/151#exemption_individual_eligible: holds
+- name: joint_senior_deduction_two_qualified_individuals_partial_phaseout
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/151#input.taxable_year_begins_after_2017: true
+    us:statutes/26/151#input.taxable_year_begins_before_2029: true
+    us:statutes/26/151#input.taxpayer_is_individual: true
+    us:statutes/26/151#input.filing_status: 1
+    us:statutes/26/151#input.adjusted_gross_income: 160000
+    us:statutes/26/151#input.applicable_amount_in_effect_under_section_68_b: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/151#input.taxpayer_is_married_individual_within_section_7703: true
+    us:statutes/26/151#relation.exemption_individual_of_tax_unit:
+    - us:statutes/26/151#input.age: 70
+      us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+      us:statutes/26/151#input.is_taxpayer: true
+      us:statutes/26/151#input.is_spouse_of_taxpayer: false
+      us:statutes/26/151#input.filing_status: 1
+      us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+      us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+      us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: true
+      us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+      us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+    - us:statutes/26/151#input.age: 68
+      us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+      us:statutes/26/151#input.is_taxpayer: false
+      us:statutes/26/151#input.is_spouse_of_taxpayer: true
+      us:statutes/26/151#input.filing_status: 1
+      us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+      us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+      us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: true
+      us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+      us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+    us:statutes/26/151#relation.senior_deduction_individual_of_tax_unit:
+    - us:statutes/26/151#input.age: 70
+      us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+      us:statutes/26/151#input.is_taxpayer: true
+      us:statutes/26/151#input.is_spouse_of_taxpayer: false
+      us:statutes/26/151#input.filing_status: 1
+      us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+      us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+      us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: true
+      us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+      us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+    - us:statutes/26/151#input.age: 68
+      us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+      us:statutes/26/151#input.is_taxpayer: false
+      us:statutes/26/151#input.is_spouse_of_taxpayer: true
+      us:statutes/26/151#input.filing_status: 1
+      us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+      us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+      us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: true
+      us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+      us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+  output:
+    us:statutes/26/151#statutory_exemption_amount_base: 2000
+    us:statutes/26/151#exemption_phaseout_rate_per_increment: 0.02
+    us:statutes/26/151#exemption_phaseout_increment: 2500
+    us:statutes/26/151#exemption_phaseout_increment_separate: 1250
+    us:statutes/26/151#exemption_phaseout_maximum_percentage: 1
+    us:statutes/26/151#post_2017_exemption_amount: 0
+    us:statutes/26/151#senior_deduction_base_amount: 6000
+    us:statutes/26/151#senior_deduction_phaseout_rate: 0.06
+    us:statutes/26/151#senior_deduction_phaseout_threshold_other: 75000
+    us:statutes/26/151#senior_deduction_phaseout_threshold_joint: 150000
+    us:statutes/26/151#exemption_amount: 0
+    us:statutes/26/151#exemption_phaseout_applicable_percentage: 1
+    us:statutes/26/151#section_151_exemption_deduction: 0
+    us:statutes/26/151#senior_deduction_modified_adjusted_gross_income: 160000
+    us:statutes/26/151#senior_deduction_phaseout_threshold: 150000
+    us:statutes/26/151#senior_deduction_amount_per_qualified_individual: 5400
+    us:statutes/26/151#senior_deduction_eligible: holds
+    us:statutes/26/151#senior_deduction: 10800
+- name: married_separate_taxpayer_not_eligible_for_senior_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/151#input.taxable_year_begins_after_2017: true
+    us:statutes/26/151#input.taxable_year_begins_before_2029: true
+    us:statutes/26/151#input.taxpayer_is_individual: true
+    us:statutes/26/151#input.filing_status: 2
+    us:statutes/26/151#input.adjusted_gross_income: 50000
+    us:statutes/26/151#input.applicable_amount_in_effect_under_section_68_b: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_911: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_931: 0
+    us:statutes/26/151#input.amount_excluded_from_gross_income_under_section_933: 0
+    us:statutes/26/151#input.taxpayer_is_married_individual_within_section_7703: true
+    us:statutes/26/151#relation.exemption_individual_of_tax_unit: []
+    us:statutes/26/151#relation.senior_deduction_individual_of_tax_unit:
+    - us:statutes/26/151#input.age: 70
+      us:statutes/26/151#input.qualified_individual_social_security_number_included_on_return: true
+      us:statutes/26/151#input.is_taxpayer: true
+      us:statutes/26/151#input.is_spouse_of_taxpayer: false
+      us:statutes/26/151#input.filing_status: 2
+      us:statutes/26/151#input.tin_included_on_return_claiming_exemption: true
+      us:statutes/26/151#input.is_dependent_under_section_152_of_taxpayer: false
+      us:statutes/26/151#input.joint_return_made_by_taxpayer_and_spouse: false
+      us:statutes/26/151#input.spouse_has_no_gross_income_for_calendar_year: false
+      us:statutes/26/151#input.spouse_is_dependent_of_another_taxpayer: false
+  output:
+    us:statutes/26/151#senior_deduction_modified_adjusted_gross_income: 50000
+    us:statutes/26/151#senior_deduction_phaseout_threshold: 75000
+    us:statutes/26/151#senior_deduction_amount_per_qualified_individual: 6000
+    us:statutes/26/151#senior_deduction_eligible: not_holds
+    us:statutes/26/151#senior_deduction: 0

--- a/statutes/26/151.yaml
+++ b/statutes/26/151.yaml
@@ -1,0 +1,469 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/151
+  summary: |-
+    (a) In the case of an individual, the exemptions provided by this section shall be allowed as deductions in computing taxable income.
+    (b) An exemption of the exemption amount for the taxpayer; and an additional exemption of the exemption amount for the spouse of the taxpayer if a joint return is not made by the taxpayer and his spouse, and if the spouse, for the calendar year in which the taxable year of the taxpayer begins, has no gross income and is not the dependent of another taxpayer.
+    (c) An exemption of the exemption amount for each individual who is a dependent (as defined in section 152) of the taxpayer for the taxable year.
+    (d)(1) Except as otherwise provided in this subsection, the term "exemption amount" means $2,000.
+    (d)(2) In the case of an individual with respect to whom a deduction under this section is allowable to another taxpayer for a taxable year beginning in the calendar year in which the individual's taxable year begins, the exemption amount applicable to such individual for such individual's taxable year shall be zero.
+    (d)(3) In the case of any taxpayer whose adjusted gross income for the taxable year exceeds the applicable amount in effect under section 68(b), the exemption amount shall be reduced by the applicable percentage. The applicable percentage means 2 percentage points for each $2,500 (or fraction thereof) by which adjusted gross income exceeds the applicable amount; for a married individual filing a separate return, substitute $1,250 for $2,500. In no event shall the applicable percentage exceed 100 percent.
+    (d)(5) In the case of a taxable year beginning after December 31, 2017, the term "exemption amount" means zero. For purposes of any other provision of this title, that reduction to zero shall not be taken into account in determining whether a deduction is allowed or allowable, or whether a taxpayer is entitled to a deduction, under this section. In the case of a taxable year beginning before January 1, 2029, there shall be allowed a deduction in an amount equal to $6,000 for each qualified individual with respect to the taxpayer. "Qualified individual" means the taxpayer, if the taxpayer has attained age 65 before the close of the taxable year, and, in the case of a joint return, the taxpayer's spouse, if such spouse has attained age 65 before the close of the taxable year. The $6,000 amount is reduced, but not below zero, by 6 percent of so much of modified adjusted gross income as exceeds $75,000 ($150,000 in the case of a joint return). Modified adjusted gross income means adjusted gross income increased by any amount excluded from gross income under section 911, 931, or 933. Clause (i) shall not apply with respect to a qualified individual unless the taxpayer includes such qualified individual's social security number on the return. If the taxpayer is a married individual (within the meaning of section 7703), this subparagraph applies only if the taxpayer and spouse file a joint return.
+    (e) No exemption shall be allowed under this section with respect to any individual unless the TIN of such individual is included on the return claiming the exemption.
+rules:
+  - name: exemption_individual_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: exemption_individual_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+
+  - name: senior_deduction_individual_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: senior_deduction_individual_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+
+  - name: statutory_exemption_amount_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: the term "exemption amount" means $2,000
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2000
+
+  - name: exemption_phaseout_rate_per_increment
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 151(d)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: applicable percentage means 2 percentage points for each $2,500 (or fraction thereof)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.02
+
+  - name: exemption_phaseout_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: for each $2,500 (or fraction thereof)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2500
+
+  - name: exemption_phaseout_increment_separate
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: In the case of a married individual filing a separate return, the preceding sentence shall be applied by substituting "$1,250" for "$2,500".
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1250
+
+  - name: exemption_phaseout_maximum_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 151(d)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: In no event shall the applicable percentage exceed 100 percent.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1
+
+  - name: post_2017_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: In the case of a taxable year beginning after December 31, 2017 ... The term "exemption amount" means zero.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0
+
+  - name: senior_deduction_base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: there shall be allowed a deduction in an amount equal to $6,000 for each qualified individual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          6000
+
+  - name: senior_deduction_age_threshold
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 151(d)(5)(C)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: has attained age 65 before the close of the taxable year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          65
+
+  - name: senior_deduction_phaseout_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 151(d)(5)(C)(iii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: shall be reduced (but not below zero) by 6 percent
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.06
+
+  - name: senior_deduction_phaseout_threshold_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(iii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: exceeds $75,000 ($150,000 in the case of a joint return)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          75000
+
+  - name: senior_deduction_phaseout_threshold_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(iii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: $150,000 in the case of a joint return
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          150000
+
+  - name: exemption_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(d)(1), (d)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: Except as otherwise provided in this subsection, the term "exemption amount" means $2,000; in the case of a taxable year beginning after December 31, 2017, the term "exemption amount" means zero.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if taxable_year_begins_after_2017: post_2017_exemption_amount else: statutory_exemption_amount_base
+
+  - name: exemption_phaseout_applicable_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 151(d)(3)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: applicable percentage means 2 percentage points for each $2,500 (or fraction thereof) by which adjusted gross income exceeds the applicable amount ... married individual filing a separate return ... "$1,250" ... shall not exceed 100 percent
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          min(
+              exemption_phaseout_maximum_percentage,
+              exemption_phaseout_rate_per_increment
+              * ceil(
+                  max(0, adjusted_gross_income - applicable_amount_in_effect_under_section_68_b)
+                  / (if filing_status == 2: exemption_phaseout_increment_separate else: exemption_phaseout_increment)
+              )
+          )
+
+  - name: exemption_individual_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 151(b), (c), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: An exemption ... for the taxpayer; and an additional exemption ... for the spouse ... if a joint return is not made ... spouse ... has no gross income and is not the dependent of another taxpayer. An exemption ... for each individual who is a dependent ... No exemption shall be allowed ... unless the TIN of such individual is included on the return claiming the exemption.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          tin_included_on_return_claiming_exemption
+          and (
+              is_taxpayer
+              or is_dependent_under_section_152_of_taxpayer
+              or (
+                  is_spouse_of_taxpayer
+                  and not joint_return_made_by_taxpayer_and_spouse
+                  and spouse_has_no_gross_income_for_calendar_year
+                  and not spouse_is_dependent_of_another_taxpayer
+              )
+          )
+
+  - name: section_151_exemption_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(a)-(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: In the case of an individual, the exemptions provided by this section shall be allowed as deductions in computing taxable income.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if taxpayer_is_individual:
+              exemption_amount * count_where(exemption_individual_of_tax_unit, exemption_individual_eligible)
+          else:
+              0
+
+  - name: senior_deduction_qualified_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 151(d)(5)(C)(ii), (iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: qualified individual means the taxpayer, if the taxpayer has attained age 65 before the close of the taxable year, and in the case of a joint return, the taxpayer's spouse, if such spouse has attained age 65 before the close of the taxable year. Clause (i) shall not apply ... unless the taxpayer includes such qualified individual's social security number on the return.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          age >= senior_deduction_age_threshold
+          and qualified_individual_social_security_number_included_on_return
+          and (
+              is_taxpayer
+              or (
+                  is_spouse_of_taxpayer
+                  and filing_status == 1
+              )
+          )
+
+  - name: senior_deduction_modified_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(iii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: modified adjusted gross income means the adjusted gross income of the taxpayer for the taxable year increased by any amount excluded from gross income under section 911, 931, or 933
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          adjusted_gross_income
+          + amount_excluded_from_gross_income_under_section_911
+          + amount_excluded_from_gross_income_under_section_931
+          + amount_excluded_from_gross_income_under_section_933
+
+  - name: senior_deduction_phaseout_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(iii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: exceeds $75,000 ($150,000 in the case of a joint return)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if filing_status == 1: senior_deduction_phaseout_threshold_joint else: senior_deduction_phaseout_threshold_other
+
+  - name: senior_deduction_amount_per_qualified_individual
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(d)(5)(C)(i), (iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: deduction in an amount equal to $6,000 for each qualified individual ... $6,000 amount ... shall be reduced (but not below zero) by 6 percent of so much of modified adjusted gross income as exceeds $75,000 ($150,000 in the case of a joint return)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(
+              0,
+              senior_deduction_base_amount
+              - (
+                  senior_deduction_phaseout_rate
+                  * max(0, senior_deduction_modified_adjusted_gross_income - senior_deduction_phaseout_threshold)
+              )
+          )
+
+  - name: senior_deduction_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 151(d)(5)(C)(i), (v)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: In the case of a taxable year beginning before January 1, 2029 ... If the taxpayer is a married individual (within the meaning of section 7703), this subparagraph shall apply only if the taxpayer and the taxpayer's spouse file a joint return for the taxable year.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          taxable_year_begins_before_2029
+          and (
+              not taxpayer_is_married_individual_within_section_7703
+              or filing_status == 1
+          )
+
+  - name: senior_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 151(d)(5)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/151
+              text: there shall be allowed a deduction in an amount equal to $6,000 for each qualified individual with respect to the taxpayer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if senior_deduction_eligible:
+              senior_deduction_amount_per_qualified_individual
+              * count_where(senior_deduction_individual_of_tax_unit, senior_deduction_qualified_individual)
+          else:
+              0


### PR DESCRIPTION
## Summary
- add encoder-applied RuleSpec for 26 USC 151 personal exemptions and the temporary senior deduction
- add companion tests for person-level eligibility, SSN exclusion, joint senior phaseout, and married-separate senior disallowance
- include the signed encoder apply manifest for the generated files

## Validation
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/151.test.yaml --root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/151.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/151.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/151.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 80 --fail-on-unmapped --fail-on-untested-comparable