### PR TITLE
Encode 26 USC 3221

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3221.json
+++ b/.axiom/encoding-manifests/statutes/26/3221.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3221.yaml",
+      "sha256": "a4b94dadc8d4c6e3dc6826b9d9a0fdc3a35339118df161d04a8e29307d4e47ab"
+    },
+    {
+      "path": "statutes/26/3221.test.yaml",
+      "sha256": "8edfceedefc3f1ff277166cd3b2efef66821328d16e4e253c9f1db96a96476ed"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ac3ef1a7b0a22cc18333968ee6b9e342a1b780b4",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.106",
+    "version_commit": "ac3ef1a7b0a22cc18333968ee6b9e342a1b780b4"
+  },
+  "axiom_encode_version": "0.2.106",
+  "backend": "codex",
+  "citation": "26 USC 3221",
+  "context_manifest_file": "/tmp/axiom-encode-3221-apply-2/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3221/workspace/context-manifest.json",
+  "context_manifest_sha256": "d48f958e8b3d1ceb81a5d7326bd6aa379785876af1aa74bc5190982c56c4ec9d",
+  "generated_at": "2026-05-24T01:19:53.902014+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3221-apply-2/codex-gpt-5.3-codex-spark/statutes/26/3221.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3221-apply-2",
+  "generated_output_sha256": "a4b94dadc8d4c6e3dc6826b9d9a0fdc3a35339118df161d04a8e29307d4e47ab",
+  "generation_prompt_sha256": "a239b71c3b37cafb755646cc40860eab91da2cbcd5588fbb87c1845273481a16",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "98d53ca4",
+  "runner": "codex-gpt-5.3-codex-spark",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c97bbe6e1e7530b21d9d26a0187503fc812443632646b843e1a03f4749ef2c48"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3221-apply-2/traces/codex-gpt-5.3-codex-spark/26-USC-3221.json",
+  "trace_sha256": "b3510284937ed718347afe2fb5947140c678a26feb5df50b6e1e1b39db3200b2"
+}

--- a/statutes/26/3221.test.yaml
+++ b/statutes/26/3221.test.yaml
@@ -1,0 +1,20 @@
+- name: tier_2_employer_tax_positive_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3221#input.compensation_paid: 1000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.6
+  output:
+    us:statutes/26/3221#tier_2_employer_tax: 181
+- name: tier_2_employer_tax_non_positive_compensation_is_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3221#input.compensation_paid: -1000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.6
+  output:
+    us:statutes/26/3221#tier_2_employer_tax: 0

--- a/statutes/26/3221.yaml
+++ b/statutes/26/3221.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3221
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the applicable percentage of compensation paid during any calendar year by such employer for services rendered to such employer. For purposes of the preceding sentence, the term “applicable percentage” means the percentage equal to the sum of the rates of tax in effect under subsections (a) and (b) of section 3111 for the calendar year.
+
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the percentage determined under section 3241 for any calendar year of the compensation paid during such calendar year by such employer for services rendered to such employer.
+
+    (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
+  deferred_outputs:
+    - output: us:statutes/26/3221/a#tier_1_employer_tax
+      reason: Subsection (a) requires rates from section 3111(a) and (b), but the copied 26 USC 3111 context is not executable in this workspace.
+rules:
+  - name: tier_2_employer_tax
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3221(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3221
+              source_text: (b) Tier 2 tax ...
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+              output: section_3211_and_3221_applicable_percentage_for_tax_unit
+              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          section_3211_and_3221_applicable_percentage_for_tax_unit * max(0, compensation_paid)


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3221(b) RRTA tier 2 employer tax
- include companion tests for positive and non-positive compensation
- include axiom-encode apply manifest proving generation by `axiom-encode encode --apply`

## Provenance
- axiom-encode 0.2.106
- encoder commit `ac3ef1a7b0a22cc18333968ee6b9e342a1b780b4`
- run id `98d53ca4`
- generated files: `statutes/26/3221.yaml`, `statutes/26/3221.test.yaml`, `.axiom/encoding-manifests/statutes/26/3221.json`

## Validation
- `uv run axiom-encode proof-validate /tmp/rulespec-us-26-3221/statutes/26/3221.yaml`
- `uv run axiom-encode validate /tmp/rulespec-us-26-3221/statutes/26/3221.yaml --skip-reviewers`
- `uv run axiom-encode test --root /tmp/rulespec-us-26-3221 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine statutes/26/3221.test.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /tmp/rulespec-us-26-3221 --base-ref origin/main --head-ref HEAD --json`
