### PR TITLE
Encode section 1402(b) self-employment income

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/1402/b.json
+++ b/.axiom/encoding-manifests/statutes/26/1402/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/1402/b.yaml",
+      "sha256": "d9ef868fb8d2bf455bcf2a559ed6ec40342027336002f1354ba49f53af328120"
+    },
+    {
+      "path": "statutes/26/1402/b.test.yaml",
+      "sha256": "7c603ac6081d1eadede5e0a5e6a052d4b1a024c422210b329a1e1ac642647223"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "78eff9b05e2cd04b9d31b65a80aae7f42b7d9929",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-excess-cap-semantics",
+    "version": "0.2.120",
+    "version_commit": "78eff9b05e2cd04b9d31b65a80aae7f42b7d9929"
+  },
+  "axiom_encode_version": "0.2.120",
+  "backend": "codex",
+  "citation": "26 USC 1402(b)",
+  "context_manifest_file": "/tmp/axiom-encode-1402b-0.2.120/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-1402-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "b1c2db72b858ccf18f46390f4926e7ab7adf7b6b8d845953f95eeabedde67af4",
+  "generated_at": "2026-05-24T05:08:51.182558+00:00",
+  "generated_output_file": "/tmp/axiom-encode-1402b-0.2.120/codex-gpt-5.3-codex-spark/statutes/26/1402/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-1402b-0.2.120",
+  "generated_output_sha256": "d9ef868fb8d2bf455bcf2a559ed6ec40342027336002f1354ba49f53af328120",
+  "generation_prompt_sha256": "9880645afb9e079527cbbcf15289bdb111ca40c8330cd76bcb6f2eac9892195d",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "8b51e378",
+  "runner": "codex-gpt-5.3-codex-spark",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "40433656f390c89346293a3490be06393032adfe95e3810b24814980b6edc4ac"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-1402b-0.2.120/traces/codex-gpt-5.3-codex-spark/26-USC-1402-b.json",
+  "trace_sha256": "89a55803e7536cbde7af3650780daf193e4db09e12ff51b33496b2e33abbe653"
+}

--- a/statutes/26/1402/b.test.yaml
+++ b/statutes/26/1402/b.test.yaml
@@ -1,0 +1,73 @@
+- name: includes_chapter-wide_territory_exempt_nonresident_with_above_threshold_and_no_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 5000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 100
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: true
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: true
+  output:
+    us:statutes/26/1402/b#self_employment_income_inclusion_threshold: 400
+    us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: not_holds
+    us:statutes/26/1402/b#self_employment_income: 923.5
+    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 923.5
+- name: below_threshold_yields_zero
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 350
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 50
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 5000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 10
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: not_holds
+    us:statutes/26/1402/b#self_employment_income: 0
+    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 0
+- name: capping_applies_only_for_section_1401_a
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 2500
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 1200
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 500
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: not_holds
+    us:statutes/26/1402/b#self_employment_income: 2124.05
+    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 700
+- name: nonresident_alien_without_agreement_is_excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1500
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 300
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 5000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 1000
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: true
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: holds
+    us:statutes/26/1402/b#self_employment_income: 0
+    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 0

--- a/statutes/26/1402/b.yaml
+++ b/statutes/26/1402/b.yaml
@@ -1,0 +1,118 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/1402
+  summary: |-
+    (b) Self-employment income The term “self-employment income” means the net earnings from self-employment derived by an individual (other than a nonresident alien individual, except as provided by an agreement under section 233 of the Social Security Act) during any taxable year; except that such term shall not include— (1) in the case of the tax imposed by section 1401(a), that part of the net earnings from self-employment which is in excess of (i) an amount equal to the contribution and benefit base (as determined under section 230 of the Social Security Act) which is effective for the calendar year in which such taxable year begins, minus (ii) the amount of the wages paid to such individual during such taxable years; or (2) the net earnings from self-employment, if such net earnings for the taxable year are less than $400. For purposes of paragraph (1), the term “wages” (A) includes such remuneration paid to an employee for services included under an agreement entered into pursuant to the provisions of section 3121( l ) (relating to coverage of citizens of the United States who are employees of foreign affiliates of American employers), as would be wages under section 3121(a) if such services constituted employment under section 3121(b), and (B) includes compensation which is subject to the tax imposed by section 3201 or 3211. An individual who is not a citizen of the United States but who is a resident of the Commonwealth of Puerto Rico, the Virgin Islands, Guam, or American Samoa shall not, for purposes of this chapter be considered to be a nonresident alien individual. In the case of church employee income, the special rules of subsection (j)(2) shall apply for purposes of paragraph (2).
+imports:
+  - us:statutes/26/1402/a#net_earnings_from_self_employment
+rules:
+  - name: self_employment_income_inclusion_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 1402(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/1402
+              span: 26 USC 1402(b)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          400
+
+  - name: self_employment_income_excluded_for_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 1402(b), first sentence and final sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/1402
+              span: 26 USC 1402(b)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_is_nonresident_alien
+          and not social_security_agreement_under_section_233_applies_to_nonresident_alien
+          and not individual_is_noncitizen_territory_resident
+
+  - name: self_employment_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/1402
+              span: 26 USC 1402(b)(2)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1402/a#net_earnings_from_self_employment
+              output: net_earnings_from_self_employment
+              hash: sha256:ab9e44c995d39fa28ace7be3236ac8fb99310ee67b20adf112da049fbe7007b5
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if self_employment_income_excluded_for_taxpayer: 0
+          else:
+            if net_earnings_from_self_employment < self_employment_income_inclusion_threshold:
+              0
+            else:
+              net_earnings_from_self_employment
+
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/1402
+              span: 26 USC 1402(b)(1)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1402/a#net_earnings_from_self_employment
+              output: net_earnings_from_self_employment
+              hash: sha256:ab9e44c995d39fa28ace7be3236ac8fb99310ee67b20adf112da049fbe7007b5
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if self_employment_income_excluded_for_taxpayer: 0
+          else:
+            if net_earnings_from_self_employment < self_employment_income_inclusion_threshold:
+              0
+            else:
+              min(
+                net_earnings_from_self_employment,
+                max(
+                  0,
+                  contribution_and_benefit_base_under_section_230_of_social_security_act
+                  - wages_paid_to_individual_for_section_1401_a
+                )
+              )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 1402(b) self-employment income
- expose `self_employment_income_for_section_1401_a` with the Social Security contribution-and-benefit base minus wages cap
- include signed axiom-encode apply manifest

## Tests
- uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode test statutes/26/1402/b.test.yaml --root /tmp/rulespec-us-seca-chain --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --json
- uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode guard-generated --repo /tmp/rulespec-us-seca-chain --base-ref origin/main --head-ref HEAD --json

## Note
- I tried regenerating 1402(a) and 1401 as the next integrated chain step. 1401 currently cannot import 1402(b) while 1402(a) imports 1401 rate outputs, so this PR keeps the generated 1402(b) subsection separate and does not hand-edit generated RuleSpec.