### PR TITLE
Encode section 1401 rate boundaries

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/1401/a/rate.json
+++ b/.axiom/encoding-manifests/statutes/26/1401/a/rate.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/1401/a/rate.yaml",
+      "sha256": "ff4ad3c6a9774807ea9d6ec00e410bb02e656b8878b6f6cf6d67754bc628c02e"
+    },
+    {
+      "path": "statutes/26/1401/a/rate.test.yaml",
+      "sha256": "633e67ff77c928a3bdf11b8cee86330f369c0c72fcd9269123244968a60233a0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7b45f488a3642ae62bd9ae8b4b342dda3b5e2a5e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.125",
+    "version_commit": "7b45f488a3642ae62bd9ae8b4b342dda3b5e2a5e"
+  },
+  "axiom_encode_version": "0.2.125",
+  "backend": "openai",
+  "citation": "us/statute/26/1401/a/rate",
+  "context_manifest_file": "/tmp/axiom-encode-1401-a-rate-apply/_eval_workspaces/openai-gpt-5.5/us-statute-26-1401-a-rate/workspace/context-manifest.json",
+  "context_manifest_sha256": "0f962faa8463b0b0834f4656aedda8a3803d72134101eb5b9670b6e53124dddf",
+  "generated_at": "2026-05-24T07:32:28.722412+00:00",
+  "generated_output_file": "/tmp/axiom-encode-1401-a-rate-apply/openai-gpt-5.5/statutes/26/1401/a/rate.yaml",
+  "generated_output_root": "/tmp/axiom-encode-1401-a-rate-apply",
+  "generated_output_sha256": "ff4ad3c6a9774807ea9d6ec00e410bb02e656b8878b6f6cf6d67754bc628c02e",
+  "generation_prompt_sha256": "299e2d4232a4ec0f9f318914e2ce295a7f3ef4e85d5014b1282bfaa6944a136e",
+  "model": "gpt-5.5",
+  "run_id": "0702676d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "378c34f9f33efaa27b8eb2e91e7c4d1c49d0f78a572b9edf502508745471d191"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-1401-a-rate-apply/traces/openai-gpt-5.5/us-statute-26-1401-a-rate.json",
+  "trace_sha256": "4996b94a89dfef7f12412cb53a41697f376ecfbee4f80f31fbb6ecffe8a63e7a"
+}

--- a/.axiom/encoding-manifests/statutes/26/1401/b/1/rate.json
+++ b/.axiom/encoding-manifests/statutes/26/1401/b/1/rate.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/1401/b/1/rate.yaml",
+      "sha256": "4b13c38511ce6cc289677d8d1a1cbb856a68e16bb07485108094867716dccd44"
+    },
+    {
+      "path": "statutes/26/1401/b/1/rate.test.yaml",
+      "sha256": "9e2217a4e68916df335bebcaa1add489a2e47848c24770343d086a1797167249"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7b45f488a3642ae62bd9ae8b4b342dda3b5e2a5e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.125",
+    "version_commit": "7b45f488a3642ae62bd9ae8b4b342dda3b5e2a5e"
+  },
+  "axiom_encode_version": "0.2.125",
+  "backend": "openai",
+  "citation": "us/statute/26/1401/b/1/rate",
+  "context_manifest_file": "/tmp/axiom-encode-1401-b-1-rate-apply/_eval_workspaces/openai-gpt-5.5/us-statute-26-1401-b-1-rate/workspace/context-manifest.json",
+  "context_manifest_sha256": "79e0c8a92b7832465f42b9e0917da65cb4a3f2091e3ad10ef90e7ac12a510d32",
+  "generated_at": "2026-05-24T07:33:14.562043+00:00",
+  "generated_output_file": "/tmp/axiom-encode-1401-b-1-rate-apply/openai-gpt-5.5/statutes/26/1401/b/1/rate.yaml",
+  "generated_output_root": "/tmp/axiom-encode-1401-b-1-rate-apply",
+  "generated_output_sha256": "4b13c38511ce6cc289677d8d1a1cbb856a68e16bb07485108094867716dccd44",
+  "generation_prompt_sha256": "15ec925815564493176bf7cdbbedf324d8ef092f09d2f764cc26af9b8a2543ce",
+  "model": "gpt-5.5",
+  "run_id": "fa688487",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4c3a8c23789753d46904759e206dd4a7fae04c7aa2bece300e54d5697e71f544"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-1401-b-1-rate-apply/traces/openai-gpt-5.5/us-statute-26-1401-b-1-rate.json",
+  "trace_sha256": "ec7ee78629b1cfba9a7bf926ca0c125eae16866b46056b1d553a12b7113488aa"
+}

--- a/statutes/26/1401/a/rate.test.yaml
+++ b/statutes/26/1401/a/rate.test.yaml
@@ -1,0 +1,8 @@
+- name: old_age_survivors_and_disability_insurance_tax_rate_is_12_4_percent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate: 0.124

--- a/statutes/26/1401/a/rate.yaml
+++ b/statutes/26/1401/a/rate.yaml
@@ -1,0 +1,25 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/1401
+  summary: |-
+    (a) Old-age, survivors, and disability insurance In addition to other taxes, there shall be imposed for each taxable year, on the self-employment income of every individual, a tax equal to 12.4 percent of the amount of the self-employment income for such taxable year.
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 1401(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/1401
+              span: 26 USC 1401(a), "a tax equal to 12.4 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.124

--- a/statutes/26/1401/b/1/rate.test.yaml
+++ b/statutes/26/1401/b/1/rate.test.yaml
@@ -1,0 +1,8 @@
+- name: self_employment_income_tax_rate_is_2_9_percent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate: 0.029

--- a/statutes/26/1401/b/1/rate.yaml
+++ b/statutes/26/1401/b/1/rate.yaml
@@ -1,0 +1,25 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/1401
+  summary: |-
+    (1) In general In addition to the tax imposed by the preceding subsection, there shall be imposed for each taxable year, on the self-employment income of every individual, a tax equal to 2.9 percent of the amount of the self-employment income for such taxable year.
+rules:
+  - name: self_employment_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 1401(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/1401
+              span: 26 USC 1401(b)(1), "2.9 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.029


### PR DESCRIPTION
## Summary
- Adds generated/signed rate-boundary artifacts for `26 USC 1401(a)` and `26 USC 1401(b)(1)`.
- These expose the OASDI self-employment tax rate and hospital-insurance self-employment tax rate as narrow `/rate` parameters.
- Generated with merged `axiom-encode` 0.2.125 from PR #135; no hand edits to RuleSpec artifacts.

## Validation
- `uv run --with /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode test statutes/26/1401/a/rate.test.yaml --root /tmp/rulespec-us-1401-rate-boundaries --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --json`
- `uv run --with /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode test statutes/26/1401/b/1/rate.test.yaml --root /tmp/rulespec-us-1401-rate-boundaries --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --json`
- `uv run --with /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode guard-generated --repo /tmp/rulespec-us-1401-rate-boundaries --base-ref origin/main --head-ref HEAD --json`

## Follow-up
- Non-apply attempts for executable `1401(a)`, `1401(b)(1)`, and top-level `1401` exposed encoder gaps, so this PR intentionally keeps only the safe generated rate boundaries.