### PR TITLE
Encode 26 USC 213 medical expense deduction

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/213.json
+++ b/.axiom/encoding-manifests/statutes/26/213.json
@@ -1,0 +1,39 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/213.yaml",
+      "sha256": "e56c9c857c8c6be9b5d61bebee3a20c1f9a70b66f8c195851fb53d22451d87e2"
+    },
+    {
+      "path": "statutes/26/213.test.yaml",
+      "sha256": "9c99f640c3ba9509e9e1eb5cef7a5da49aa344b4f85a8fae51206f9bb2ec677e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "dfba85dc23dec385a53989198bc4cf9ef4037c65",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+  },
+  "axiom_encode_version": "0.2.68",
+  "backend": "openai",
+  "citation": "26 USC 213",
+  "context_manifest_file": "/tmp/axiom-encode-26-213-medical-expense-deduction-openai-2/_eval_workspaces/openai-gpt-5.5/26-USC-213/workspace/context-manifest.json",
+  "context_manifest_sha256": "58ef1990930338672fe635ebc076de6105522be59a43b37e4314d1cf83277e9f",
+  "generated_at": "2026-05-15T13:22:07.898051+00:00",
+  "generated_output_file": "/tmp/axiom-encode-26-213-medical-expense-deduction-openai-2/openai-gpt-5.5/statutes/26/213.yaml",
+  "generated_output_root": "/tmp/axiom-encode-26-213-medical-expense-deduction-openai-2",
+  "generated_output_sha256": "e56c9c857c8c6be9b5d61bebee3a20c1f9a70b66f8c195851fb53d22451d87e2",
+  "generation_prompt_sha256": "52d06844e747f203e3c6d48d885d6672865fa56376df59f5ba8f1098f5fbca5f",
+  "model": "gpt-5.5",
+  "run_id": "9a8b05cd",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "649dfd9d528634143c554fc7d6c446d3207be00fc686f9bc8704bbc5df4caa61"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-26-213-medical-expense-deduction-openai-2/traces/openai-gpt-5.5/26-USC-213.json",
+  "trace_sha256": "57a388f99b90afbfd1ca72fdcd291a95174b14b3aa516cfb6b9429832ee0c9cf"
+}

--- a/statutes/26/213.test.yaml
+++ b/statutes/26/213.test.yaml
@@ -1,0 +1,117 @@
+- name: tax_unit_medical_expense_deduction_after_section_21_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/213#input.medical_care_expenses_paid_not_compensated_by_insurance_or_otherwise: 12000
+    us:statutes/26/213#input.expenses_allowed_as_credit_under_section_21: 1000
+    us:statutes/26/213#input.adjusted_gross_income: 100000
+  output:
+    us:statutes/26/213#medical_expense_agi_floor_rate: 0.075
+    us:statutes/26/213#medical_care_expenses_after_section_21_exclusion: 11000
+    us:statutes/26/213#medical_care_deduction: 3500
+- name: person_ltc_premium_limit_with_indexing
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/213#input.age: 55
+    us:statutes/26/213#input.medical_care_cost_adjustment: 0.1
+    us:statutes/26/213#input.qualified_long_term_care_insurance_premiums_paid: 900
+  output:
+    us:statutes/26/213#ltc_premium_age_threshold_40: 40
+    us:statutes/26/213#ltc_premium_age_threshold_50: 50
+    us:statutes/26/213#ltc_premium_age_threshold_60: 60
+    us:statutes/26/213#ltc_premium_age_threshold_70: 70
+    us:statutes/26/213#ltc_premium_limit_age_40_or_less_base: 200
+    us:statutes/26/213#ltc_premium_limit_age_over_40_through_50_base: 375
+    us:statutes/26/213#ltc_premium_limit_age_over_50_through_60_base: 750
+    us:statutes/26/213#ltc_premium_limit_age_over_60_through_70_base: 2000
+    us:statutes/26/213#ltc_premium_limit_age_over_70_base: 2500
+    us:statutes/26/213#ltc_premium_increase_rounding_multiple: 10
+    us:statutes/26/213#eligible_ltc_premium_base_limit: 750
+    us:statutes/26/213#eligible_ltc_premium_indexed_limit: 830
+    us:statutes/26/213#eligible_ltc_premiums_taken_into_account: 830
+- name: payment_positive_paths_for_medicine_lodging_decedent_and_exclusions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/213#input.payment_is_for_medicine_or_drug: true
+    us:statutes/26/213#input.medicine_or_drug_is_prescribed_drug: true
+    us:statutes/26/213#input.medicine_or_drug_is_insulin: false
+    us:statutes/26/213#input.payment_is_for_lodging_away_from_home: true
+    us:statutes/26/213#input.lodging_is_not_lavish_or_extravagant_under_circumstances: true
+    us:statutes/26/213#input.lodging_is_primarily_for_and_essential_to_medical_care: true
+    us:statutes/26/213#input.medical_care_is_provided_by_physician_in_licensed_hospital_or_equivalent_facility: true
+    us:statutes/26/213#input.significant_element_of_personal_pleasure_recreation_or_vacation_in_travel: false
+    us:statutes/26/213#input.lodging_amount_paid: 400
+    us:statutes/26/213#input.lodging_nights: 3
+    us:statutes/26/213#input.lodging_individuals: 2
+    us:statutes/26/213#input.expense_is_for_medical_care_of_decedent_taxpayer: true
+    us:statutes/26/213#input.expense_paid_out_of_estate_during_one_year_period_after_death: true
+    us:statutes/26/213#input.amount_allowable_under_section_2053: false
+    us:statutes/26/213#input.statement_filed_that_amount_not_allowed_under_section_2053: false
+    us:statutes/26/213#input.waiver_filed_of_right_to_section_2053_deduction: false
+    us:statutes/26/213#input.procedure_is_cosmetic_surgery_or_similar: true
+    ? us:statutes/26/213#input.procedure_directed_at_improving_appearance_without_meaningfully_promoting_body_function_or_preventing_or_treating_illness
+    : true
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_congenital_abnormality: false
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_accident_or_trauma: false
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_disfiguring_disease: false
+    us:statutes/26/213#input.payment_is_for_qualified_long_term_care_service: true
+    us:statutes/26/213#input.payment_is_section_105_b_reimbursement_through_insurance: false
+    us:statutes/26/213#input.service_provider_is_spouse_or_relative: true
+    us:statutes/26/213#input.service_provided_by_licensed_professional_with_respect_to_service: false
+    us:statutes/26/213#input.service_provider_is_related_corporation_or_partnership: false
+  output:
+    us:statutes/26/213#medical_lodging_nightly_cap: 50
+    us:statutes/26/213#medicine_or_drug_taken_into_account: holds
+    us:statutes/26/213#lodging_treated_as_medical_care: holds
+    us:statutes/26/213#lodging_amount_taken_into_account: 300
+    us:statutes/26/213#decedent_estate_medical_expense_treated_as_paid_by_taxpayer: holds
+    us:statutes/26/213#cosmetic_surgery_excluded_from_medical_care: holds
+    us:statutes/26/213#qualified_ltc_service_payment_treated_as_not_medical_care: holds
+- name: payment_exception_paths_for_lodging_decedent_cosmetic_and_ltc_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/213#input.payment_is_for_medicine_or_drug: true
+    us:statutes/26/213#input.medicine_or_drug_is_prescribed_drug: false
+    us:statutes/26/213#input.medicine_or_drug_is_insulin: false
+    us:statutes/26/213#input.payment_is_for_lodging_away_from_home: true
+    us:statutes/26/213#input.lodging_is_not_lavish_or_extravagant_under_circumstances: true
+    us:statutes/26/213#input.lodging_is_primarily_for_and_essential_to_medical_care: true
+    us:statutes/26/213#input.medical_care_is_provided_by_physician_in_licensed_hospital_or_equivalent_facility: true
+    us:statutes/26/213#input.significant_element_of_personal_pleasure_recreation_or_vacation_in_travel: true
+    us:statutes/26/213#input.lodging_amount_paid: 400
+    us:statutes/26/213#input.lodging_nights: 3
+    us:statutes/26/213#input.lodging_individuals: 2
+    us:statutes/26/213#input.expense_is_for_medical_care_of_decedent_taxpayer: true
+    us:statutes/26/213#input.expense_paid_out_of_estate_during_one_year_period_after_death: true
+    us:statutes/26/213#input.amount_allowable_under_section_2053: true
+    us:statutes/26/213#input.statement_filed_that_amount_not_allowed_under_section_2053: false
+    us:statutes/26/213#input.waiver_filed_of_right_to_section_2053_deduction: false
+    us:statutes/26/213#input.procedure_is_cosmetic_surgery_or_similar: true
+    ? us:statutes/26/213#input.procedure_directed_at_improving_appearance_without_meaningfully_promoting_body_function_or_preventing_or_treating_illness
+    : true
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_congenital_abnormality: true
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_accident_or_trauma: false
+    us:statutes/26/213#input.procedure_necessary_to_ameliorate_deformity_from_disfiguring_disease: false
+    us:statutes/26/213#input.payment_is_for_qualified_long_term_care_service: true
+    us:statutes/26/213#input.payment_is_section_105_b_reimbursement_through_insurance: true
+    us:statutes/26/213#input.service_provider_is_spouse_or_relative: true
+    us:statutes/26/213#input.service_provided_by_licensed_professional_with_respect_to_service: false
+    us:statutes/26/213#input.service_provider_is_related_corporation_or_partnership: false
+  output:
+    us:statutes/26/213#medicine_or_drug_taken_into_account: not_holds
+    us:statutes/26/213#lodging_treated_as_medical_care: not_holds
+    us:statutes/26/213#lodging_amount_taken_into_account: 0
+    us:statutes/26/213#decedent_estate_medical_expense_treated_as_paid_by_taxpayer: not_holds
+    us:statutes/26/213#cosmetic_surgery_excluded_from_medical_care: not_holds
+    us:statutes/26/213#qualified_ltc_service_payment_treated_as_not_medical_care: not_holds

--- a/statutes/26/213.yaml
+++ b/statutes/26/213.yaml
@@ -1,0 +1,566 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/213
+  summary: |-
+    (a) Allowance of deduction There shall be allowed as a deduction the expenses paid during the taxable year, not compensated for by insurance or otherwise, for medical care of the taxpayer, his spouse, or a dependent (as defined in section 152, determined without regard to subsections (b)(1), (b)(2), and (d)(1)(B) thereof), to the extent that such expenses exceed 7.5 percent of adjusted gross income.
+
+    (b) Limitation with respect to medicine and drugs An amount paid during the taxable year for medicine or a drug shall be taken into account under subsection (a) only if such medicine or drug is a prescribed drug or is insulin.
+
+    (c) Special rule for decedents (1) Treatment of expenses paid after death For purposes of subsection (a), expenses for the medical care of the taxpayer which are paid out of his estate during the 1-year period beginning with the day after the date of his death shall be treated as paid by the taxpayer at the time incurred. (2) Limitation Paragraph (1) shall not apply if the amount paid is allowable under section 2053 as a deduction in computing the taxable estate of the decedent, but this paragraph shall not apply if (within the time and in the manner and form prescribed by the Secretary) there is filed— (A) a statement that such amount has not been allowed as a deduction under section 2053, and (B) a waiver of the right to have such amount allowed at any time as a deduction under section 2053.
+
+    (d)(1) The term “medical care” means amounts paid— (A) for the diagnosis, cure, mitigation, treatment, or prevention of disease, or for the purpose of affecting any structure or function of the body, (B) for transportation primarily for and essential to medical care referred to in subparagraph (A), (C) for qualified long-term care services, or (D) for insurance covering medical care referred to in subparagraphs (A) and (B) or for any qualified long-term care insurance contract. In the case of a qualified long-term care insurance contract, only eligible long-term care premiums shall be taken into account under subparagraph (D).
+    (d)(2) Amounts paid for lodging (not lavish or extravagant under the circumstances) while away from home primarily for and essential to medical care referred to in paragraph (1)(A) shall be treated as amounts paid for medical care if the medical care is provided by a physician in a licensed hospital (or related or equivalent facility), and there is no significant element of personal pleasure, recreation, or vacation. The amount taken into account shall not exceed $50 for each night for each individual.
+    (d)(3) “Prescribed drug” means a drug or biological which requires a prescription of a physician for its use by an individual.
+    (d)(5) Any child to whom section 152(e) applies shall be treated as a dependent of both parents for purposes of this section.
+    (d)(9) “Medical care” does not include cosmetic surgery or other similar procedures, unless necessary to ameliorate a deformity arising from, or directly related to, a congenital abnormality, personal injury resulting from an accident or trauma, or disfiguring disease. “Cosmetic surgery” means any procedure directed at improving the patient’s appearance and not meaningfully promoting proper body function or preventing or treating illness or disease.
+    (d)(10) “Eligible long-term care premiums” means the amount paid during a taxable year for any qualified long-term care insurance contract covering an individual, to the extent such amount does not exceed: age 40 or less $200; more than 40 but not more than 50 $375; more than 50 but not more than 60 $750; more than 60 but not more than 70 $2,000; more than 70 $2,500. After 1997, each dollar amount is increased by the medical care cost adjustment, with increases rounded to the nearest multiple of $10.
+    (d)(11) An amount paid for a qualified long-term care service provided to an individual shall be treated as not paid for medical care if provided by the spouse or a relative unless by a licensed professional, or by a related corporation or partnership. This paragraph shall not apply for purposes of section 105(b) with respect to reimbursements through insurance.
+
+    (e) Exclusion of amounts allowed for care of certain dependents Any expense allowed as a credit under section 21 shall not be treated as an expense paid for medical care.
+rules:
+  - name: medical_expense_agi_floor_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 213(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "to the extent that such expenses exceed 7.5 percent of adjusted gross income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.075
+
+  - name: medical_lodging_nightly_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "The amount taken into account under the preceding sentence shall not exceed $50 for each night for each individual."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          50
+
+  - name: ltc_premium_age_threshold_40
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "40 or less"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          40
+
+  - name: ltc_premium_age_threshold_50
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "More than 40 but not more than 50"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          50
+
+  - name: ltc_premium_age_threshold_60
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "More than 50 but not more than 60"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          60
+
+  - name: ltc_premium_age_threshold_70
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "More than 60 but not more than 70"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          70
+
+  - name: ltc_premium_limit_age_40_or_less_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/statute/26/213
+              table:
+                header: "eligible long-term care premiums limitation table"
+                row: "40 or less"
+                column: "The limitation is"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          200
+
+  - name: ltc_premium_limit_age_over_40_through_50_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/statute/26/213
+              table:
+                header: "eligible long-term care premiums limitation table"
+                row: "More than 40 but not more than 50"
+                column: "The limitation is"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          375
+
+  - name: ltc_premium_limit_age_over_50_through_60_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/statute/26/213
+              table:
+                header: "eligible long-term care premiums limitation table"
+                row: "More than 50 but not more than 60"
+                column: "The limitation is"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          750
+
+  - name: ltc_premium_limit_age_over_60_through_70_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/statute/26/213
+              table:
+                header: "eligible long-term care premiums limitation table"
+                row: "More than 60 but not more than 70"
+                column: "The limitation is"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2000
+
+  - name: ltc_premium_limit_age_over_70_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/statute/26/213
+              table:
+                header: "eligible long-term care premiums limitation table"
+                row: "More than 70"
+                column: "The limitation is"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2500
+
+  - name: ltc_premium_increase_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 213(d)(10)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "If any increase determined under the preceding sentence is not a multiple of $10, such increase shall be rounded to the nearest multiple of $10."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10
+
+  - name: eligible_ltc_premium_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(d)(10)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "The limitation table applies by attained age before the close of the taxable year."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if age <= ltc_premium_age_threshold_40:
+              ltc_premium_limit_age_40_or_less_base
+          else:
+              if age <= ltc_premium_age_threshold_50:
+                  ltc_premium_limit_age_over_40_through_50_base
+              else:
+                  if age <= ltc_premium_age_threshold_60:
+                      ltc_premium_limit_age_over_50_through_60_base
+                  else:
+                      if age <= ltc_premium_age_threshold_70:
+                          ltc_premium_limit_age_over_60_through_70_base
+                      else:
+                          ltc_premium_limit_age_over_70_base
+
+  - name: eligible_ltc_premium_indexed_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(d)(10)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "each dollar amount contained in subparagraph (A) shall be increased by the medical care cost adjustment ... rounded to the nearest multiple of $10"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          eligible_ltc_premium_base_limit
+          + floor(
+              (
+                  (
+                      eligible_ltc_premium_base_limit
+                      * medical_care_cost_adjustment
+                  )
+                  / ltc_premium_increase_rounding_multiple
+              )
+              + 0.5
+          )
+          * ltc_premium_increase_rounding_multiple
+
+  - name: eligible_ltc_premiums_taken_into_account
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(d)(1)(D), 213(d)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "only eligible long-term care premiums ... shall be taken into account"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "means the amount paid during a taxable year ... to the extent such amount does not exceed the limitation"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          min(
+              qualified_long_term_care_insurance_premiums_paid,
+              eligible_ltc_premium_indexed_limit
+          )
+
+  - name: medicine_or_drug_taken_into_account
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 213(b), 213(d)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "only if such medicine or drug is a prescribed drug or is insulin"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "prescribed drug means a drug or biological which requires a prescription of a physician for its use by an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          payment_is_for_medicine_or_drug
+          and (
+              medicine_or_drug_is_prescribed_drug
+              or medicine_or_drug_is_insulin
+          )
+
+  - name: lodging_treated_as_medical_care
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 213(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "Amounts paid for lodging ... while away from home primarily for and essential to medical care ... shall be treated as amounts paid for medical care if..."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          payment_is_for_lodging_away_from_home
+          and lodging_is_not_lavish_or_extravagant_under_circumstances
+          and lodging_is_primarily_for_and_essential_to_medical_care
+          and medical_care_is_provided_by_physician_in_licensed_hospital_or_equivalent_facility
+          and not significant_element_of_personal_pleasure_recreation_or_vacation_in_travel
+
+  - name: lodging_amount_taken_into_account
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "The amount taken into account under the preceding sentence shall not exceed $50 for each night for each individual."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if lodging_treated_as_medical_care:
+              min(
+                  lodging_amount_paid,
+                  medical_lodging_nightly_cap * lodging_nights * lodging_individuals
+              )
+          else:
+              0
+
+  - name: decedent_estate_medical_expense_treated_as_paid_by_taxpayer
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 213(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "expenses ... paid out of his estate during the 1-year period beginning with the day after the date of his death shall be treated as paid by the taxpayer at the time incurred"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "shall not apply if the amount paid is allowable under section 2053 ... but this paragraph shall not apply if ... there is filed ... a statement ... and ... a waiver"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          expense_is_for_medical_care_of_decedent_taxpayer
+          and expense_paid_out_of_estate_during_one_year_period_after_death
+          and (
+              not amount_allowable_under_section_2053
+              or (
+                  statement_filed_that_amount_not_allowed_under_section_2053
+                  and waiver_filed_of_right_to_section_2053_deduction
+              )
+          )
+
+  - name: cosmetic_surgery_excluded_from_medical_care
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 213(d)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "medical care does not include cosmetic surgery or other similar procedures, unless the surgery or procedure is necessary to ameliorate a deformity..."
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "cosmetic surgery means any procedure which is directed at improving the patient’s appearance and does not meaningfully promote the proper function of the body or prevent or treat illness or disease"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          procedure_is_cosmetic_surgery_or_similar
+          and procedure_directed_at_improving_appearance_without_meaningfully_promoting_body_function_or_preventing_or_treating_illness
+          and not procedure_necessary_to_ameliorate_deformity_from_congenital_abnormality
+          and not procedure_necessary_to_ameliorate_deformity_from_accident_or_trauma
+          and not procedure_necessary_to_ameliorate_deformity_from_disfiguring_disease
+
+  - name: qualified_ltc_service_payment_treated_as_not_medical_care
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 213(d)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "An amount paid for a qualified long-term care service ... shall be treated as not paid for medical care if such service is provided— (A) by the spouse ... or by a relative ... unless ... by a licensed professional ... or (B) by a corporation or partnership which is related..."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "This paragraph shall not apply for purposes of section 105(b) with respect to reimbursements through insurance."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          payment_is_for_qualified_long_term_care_service
+          and not payment_is_section_105_b_reimbursement_through_insurance
+          and (
+              (
+                  service_provider_is_spouse_or_relative
+                  and not service_provided_by_licensed_professional_with_respect_to_service
+              )
+              or service_provider_is_related_corporation_or_partnership
+          )
+
+  - name: medical_care_expenses_after_section_21_exclusion
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(a), 213(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "expenses paid during the taxable year, not compensated for by insurance or otherwise, for medical care"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "Any expense allowed as a credit under section 21 shall not be treated as an expense paid for medical care."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(
+              0,
+              medical_care_expenses_paid_not_compensated_by_insurance_or_otherwise
+              - expenses_allowed_as_credit_under_section_21
+          )
+
+  - name: medical_care_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 213(a), 213(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "There shall be allowed as a deduction ... to the extent that such expenses exceed 7.5 percent of adjusted gross income."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/213
+              text: "Any expense allowed as a credit under section 21 shall not be treated as an expense paid for medical care."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(
+              0,
+              medical_care_expenses_after_section_21_exclusion
+              - adjusted_gross_income * medical_expense_agi_floor_rate
+          )


### PR DESCRIPTION
## Summary
- add encoder-generated RuleSpec for 26 USC 213 medical expense deduction
- add companion tests for medical expense floor, long-term-care premium limits, medicine/drug, lodging, decedent, cosmetic-surgery, and LTC-service branches
- add signed encoder apply manifest for the generated files

## Validation
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/213.test.yaml --root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/213.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/213.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/213.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 100 --fail-on-unmapped --fail-on-untested-comparable