### PR TITLE
Regenerate railroad payroll rate references

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3201.json
+++ b/.axiom/encoding-manifests/statutes/26/3201.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "4ac885448ea213c14761037765c697a2bd6899854157ff1063e910dc2b51daaa"
+      "sha256": "8a49195bc6db8cfae8e3816007f20733a71dc90b8038921cbfe1dc4cb7da2029"
     },
     {
       "path": "statutes/26/3201.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "56e0cf33388799321328a78e403013e07455b542",
+    "commit": "f116db0792f340fbb64c62b1e2ac477586731dd2",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.101",
-    "version_commit": "56e0cf33388799321328a78e403013e07455b542"
+    "version": "0.2.111",
+    "version_commit": "f116db0792f340fbb64c62b1e2ac477586731dd2"
   },
-  "axiom_encode_version": "0.2.101",
+  "axiom_encode_version": "0.2.111",
   "backend": "codex",
   "citation": "26 USC 3201",
-  "context_manifest_file": "/tmp/axiom-encode-3201-apply-9/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3201/workspace/context-manifest.json",
-  "context_manifest_sha256": "6e39e82d8077e8f20ddfccb5e65f3225424614b0100b4c6bc09d0017bd79b003",
-  "generated_at": "2026-05-24T00:11:15.628769+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3201-apply-9/codex-gpt-5.3-codex-spark/statutes/26/3201.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3201-apply-9",
-  "generated_output_sha256": "4ac885448ea213c14761037765c697a2bd6899854157ff1063e910dc2b51daaa",
-  "generation_prompt_sha256": "9c8e3fd5f76f406af22895f6eaea488a4685e7ee802f286c5ecce5fd0487b46d",
+  "context_manifest_file": "/tmp/axiom-encode-3201-v111/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3201/workspace/context-manifest.json",
+  "context_manifest_sha256": "643de451a7ccb2351c4b4b47ae1c1d096d3b02ea7e875c02d47872bdc0dc1cd5",
+  "generated_at": "2026-05-24T03:33:01.890902+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3201-v111/codex-gpt-5.3-codex-spark/statutes/26/3201.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3201-v111",
+  "generated_output_sha256": "8a49195bc6db8cfae8e3816007f20733a71dc90b8038921cbfe1dc4cb7da2029",
+  "generation_prompt_sha256": "ad8aaf27340d25e14d426be9ba4d4a1efb0121aad2a5e7032b51ac8570544ef7",
   "model": "gpt-5.3-codex-spark",
-  "run_id": "ec8d49c3",
+  "run_id": "16aadda2",
   "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "785d547a90058bab98efccd21d6df66e034f04b9e7aa96580c7aa502827f0831"
+    "value": "8743b0bcd380dbcf055bcb3c34400c0c62d82fb06e1da6f77eab3c2f2c569778"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3201-apply-9/traces/codex-gpt-5.3-codex-spark/26-USC-3201.json",
-  "trace_sha256": "7909522fceac67c24ead095e1e4fb92772562749db8a425400a8c73245bfc092"
+  "trace_file": "/tmp/axiom-encode-3201-v111/traces/codex-gpt-5.3-codex-spark/26-USC-3201.json",
+  "trace_sha256": "977f6cda62047851da08994be396c3e79ae538b1611f4e94f763c01dabf01a4d"
 }

--- a/.axiom/encoding-manifests/statutes/26/3211.json
+++ b/.axiom/encoding-manifests/statutes/26/3211.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3211.yaml",
-      "sha256": "96ab9bf2a9085318335afa0d1845dea7af775728a326271e8337fd7c1edf7dc4"
+      "sha256": "a7c72b7c818149d27d0a81218505c6984278473003b14d454fda833acf0f44f8"
     },
     {
       "path": "statutes/26/3211.test.yaml",
-      "sha256": "f9e4418e97839a0a53d6e4e69eb6018d414c7e5ab1b98dff0ddb04dffc47af05"
+      "sha256": "326355aa7b59f6cd239376ef786ebeba74801e136cf3c3d82039ec731e992e22"
     }
   ],
   "axiom_encode_git": {
-    "commit": "122be60162f19d4d72c64d628862a23c2a3d7ff4",
+    "commit": "f116db0792f340fbb64c62b1e2ac477586731dd2",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.105",
-    "version_commit": "122be60162f19d4d72c64d628862a23c2a3d7ff4"
+    "version": "0.2.111",
+    "version_commit": "f116db0792f340fbb64c62b1e2ac477586731dd2"
   },
-  "axiom_encode_version": "0.2.105",
+  "axiom_encode_version": "0.2.111",
   "backend": "codex",
   "citation": "26 USC 3211",
-  "context_manifest_file": "/tmp/axiom-encode-3211-apply-4/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3211/workspace/context-manifest.json",
-  "context_manifest_sha256": "8c1b616ef68886d2bfa18f739a9b7f65be4584c0b0b97487500c1e44d45231b0",
-  "generated_at": "2026-05-24T00:58:52.416333+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3211-apply-4/codex-gpt-5.3-codex-spark/statutes/26/3211.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3211-apply-4",
-  "generated_output_sha256": "96ab9bf2a9085318335afa0d1845dea7af775728a326271e8337fd7c1edf7dc4",
-  "generation_prompt_sha256": "209ea4105354c7a6bee42a4c0bc7fcb53461a0903c8580f3d8455f98e7352cf2",
+  "context_manifest_file": "/tmp/axiom-encode-3211-v111-retry/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3211/workspace/context-manifest.json",
+  "context_manifest_sha256": "fcffa594de999210a91393f1d44af725081ecf22d00b5902c9dbe55ed1dc7bfb",
+  "generated_at": "2026-05-24T03:35:28.501630+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3211-v111-retry/codex-gpt-5.3-codex-spark/statutes/26/3211.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3211-v111-retry",
+  "generated_output_sha256": "a7c72b7c818149d27d0a81218505c6984278473003b14d454fda833acf0f44f8",
+  "generation_prompt_sha256": "b6cc583734aacffa0ccb7373f177ba39945e3270f26c7907306c9252d16d2ec5",
   "model": "gpt-5.3-codex-spark",
-  "run_id": "8f05a959",
+  "run_id": "c5f712d4",
   "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7f0fc722819752a45667a342204d63d4ccce5e377862e7b3ff85f4a71f0904f9"
+    "value": "f5b1e4bb3d607c1a26221f5dfdd022e3443e743598486027c31d6129dd2a6bad"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3211-apply-4/traces/codex-gpt-5.3-codex-spark/26-USC-3211.json",
-  "trace_sha256": "62930cf94f225264185701c2999e5680daf1b93c7d62e75eab76524762fbb41a"
+  "trace_file": "/tmp/axiom-encode-3211-v111-retry/traces/codex-gpt-5.3-codex-spark/26-USC-3211.json",
+  "trace_sha256": "83289d0d8d86e4e1c1a215ef3d97d42951ca5dd27107f540daf164e92d60c94c"
 }

--- a/.axiom/encoding-manifests/statutes/26/3221.json
+++ b/.axiom/encoding-manifests/statutes/26/3221.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3221.yaml",
-      "sha256": "a4b94dadc8d4c6e3dc6826b9d9a0fdc3a35339118df161d04a8e29307d4e47ab"
+      "sha256": "657e700f287fc560a56d83fa96958328f75822769a9caa4542b88d088570daf9"
     },
     {
       "path": "statutes/26/3221.test.yaml",
-      "sha256": "8edfceedefc3f1ff277166cd3b2efef66821328d16e4e253c9f1db96a96476ed"
+      "sha256": "6894780973fa7d5c46f3bd72a0276e3a47c44f8a6725b819e9656ce8cf63297f"
     }
   ],
   "axiom_encode_git": {
-    "commit": "ac3ef1a7b0a22cc18333968ee6b9e342a1b780b4",
+    "commit": "f116db0792f340fbb64c62b1e2ac477586731dd2",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.106",
-    "version_commit": "ac3ef1a7b0a22cc18333968ee6b9e342a1b780b4"
+    "version": "0.2.111",
+    "version_commit": "f116db0792f340fbb64c62b1e2ac477586731dd2"
   },
-  "axiom_encode_version": "0.2.106",
+  "axiom_encode_version": "0.2.111",
   "backend": "codex",
   "citation": "26 USC 3221",
-  "context_manifest_file": "/tmp/axiom-encode-3221-apply-2/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3221/workspace/context-manifest.json",
-  "context_manifest_sha256": "d48f958e8b3d1ceb81a5d7326bd6aa379785876af1aa74bc5190982c56c4ec9d",
-  "generated_at": "2026-05-24T01:19:53.902014+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3221-apply-2/codex-gpt-5.3-codex-spark/statutes/26/3221.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3221-apply-2",
-  "generated_output_sha256": "a4b94dadc8d4c6e3dc6826b9d9a0fdc3a35339118df161d04a8e29307d4e47ab",
-  "generation_prompt_sha256": "a239b71c3b37cafb755646cc40860eab91da2cbcd5588fbb87c1845273481a16",
+  "context_manifest_file": "/tmp/axiom-encode-3221-v111/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3221/workspace/context-manifest.json",
+  "context_manifest_sha256": "1a70da4c4cd36b2ea41678d37dbdfedc91ed92015680170c225c2d93e1a62024",
+  "generated_at": "2026-05-24T03:36:42.371891+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3221-v111/codex-gpt-5.3-codex-spark/statutes/26/3221.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3221-v111",
+  "generated_output_sha256": "657e700f287fc560a56d83fa96958328f75822769a9caa4542b88d088570daf9",
+  "generation_prompt_sha256": "9892729683776996ab349f1300b4e4c5a9b26515b5acbc74e867bc14432a4084",
   "model": "gpt-5.3-codex-spark",
-  "run_id": "98d53ca4",
+  "run_id": "a918ed8a",
   "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c97bbe6e1e7530b21d9d26a0187503fc812443632646b843e1a03f4749ef2c48"
+    "value": "f2ff78fe799ef2df023886a0a49a6e4076fa1d849ca76fa2747e0c5938fd3e80"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3221-apply-2/traces/codex-gpt-5.3-codex-spark/26-USC-3221.json",
-  "trace_sha256": "b3510284937ed718347afe2fb5947140c678a26feb5df50b6e1e1b39db3200b2"
+  "trace_file": "/tmp/axiom-encode-3221-v111/traces/codex-gpt-5.3-codex-spark/26-USC-3221.json",
+  "trace_sha256": "b91872850fc729c73a7b19d08a6d78e3c2142baea820d768c03e018231751f7a"
 }

--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3"
+      "sha256": "43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
-      "sha256": "3097e47f610fb5db20c4c34d51507739a0ce0479aba73e23b82a3ac104d79734"
+      "sha256": "0b8bc35331f18e808b8c3564999a4dda268b29fdad1c95c7199bc7fed96f73bf"
     }
   ],
   "axiom_encode_git": {
-    "commit": "f7ffb8be4550319b6ddc52b5a6d98356976d7829",
+    "commit": "f116db0792f340fbb64c62b1e2ac477586731dd2",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.98",
-    "version_commit": "f7ffb8be4550319b6ddc52b5a6d98356976d7829"
+    "version": "0.2.111",
+    "version_commit": "f116db0792f340fbb64c62b1e2ac477586731dd2"
   },
-  "axiom_encode_version": "0.2.98",
+  "axiom_encode_version": "0.2.111",
   "backend": "codex",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/tmp/axiom-encode-3241b-apply-6/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "05df7d3ed190696babd3c2bc29a48862e00c30a64bab2925d1e94bda3a9b911a",
-  "generated_at": "2026-05-23T22:25:25.708674+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3241b-apply-6/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3241b-apply-6",
-  "generated_output_sha256": "48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3",
-  "generation_prompt_sha256": "964ba82185e7862a15f7031d0ccd102579abe472f700c6553c64346e488671f5",
+  "context_manifest_file": "/tmp/axiom-encode-3241b-v111/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "ab0dabb758fd53df3f2e1520e665470b602d61bcf8fca9c55aea35626dbf35ab",
+  "generated_at": "2026-05-24T03:31:55.407696+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3241b-v111/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3241b-v111",
+  "generated_output_sha256": "43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc",
+  "generation_prompt_sha256": "653e0d6a46795f03ebdd4ad23a5217f038b506b0f1555b26ca3ea2f8be505f10",
   "model": "gpt-5.3-codex-spark",
-  "run_id": "01e7a3aa",
+  "run_id": "6a829d3e",
   "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "fcc373ece387d329f7fd8c4502f6fe36d99f04763b2f86789bc6a19dba694bb6"
+    "value": "6fc4d87a6f4391e048678ff04a490ba78ef5507b52c12411ee68e8ad9b4ff355"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3241b-apply-6/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
-  "trace_sha256": "a599fd8f3b15cfdbb93b5dc5026b5265b787175e53859fd914fdbd7be5f3371a"
+  "trace_file": "/tmp/axiom-encode-3241b-v111/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
+  "trace_sha256": "c2fc69cb0410f53bb5131e259c291c0fa7f5a5515d2fdcca623098ad630fd154"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -1,6 +1,6 @@
 format: rulespec/v1
 imports:
-  - us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit
+  - us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
 module:
   proof_validation:
     required: true
@@ -14,8 +14,7 @@ module:
     (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
   deferred_outputs:
     - output: us:statutes/26/3201/a#tier_1_employee_tax
-      reason: |
-        Subsection (a) requires rates from section 3101(a) and 3101(b), but section 3101 is copied as non-executable and unavailable here for direct computation.
+      reason: Subsection (a) relies on the rates in 26 USC 3101(a) and 26 USC 3101(b), but section 3101 is available only as non-executable context in this workspace and has no importable applicable percentage value for this computation.
 rules:
   - name: tier_2_employee_tax
     kind: derived
@@ -35,14 +34,14 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit
-              output: section_3201_applicable_percentage_for_tax_unit
-              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+              target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
+              output: applicable_percentage_for_section_3201_b
+              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
     versions:
       - effective_from: '1990-01-01'
         formula: |-
           max(
             0,
             compensation_received_for_services_rendered_by_employee_for_calendar_year
-            * section_3201_applicable_percentage_for_tax_unit
+            * applicable_percentage_for_section_3201_b
           )

--- a/statutes/26/3211.test.yaml
+++ b/statutes/26/3211.test.yaml
@@ -8,13 +8,13 @@
     us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
   output:
     us:statutes/26/3211#tier_2_employee_representative_tax: 221.0
-- name: tier_2_employee_representative_tax_zero_compensation
+- name: tier_2_employee_representative_tax_negative_compensation_floored_to_zero
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3211#input.compensation_received_for_services_as_employee_representative: 0
+    us:statutes/26/3211#input.compensation_received_for_services_as_employee_representative: -500
     us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.5
   output:
-    us:statutes/26/3211#tier_2_employee_representative_tax: 0
+    us:statutes/26/3211#tier_2_employee_representative_tax: 0.0

--- a/statutes/26/3211.yaml
+++ b/statutes/26/3211.yaml
@@ -1,6 +1,6 @@
 format: rulespec/v1
 imports:
-  - us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+  - us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
 module:
   proof_validation:
     required: true
@@ -15,10 +15,7 @@ module:
   deferred_outputs:
     - output: us:statutes/26/3211/a#tier_1_employee_representative_tax
       reason: >-
-        Subsection (a) depends on rates under sections 3101(a), 3101(b), 3111(a), and
-        3111(b), but the copied context for those citations is non-executable for this
-        run. The tier 1 amount is therefore deferred rather than modeled with local
-        cross-reference placeholders.
+        Subsection (a) requires a rate equal to the sum of rates under sections 3101(a), 3101(b), 3111(a), and 3111(b), but copied context for sections 3101 and 3111 is non-executable in this workspace and exports no usable rates.
 rules:
   - name: tier_2_employee_representative_tax
     kind: derived
@@ -38,10 +35,11 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
-              output: section_3211_and_3221_applicable_percentage_for_tax_unit
-              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+              target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
+              output: applicable_percentage_for_sections_3211_b_and_3221_b
+              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          section_3211_and_3221_applicable_percentage_for_tax_unit * max(0, compensation_received_for_services_as_employee_representative)
+          max(0, compensation_received_for_services_as_employee_representative)
+          * applicable_percentage_for_sections_3211_b_and_3221_b

--- a/statutes/26/3221.test.yaml
+++ b/statutes/26/3221.test.yaml
@@ -1,20 +1,20 @@
-- name: tier_2_employer_tax_positive_compensation
+- name: tier_2_employer_tax_positive
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3221#input.compensation_paid: 1000
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.6
+    us:statutes/26/3221#input.compensation_paid: 10000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.4
   output:
-    us:statutes/26/3221#tier_2_employer_tax: 181
-- name: tier_2_employer_tax_non_positive_compensation_is_zero
+    us:statutes/26/3221#tier_2_employer_tax: 2210
+- name: tier_2_employer_tax_zero_compensation
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3221#input.compensation_paid: -1000
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.6
+    us:statutes/26/3221#input.compensation_paid: 0
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 7.2
   output:
     us:statutes/26/3221#tier_2_employer_tax: 0

--- a/statutes/26/3221.yaml
+++ b/statutes/26/3221.yaml
@@ -1,20 +1,6 @@
 format: rulespec/v1
 imports:
-- us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
-module:
-  proof_validation:
-    required: true
-  source_verification:
-    corpus_citation_path: us/statute/26/3221
-  summary: |-
-    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the applicable percentage of compensation paid during any calendar year by such employer for services rendered to such employer. For purposes of the preceding sentence, the term “applicable percentage” means the percentage equal to the sum of the rates of tax in effect under subsections (a) and (b) of section 3111 for the calendar year.
-
-    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the percentage determined under section 3241 for any calendar year of the compensation paid during such calendar year by such employer for services rendered to such employer.
-
-    (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
-  deferred_outputs:
-    - output: us:statutes/26/3221/a#tier_1_employer_tax
-      reason: Subsection (a) requires rates from section 3111(a) and (b), but the copied 26 USC 3111 context is not executable in this workspace.
+  - us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
 rules:
   - name: tier_2_employer_tax
     kind: derived
@@ -30,14 +16,27 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3221
-              source_text: (b) Tier 2 tax ...
           - path: versions[0].formula
             kind: import
             import:
-              target: us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
-              output: section_3211_and_3221_applicable_percentage_for_tax_unit
-              hash: sha256:48421957c1b450fa193c3b106617e6f1bba0f5833a8c5e93258ad25fb2a2f7b3
+              target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
+              output: applicable_percentage_for_sections_3211_b_and_3221_b
+              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          section_3211_and_3221_applicable_percentage_for_tax_unit * max(0, compensation_paid)
+          max(0, compensation_paid) * applicable_percentage_for_sections_3211_b_and_3221_b
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3221
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the applicable percentage of compensation paid during any calendar year by such employer for services rendered to such employer. For purposes of the preceding sentence, the term “applicable percentage” means the percentage equal to the sum of the rates of tax in effect under subsections (a) and (b) of section 3111 for the calendar year.
+
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on every employer an excise tax, with respect to having individuals in his employ, equal to the percentage determined under section 3241 for any calendar year of the compensation paid during such calendar year by such employer for services rendered to such employer.
+
+    (c) Cross reference For application of different contribution bases with respect to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
+  deferred_outputs:
+    - output: us:statutes/26/3221/a#tier_1_employer_tax
+      reason: Tier 1 requires a rate defined as the sum of rates under 26 USC 3111(a) and 26 USC 3111(b); 26 USC 3111 is copied as non-executable context, so tier-1 computation cannot be represented here without introducing a prohibited local stand-in.

--- a/statutes/26/3241/b.test.yaml
+++ b/statutes/26/3241/b.test.yaml
@@ -1,13 +1,25 @@
-- name: ratio_below_2_5
+- name: ratio_under_first_band
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.4
   output:
-    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.221
-    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.049
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_2_5: 2.5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_3_0: 3
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_3_5: 3.5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_4_0: 4
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_6_1: 6.1
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_6_5: 6.5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_7_0: 7
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_7_5: 7.5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_8_0: 8
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_8_5: 8.5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_9_0: 9
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 1
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.221
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.049
 - name: ratio_at_2_5
   period:
     period_kind: tax_year
@@ -16,34 +28,28 @@
   input:
     us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.5
   output:
-    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.181
-    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.049
-- name: ratio_between_6_1_and_6_5
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 2
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.181
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.049
+- name: ratio_mid_high_band
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 6.3
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 7.2
   output:
-    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.126
-    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.044
-- name: ratio_at_9_0_and_above
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 8
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.116
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.034
+- name: ratio_at_9_plus
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9.0
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9
   output:
-    us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit: 0.082
-    us:statutes/26/3241/b#section_3201_applicable_percentage_for_tax_unit: 0.0
-- name: auto_output_average_account_benefits_ratio_band
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 0
-  output:
-    us:statutes/26/3241/b#average_account_benefits_ratio_band: 1
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 12
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.082
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -4,35 +4,174 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3241
-  summary: '(b) Tax rate schedule | Average account benefits ratio | Applicable percentage
-    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b)
-
-    At least | But less than
-
-    .............. | 2.5 | 22.1 | 4.9
-
-    2.5 | 3.0 | 18.1 | 4.9
-
-    3.0 | 3.5 | 15.1 | 4.9
-
-    3.5 | 4.0 | 14.1 | 4.9
-
-    4.0 | 6.1 | 13.1 | 4.9
-
-    6.1 | 6.5 | 12.6 | 4.4
-
-    6.5 | 7.0 | 12.1 | 3.9
-
-    7.0 | 7.5 | 11.6 | 3.4
-
-    7.5 | 8.0 | 11.1 | 2.9
-
-    8.0 | 8.5 | 10.1 | 1.9
-
-    8.5 | 9.0 | 9.1 | 0.9
-
-    9.0 | .............. | 8.2 | 0'
+  summary: |-
+    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 | 3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1 | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5 | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0 | .............. | 8.2 | 0 |
 rules:
+- name: average_account_benefits_ratio_band_threshold_2_5
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      2.5
+- name: average_account_benefits_ratio_band_threshold_3_0
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      3.0
+- name: average_account_benefits_ratio_band_threshold_3_5
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      3.5
+- name: average_account_benefits_ratio_band_threshold_4_0
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      4.0
+- name: average_account_benefits_ratio_band_threshold_6_1
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      6.1
+- name: average_account_benefits_ratio_band_threshold_6_5
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      6.5
+- name: average_account_benefits_ratio_band_threshold_7_0
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      7.0
+- name: average_account_benefits_ratio_band_threshold_7_5
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      7.5
+- name: average_account_benefits_ratio_band_threshold_8_0
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      8.0
+- name: average_account_benefits_ratio_band_threshold_8_5
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      8.5
+- name: average_account_benefits_ratio_band_threshold_9_0
+  kind: parameter
+  dtype: Float
+  source: 26 USC 3241(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3241
+  versions:
+  - effective_from: 1990-01-01
+    formula: |-
+      9.0
 - name: average_account_benefits_ratio_band
   kind: derived
   entity: TaxUnit
@@ -46,29 +185,22 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/26/3241
-          corpus_span: (b) at least / but less than interval table
   versions:
-  - effective_from: '1990-01-01'
-    formula: "if average_account_benefits_ratio < 2.5:\n  1\nelse:\n  if average_account_benefits_ratio\
-      \ >= 2.5 and average_account_benefits_ratio < 3.0:\n    2\n  else:\n    if average_account_benefits_ratio\
-      \ >= 3.0 and average_account_benefits_ratio < 3.5:\n      3\n    else:\n   \
-      \   if average_account_benefits_ratio >= 3.5 and average_account_benefits_ratio\
-      \ < 4.0:\n        4\n      else:\n        if average_account_benefits_ratio\
-      \ >= 4.0 and average_account_benefits_ratio < 6.1:\n          5\n        else:\n\
-      \          if average_account_benefits_ratio >= 6.1 and average_account_benefits_ratio\
-      \ < 6.5:\n            6\n          else:\n            if average_account_benefits_ratio\
-      \ >= 6.5 and average_account_benefits_ratio < 7.0:\n              7\n      \
-      \      else:\n              if average_account_benefits_ratio >= 7.0 and average_account_benefits_ratio\
-      \ < 7.5:\n                8\n              else:\n                if average_account_benefits_ratio\
-      \ >= 7.5 and average_account_benefits_ratio < 8.0:\n                  9\n  \
-      \              else:\n                  if average_account_benefits_ratio >=\
-      \ 8.0 and average_account_benefits_ratio < 8.5:\n                    10\n  \
-      \                else:\n                    if average_account_benefits_ratio\
-      \ >= 8.5 and average_account_benefits_ratio < 9.0:\n                      11\n\
-      \                    else:\n                      if average_account_benefits_ratio\
-      \ >= 9.0:\n                        12\n                      else:\n       \
-      \                 1"
-- name: section_3211_3221_applicable_percentage_by_ratio_band
+  - effective_from: 1990-01-01
+    formula: |-
+      if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_2_5: 1
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_0: 2
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_5: 3
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_4_0: 4
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_6_1: 5
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_6_5: 6
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_7_0: 7
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_7_5: 8
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_8_0: 9
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_8_5: 10
+      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_9_0: 11
+      else: 12
+- name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
   kind: parameter
   dtype: Rate
   indexed_by: average_account_benefits_ratio_band
@@ -82,10 +214,10 @@ rules:
           corpus_citation_path: us/statute/26/3241
           table:
             header: Applicable percentage for sections 3211(b) and 3221(b)
-            row_key: average account benefits ratio interval band
+            row_key: average_account_benefits_ratio_band
             column_key: applicable percentage
   versions:
-  - effective_from: '1990-01-01'
+  - effective_from: 1990-01-01
     values:
       1: 0.221
       2: 0.181
@@ -99,7 +231,7 @@ rules:
       10: 0.101
       11: 0.091
       12: 0.082
-- name: section_3201_applicable_percentage_by_ratio_band
+- name: applicable_percentage_for_section_3201_b_by_ratio_band
   kind: parameter
   dtype: Rate
   indexed_by: average_account_benefits_ratio_band
@@ -113,10 +245,10 @@ rules:
           corpus_citation_path: us/statute/26/3241
           table:
             header: Applicable percentage for section 3201(b)
-            row_key: average account benefits ratio interval band
+            row_key: average_account_benefits_ratio_band
             column_key: applicable percentage
   versions:
-  - effective_from: '1990-01-01'
+  - effective_from: 1990-01-01
     values:
       1: 0.049
       2: 0.049
@@ -129,8 +261,8 @@ rules:
       9: 0.029
       10: 0.019
       11: 0.009
-      12: 0.0
-- name: section_3211_and_3221_applicable_percentage_for_tax_unit
+      12: 0
+- name: applicable_percentage_for_sections_3211_b_and_3221_b
   kind: derived
   entity: TaxUnit
   dtype: Rate
@@ -143,11 +275,12 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/26/3241
-          corpus_span: (b) rate table column for sections 3211(b) and 3221(b)
+          corpus_span: (b) applicable percentage for sections 3211(b) and 3221(b)
   versions:
-  - effective_from: '1990-01-01'
-    formula: section_3211_3221_applicable_percentage_by_ratio_band[average_account_benefits_ratio_band]
-- name: section_3201_applicable_percentage_for_tax_unit
+  - effective_from: 1990-01-01
+    formula: |-
+      applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
+- name: applicable_percentage_for_section_3201_b
   kind: derived
   entity: TaxUnit
   dtype: Rate
@@ -160,7 +293,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/26/3241
-          corpus_span: (b) rate table column for section 3201(b)
+          corpus_span: (b) applicable percentage for section 3201(b)
   versions:
-  - effective_from: '1990-01-01'
-    formula: section_3201_applicable_percentage_by_ratio_band[average_account_benefits_ratio_band]
+  - effective_from: 1990-01-01
+    formula: |-
+      applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3241(b) table outputs with neutral shared-rate names
- refresh 26 USC 3201, 3211, and 3221 imports to use the generated shared-rate outputs
- update generated manifests from axiom-encode 0.2.111

## Validation
- axiom-encode validate statutes/26/3241/b.yaml --skip-reviewers
- axiom-encode validate statutes/26/3201.yaml --skip-reviewers
- axiom-encode validate statutes/26/3211.yaml --skip-reviewers
- axiom-encode validate statutes/26/3221.yaml --skip-reviewers
- axiom-encode proof-validate for 3241(b), 3201, 3211, 3221
- axiom-encode test for 3241(b), 3201, 3211, 3221: 4 files, 10 cases
- axiom-encode guard-generated: passed