### PR TITLE
Add 2026 SSA automatic determination rules

### DIFF
--- a/.axiom/encoding-manifests/policies/ssa/pia-bend-points/2026.json
+++ b/.axiom/encoding-manifests/policies/ssa/pia-bend-points/2026.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.yaml",
-      "sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664"
+      "path": "policies/ssa/pia-bend-points/2026.yaml",
+      "sha256": "dd39d3ceda711c0eca7e2a752561c368efd59d64dbf35343b16d1cd5e7c882e0"
     },
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.test.yaml",
-      "sha256": "abf0ecdd18509fe66aa0abf335aa517b987b87b70cd2f6ac58676c6f66eaa590"
+      "path": "policies/ssa/pia-bend-points/2026.test.yaml",
+      "sha256": "bafb0c0588fbea2f53f078e10f046b5fd4e6fcbcb1608ea805e7f1b982402658"
     }
   ],
   "axiom_encode_git": {
@@ -18,13 +18,13 @@
   },
   "axiom_encode_version": "0.2.86",
   "backend": "manual",
-  "citation": "us:policies/ssa/contribution-and-benefit-base/2026",
+  "citation": "us:policies/ssa/pia-bend-points/2026",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-18T00:15:59.046815+00:00",
-  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/contribution-and-benefit-base/2026.yaml",
+  "generated_at": "2026-05-18T00:15:59.049190+00:00",
+  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/pia-bend-points/2026.yaml",
   "generated_output_root": "/Users/maxghenis/ssa-worktree/rulespec-us",
-  "generated_output_sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664",
+  "generated_output_sha256": "dd39d3ceda711c0eca7e2a752561c368efd59d64dbf35343b16d1cd5e7c882e0",
   "generation_prompt_sha256": null,
   "model": "codex-gpt-5",
   "run_id": "manual-ssa-2026-automatic-determinations",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3b2af313219e773cca6a733b5ce634e97a4ac97f5e9d0878705a09133114b78d"
+    "value": "79fa296fdd9e1d6ca63356d3adaa11daaa5717cc9119530c44c1be004d0a5e53"
   },
   "tool": "axiom-encode manual-apply-manifest",
   "trace_file": null,

--- a/.axiom/encoding-manifests/policies/ssa/quarter-of-coverage/2026.json
+++ b/.axiom/encoding-manifests/policies/ssa/quarter-of-coverage/2026.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.yaml",
-      "sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664"
+      "path": "policies/ssa/quarter-of-coverage/2026.yaml",
+      "sha256": "23bcee6c950e8ddcf62b9b7f83afc5eb32366e741868fdf8e57d22e038a02000"
     },
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.test.yaml",
-      "sha256": "abf0ecdd18509fe66aa0abf335aa517b987b87b70cd2f6ac58676c6f66eaa590"
+      "path": "policies/ssa/quarter-of-coverage/2026.test.yaml",
+      "sha256": "cd8b813042fd1b58dbc25c8e3c84c9a3e2d30afd812c2fc904027b0ce70cadc4"
     }
   ],
   "axiom_encode_git": {
@@ -18,13 +18,13 @@
   },
   "axiom_encode_version": "0.2.86",
   "backend": "manual",
-  "citation": "us:policies/ssa/contribution-and-benefit-base/2026",
+  "citation": "us:policies/ssa/quarter-of-coverage/2026",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-18T00:15:59.046815+00:00",
-  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/contribution-and-benefit-base/2026.yaml",
+  "generated_at": "2026-05-18T00:15:59.048013+00:00",
+  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/quarter-of-coverage/2026.yaml",
   "generated_output_root": "/Users/maxghenis/ssa-worktree/rulespec-us",
-  "generated_output_sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664",
+  "generated_output_sha256": "23bcee6c950e8ddcf62b9b7f83afc5eb32366e741868fdf8e57d22e038a02000",
   "generation_prompt_sha256": null,
   "model": "codex-gpt-5",
   "run_id": "manual-ssa-2026-automatic-determinations",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3b2af313219e773cca6a733b5ce634e97a4ac97f5e9d0878705a09133114b78d"
+    "value": "c28493131a6d0d1c7cc8d5a7d8879d9a913fc600aea8a54e55e56a288b51ef3f"
   },
   "tool": "axiom-encode manual-apply-manifest",
   "trace_file": null,

--- a/.axiom/encoding-manifests/policies/ssa/retirement-earnings-test/2026.json
+++ b/.axiom/encoding-manifests/policies/ssa/retirement-earnings-test/2026.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.yaml",
-      "sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664"
+      "path": "policies/ssa/retirement-earnings-test/2026.yaml",
+      "sha256": "d26c6c5e417d229a428ac58c3315f2f6403333e4484429803bd5ec5bb894f776"
     },
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.test.yaml",
-      "sha256": "abf0ecdd18509fe66aa0abf335aa517b987b87b70cd2f6ac58676c6f66eaa590"
+      "path": "policies/ssa/retirement-earnings-test/2026.test.yaml",
+      "sha256": "c85e6690042bb5a4b2d63c9371e28cf8ac3256f8980809225b19239a22b51832"
     }
   ],
   "axiom_encode_git": {
@@ -18,13 +18,13 @@
   },
   "axiom_encode_version": "0.2.86",
   "backend": "manual",
-  "citation": "us:policies/ssa/contribution-and-benefit-base/2026",
+  "citation": "us:policies/ssa/retirement-earnings-test/2026",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-18T00:15:59.046815+00:00",
-  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/contribution-and-benefit-base/2026.yaml",
+  "generated_at": "2026-05-18T00:15:59.048601+00:00",
+  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/retirement-earnings-test/2026.yaml",
   "generated_output_root": "/Users/maxghenis/ssa-worktree/rulespec-us",
-  "generated_output_sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664",
+  "generated_output_sha256": "d26c6c5e417d229a428ac58c3315f2f6403333e4484429803bd5ec5bb894f776",
   "generation_prompt_sha256": null,
   "model": "codex-gpt-5",
   "run_id": "manual-ssa-2026-automatic-determinations",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3b2af313219e773cca6a733b5ce634e97a4ac97f5e9d0878705a09133114b78d"
+    "value": "f6c648e804e98a7feb7c61ab3c579f33fd575ebad686b519e68d97429893f569"
   },
   "tool": "axiom-encode manual-apply-manifest",
   "trace_file": null,

--- a/.axiom/encoding-manifests/policies/ssa/substantial-gainful-activity/2026.json
+++ b/.axiom/encoding-manifests/policies/ssa/substantial-gainful-activity/2026.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.yaml",
-      "sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664"
+      "path": "policies/ssa/substantial-gainful-activity/2026.yaml",
+      "sha256": "1119d741a4cf05cd7af922573ed033e2529bc9c82a969ab010b935b8743f6f05"
     },
     {
-      "path": "policies/ssa/contribution-and-benefit-base/2026.test.yaml",
-      "sha256": "abf0ecdd18509fe66aa0abf335aa517b987b87b70cd2f6ac58676c6f66eaa590"
+      "path": "policies/ssa/substantial-gainful-activity/2026.test.yaml",
+      "sha256": "18f36194a02015922c023c3700744f1d9f2f4c02c8c4bef3722cc58827c1e4a8"
     }
   ],
   "axiom_encode_git": {
@@ -18,13 +18,13 @@
   },
   "axiom_encode_version": "0.2.86",
   "backend": "manual",
-  "citation": "us:policies/ssa/contribution-and-benefit-base/2026",
+  "citation": "us:policies/ssa/substantial-gainful-activity/2026",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-18T00:15:59.046815+00:00",
-  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/contribution-and-benefit-base/2026.yaml",
+  "generated_at": "2026-05-18T00:15:59.049653+00:00",
+  "generated_output_file": "/Users/maxghenis/ssa-worktree/rulespec-us/policies/ssa/substantial-gainful-activity/2026.yaml",
   "generated_output_root": "/Users/maxghenis/ssa-worktree/rulespec-us",
-  "generated_output_sha256": "a9c7c7c7806ecb40db5f5f23a28b30eac79964e8a2fd3c4870692d78cdd27664",
+  "generated_output_sha256": "1119d741a4cf05cd7af922573ed033e2529bc9c82a969ab010b935b8743f6f05",
   "generation_prompt_sha256": null,
   "model": "codex-gpt-5",
   "run_id": "manual-ssa-2026-automatic-determinations",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3b2af313219e773cca6a733b5ce634e97a4ac97f5e9d0878705a09133114b78d"
+    "value": "47d897dab7410d97fe181a9df44be700c53629b0db5999bf6554012f8f5d7291"
   },
   "tool": "axiom-encode manual-apply-manifest",
   "trace_file": null,

--- a/policies/ssa/contribution-and-benefit-base/2026.test.yaml
+++ b/policies/ssa/contribution-and-benefit-base/2026.test.yaml
@@ -6,10 +6,5 @@
     end: '2026-12-31'
   input: {}
   output:
-    us:policies/ssa/contribution-and-benefit-base/2026#base_year_contribution_and_benefit_base: 60600
-    us:policies/ssa/contribution-and-benefit-base/2026#base_year_average_wage_index: 22935.42
-    us:policies/ssa/contribution-and-benefit-base/2026#computation_year_average_wage_index: 69846.57
-    us:policies/ssa/contribution-and-benefit-base/2026#prior_year_contribution_and_benefit_base: 176100
-    us:policies/ssa/contribution-and-benefit-base/2026#contribution_and_benefit_base_rounding_multiple: 300
     us:policies/ssa/contribution-and-benefit-base/2026#wage_indexed_contribution_and_benefit_base: 184500
     us:policies/ssa/contribution-and-benefit-base/2026#contribution_and_benefit_base_under_section_230_of_social_security_act: 184500

--- a/policies/ssa/pia-bend-points/2026.test.yaml
+++ b/policies/ssa/pia-bend-points/2026.test.yaml
@@ -1,0 +1,10 @@
+- name: pia_bend_points_2026_are_wage_indexed_amounts
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ssa/pia-bend-points/2026#first_pia_bend_point: 1286
+    us:policies/ssa/pia-bend-points/2026#second_pia_bend_point: 7749

--- a/policies/ssa/pia-bend-points/2026.yaml
+++ b/policies/ssa/pia-bend-points/2026.yaml
@@ -1,0 +1,128 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+  summary: |-
+    For 2026, the PIA formula bend points are determined by multiplying the 1979 bend points by the ratio of the national average wage index for 2024 to that for 1977, with the results rounded to the nearest dollar.
+
+    Calculation details | Average wage indices | For 1977 | 9,779.44 | | For 2024 | 69,846.57 | | Bend points for 1979 | First | $180 | | Second | $1,085 | | Computation of bend points for 2026 | First bend point | $180 times 69,846.57 divided by 9,779.44 equals $1,285.59, which rounds to $1,286 | | Second bend point | $1,085 times 69,846.57 divided by 9,779.44 equals $7,749.27, which rounds to $7,749 |
+rules:
+  - name: base_year_first_pia_bend_point
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "Bend points for 1979 First:$180"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          180
+  - name: base_year_second_pia_bend_point
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "Second:$1,085"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1085
+  - name: pia_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "For 1977:9,779.44"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          9779.44
+  - name: pia_computation_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "For 2024:69,846.57"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          69846.57
+  - name: pia_bend_point_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "equals $1,285.59, which rounds to $1,286"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1
+  - name: first_pia_bend_point
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "$180 times 69,846.57 divided by 9,779.44 equals $1,285.59, which rounds to $1,286"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((base_year_first_pia_bend_point * pia_computation_year_average_wage_index / pia_base_year_average_wage_index) / pia_bend_point_rounding_multiple) + (1 / 2)) * pia_bend_point_rounding_multiple
+  - name: second_pia_bend_point
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Primary Insurance Amount, determination of the PIA bend points for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/pia-bend-points/2026/block-1
+              excerpt: "$1,085 times 69,846.57 divided by 9,779.44 equals $7,749.27, which rounds to $7,749"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((base_year_second_pia_bend_point * pia_computation_year_average_wage_index / pia_base_year_average_wage_index) / pia_bend_point_rounding_multiple) + (1 / 2)) * pia_bend_point_rounding_multiple

--- a/policies/ssa/quarter-of-coverage/2026.test.yaml
+++ b/policies/ssa/quarter-of-coverage/2026.test.yaml
@@ -1,0 +1,10 @@
+- name: quarter_of_coverage_2026_is_wage_indexed_amount
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ssa/quarter-of-coverage/2026#wage_indexed_quarter_of_coverage_amount: 1890
+    us:policies/ssa/quarter-of-coverage/2026#quarter_of_coverage_amount: 1890

--- a/policies/ssa/quarter-of-coverage/2026.yaml
+++ b/policies/ssa/quarter-of-coverage/2026.yaml
@@ -1,0 +1,138 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+  summary: |-
+    The 2026 quarter of coverage amount is the 1978 amount of $250 multiplied by the ratio of the national average wage index for 2024 to that for 1976, or, if larger, the 2025 amount of $1,810. If the amount so determined is not a multiple of $10, it is rounded to the nearest multiple of $10.
+
+    Calculation details | Amounts in formula | 1978 earnings for one QC | $250 | | 1976 average wage index | 9,226.48 | | 2024 average wage index | 69,846.57 | | Computation | $250 times 69,846.57 divided by 9,226.48 equals $1,892.56, which rounds to $1,890 | | Higher amount | $1,890 exceeds the amount for 2025, so the earnings needed to earn one QC in 2026 is $1,890 |
+rules:
+  - name: base_year_quarter_of_coverage_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Quarter of Coverage, determination of the quarter of coverage amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "1978 earnings for one QC$250"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          250
+  - name: quarter_of_coverage_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Quarter of Coverage, calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "1976 average wage index 9,226.48"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          9226.48
+  - name: quarter_of_coverage_computation_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Quarter of Coverage, calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "2024 average wage index 69,846.57"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          69846.57
+  - name: prior_year_quarter_of_coverage_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Quarter of Coverage, determination of the quarter of coverage amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "the 2025 amount of $1,810"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1810
+  - name: quarter_of_coverage_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Quarter of Coverage, determination of the quarter of coverage amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "rounded to the nearest multiple of $10"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10
+  - name: wage_indexed_quarter_of_coverage_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Quarter of Coverage, determination of the quarter of coverage amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "the 1978 amount of $250 multiplied by the ratio of the national average wage index for 2024 to that for 1976"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "$250 times 69,846.57 divided by 9,226.48 equals $1,892.56, which rounds to $1,890"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((base_year_quarter_of_coverage_amount * quarter_of_coverage_computation_year_average_wage_index / quarter_of_coverage_base_year_average_wage_index) / quarter_of_coverage_rounding_multiple) + (1 / 2)) * quarter_of_coverage_rounding_multiple
+  - name: quarter_of_coverage_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Quarter of Coverage, determination of the quarter of coverage amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "or, if larger, the 2025 amount of $1,810"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/quarter-of-coverage/2026/block-1
+              excerpt: "$1,890 exceeds the amount for 2025, so the earnings needed to earn one QC in 2026 is $1,890"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(wage_indexed_quarter_of_coverage_amount, prior_year_quarter_of_coverage_amount)

--- a/policies/ssa/retirement-earnings-test/2026.test.yaml
+++ b/policies/ssa/retirement-earnings-test/2026.test.yaml
@@ -1,0 +1,14 @@
+- name: retirement_earnings_test_2026_exempt_amounts
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ssa/retirement-earnings-test/2026#wage_indexed_lower_monthly_exempt_amount: 2040
+    us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_monthly_exempt_amount: 2040
+    us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_annual_exempt_amount: 24480
+    us:policies/ssa/retirement-earnings-test/2026#wage_indexed_higher_monthly_exempt_amount: 5430
+    us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_monthly_exempt_amount: 5430
+    us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_annual_exempt_amount: 65160

--- a/policies/ssa/retirement-earnings-test/2026.yaml
+++ b/policies/ssa/retirement-earnings-test/2026.yaml
@@ -1,0 +1,276 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+  summary: |-
+    For 2026, the lower monthly exempt amount is the larger of the 1994 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 1992, or the 2025 monthly exempt amount of $1,950. If the amount so determined is not a multiple of $10, it is rounded to the nearest multiple of $10, and the annual exempt amount is 12 times the rounded monthly exempt amount.
+
+    For 2026, the higher monthly exempt amount is the larger of the 2002 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 2000, or the 2025 monthly exempt amount of $5,180. If the amount so determined is not a multiple of $10, it is rounded to the nearest multiple of $10, and the annual exempt amount is 12 times the rounded monthly exempt amount.
+rules:
+  - name: lower_base_year_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "1994 monthly exempt amount$670"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          670
+  - name: lower_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determination of Exempt Amounts, lower monthly exempt amount calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "1992 average wage index 22,935.42"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          22935.42
+  - name: retirement_earnings_test_computation_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determination of Exempt Amounts, calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "2024 average wage index 69,846.57"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          69846.57
+  - name: prior_year_lower_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the 2025 monthly exempt amount of $1,950"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1950
+  - name: retirement_earnings_test_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower and higher monthly exempt amount calculations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "If the amount so determined is not a multiple of $10, we round it to the nearest multiple of $10."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10
+  - name: wage_indexed_lower_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the 1994 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 1992"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "$670 times (69,846.57 divided by 22,935.42) equals $2,040.39, which rounds to $2,040"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((lower_base_year_monthly_exempt_amount * retirement_earnings_test_computation_year_average_wage_index / lower_base_year_average_wage_index) / retirement_earnings_test_rounding_multiple) + (1 / 2)) * retirement_earnings_test_rounding_multiple
+  - name: retirement_earnings_test_lower_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the larger of: the 1994 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 1992, or the 2025 monthly exempt amount of $1,950"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "$2,040 exceeds the monthly exempt amount for 2025, so the monthly exempt amount for 2026 is $2,040"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(wage_indexed_lower_monthly_exempt_amount, prior_year_lower_monthly_exempt_amount)
+  - name: retirement_earnings_test_lower_annual_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, lower annual exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "The annual exempt amount is then 12 times the rounded monthly exempt amount."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "The annual exempt amount for 2026 is 12 times the monthly amount $2,040, or $24,480."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          retirement_earnings_test_lower_monthly_exempt_amount * 12
+  - name: higher_base_year_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, higher monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "2002 monthly exempt amount $2,500"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2500
+  - name: higher_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determination of Exempt Amounts, higher monthly exempt amount calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "2000 average wage index 32,154.82"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          32154.82
+  - name: prior_year_higher_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, higher monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the 2025 monthly exempt amount of $5,180"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          5180
+  - name: wage_indexed_higher_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, higher monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the 2002 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 2000"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "$2,500 times (69,846.57 divided by 32,154.82) equals $5,430.49, which rounds to $5,430"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((higher_base_year_monthly_exempt_amount * retirement_earnings_test_computation_year_average_wage_index / higher_base_year_average_wage_index) / retirement_earnings_test_rounding_multiple) + (1 / 2)) * retirement_earnings_test_rounding_multiple
+  - name: retirement_earnings_test_higher_monthly_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, higher monthly exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "the larger of: the 2002 monthly exempt amount multiplied by the ratio of the national average wage index for 2024 to that for 2000, or the 2025 monthly exempt amount of $5,180"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "$5,430 exceeds the monthly exempt amount for 2025, so the monthly exempt amount for 2026 is $5,430"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(wage_indexed_higher_monthly_exempt_amount, prior_year_higher_monthly_exempt_amount)
+  - name: retirement_earnings_test_higher_annual_exempt_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determination of Exempt Amounts, higher annual exempt amount for 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "The annual exempt amount is then 12 times the rounded monthly exempt amount."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/retirement-earnings-test/2026/block-1
+              excerpt: "The annual exempt amount for 2026 is 12 times the monthly amount $5,430, or $65,160."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          retirement_earnings_test_higher_monthly_exempt_amount * 12

--- a/policies/ssa/substantial-gainful-activity/2026.test.yaml
+++ b/policies/ssa/substantial-gainful-activity/2026.test.yaml
@@ -1,0 +1,12 @@
+- name: substantial_gainful_activity_2026_amounts
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ssa/substantial-gainful-activity/2026#wage_indexed_blind_sga_amount: 2830
+    us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_blind_monthly_amount: 2830
+    us:policies/ssa/substantial-gainful-activity/2026#wage_indexed_non_blind_disabled_sga_amount: 1690
+    us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_non_blind_disabled_monthly_amount: 1690

--- a/policies/ssa/substantial-gainful-activity/2026.yaml
+++ b/policies/ssa/substantial-gainful-activity/2026.yaml
@@ -1,0 +1,232 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+  summary: |-
+    For 2026, the SGA amount for statutorily blind individuals is the 1994 monthly SGA amount multiplied by the ratio of the national average wage index for 2024 to that for 1992, or, if larger, the corresponding 2025 amount of $2,700. If the amount so calculated is not a multiple of $10, it is rounded to the nearest multiple of $10.
+
+    For 2026, the SGA amount for non-blind disabled individuals is the 2000 monthly SGA amount multiplied by the ratio of the national average wage index for 2024 to that for 1998, or, if larger, the corresponding 2025 amount of $1,620. If the amount so calculated is not a multiple of $10, it is rounded to the nearest multiple of $10.
+rules:
+  - name: blind_base_year_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the blind
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "1994 monthly SGA amount$930"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          930
+  - name: blind_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determinations of Substantial Gainful Activity, SGA for the blind calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "1992 average wage index 22,935.42"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          22935.42
+  - name: substantial_gainful_activity_computation_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determinations of Substantial Gainful Activity, calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "2024 average wage index 69,846.57"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          69846.57
+  - name: prior_year_blind_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the blind
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "such SGA amount for 2025 ($2,700)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2700
+  - name: substantial_gainful_activity_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA amount calculations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "If the amount so calculated is not a multiple of $10, we round it to the nearest multiple of $10."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10
+  - name: wage_indexed_blind_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the blind
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "the monthly SGA amount for statutorily blind individuals for 2026 is such SGA amount for 1994 multiplied by the ratio of the national average wage index for 2024 to that for 1992"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "$930 times (69,846.57 divided by 22,935.42) equals $2,832.18, which rounds to $2,830"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((blind_base_year_sga_amount * substantial_gainful_activity_computation_year_average_wage_index / blind_base_year_average_wage_index) / substantial_gainful_activity_rounding_multiple) + (1 / 2)) * substantial_gainful_activity_rounding_multiple
+  - name: substantial_gainful_activity_blind_monthly_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the blind
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "or, if larger, such SGA amount for 2025 ($2,700)"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "$2,830 exceeds the corresponding amount for 2025, so the amount for 2026 is $2,830"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(wage_indexed_blind_sga_amount, prior_year_blind_sga_amount)
+  - name: non_blind_disabled_base_year_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the non-blind disabled
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "2000 monthly SGA amount$700"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          700
+  - name: non_blind_disabled_base_year_average_wage_index
+    kind: parameter
+    dtype: Decimal
+    source: Determinations of Substantial Gainful Activity, SGA for the non-blind disabled calculation details
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "1998 average wage index 28,861.44"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          28861.44
+  - name: prior_year_non_blind_disabled_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the non-blind disabled
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "such SGA amount for 2025 ($1,620)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1620
+  - name: wage_indexed_non_blind_disabled_sga_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the non-blind disabled
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "such SGA amount for 2000 multiplied by the ratio of the national average wage index for 2024 to that for 1998"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "$700 times (69,846.57 divided by 28,861.44) equals $1,694.05, which rounds to $1,690"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          floor(((non_blind_disabled_base_year_sga_amount * substantial_gainful_activity_computation_year_average_wage_index / non_blind_disabled_base_year_average_wage_index) / substantial_gainful_activity_rounding_multiple) + (1 / 2)) * substantial_gainful_activity_rounding_multiple
+  - name: substantial_gainful_activity_non_blind_disabled_monthly_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Determinations of Substantial Gainful Activity, SGA for the non-blind disabled
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "or, if larger such SGA amount for 2025 ($1,620)"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/substantial-gainful-activity/2026/block-1
+              excerpt: "$1,690 exceeds the corresponding amount for 2025, so the amount for 2026 is $1,690"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(wage_indexed_non_blind_disabled_sga_amount, prior_year_non_blind_disabled_sga_amount)

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -118,7 +118,9 @@ def test_rulespec_files_use_rulespec_v1_shape() -> None:
             invalid.append(f"{path.relative_to(ROOT)}: missing format: rulespec/v1")
         rules = payload.get("rules")
         if not isinstance(rules, list) or not rules:
-            invalid.append(f"{path.relative_to(ROOT)}: missing non-empty rules list")
+            status = (payload.get("module") or {}).get("status")
+            if status not in {"deferred", "entity_not_supported"}:
+                invalid.append(f"{path.relative_to(ROOT)}: missing non-empty rules list")
             continue
         for index, rule in enumerate(rules):
             if not isinstance(rule, dict):


### PR DESCRIPTION
## Summary
- add 2026 SSA automatic determinations for quarter of coverage, retirement earnings test exempt amounts, PIA bend points, and substantial gainful activity thresholds
- keep statutory base amounts, average wage indices, rounding increments, and prior-year floors visible as named RuleSpec parameters
- trim the existing CBB companion test to query executable derived outputs only
- allow explicit non-executable RuleSpec modules with `module.status: deferred` or `entity_not_supported` and `rules: []`
- add signed encoder manifests for the changed SSA RuleSpec artifacts

## Dependencies / CI
- Source validation uses corpus source blocks from TheAxiomFoundation/axiom-corpus#53
- Full-repo rulespec validation also needs TheAxiomFoundation/axiom-encode#61, which fixes:
  - a source-verification false failure where `source_verification.values` were checked against `module.summary` instead of declared corpus source text
  - existing numeric `#input.filing_status` companion-test fixtures tracked in TheAxiomFoundation/rulespec-us#41
- Local validation of the first previously failing AMT file now passes with axiom-encode#61 applied.

## Checks
- `AXIOM_CORPUS_REPO=/Users/maxghenis/ssa-worktree/axiom-corpus uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode validate <each SSA 2026 policy file> --skip-reviewers --json`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode proof-validate <each SSA 2026 policy file> --json`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode test --root /Users/maxghenis/ssa-worktree/rulespec-us <five SSA 2026 test files> --json`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=*** uv run --project /Users/maxghenis/ssa-worktree/axiom-encode axiom-encode guard-generated --repo /Users/maxghenis/ssa-worktree/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uvx --with pyyaml pytest tests/test_repository_layout.py`
