### PR TITLE
Encode section 3121 wage exclusions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/13.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/13.yaml",
+      "sha256": "0fca794b5bfb7fb510535ff46b189c0d2f493771b41e85a1666a7f56a208a9af"
+    },
+    {
+      "path": "statutes/26/3121/a/13.test.yaml",
+      "sha256": "c743b4822ddd3699c0a8a59b3edc651a4cf23cf1f4a324e8ac0d8c4e2410221c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3c40bb099388feb617aaf57dc853c1ed87167291",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.136",
+    "version_commit": "3c40bb099388feb617aaf57dc853c1ed87167291"
+  },
+  "axiom_encode_version": "0.2.136",
+  "backend": "codex",
+  "citation": "26 USC 3121(a)(13)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/_eval_workspaces/codex-gpt-5.5/26-USC-3121-a-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "ec9cc1d4cd53bb5ceccec0b1acd2d15cfd4378bba6f5eefae14729eeac97e19f",
+  "generated_at": "2026-05-24T12:33:10.290983+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/codex-gpt-5.5/statutes/26/3121/a/13.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5",
+  "generated_output_sha256": "0fca794b5bfb7fb510535ff46b189c0d2f493771b41e85a1666a7f56a208a9af",
+  "generation_prompt_sha256": "ce472f47cd741389e8b65c3be1fbc9f922793e988ed29e779946998f84719969",
+  "model": "gpt-5.5",
+  "run_id": "55d0835a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a4e7486dda2cc9dbd76ba077f9d830409410991a380ffe4855a225fa12f458f0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/traces/codex-gpt-5.5/26-USC-3121-a-13.json",
+  "trace_sha256": "4e70c6077ab3f8b2437c520fcc636fa85ecfd8cab1b2051e6c5b42b52c6b6b44"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/a/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/14.yaml",
+      "sha256": "59594fb5f4b76fddf3258d12c01e463891ab24200cbdb4fbf477bd440fef6577"
+    },
+    {
+      "path": "statutes/26/3121/a/14.test.yaml",
+      "sha256": "2a24b46b7440644cf6b535d015253b4b04a7d8cca8809fbe446b3f5e00bd5aea"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3c40bb099388feb617aaf57dc853c1ed87167291",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.136",
+    "version_commit": "3c40bb099388feb617aaf57dc853c1ed87167291"
+  },
+  "axiom_encode_version": "0.2.136",
+  "backend": "codex",
+  "citation": "26 USC 3121(a)(14)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/_eval_workspaces/codex-gpt-5.5/26-USC-3121-a-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "c5d4dc1d8a0d4e24990d5939db30298993c3656ab0dd7e965c226745278eb9bf",
+  "generated_at": "2026-05-24T12:36:18.897396+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/codex-gpt-5.5/statutes/26/3121/a/14.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5",
+  "generated_output_sha256": "59594fb5f4b76fddf3258d12c01e463891ab24200cbdb4fbf477bd440fef6577",
+  "generation_prompt_sha256": "a1267b198a6ea3b33d8896e8f100d1f0f2cd200a694a11ae688b43d83244107b",
+  "model": "gpt-5.5",
+  "run_id": "b9fd2fe6",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "163eef458d659156367d9847e4bab114d86816637adf3c7ca92b0c22a16075c3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/traces/codex-gpt-5.5/26-USC-3121-a-14.json",
+  "trace_sha256": "baca5a18af7a8b3a1901e4ee14a0615e39dd2416c3865c76e920307aa29bb307"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/a/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/15.yaml",
+      "sha256": "3d92d9524ea83eeeaf6fa8e76748ce80e3cbcdee28a87ce6e7ec4a2150834b62"
+    },
+    {
+      "path": "statutes/26/3121/a/15.test.yaml",
+      "sha256": "0b91deaafbbd09ba55fc207aa549785153b6a658b504a8c82ab316a133738e5d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3c40bb099388feb617aaf57dc853c1ed87167291",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.136",
+    "version_commit": "3c40bb099388feb617aaf57dc853c1ed87167291"
+  },
+  "axiom_encode_version": "0.2.136",
+  "backend": "codex",
+  "citation": "26 USC 3121(a)(15)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/_eval_workspaces/codex-gpt-5.5/26-USC-3121-a-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "fe02b571e82c67e9e05d73e027f71d9298c763a8d043749263ce9eed82f56b84",
+  "generated_at": "2026-05-24T12:39:40.997828+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/codex-gpt-5.5/statutes/26/3121/a/15.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5",
+  "generated_output_sha256": "3d92d9524ea83eeeaf6fa8e76748ce80e3cbcdee28a87ce6e7ec4a2150834b62",
+  "generation_prompt_sha256": "cfb24613578ccb7a930bdfded3c31e956cd91c8d71e998a47eae2f2d2fe7a362",
+  "model": "gpt-5.5",
+  "run_id": "0b74c4ef",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "91eaa3659c7b5998a3909d83acb2f1d197bd5a07ab9ea81faa5656928465a583"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/traces/codex-gpt-5.5/26-USC-3121-a-15.json",
+  "trace_sha256": "52df21629099619ede1779ed03013533fda6071e1d5f017d3880d49143d9b54f"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/a/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/2.yaml",
+      "sha256": "b4a2ace15ad3dee7b58aff3f09d00041b2392f225a66db196bb637db4699bad2"
+    },
+    {
+      "path": "statutes/26/3121/a/2.test.yaml",
+      "sha256": "410236921c6c7a51a193420d3cfcc4f61da3ddf94d98c56a03feb1260bb2d392"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3c40bb099388feb617aaf57dc853c1ed87167291",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.136",
+    "version_commit": "3c40bb099388feb617aaf57dc853c1ed87167291"
+  },
+  "axiom_encode_version": "0.2.136",
+  "backend": "codex",
+  "citation": "26 USC 3121(a)(2)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/_eval_workspaces/codex-gpt-5.5/26-USC-3121-a-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "95cc7ec11bd49bbffde1cb9df2a954867e12d1d87d0392ee41406e8fbdd3c0eb",
+  "generated_at": "2026-05-24T12:24:53.888761+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/codex-gpt-5.5/statutes/26/3121/a/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5",
+  "generated_output_sha256": "b4a2ace15ad3dee7b58aff3f09d00041b2392f225a66db196bb637db4699bad2",
+  "generation_prompt_sha256": "b1b19dc88b613b02979cebf49e304ac4f0fa92d260229c3252357dfb93b9963b",
+  "model": "gpt-5.5",
+  "run_id": "3630c0e4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5f629dacf957f9263e2c72233f673cdc9ae31967b6ab509c9178ded2ee11b5e6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/traces/codex-gpt-5.5/26-USC-3121-a-2.json",
+  "trace_sha256": "e2b4148f435d845d069a39233bc5454e5f7a80d5d291b96dbd227fe3f6863c0f"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/a/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/4.yaml",
+      "sha256": "227e38328292e6c92290c108f0ca29845158d259bf2e5c9d8918c7982b70b0fb"
+    },
+    {
+      "path": "statutes/26/3121/a/4.test.yaml",
+      "sha256": "eefc44b6fb493a82965b9482f57aafdc4bfd29950e1c6150320d67f23cb2ac09"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3c40bb099388feb617aaf57dc853c1ed87167291",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.136",
+    "version_commit": "3c40bb099388feb617aaf57dc853c1ed87167291"
+  },
+  "axiom_encode_version": "0.2.136",
+  "backend": "codex",
+  "citation": "26 USC 3121(a)(4)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/_eval_workspaces/codex-gpt-5.5/26-USC-3121-a-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "98db3a2e1a54ad3ad735002c29a253359e172b02382cb7037bac90b84762e6e9",
+  "generated_at": "2026-05-24T12:30:58.262259+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/codex-gpt-5.5/statutes/26/3121/a/4.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5",
+  "generated_output_sha256": "227e38328292e6c92290c108f0ca29845158d259bf2e5c9d8918c7982b70b0fb",
+  "generation_prompt_sha256": "d3d9539f99e6c90652abbf147b0ce6b3bf5f0db4ff2ef91986bd98e3cffbe423",
+  "model": "gpt-5.5",
+  "run_id": "a73c3369",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "43542ca05e3179053637f9ff39295d280159df59185546df6569c638ae53dee9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings-3121-wage-exclusions-v5/traces/codex-gpt-5.5/26-USC-3121-a-4.json",
+  "trace_sha256": "1f6f10120a1c9312dd5014d6a498592f13bec644a8e68cc134ac4503b33b7403"
+}

--- a/statutes/26/3121/a/13.test.yaml
+++ b/statutes/26/3121/a/13.test.yaml
@@ -1,0 +1,84 @@
+- name: qualifying death termination plan payment excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/a/13#input.payment_amount: 5000
+    us:statutes/26/3121/a/13#input.payment_or_series_of_payments_made_by_employer_to_employee_or_employee_dependent: true
+    us:statutes/26/3121/a/13#input.payment_paid_upon_or_after_termination_of_employee_employment_relationship: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_death: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_retirement_for_disability: false
+    us:statutes/26/3121/a/13#input.payment_made_under_plan_established_by_employer: true
+    us:statutes/26/3121/a/13#input.employer_plan_makes_provision_for_employees_generally_or_class_or_classes: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee_dependent: false
+    us:statutes/26/3121/a/13#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_terminated: false
+  output:
+    us:statutes/26/3121/a/13#payment_made_upon_or_after_termination_for_death_or_disability_retirement: holds
+    us:statutes/26/3121/a/13#employer_plan_for_employees_or_classes_covers_payment_recipient: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_exclusion_applies: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_excluded_from_wages: 5000
+- name: qualifying disability retirement dependent payment excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/a/13#input.payment_amount: 7000
+    us:statutes/26/3121/a/13#input.payment_or_series_of_payments_made_by_employer_to_employee_or_employee_dependent: true
+    us:statutes/26/3121/a/13#input.payment_paid_upon_or_after_termination_of_employee_employment_relationship: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_death: false
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_retirement_for_disability: true
+    us:statutes/26/3121/a/13#input.payment_made_under_plan_established_by_employer: true
+    us:statutes/26/3121/a/13#input.employer_plan_makes_provision_for_employees_generally_or_class_or_classes: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee: false
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee_dependent: true
+    us:statutes/26/3121/a/13#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_terminated: false
+  output:
+    us:statutes/26/3121/a/13#payment_made_upon_or_after_termination_for_death_or_disability_retirement: holds
+    us:statutes/26/3121/a/13#employer_plan_for_employees_or_classes_covers_payment_recipient: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_exclusion_applies: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_excluded_from_wages: 7000
+- name: payment not because of death or disability retirement not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/a/13#input.payment_amount: 5000
+    us:statutes/26/3121/a/13#input.payment_or_series_of_payments_made_by_employer_to_employee_or_employee_dependent: true
+    us:statutes/26/3121/a/13#input.payment_paid_upon_or_after_termination_of_employee_employment_relationship: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_death: false
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_retirement_for_disability: false
+    us:statutes/26/3121/a/13#input.payment_made_under_plan_established_by_employer: true
+    us:statutes/26/3121/a/13#input.employer_plan_makes_provision_for_employees_generally_or_class_or_classes: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee_dependent: false
+    us:statutes/26/3121/a/13#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_terminated: false
+  output:
+    us:statutes/26/3121/a/13#payment_made_upon_or_after_termination_for_death_or_disability_retirement: not_holds
+    us:statutes/26/3121/a/13#employer_plan_for_employees_or_classes_covers_payment_recipient: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_exclusion_applies: not_holds
+    us:statutes/26/3121/a/13#termination_plan_payment_excluded_from_wages: 0
+- name: payment that would have been paid without termination not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/a/13#input.payment_amount: 5000
+    us:statutes/26/3121/a/13#input.payment_or_series_of_payments_made_by_employer_to_employee_or_employee_dependent: true
+    us:statutes/26/3121/a/13#input.payment_paid_upon_or_after_termination_of_employee_employment_relationship: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_death: true
+    us:statutes/26/3121/a/13#input.termination_of_employee_employment_relationship_because_of_retirement_for_disability: false
+    us:statutes/26/3121/a/13#input.payment_made_under_plan_established_by_employer: true
+    us:statutes/26/3121/a/13#input.employer_plan_makes_provision_for_employees_generally_or_class_or_classes: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee: true
+    us:statutes/26/3121/a/13#input.payment_recipient_is_employee_dependent: false
+    us:statutes/26/3121/a/13#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_terminated: true
+  output:
+    us:statutes/26/3121/a/13#payment_made_upon_or_after_termination_for_death_or_disability_retirement: holds
+    us:statutes/26/3121/a/13#employer_plan_for_employees_or_classes_covers_payment_recipient: holds
+    us:statutes/26/3121/a/13#termination_plan_payment_exclusion_applies: not_holds
+    us:statutes/26/3121/a/13#termination_plan_payment_excluded_from_wages: 0

--- a/statutes/26/3121/a/13.yaml
+++ b/statutes/26/3121/a/13.yaml
@@ -1,0 +1,108 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (13) any payment or series of payments by an employer to an employee or any of his dependents which is paid— (A) upon or after the termination of an employee’s employment relationship because of (i) death, or (ii) retirement for disability, and (B) under a plan established by the employer which makes provision for his employees generally or a class or classes of his employees (or for such employees or class or classes of employees and their dependents), other than any such payment or series of payments which would have been paid if the employee’s employment relationship had not been so terminated;
+rules:
+  - name: payment_made_upon_or_after_termination_for_death_or_disability_retirement
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(13)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "paid— (A) upon or after the termination of an employee’s employment relationship because of (i) death, or (ii) retirement for disability"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_paid_upon_or_after_termination_of_employee_employment_relationship
+          and (termination_of_employee_employment_relationship_because_of_death or termination_of_employee_employment_relationship_because_of_retirement_for_disability)
+  - name: employer_plan_for_employees_or_classes_covers_payment_recipient
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(13)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under a plan established by the employer which makes provision for his employees generally or a class or classes of his employees (or for such employees or class or classes of employees and their dependents)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_under_plan_established_by_employer
+          and employer_plan_makes_provision_for_employees_generally_or_class_or_classes
+          and (payment_recipient_is_employee or payment_recipient_is_employee_dependent)
+  - name: termination_plan_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment or series of payments by an employer to an employee or any of his dependents"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "paid— (A) upon or after the termination of an employee’s employment relationship because of (i) death, or (ii) retirement for disability"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under a plan established by the employer which makes provision for his employees generally or a class or classes of his employees (or for such employees or class or classes of employees and their dependents)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than any such payment or series of payments which would have been paid if the employee’s employment relationship had not been so terminated"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_or_series_of_payments_made_by_employer_to_employee_or_employee_dependent
+          and payment_made_upon_or_after_termination_for_death_or_disability_retirement
+          and employer_plan_for_employees_or_classes_covers_payment_recipient
+          and not payment_or_series_would_have_been_paid_if_employment_relationship_had_not_terminated
+  - name: termination_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment or series of payments by an employer to an employee or any of his dependents"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than any such payment or series of payments which would have been paid if the employee’s employment relationship had not been so terminated"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if termination_plan_payment_exclusion_applies: payment_amount else: 0

--- a/statutes/26/3121/a/14.test.yaml
+++ b/statutes/26/3121/a/14.test.yaml
@@ -1,0 +1,68 @@
+- name: qualifying survivor or estate post death year payment excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/14#input.payment_amount: 5000
+      us:statutes/26/3121/a/14#input.payment_made_by_employer: true
+      us:statutes/26/3121/a/14#input.payment_made_to_survivor_or_estate_of_former_employee: true
+      us:statutes/26/3121/a/14#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+  output:
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_excluded_from_wages:
+    - 5000
+- name: payment not made by employer not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/14#input.payment_amount: 5000
+      us:statutes/26/3121/a/14#input.payment_made_by_employer: false
+      us:statutes/26/3121/a/14#input.payment_made_to_survivor_or_estate_of_former_employee: true
+      us:statutes/26/3121/a/14#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+  output:
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_excluded_from_wages:
+    - 0
+- name: payment not to survivor or estate not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/14#input.payment_amount: 5000
+      us:statutes/26/3121/a/14#input.payment_made_by_employer: true
+      us:statutes/26/3121/a/14#input.payment_made_to_survivor_or_estate_of_former_employee: false
+      us:statutes/26/3121/a/14#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+  output:
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_excluded_from_wages:
+    - 0
+- name: payment not after death calendar year not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/14#input.payment_amount: 5000
+      us:statutes/26/3121/a/14#input.payment_made_by_employer: true
+      us:statutes/26/3121/a/14#input.payment_made_to_survivor_or_estate_of_former_employee: true
+      us:statutes/26/3121/a/14#input.payment_made_after_calendar_year_in_which_former_employee_died: false
+  output:
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/14#survivor_or_estate_post_death_year_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/14.yaml
+++ b/statutes/26/3121/a/14.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (14) any payment made by an employer to a survivor or the estate of a former employee after the calendar year in which such employee died;
+rules:
+  - name: survivor_or_estate_post_death_year_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made by an employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "to a survivor or the estate of a former employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "after the calendar year in which such employee died"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer
+          and payment_made_to_survivor_or_estate_of_former_employee
+          and payment_made_after_calendar_year_in_which_former_employee_died
+  - name: survivor_or_estate_post_death_year_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made by an employer to a survivor or the estate of a former employee after the calendar year in which such employee died"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if survivor_or_estate_post_death_year_payment_exclusion_applies: payment_amount else: 0

--- a/statutes/26/3121/a/15.test.yaml
+++ b/statutes/26/3121/a/15.test.yaml
@@ -1,0 +1,101 @@
+- name: qualifying disability insurance payment is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/15#input.payment_amount: 1200
+      us:statutes/26/3121/a/15#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/15#input.employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made: true
+      us:statutes/26/3121/a/15#input.disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made: true
+      ? us:statutes/26/3121/a/15#input.employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+      : true
+  output:
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages:
+    - 1200
+- name: payment not made by employer to employee is not excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/15#input.payment_amount: 1200
+      us:statutes/26/3121/a/15#input.payment_made_by_employer_to_employee: false
+      us:statutes/26/3121/a/15#input.employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made: true
+      us:statutes/26/3121/a/15#input.disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made: true
+      ? us:statutes/26/3121/a/15#input.employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+      : true
+  output:
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages:
+    - 0
+- name: employee not entitled to section 223a disability insurance benefits is not
+    excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/15#input.payment_amount: 1200
+      us:statutes/26/3121/a/15#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/15#input.employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made: false
+      us:statutes/26/3121/a/15#input.disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made: true
+      ? us:statutes/26/3121/a/15#input.employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+      : true
+  output:
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages:
+    - 0
+- name: entitlement commencing in payment calendar year is not excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/15#input.payment_amount: 1200
+      us:statutes/26/3121/a/15#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/15#input.employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made: true
+      us:statutes/26/3121/a/15#input.disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made: false
+      ? us:statutes/26/3121/a/15#input.employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+      : true
+  output:
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages:
+    - 0
+- name: employee services during payment period prevent exclusion
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/15#input.payment_amount: 1200
+      us:statutes/26/3121/a/15#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/15#input.employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made: true
+      us:statutes/26/3121/a/15#input.disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made: true
+      ? us:statutes/26/3121/a/15#input.employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+      : false
+  output:
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/15.yaml
+++ b/statutes/26/3121/a/15.yaml
@@ -1,0 +1,56 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (15) any payment made by an employer to an employee, if at the time such payment is made such employee is entitled to disability insurance benefits under section 223(a) of the Social Security Act and such entitlement commenced prior to the calendar year in which such payment is made, and if such employee did not perform any services for such employer during the period for which such payment is made;
+rules:
+  - name: social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made by an employer to an employee, if at the time such payment is made such employee is entitled to disability insurance benefits under section 223(a) of the Social Security Act and such entitlement commenced prior to the calendar year in which such payment is made, and if such employee did not perform any services for such employer during the period for which such payment is made"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer_to_employee
+          and employee_entitled_to_disability_insurance_benefits_under_section_223_a_at_time_payment_made
+          and disability_insurance_benefits_entitlement_commenced_before_calendar_year_payment_made
+          and employee_did_not_perform_any_services_for_such_employer_during_period_for_which_payment_made
+
+  - name: social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3121(a)(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made by an employer to an employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/15#social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies
+              output: social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if social_security_disability_insurance_prior_year_no_services_payment_exclusion_applies: payment_amount else: 0

--- a/statutes/26/3121/a/2.test.yaml
+++ b/statutes/26/3121/a/2.test.yaml
@@ -1,0 +1,208 @@
+- name: death_payment_non_group_term_life_excluded_without_gross_income_reduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 1000
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: true
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 400
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 1000
+- name: group_term_life_includible_amount_reduces_death_payment_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 1000
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: true
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: true
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 400
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 600
+- name: direct_sickness_payment_received_under_workmans_compensation_law_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 900
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: true
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: false
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 900
+- name: direct_sickness_payment_not_under_workmans_compensation_law_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 900
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: false
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - not_holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 0
+- name: medical_expense_payment_excluded_without_workmans_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 700
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: false
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 700
+- name: employer_insurance_annuity_or_fund_amount_for_sickness_payment_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 1200
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: false
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : true
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: false
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 1200
+- name: payment_outside_employer_plan_or_system_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 800
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: true
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - not_holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 0
+- name: payment_not_to_or_on_behalf_and_not_employer_fund_amount_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/2#input.payment_amount: 800
+      us:statutes/26/3121/a/2#input.payment_made_to_employee_or_dependent: false
+      us:statutes/26/3121/a/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      ? us:statutes/26/3121/a/2#input.payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment
+      : false
+      us:statutes/26/3121/a/2#input.payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class: true
+      us:statutes/26/3121/a/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3121/a/2#input.payment_received_under_workmans_compensation_law: false
+      ? us:statutes/26/3121/a/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/2#input.payment_on_account_of_death: true
+      us:statutes/26/3121/a/2#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3121/a/2#input.group_term_life_insurance_payment_amount_includible_in_employee_gross_income: 0
+  output:
+    us:statutes/26/3121/a/2#payment_eligible_for_employer_plan_sickness_medical_death_exclusion:
+    - not_holds
+    us:statutes/26/3121/a/2#employer_plan_sickness_medical_death_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/2.yaml
+++ b/statutes/26/3121/a/2.yaml
@@ -1,0 +1,56 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (2) the amount of any payment (including any amount paid by an employer for insurance or annuities, or into a fund, to provide for any such payment) made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer which makes provision for his employees generally (or for his employees generally and their dependents) or for a class or classes of his employees (or for a class or classes of his employees and their dependents), on account of— (A) sickness or accident disability (but, in the case of payments made to an employee or any of his dependents, this subparagraph shall exclude from the term “wages” only payments which are received under a workman’s compensation law), or (B) medical or hospitalization expenses in connection with sickness or accident disability, or (C) death, except that this paragraph does not apply to a payment for group-term life insurance to the extent that such payment is includible in the gross income of the employee; [
+rules:
+  - name: payment_eligible_for_employer_plan_sickness_medical_death_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(2), parent text and subparagraphs (A)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (payment_made_to_employee_or_dependent or payment_made_on_behalf_of_employee_or_dependent or payment_is_employer_paid_insurance_annuity_or_fund_amount_to_provide_employee_or_dependent_payment) and payment_made_under_employer_established_plan_or_system_for_employees_generally_or_class and ((payment_on_account_of_sickness_or_accident_disability and (not payment_made_to_employee_or_dependent or payment_received_under_workmans_compensation_law)) or payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability or payment_on_account_of_death)
+  - name: employer_plan_sickness_medical_death_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(2), amount clause and group-term life insurance exception
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_eligible_for_employer_plan_sickness_medical_death_exclusion: max(0, payment_amount - (if payment_is_for_group_term_life_insurance: min(payment_amount, group_term_life_insurance_payment_amount_includible_in_employee_gross_income) else: 0)) else: 0

--- a/statutes/26/3121/a/4.test.yaml
+++ b/statutes/26/3121/a/4.test.yaml
@@ -1,0 +1,100 @@
+- name: sickness_payment_to_employee_after_waiting_period_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/4#input.payment_amount: 1000
+      us:statutes/26/3121/a/4#input.payment_on_account_of_sickness_or_accident_disability: true
+      ? us:statutes/26/3121/a/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      ? us:statutes/26/3121/a/4#input.payment_made_after_expiration_of_six_calendar_months_following_last_calendar_month_employee_worked_for_employer
+      : true
+  output:
+    us:statutes/26/3121/a/4#payment_has_sickness_disability_or_related_medical_purpose:
+    - holds
+    us:statutes/26/3121/a/4#payment_made_by_employer_to_or_on_behalf_of_employee:
+    - holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_excluded_from_wages:
+    - 1000
+- name: medical_expense_payment_on_behalf_after_waiting_period_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/4#input.payment_amount: 700
+      us:statutes/26/3121/a/4#input.payment_on_account_of_sickness_or_accident_disability: false
+      ? us:statutes/26/3121/a/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : true
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_to_employee: false
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/4#input.payment_made_after_expiration_of_six_calendar_months_following_last_calendar_month_employee_worked_for_employer
+      : true
+  output:
+    us:statutes/26/3121/a/4#payment_has_sickness_disability_or_related_medical_purpose:
+    - holds
+    us:statutes/26/3121/a/4#payment_made_by_employer_to_or_on_behalf_of_employee:
+    - holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_excluded_from_wages:
+    - 700
+- name: qualifying_payment_before_waiting_period_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/4#input.payment_amount: 900
+      us:statutes/26/3121/a/4#input.payment_on_account_of_sickness_or_accident_disability: true
+      ? us:statutes/26/3121/a/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      ? us:statutes/26/3121/a/4#input.payment_made_after_expiration_of_six_calendar_months_following_last_calendar_month_employee_worked_for_employer
+      : false
+  output:
+    us:statutes/26/3121/a/4#payment_has_sickness_disability_or_related_medical_purpose:
+    - holds
+    us:statutes/26/3121/a/4#payment_made_by_employer_to_or_on_behalf_of_employee:
+    - holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_excluded_from_wages:
+    - 0
+- name: payment_without_qualifying_purpose_or_employer_employee_transfer_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/4#input.payment_amount: 800
+      us:statutes/26/3121/a/4#input.payment_on_account_of_sickness_or_accident_disability: false
+      ? us:statutes/26/3121/a/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_to_employee: false
+      us:statutes/26/3121/a/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      ? us:statutes/26/3121/a/4#input.payment_made_after_expiration_of_six_calendar_months_following_last_calendar_month_employee_worked_for_employer
+      : true
+  output:
+    us:statutes/26/3121/a/4#payment_has_sickness_disability_or_related_medical_purpose:
+    - not_holds
+    us:statutes/26/3121/a/4#payment_made_by_employer_to_or_on_behalf_of_employee:
+    - not_holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/4#post_work_sickness_disability_medical_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/4.yaml
+++ b/statutes/26/3121/a/4.yaml
@@ -1,0 +1,90 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (4) any payment on account of sickness or accident disability, or medical or hospitalization expenses in connection with sickness or accident disability, made by an employer to, or on behalf of, an employee after the expiration of 6 calendar months following the last calendar month in which the employee worked for such employer;
+rules:
+  - name: payment_has_sickness_disability_or_related_medical_purpose
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(4), sickness, accident disability, medical, and hospitalization clauses
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_on_account_of_sickness_or_accident_disability
+          or payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+  - name: payment_made_by_employer_to_or_on_behalf_of_employee
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(4), employer-to-employee payment clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer_to_employee
+          or payment_made_by_employer_on_behalf_of_employee
+  - name: post_work_sickness_disability_medical_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_has_sickness_disability_or_related_medical_purpose
+          and payment_made_by_employer_to_or_on_behalf_of_employee
+          and payment_made_after_expiration_of_six_calendar_months_following_last_calendar_month_employee_worked_for_employer
+  - name: post_work_sickness_disability_medical_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(4), excluded payment clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if post_work_sickness_disability_medical_payment_exclusion_applies: max(0, payment_amount) else: 0


### PR DESCRIPTION
## Summary
- Encode generated RuleSpec for 26 USC 3121(a)(2), (4), (13), (14), and (15) payroll wage exclusions.
- Add generated companion tests for each subsection covering positive and negative controls.
- Add signed axiom-encode apply manifests for each generated artifact.

## Provenance
Generated via `axiom-encode encode --apply` from axiom-encode `3c40bb099388feb617aaf57dc853c1ed87167291` / version `0.2.136`. No manual RuleSpec edits.

## Checks
- `axiom-encode compile` for all 5 generated YAML files
- `axiom-encode test` over all 5 generated companion test files: 25 cases, 0 failures
- `axiom-encode proof-validate` for all 5 generated YAML files
- `axiom-encode guard-generated --repo /tmp/rulespec-us-3121-wage-exclusions-v5 --base-ref origin/main --json`
- Verified all derived rules in the new files are covered by their companion tests

Known unrelated gap: `uv run --with pytest --with pyyaml python -m pytest tests/test_repository_layout.py` still has a pre-existing broad missing-output failure across existing files; the new 3121 files are not in that missing set.