### PR TITLE
Encode 26 USC 3201

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3201.json
+++ b/.axiom/encoding-manifests/statutes/26/3201.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3201.yaml",
+      "sha256": "4ac885448ea213c14761037765c697a2bd6899854157ff1063e910dc2b51daaa"
+    },
+    {
+      "path": "statutes/26/3201.test.yaml",
+      "sha256": "bd809522f845a7dc7cbca61edd7e3a6cbb3c059185b571efdff87da51bda1514"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "56e0cf33388799321328a78e403013e07455b542",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.101",
+    "version_commit": "56e0cf33388799321328a78e403013e07455b542"
+  },
+  "axiom_encode_version": "0.2.101",
+  "backend": "codex",
+  "citation": "26 USC 3201",
+  "context_manifest_file": "/tmp/axiom-encode-3201-apply-9/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3201/workspace/context-manifest.json",
+  "context_manifest_sha256": "6e39e82d8077e8f20ddfccb5e65f3225424614b0100b4c6bc09d0017bd79b003",
+  "generated_at": "2026-05-24T00:11:15.628769+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3201-apply-9/codex-gpt-5.3-codex-spark/statutes/26/3201.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3201-apply-9",
+  "generated_output_sha256": "4ac885448ea213c14761037765c697a2bd6899854157ff1063e910dc2b51daaa",
+  "generation_prompt_sha256": "9c8e3fd5f76f406af22895f6eaea488a4685e7ee802f286c5ecce5fd0487b46d",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "ec8d49c3",
+  "runner": "codex-gpt-5.3-codex-spark",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "785d547a90058bab98efccd21d6df66e034f04b9e7aa96580c7aa502827f0831"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3201-apply-9/traces/codex-gpt-5.3-codex-spark/26-USC-3201.json",
+  "trace_sha256": "7909522fceac67c24ead095e1e4fb92772562749db8a425400a8c73245bfc092"
+}

--- a/statutes/26/3201.test.yaml
+++ b/statutes/26/3201.test.yaml
@@ -1,0 +1,20 @@
+- name: tier_2_employee_tax_with_3241_band_1
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3201#input.compensation_received_for_services_rendered_by_employee_for_calendar_year: 100000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+  output:
+    us:statutes/26/3201#tier_2_employee_tax: 4900
+- name: tier_2_employee_tax_with_3241_zero_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3201#input.compensation_received_for_services_rendered_by_employee_for_calendar_year: 100000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9.0
+  output:
+    us:statutes/26/3201#tier_2_employee_tax: 0

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -1,0 +1,48 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3201
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on the income of each employee a tax equal to the applicable percentage of the compensation received during any calendar year by such employee for services rendered by such employee. For purposes of the preceding sentence, the term “applicable percentage” means the percentage equal to the sum of the rates of tax in effect under subsections (a) and (b) of section 3101 for the calendar year.
+
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on the income of each employee a tax equal to the percentage determined under section 3241 for any calendar year of the compensation received during such calendar year by such employee for services rendered by such employee.
+
+    (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
+  deferred_outputs:
+    - output: us:statutes/26/3201/a#tier_1_employee_tax
+      reason: |
+        Subsection (a) requires rates from section 3101(a) and 3101(b), but section 3101 is copied as non-executable and unavailable here for direct computation.
+rules:
+  - name: tier_2_employee_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3201(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3201
+              corpus_span: (b)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit
+              output: section_3201_applicable_percentage_for_tax_unit
+              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+            0,
+            compensation_received_for_services_rendered_by_employee_for_calendar_year
+            * section_3201_applicable_percentage_for_tax_unit
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3201
- encode subsection (b) tier 2 employee tax at Person scope using the generated 3241(b) applicable percentage
- defer subsection (a) tier 1 employee tax because 26 USC 3101 is currently non-executable
- include signed axiom-encode apply manifest from merged encoder 0.2.101 commit 56e0cf3

## Validation
- uv run axiom-encode validate /tmp/rulespec-us-26-3201/statutes/26/3201.yaml --skip-reviewers
- generated with axiom-encode encode "26 USC 3201" --apply --no-sync