### PR TITLE
Allow explicit non-executable empty RuleSpec modules

### DIFF
--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -18,6 +18,7 @@ DISALLOWED_GENERIC_RULE_NAMES = {
     "threshold",
     "value",
 }
+ALLOWED_EMPTY_RULE_STATUSES = {"deferred", "entity_not_supported"}
 
 
 def iter_repo_files() -> list[Path]:
@@ -117,8 +118,17 @@ def test_rulespec_files_use_rulespec_v1_shape() -> None:
         if payload.get("format") != "rulespec/v1":
             invalid.append(f"{path.relative_to(ROOT)}: missing format: rulespec/v1")
         rules = payload.get("rules")
-        if not isinstance(rules, list) or not rules:
-            invalid.append(f"{path.relative_to(ROOT)}: missing non-empty rules list")
+        if not isinstance(rules, list):
+            invalid.append(f"{path.relative_to(ROOT)}: missing rules list")
+            continue
+        if not rules:
+            module = payload.get("module")
+            status = module.get("status") if isinstance(module, dict) else None
+            if status not in ALLOWED_EMPTY_RULE_STATUSES:
+                invalid.append(
+                    f"{path.relative_to(ROOT)}: empty rules list without "
+                    "explicit non-executable module status"
+                )
             continue
         for index, rule in enumerate(rules):
             if not isinstance(rule, dict):


### PR DESCRIPTION
## Summary
- update the repository layout test to allow `rules: []` only when `module.status` is explicitly non-executable
- keep rejecting missing rule lists and accidental empty executable modules

## Why
The encoder and validator permit `module.status: deferred` or `entity_not_supported` with `rules: []`. The repository test was stricter and currently fails on existing main-branch generated files for sections 3101, 3111, 45A, and 45A(d), blocking unrelated generated RuleSpec PRs.

## Validation
- /Users/maxghenis/ssa-worktree/axiom-encode/.venv/bin/python -m pytest -q tests/test_repository_layout.py
