### PR TITLE
Encode 26 USC 3241(b) tax rate schedule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3241/b.yaml",
+      "sha256": "48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3"
+    },
+    {
+      "path": "statutes/26/3241/b.test.yaml",
+      "sha256": "3097e47f610fb5db20c4c34d51507739a0ce0479aba73e23b82a3ac104d79734"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f7ffb8be4550319b6ddc52b5a6d98356976d7829",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.98",
+    "version_commit": "f7ffb8be4550319b6ddc52b5a6d98356976d7829"
+  },
+  "axiom_encode_version": "0.2.98",
+  "backend": "codex",
+  "citation": "26 USC 3241(b)",
+  "context_manifest_file": "/tmp/axiom-encode-3241b-apply-6/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "05df7d3ed190696babd3c2bc29a48862e00c30a64bab2925d1e94bda3a9b911a",
+  "generated_at": "2026-05-23T22:25:25.708674+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3241b-apply-6/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3241b-apply-6",
+  "generated_output_sha256": "48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3",
+  "generation_prompt_sha256": "964ba82185e7862a15f7031d0ccd102579abe472f700c6553c64346e488671f5",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "01e7a3aa",
+  "runner": "codex-gpt-5.3-codex-spark",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fcc373ece387d329f7fd8c4502f6fe36d99f04763b2f86789bc6a19dba694bb6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3241b-apply-6/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
+  "trace_sha256": "a599fd8f3b15cfdbb93b5dc5026b5265b787175e53859fd914fdbd7be5f3371a"
+}

--- a/statutes/26/3241/b.test.yaml
+++ b/statutes/26/3241/b.test.yaml
@@ -1,0 +1,49 @@
+- name: ratio_below_2_5
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+  output:
+    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.221
+    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.049
+- name: ratio_at_2_5
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.5
+  output:
+    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.181
+    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.049
+- name: ratio_between_6_1_and_6_5
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 6.3
+  output:
+    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.126
+    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.044
+- name: ratio_at_9_0_and_above
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9.0
+  output:
+    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.082
+    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.0
+- name: auto_output_average_account_benefits_ratio_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 0
+  output:
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 1

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -1,0 +1,166 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+  summary: '(b) Tax rate schedule | Average account benefits ratio | Applicable percentage
+    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b)
+
+    At least | But less than
+
+    .............. | 2.5 | 22.1 | 4.9
+
+    2.5 | 3.0 | 18.1 | 4.9
+
+    3.0 | 3.5 | 15.1 | 4.9
+
+    3.5 | 4.0 | 14.1 | 4.9
+
+    4.0 | 6.1 | 13.1 | 4.9
+
+    6.1 | 6.5 | 12.6 | 4.4
+
+    6.5 | 7.0 | 12.1 | 3.9
+
+    7.0 | 7.5 | 11.6 | 3.4
+
+    7.5 | 8.0 | 11.1 | 2.9
+
+    8.0 | 8.5 | 10.1 | 1.9
+
+    8.5 | 9.0 | 9.1 | 0.9
+
+    9.0 | .............. | 8.2 | 0'
+rules:
+- name: average_account_benefits_ratio_band
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3241
+          corpus_span: (b) at least / but less than interval table
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "if average_account_benefits_ratio < 2.5:\n  1\nelse:\n  if average_account_benefits_ratio\
+      \ >= 2.5 and average_account_benefits_ratio < 3.0:\n    2\n  else:\n    if average_account_benefits_ratio\
+      \ >= 3.0 and average_account_benefits_ratio < 3.5:\n      3\n    else:\n   \
+      \   if average_account_benefits_ratio >= 3.5 and average_account_benefits_ratio\
+      \ < 4.0:\n        4\n      else:\n        if average_account_benefits_ratio\
+      \ >= 4.0 and average_account_benefits_ratio < 6.1:\n          5\n        else:\n\
+      \          if average_account_benefits_ratio >= 6.1 and average_account_benefits_ratio\
+      \ < 6.5:\n            6\n          else:\n            if average_account_benefits_ratio\
+      \ >= 6.5 and average_account_benefits_ratio < 7.0:\n              7\n      \
+      \      else:\n              if average_account_benefits_ratio >= 7.0 and average_account_benefits_ratio\
+      \ < 7.5:\n                8\n              else:\n                if average_account_benefits_ratio\
+      \ >= 7.5 and average_account_benefits_ratio < 8.0:\n                  9\n  \
+      \              else:\n                  if average_account_benefits_ratio >=\
+      \ 8.0 and average_account_benefits_ratio < 8.5:\n                    10\n  \
+      \                else:\n                    if average_account_benefits_ratio\
+      \ >= 8.5 and average_account_benefits_ratio < 9.0:\n                      11\n\
+      \                    else:\n                      if average_account_benefits_ratio\
+      \ >= 9.0:\n                        12\n                      else:\n       \
+      \                 1"
+- name: section_3211_3221_applicable_percentage_by_ratio_band
+  kind: parameter
+  dtype: Rate
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          table:
+            header: Applicable percentage for sections 3211(b) and 3221(b)
+            row_key: average account benefits ratio interval band
+            column_key: applicable percentage
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      1: 0.221
+      2: 0.181
+      3: 0.151
+      4: 0.141
+      5: 0.131
+      6: 0.126
+      7: 0.121
+      8: 0.116
+      9: 0.111
+      10: 0.101
+      11: 0.091
+      12: 0.082
+- name: section_3201_applicable_percentage_by_ratio_band
+  kind: parameter
+  dtype: Rate
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          table:
+            header: Applicable percentage for section 3201(b)
+            row_key: average account benefits ratio interval band
+            column_key: applicable percentage
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      1: 0.049
+      2: 0.049
+      3: 0.049
+      4: 0.049
+      5: 0.049
+      6: 0.044
+      7: 0.039
+      8: 0.034
+      9: 0.029
+      10: 0.019
+      11: 0.009
+      12: 0.0
+- name: section_3211_and_3221_applicable_percentage_for_tax_unit
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3241
+          corpus_span: (b) rate table column for sections 3211(b) and 3221(b)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: section_3211_3221_applicable_percentage_by_ratio_band[average_account_benefits_ratio_band]
+- name: section_3201_applicable_percentage_for_tax_unit
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3241
+          corpus_span: (b) rate table column for section 3201(b)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: section_3201_applicable_percentage_by_ratio_band[average_account_benefits_ratio_band]


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3241(b)'s average account benefits ratio tax rate schedule
- add generated companion tests for open lower row, 2.5 boundary, 6.1 interval, and 9.0 open upper row
- include signed axiom-encode apply manifest

## Provenance
- generated via `axiom-encode encode --apply`
- axiom-encode version: 0.2.98
- axiom-encode commit: f7ffb8be4550319b6ddc52b5a6d98356976d7829
- run id: 01e7a3aa

## Validation
- `uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers`