### PR TITLE
Encode 26 USC 3211

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3211.json
+++ b/.axiom/encoding-manifests/statutes/26/3211.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3211.yaml",
+      "sha256": "96ab9bf2a9085318335afa0d1845dea7af775728a326271e8337fd7c1edf7dc4"
+    },
+    {
+      "path": "statutes/26/3211.test.yaml",
+      "sha256": "f9e4418e97839a0a53d6e4e69eb6018d414c7e5ab1b98dff0ddb04dffc47af05"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "122be60162f19d4d72c64d628862a23c2a3d7ff4",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.105",
+    "version_commit": "122be60162f19d4d72c64d628862a23c2a3d7ff4"
+  },
+  "axiom_encode_version": "0.2.105",
+  "backend": "codex",
+  "citation": "26 USC 3211",
+  "context_manifest_file": "/tmp/axiom-encode-3211-apply-4/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3211/workspace/context-manifest.json",
+  "context_manifest_sha256": "8c1b616ef68886d2bfa18f739a9b7f65be4584c0b0b97487500c1e44d45231b0",
+  "generated_at": "2026-05-24T00:58:52.416333+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3211-apply-4/codex-gpt-5.3-codex-spark/statutes/26/3211.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3211-apply-4",
+  "generated_output_sha256": "96ab9bf2a9085318335afa0d1845dea7af775728a326271e8337fd7c1edf7dc4",
+  "generation_prompt_sha256": "209ea4105354c7a6bee42a4c0bc7fcb53461a0903c8580f3d8455f98e7352cf2",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "8f05a959",
+  "runner": "codex-gpt-5.3-codex-spark",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7f0fc722819752a45667a342204d63d4ccce5e377862e7b3ff85f4a71f0904f9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3211-apply-4/traces/codex-gpt-5.3-codex-spark/26-USC-3211.json",
+  "trace_sha256": "62930cf94f225264185701c2999e5680daf1b93c7d62e75eab76524762fbb41a"
+}

--- a/statutes/26/3211.test.yaml
+++ b/statutes/26/3211.test.yaml
@@ -1,0 +1,20 @@
+- name: tier_2_employee_representative_tax_positive_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3211#input.compensation_received_for_services_as_employee_representative: 1000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+  output:
+    us:statutes/26/3211#tier_2_employee_representative_tax: 221.0
+- name: tier_2_employee_representative_tax_zero_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3211#input.compensation_received_for_services_as_employee_representative: 0
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.5
+  output:
+    us:statutes/26/3211#tier_2_employee_representative_tax: 0

--- a/statutes/26/3211.yaml
+++ b/statutes/26/3211.yaml
@@ -1,0 +1,47 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3211
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on the income of each employee representative a tax equal to the applicable percentage of the compensation received during any calendar year by such employee representative for services rendered by such employee representative. For purposes of the preceding sentence, the term “applicable percentage” means the percentage equal to the sum of the rates of tax in effect under subsections (a) and (b) of section 3101 and subsections (a) and (b) of section 3111 for the calendar year.
+
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on the income of each employee representative a tax equal to the percentage determined under section 3241 for any calendar year of the compensation received during such calendar year by such employee representative for services rendered by such employee representative.
+
+    (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
+  deferred_outputs:
+    - output: us:statutes/26/3211/a#tier_1_employee_representative_tax
+      reason: >-
+        Subsection (a) depends on rates under sections 3101(a), 3101(b), 3111(a), and
+        3111(b), but the copied context for those citations is non-executable for this
+        run. The tier 1 amount is therefore deferred rather than modeled with local
+        cross-reference placeholders.
+rules:
+  - name: tier_2_employee_representative_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3211(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3211
+              corpus_span: (b)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+              output: section_3211_and_3221_applicable_percentage_for_tax_unit
+              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          section_3211_and_3221_applicable_percentage_for_tax_unit * max(0, compensation_received_for_services_as_employee_representative)


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3211(b) tier 2 employee-representative tax
- defer 26 USC 3211(a) tier 1 tax because the rate-source files are currently non-executable context
- add generated companion tests and encoder apply manifest

## Provenance
- generated with axiom-encode 0.2.105
- encoder commit 122be60162f19d4d72c64d628862a23c2a3d7ff4
- run id 8f05a959

## Tests
- `uv run axiom-encode proof-validate /tmp/rulespec-us-26-3211/statutes/26/3211.yaml`
- `uv run axiom-encode validate /tmp/rulespec-us-26-3211/statutes/26/3211.yaml --skip-reviewers`
- `uv run axiom-encode test --root /tmp/rulespec-us-26-3211 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine statutes/26/3211.test.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /tmp/rulespec-us-26-3211 --base-ref origin/main --head-ref HEAD`
- `uv run axiom-encode oracle-coverage --root /tmp/rulespec-coverage-3211 --oracle policyengine --program tax --json | jq '.items[] | select(.legal_id=="us:statutes/26/3211#tier_2_employee_representative_tax")'`

Note: full tax oracle coverage with `--fail-on-unmapped` still reports three pre-existing unrelated unmapped outputs in 26 USC 443(a)(1) and 68(b).