### PR TITLE
Encode section 1401 child taxes

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/1401/a.json
+++ b/.axiom/encoding-manifests/statutes/26/1401/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/1401/a.yaml",
+      "sha256": "069cdd781afab99ae6644e2df92b23bbf58ebdbcc60f4fcdc577a436ed2a3df2"
+    },
+    {
+      "path": "statutes/26/1401/a.test.yaml",
+      "sha256": "b236635ebefca540b08bdfcc78ba4c92a57a5ffc2fc544ab14ca987f6f8ba7db"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "54a948e8c69cc768314f7b3de4cb0068890bfbd6",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.130",
+    "version_commit": "54a948e8c69cc768314f7b3de4cb0068890bfbd6"
+  },
+  "axiom_encode_version": "0.2.130",
+  "backend": "openai",
+  "citation": "us/statute/26/1401/a",
+  "context_manifest_file": "/tmp/axiom-encode-1401-a-seca-tax-apply-v5/_eval_workspaces/openai-gpt-5.5/us-statute-26-1401-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "91754992f934db83298c968b29a8aa8af5f34d6a8377be58b61557e6edfedbc6",
+  "generated_at": "2026-05-24T09:35:57.600688+00:00",
+  "generated_output_file": "/tmp/axiom-encode-1401-a-seca-tax-apply-v5/openai-gpt-5.5/statutes/26/1401/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-1401-a-seca-tax-apply-v5",
+  "generated_output_sha256": "069cdd781afab99ae6644e2df92b23bbf58ebdbcc60f4fcdc577a436ed2a3df2",
+  "generation_prompt_sha256": "ccc16558eaadf9a64ba0e1eae69d6006cfc576517ebc0aae2f7f75b60f6dacab",
+  "model": "gpt-5.5",
+  "run_id": "cb34e5b5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fe2920eaa8353c5c0b0f16cdc847dc53ca9eb83877ad85f3bb5a89fe7be1a02a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-1401-a-seca-tax-apply-v5/traces/openai-gpt-5.5/us-statute-26-1401-a.json",
+  "trace_sha256": "777815e5559900b89e45333d88b803424cf095c00b5ca292c30f259e5ad25142"
+}

--- a/.axiom/encoding-manifests/statutes/26/1401/b/1.json
+++ b/.axiom/encoding-manifests/statutes/26/1401/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/1401/b/1.yaml",
+      "sha256": "1254c5c0873aa5e91f3d53a986e7e091650f11d366b567859388a96dda40382d"
+    },
+    {
+      "path": "statutes/26/1401/b/1.test.yaml",
+      "sha256": "1ea7d8d529d7662b40449d2d318d0e1275e88c0be37b9d9c74d6226320dc420a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "54a948e8c69cc768314f7b3de4cb0068890bfbd6",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.130",
+    "version_commit": "54a948e8c69cc768314f7b3de4cb0068890bfbd6"
+  },
+  "axiom_encode_version": "0.2.130",
+  "backend": "openai",
+  "citation": "us/statute/26/1401/b/1",
+  "context_manifest_file": "/tmp/axiom-encode-1401-b-1-seca-tax-apply-v5/_eval_workspaces/openai-gpt-5.5/us-statute-26-1401-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "518fa2c1025b392e456b13a2e123eacaeb4de86b9e01b7e24da36122b602d592",
+  "generated_at": "2026-05-24T09:34:18.649205+00:00",
+  "generated_output_file": "/tmp/axiom-encode-1401-b-1-seca-tax-apply-v5/openai-gpt-5.5/statutes/26/1401/b/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-1401-b-1-seca-tax-apply-v5",
+  "generated_output_sha256": "1254c5c0873aa5e91f3d53a986e7e091650f11d366b567859388a96dda40382d",
+  "generation_prompt_sha256": "6b8aaa79e837190b8234deceb4b35b0c77ecc212038265d69d4b2d95e3e7d1b6",
+  "model": "gpt-5.5",
+  "run_id": "6b476f3d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "895d3b7a872d5f88aa63f75bdb30c53ae4e0aa8ab420cccb0ace106e96eb1b48"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-1401-b-1-seca-tax-apply-v5/traces/openai-gpt-5.5/us-statute-26-1401-b-1.json",
+  "trace_sha256": "281fcd5aec986c78115d8d01f4b76f3b12281f662ce8c7eb7c7604ebf2513835"
+}

--- a/statutes/26/1401/a.test.yaml
+++ b/statutes/26/1401/a.test.yaml
@@ -1,0 +1,40 @@
+- name: old_age_survivors_and_disability_insurance_tax_applies_12_4_percent_to_self_employment_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 5000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 100
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax: 114.514
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 1000
+      employment_income: 100
+- name: old_age_survivors_and_disability_insurance_tax_uses_section_1401_a_self_employment_income_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 2500
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 1200
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 500
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax: 86.8
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 2300
+      employment_income: 167900

--- a/statutes/26/1401/a.yaml
+++ b/statutes/26/1401/a.yaml
@@ -1,0 +1,44 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/1401
+  summary: |-
+    (a) Old-age, survivors, and disability insurance In addition to other taxes, there shall be imposed for each taxable year, on the self-employment income of every individual, a tax equal to 12.4 percent of the amount of the self-employment income for such taxable year.
+imports:
+  - us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate
+  - us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1401(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/1401
+              span: 26 USC 1401(a), "there shall be imposed for each taxable year, on the self-employment income of every individual, a tax"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate
+              output: old_age_survivors_and_disability_insurance_tax_rate
+              hash: sha256:ff4ad3c6a9774807ea9d6ec00e410bb02e656b8878b6f6cf6d67754bc628c02e
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+              output: self_employment_income_for_section_1401_a
+              hash: sha256:d9ef868fb8d2bf455bcf2a559ed6ec40342027336002f1354ba49f53af328120
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          old_age_survivors_and_disability_insurance_tax_rate
+          * self_employment_income_for_section_1401_a

--- a/statutes/26/1401/b/1.test.yaml
+++ b/statutes/26/1401/b/1.test.yaml
@@ -1,0 +1,70 @@
+- name: self_employment_income_tax_applies_2_9_percent_to_self_employment_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 26.7815
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 1000
+- name: self_employment_income_tax_is_zero_when_self_employment_income_is_below_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 350
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 50
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 0
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 300
+- name: hospital_insurance_tax_uses_uncapped_self_employment_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 2500
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 61.59745
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 2300
+- name: self_employment_income_tax_ignores_section_1401_a_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 2500
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 1200
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 500
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 61.59745
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 2300

--- a/statutes/26/1401/b/1.yaml
+++ b/statutes/26/1401/b/1.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/1401
+  summary: |-
+    (1) In general In addition to the tax imposed by the preceding subsection, there shall be imposed for each taxable year, on the self-employment income of every individual, a tax equal to 2.9 percent of the amount of the self-employment income for such taxable year.
+imports:
+  - us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+  - us:statutes/26/1402/b#self_employment_income
+rules:
+  - name: self_employment_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1401(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/1401
+              span: 26 USC 1401(b)(1), "there shall be imposed for each taxable year, on the self-employment income of every individual, a tax equal to 2.9 percent of the amount of the self-employment income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+              output: self_employment_income_tax_rate
+              hash: sha256:4b13c38511ce6cc289677d8d1a1cbb856a68e16bb07485108094867716dccd44
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1402/b#self_employment_income
+              output: self_employment_income
+              hash: sha256:d9ef868fb8d2bf455bcf2a559ed6ec40342027336002f1354ba49f53af328120
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          self_employment_income_tax_rate * self_employment_income


### PR DESCRIPTION
## Summary
- add generated RuleSpec artifacts for 26 USC 1401(a) self-employment OASDI tax and 26 USC 1401(b)(1) Medicare self-employment tax
- include generated tests with PolicyEngine oracle inputs for comparable PE variables
- include signed axiom-encode apply manifests from axiom-encode 0.2.130 (commit 54a948e8c69cc768314f7b3de4cb0068890bfbd6)

## Validation
- axiom-encode test statutes/26/1401/a.test.yaml: 2 cases passed
- axiom-encode test statutes/26/1401/b/1.test.yaml: 4 cases passed
- axiom-encode validate statutes/26/1401/a.yaml --oracle policyengine: 2/2 comparable cases passed, score 1.0
- axiom-encode validate statutes/26/1401/b/1.yaml --oracle policyengine: 4/4 comparable cases passed, score 1.0
- axiom-encode guard-generated: passed
- axiom-encode proof-validate for both files: passed
- axiom-encode oracle-coverage: no untested comparable outputs; new 1401 child outputs are comparable and tested