### PR TITLE
Encode section 3241(b) rate table

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,40 +2,52 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc"
+      "sha256": "640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
-      "sha256": "0b8bc35331f18e808b8c3564999a4dda268b29fdad1c95c7199bc7fed96f73bf"
+      "sha256": "db1cbb2340707eedc4507b84da62b93ce70ff92a2e6db625ba3b0e5fbf83a86f"
+    },
+    {
+      "path": "statutes/26/3201.yaml",
+      "sha256": "099430a27bdcb6939ffa3847e26670040822c24ef8bd0bdc23edeb8d54da1343"
+    },
+    {
+      "path": "statutes/26/3211.yaml",
+      "sha256": "78056274fbb0b5817ce14a220c01c5bc1d726447a21cc2a10e92f651081016a5"
+    },
+    {
+      "path": "statutes/26/3221.yaml",
+      "sha256": "8ace6fdedbb8b9a7382830f796fe92250f843cfb16835770877f6189fb239c8c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "f116db0792f340fbb64c62b1e2ac477586731dd2",
+    "commit": "064da3238bf19c707fa3e46e58a316a0cc973d1f",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.111",
-    "version_commit": "f116db0792f340fbb64c62b1e2ac477586731dd2"
+    "version": "0.2.141",
+    "version_commit": "064da3238bf19c707fa3e46e58a316a0cc973d1f"
   },
-  "axiom_encode_version": "0.2.111",
+  "axiom_encode_version": "0.2.141",
   "backend": "codex",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/tmp/axiom-encode-3241b-v111/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "ab0dabb758fd53df3f2e1520e665470b602d61bcf8fca9c55aea35626dbf35ab",
-  "generated_at": "2026-05-24T03:31:55.407696+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3241b-v111/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3241b-v111",
-  "generated_output_sha256": "43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc",
-  "generation_prompt_sha256": "653e0d6a46795f03ebdd4ad23a5217f038b506b0f1555b26ca3ea2f8be505f10",
+  "context_manifest_file": "/private/tmp/axiom-encode-3241b-final-v4/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "aaca5ae48294bfe787b42cf0240d7255429d8dd980199970839c03e7a0fac703",
+  "generated_at": "2026-05-24T14:09:51.383248+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3241b-final-v4/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3241b-final-v4",
+  "generated_output_sha256": "640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6",
+  "generation_prompt_sha256": "604e0e97108f4c7c4ad516b64fb2a4bc752b3a37c557cef099142dfd7da7ac44",
   "model": "gpt-5.3-codex-spark",
-  "run_id": "6a829d3e",
+  "run_id": "07ed0b25",
   "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6fc4d87a6f4391e048678ff04a490ba78ef5507b52c12411ee68e8ad9b4ff355"
+    "value": "0a9561a46efca507d2848acb6a4ec5e1c2595adad9fe41f1e05c67effc4788b9"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3241b-v111/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
-  "trace_sha256": "c2fc69cb0410f53bb5131e259c291c0fa7f5a5515d2fdcca623098ad630fd154"
+  "trace_file": "/private/tmp/axiom-encode-3241b-final-v4/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
+  "trace_sha256": "6c611e9f81820b83eb9c308fbff3ffc6e2880a8995c6a3d0efdd1b10f15c1c22"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -36,7 +36,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
               output: applicable_percentage_for_section_3201_b
-              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
+              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3211.yaml
+++ b/statutes/26/3211.yaml
@@ -37,7 +37,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
+              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3221.yaml
+++ b/statutes/26/3221.yaml
@@ -21,7 +21,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:43f20cf82f335776980b278debdf68f46cd4c1baffa9f14f9922bf1b6cb906dc
+              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3241/b.test.yaml
+++ b/statutes/26/3241/b.test.yaml
@@ -1,4 +1,4 @@
-- name: ratio_under_first_band
+- name: ratio_below_first_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -6,21 +6,10 @@
   input:
     us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.4
   output:
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_2_5: 2.5
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_3_0: 3
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_3_5: 3.5
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_4_0: 4
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_6_1: 6.1
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_6_5: 6.5
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_7_0: 7
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_7_5: 7.5
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_8_0: 8
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_8_5: 8.5
-    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_9_0: 9
     us:statutes/26/3241/b#average_account_benefits_ratio_band: 1
     us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.221
     us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.049
-- name: ratio_at_2_5
+- name: ratio_at_2_5_boundary
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -37,18 +26,18 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 7.2
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 8.9
   output:
-    us:statutes/26/3241/b#average_account_benefits_ratio_band: 8
-    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.116
-    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.034
-- name: ratio_at_9_plus
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 11
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.091
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0.009
+- name: ratio_at_9_plus_band
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9.0
   output:
     us:statutes/26/3241/b#average_account_benefits_ratio_band: 12
     us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0.082

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -4,174 +4,16 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3241
-  summary: |-
-    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 | 3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1 | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5 | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0 | .............. | 8.2 | 0 |
+  summary: (b) Tax rate schedule | Average account benefits ratio | Applicable percentage
+    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) |
+    | | ------------------------------ | ------------------------------------------------------
+    | ----------------------------------------- | --- | | At least | But less than
+    | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 |
+    3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1
+    | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5
+    | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0
+    | .............. | 8.2 | 0 |
 rules:
-- name: average_account_benefits_ratio_band_threshold_2_5
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      2.5
-- name: average_account_benefits_ratio_band_threshold_3_0
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      3.0
-- name: average_account_benefits_ratio_band_threshold_3_5
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      3.5
-- name: average_account_benefits_ratio_band_threshold_4_0
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      4.0
-- name: average_account_benefits_ratio_band_threshold_6_1
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      6.1
-- name: average_account_benefits_ratio_band_threshold_6_5
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      6.5
-- name: average_account_benefits_ratio_band_threshold_7_0
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      7.0
-- name: average_account_benefits_ratio_band_threshold_7_5
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      7.5
-- name: average_account_benefits_ratio_band_threshold_8_0
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      8.0
-- name: average_account_benefits_ratio_band_threshold_8_5
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      8.5
-- name: average_account_benefits_ratio_band_threshold_9_0
-  kind: parameter
-  dtype: Float
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: amount
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      9.0
 - name: average_account_benefits_ratio_band
   kind: derived
   entity: TaxUnit
@@ -186,20 +28,18 @@ rules:
         source:
           corpus_citation_path: us/statute/26/3241
   versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_2_5: 1
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_0: 2
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_5: 3
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_4_0: 4
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_6_1: 5
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_6_5: 6
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_7_0: 7
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_7_5: 8
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_8_0: 9
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_8_5: 10
-      else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_9_0: 11
-      else: 12
+  - effective_from: '1990-01-01'
+    formula: 'if average_account_benefits_ratio < 2.5: 1 else: if average_account_benefits_ratio
+      >= 2.5 and average_account_benefits_ratio < 3.0: 2 else: if average_account_benefits_ratio
+      >= 3.0 and average_account_benefits_ratio < 3.5: 3 else: if average_account_benefits_ratio
+      >= 3.5 and average_account_benefits_ratio < 4.0: 4 else: if average_account_benefits_ratio
+      >= 4.0 and average_account_benefits_ratio < 6.1: 5 else: if average_account_benefits_ratio
+      >= 6.1 and average_account_benefits_ratio < 6.5: 6 else: if average_account_benefits_ratio
+      >= 6.5 and average_account_benefits_ratio < 7.0: 7 else: if average_account_benefits_ratio
+      >= 7.0 and average_account_benefits_ratio < 7.5: 8 else: if average_account_benefits_ratio
+      >= 7.5 and average_account_benefits_ratio < 8.0: 9 else: if average_account_benefits_ratio
+      >= 8.0 and average_account_benefits_ratio < 8.5: 10 else: if average_account_benefits_ratio
+      >= 8.5 and average_account_benefits_ratio < 9.0: 11 else: 12'
 - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
   kind: parameter
   dtype: Rate
@@ -215,9 +55,9 @@ rules:
           table:
             header: Applicable percentage for sections 3211(b) and 3221(b)
             row_key: average_account_benefits_ratio_band
-            column_key: applicable percentage
+            column_key: applicable_percentage
   versions:
-  - effective_from: 1990-01-01
+  - effective_from: '1990-01-01'
     values:
       1: 0.221
       2: 0.181
@@ -246,9 +86,9 @@ rules:
           table:
             header: Applicable percentage for section 3201(b)
             row_key: average_account_benefits_ratio_band
-            column_key: applicable percentage
+            column_key: applicable_percentage
   versions:
-  - effective_from: 1990-01-01
+  - effective_from: '1990-01-01'
     values:
       1: 0.049
       2: 0.049
@@ -275,11 +115,9 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/26/3241
-          corpus_span: (b) applicable percentage for sections 3211(b) and 3221(b)
   versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
+  - effective_from: '1990-01-01'
+    formula: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
 - name: applicable_percentage_for_section_3201_b
   kind: derived
   entity: TaxUnit
@@ -293,8 +131,6 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/26/3241
-          corpus_span: (b) applicable percentage for section 3201(b)
   versions:
-  - effective_from: 1990-01-01
-    formula: |-
-      applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]
+  - effective_from: '1990-01-01'
+    formula: applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3241(b) from axiom-encode 0.2.141 with signed apply provenance
- encode the average-account-benefits-ratio selector and both applicable-percentage tables with 12 source rows
- refresh 3201/3211/3221 import hashes for the regenerated 3241(b) artifact

## Generated provenance
- axiom-encode commit: 064da3238bf19c707fa3e46e58a316a0cc973d1f
- axiom-encode version: 0.2.141
- run_id: 07ed0b25
- manifest: .axiom/encoding-manifests/statutes/26/3241/b.json

## Verification
- axiom-encode encode "26 USC 3241(b)" --apply => outcome=apply_applied, compile=yes, ci=yes
- uv run axiom-encode compile /private/tmp/rulespec-us-3241-b-final-v4/statutes/26/3241/b.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode test /private/tmp/rulespec-us-3241-b-final-v4/statutes/26/3241/b.test.yaml --root /private/tmp/rulespec-us-3241-b-final-v4 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3241-b-final-v4/statutes/26/3241/b.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3241-b-final-v4 --base-ref origin/main --json
- git diff --check