### PR TITLE
Repair standard deduction status component

### DIFF
--- a/.axiom/encoding-manifests/policies/irs/rev-proc-2025-32/standard-deduction.json
+++ b/.axiom/encoding-manifests/policies/irs/rev-proc-2025-32/standard-deduction.json
@@ -2,38 +2,40 @@
   "applied_files": [
     {
       "path": "policies/irs/rev-proc-2025-32/standard-deduction.yaml",
-      "sha256": "49b675d1050569116ff8313e846ca6ac2639012332461f4273ad36f1e249cea4"
+      "sha256": "ba9fc438096d4fe08862909ea580290dadc01c8643227397bedf7f5f0516fc27"
     },
     {
       "path": "policies/irs/rev-proc-2025-32/standard-deduction.test.yaml",
-      "sha256": "6bb1a1f85eca37dd5764508096a0f7ed33281a58f00d9682454af0420d91cd46"
+      "sha256": "88b806965591cefe8e9e333c83a8085f679a8289eeef8ca8d65fb541e01fda41"
     }
   ],
   "axiom_encode_git": {
-    "commit": "e576f8086f0d32b788d3b7f104ab7b3b46764ecb",
+    "commit": "90c63d2b9d997a08bd015c2196c692b5bd6282cb",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+    "root": "/Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93",
+    "version": "0.2.93",
+    "version_commit": "90c63d2b9d997a08bd015c2196c692b5bd6282cb"
   },
-  "axiom_encode_version": "0.2.68",
-  "backend": "openai",
-  "citation": "us/policies/irs/rev-proc-2025-32/standard-deduction",
-  "context_manifest_file": "/tmp/axiom-encode-standard-deduction-apply-target/_eval_workspaces/openai-gpt-5.5/us-policies-irs-rev-proc-2025-32-standard-deduction/workspace/context-manifest.json",
-  "context_manifest_sha256": "588cd8aa1844d7b1ad850da5221e32c7fd71183e6ad48c74b8cb96500db99070",
-  "generated_at": "2026-05-12T12:12:21.683187+00:00",
-  "generated_output_file": "/tmp/axiom-encode-standard-deduction-apply-target/openai-gpt-5.5/policies/irs/rev-proc-2025-32/standard-deduction.yaml",
-  "generated_output_root": "/tmp/axiom-encode-standard-deduction-apply-target",
-  "generated_output_sha256": "49b675d1050569116ff8313e846ca6ac2639012332461f4273ad36f1e249cea4",
-  "generation_prompt_sha256": "69a723f3c38d4b5bea1a7ec6ba0e294230f1ca9d04bcbd511a93cd33e62f787b",
-  "model": "gpt-5.5",
-  "run_id": "96af5879",
-  "runner": "openai-gpt-5.5",
+  "axiom_encode_version": "0.2.93",
+  "backend": "deterministic",
+  "citation": "us:policies/irs/rev-proc-2025-32/standard-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-05-22T01:30:08.283292+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmprwv_z446/deterministic-repair/policies/irs/rev-proc-2025-32/standard-deduction.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmprwv_z446",
+  "generated_output_sha256": "ba9fc438096d4fe08862909ea580290dadc01c8643227397bedf7f5f0516fc27",
+  "generation_prompt_sha256": null,
+  "model": "tax-status-component-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "724a4abfc3e87f2cae3c3be4cd83be705572fe3d4ea198f219487f406ee331db"
+    "value": "331c5874882ec6e13d9cc25c4a8ac8ccd00c8d9fa610aca21b9ab6b8b48ae312"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-standard-deduction-apply-target/traces/openai-gpt-5.5/us-policies-irs-rev-proc-2025-32-standard-deduction.json",
-  "trace_sha256": "31c4c57388924182590b9aa997893014996721aa5f80eed9028d8adf0312d99e"
+  "tool": "axiom-encode repair-tax-status-components",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/policies/irs/rev-proc-2025-32/standard-deduction.test.yaml
+++ b/policies/irs/rev-proc-2025-32/standard-deduction.test.yaml
@@ -9,7 +9,6 @@
     us:policies/irs/rev-proc-2025-32/standard-deduction#input.earned_income: 0
     ? us:policies/irs/rev-proc-2025-32/standard-deduction#input.additional_standard_deduction_entitlement_count_under_subsection_f
     : 0
-    us:policies/irs/rev-proc-2025-32/standard-deduction#input.individual_is_unmarried_and_not_surviving_spouse: false
   output:
     us:policies/irs/rev-proc-2025-32/standard-deduction#joint_or_surviving_spouse_standard_deduction_amount: 32200
     us:policies/irs/rev-proc-2025-32/standard-deduction#head_of_household_standard_deduction_amount: 24150
@@ -35,7 +34,6 @@
     us:policies/irs/rev-proc-2025-32/standard-deduction#input.earned_income: 0
     ? us:policies/irs/rev-proc-2025-32/standard-deduction#input.additional_standard_deduction_entitlement_count_under_subsection_f
     : 1
-    us:policies/irs/rev-proc-2025-32/standard-deduction#input.individual_is_unmarried_and_not_surviving_spouse: true
   output:
     us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_by_filing_status: 24150
     us:policies/irs/rev-proc-2025-32/standard-deduction#dependent_standard_deduction_limit: 1350
@@ -53,7 +51,6 @@
     us:policies/irs/rev-proc-2025-32/standard-deduction#input.earned_income: 2000
     ? us:policies/irs/rev-proc-2025-32/standard-deduction#input.additional_standard_deduction_entitlement_count_under_subsection_f
     : 0
-    us:policies/irs/rev-proc-2025-32/standard-deduction#input.individual_is_unmarried_and_not_surviving_spouse: true
   output:
     us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_by_filing_status: 16100
     us:policies/irs/rev-proc-2025-32/standard-deduction#dependent_standard_deduction_limit: 2450
@@ -71,7 +68,6 @@
     us:policies/irs/rev-proc-2025-32/standard-deduction#input.earned_income: 0
     ? us:policies/irs/rev-proc-2025-32/standard-deduction#input.additional_standard_deduction_entitlement_count_under_subsection_f
     : 2
-    us:policies/irs/rev-proc-2025-32/standard-deduction#input.individual_is_unmarried_and_not_surviving_spouse: false
   output:
     us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_by_filing_status: 16100
     us:policies/irs/rev-proc-2025-32/standard-deduction#dependent_standard_deduction_limit: 1350

--- a/policies/irs/rev-proc-2025-32/standard-deduction.yaml
+++ b/policies/irs/rev-proc-2025-32/standard-deduction.yaml
@@ -259,7 +259,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          additional_standard_deduction_entitlement_count_under_subsection_f * (if individual_is_unmarried_and_not_surviving_spouse: additional_standard_deduction_amount_unmarried_not_surviving_spouse else: additional_standard_deduction_amount)
+          additional_standard_deduction_entitlement_count_under_subsection_f * (if filing_status == 0 or filing_status == 3: additional_standard_deduction_amount_unmarried_not_surviving_spouse else: additional_standard_deduction_amount)
 
   - name: standard_deduction
     kind: derived

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -118,7 +118,9 @@ def test_rulespec_files_use_rulespec_v1_shape() -> None:
             invalid.append(f"{path.relative_to(ROOT)}: missing format: rulespec/v1")
         rules = payload.get("rules")
         if not isinstance(rules, list) or not rules:
-            invalid.append(f"{path.relative_to(ROOT)}: missing non-empty rules list")
+            status = (payload.get("module") or {}).get("status")
+            if status not in {"deferred", "entity_not_supported"}:
+                invalid.append(f"{path.relative_to(ROOT)}: missing non-empty rules list")
             continue
         for index, rule in enumerate(rules):
             if not isinstance(rule, dict):


### PR DESCRIPTION
## Summary
- replace the generated local `individual_is_unmarried_and_not_surviving_spouse` status-component input with the filing-status enum predicate in the 2026 standard deduction policy
- remove the stale local status-component test input
- carry the repository-layout allowance for explicitly non-executable modules so a standalone PR from main can pass pytest

## Dependencies
- Depends on TheAxiomFoundation/axiom-encode#91 because the signed repair manifest was generated with axiom-encode 0.2.93 at commit `90c63d2`.
- Depends on TheAxiomFoundation/.github#3 for PR-scoped validation; the current shared workflow validates unrelated baseline files and currently reports 45 pre-existing failures on `origin/main`.

## Tests
- AXIOM_CORPUS_REPO=/Users/maxghenis/ssa-worktree/axiom-corpus uv run --project /Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93 axiom-encode validate policies/irs/rev-proc-2025-32/standard-deduction.yaml --skip-reviewers --json
- AXIOM_CORPUS_REPO=/Users/maxghenis/ssa-worktree/axiom-corpus uv run --project /Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93 axiom-encode proof-validate policies/irs/rev-proc-2025-32/standard-deduction.yaml --json
- AXIOM_ENCODE_APPLY_SIGNING_KEY=*** uv run --project /Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93 axiom-encode guard-generated --repo /Users/maxghenis/ssa-worktree/std-deduction-status-fix-clean --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- uvx --with pyyaml pytest tests/test_repository_layout.py -q -k rulespec_files_use_rulespec_v1_shape
- uv run --project /Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93 axiom-encode test --root /tmp/rulespec-us-pr-validate/rulespec-us /tmp/rulespec-us-pr-validate/rulespec-us/policies/irs/rev-proc-2025-32/standard-deduction.test.yaml --json