### PR TITLE
Regenerate section 164(f) self-employment tax deduction

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/164/f.json
+++ b/.axiom/encoding-manifests/statutes/26/164/f.json
@@ -2,38 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/164/f.yaml",
-      "sha256": "b1c8c148b8d29e00f293505ab52239455738a03b0c89f70e3747edd6d67839a7"
+      "sha256": "055d0c4806dc4349728227e1a2decc76cea915f3b902596e819248c617cc751d"
     },
     {
       "path": "statutes/26/164/f.test.yaml",
-      "sha256": "1965553e00a6205e077e4a87abd7d54db6e927c7921972f4432d03dfd61178d5"
+      "sha256": "f16250185f03c3161a93f2e980923c4d00ede48ac6eab35fd7833a9ce1dba853"
     }
   ],
   "axiom_encode_git": {
-    "commit": "5237a67d8eea450aa71ce84cea65b08cfac1ee10",
+    "commit": "2ee9eb05969f5c22d356740d67001e4d933aac30",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.146",
+    "version_commit": "0baa53301bd4240e074789f25558153475da672a"
   },
-  "axiom_encode_version": "0.2.68",
-  "backend": "deterministic",
-  "citation": "us:statutes/26/164/f",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-05-16T12:22:05.654392+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpl3fawuzh/deterministic-repair/statutes/26/164/f.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpl3fawuzh",
-  "generated_output_sha256": "b1c8c148b8d29e00f293505ab52239455738a03b0c89f70e3747edd6d67839a7",
-  "generation_prompt_sha256": null,
-  "model": "proof-import-hash-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "axiom_encode_version": "0.2.146",
+  "backend": "codex",
+  "citation": "26 USC 164(f)",
+  "context_manifest_file": "/private/tmp/axiom-encode-164-f-seca-wage-base-v8/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-164-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "c5b08edd73e222dda9ec33c703b7f0459346208681bff43a73782e45dff74e33",
+  "generated_at": "2026-05-24T15:34:11.182562+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-164-f-seca-wage-base-v8/codex-gpt-5.3-codex-spark/statutes/26/164/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-164-f-seca-wage-base-v8",
+  "generated_output_sha256": "055d0c4806dc4349728227e1a2decc76cea915f3b902596e819248c617cc751d",
+  "generation_prompt_sha256": "549b99e17dd324f160075ef2215fa506cf5694c8bfc55835422a0343bc10cc3f",
+  "model": "gpt-5.3-codex-spark",
+  "run_id": "d5ae046d",
+  "runner": "codex-gpt-5.3-codex-spark",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ca403cde5f5afee34f5d1f11fcd649df016c87f4a06bc30ab281d837942cbfea"
+    "value": "7e80169b27bfc9fa10cec6176b0cada22e5ba80ec4fee9cef2b49d35248de232"
   },
-  "tool": "axiom-encode repair-proof-import-hashes",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-164-f-seca-wage-base-v8/traces/codex-gpt-5.3-codex-spark/26-USC-164-f.json",
+  "trace_sha256": "42ce64d73e9ae03da548fec4ba158e4f59026d0d5728fa6d172d175382430c6e"
 }

--- a/statutes/26/164/f.test.yaml
+++ b/statutes/26/164/f.test.yaml
@@ -1,55 +1,71 @@
-- name: zero_self_employment_tax
+- name: positive_self_employment_tax_deduction_for_person
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 100000
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 250000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
     us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
+  output:
+    us:statutes/26/164/f#self_employment_tax_deduction: 7064.775
+    us:statutes/26/164/f#self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business: 7064.775
+- name: positive_self_employment_tax_deduction_for_person_scalar_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 100000
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 250000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+    us:statutes/26/164/f#input.taxpayer_is_individual: true
+  output:
+    us:statutes/26/164/f#self_employment_tax_deduction_fraction: 0.5
+- name: zero_self_employment_tax_deduction_when_no_net_self_employment_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 250000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
+    us:statutes/26/164/f#input.taxpayer_is_individual: true
   output:
     us:statutes/26/164/f#self_employment_tax_deduction: 0
     us:statutes/26/164/f#self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business: 0
-- name: zero_self_employment_tax_scalar_outputs
+- name: no_deduction_for_non_individual_taxpayer
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
-  output:
-    us:statutes/26/164/f#self_employment_tax_deduction_fraction: 0.5
-- name: positive_self_employment_tax
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 100000
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
-  output:
-    us:statutes/26/164/f#self_employment_tax_deduction: 7650
-    us:statutes/26/164/f#self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business: 7650
-- name: taxpayer_not_individual
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 100000
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 250000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 0
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+    us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien: false
+    us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident: false
     us:statutes/26/164/f#input.taxpayer_is_individual: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 100000
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/164/f#self_employment_tax_deduction: 0
     us:statutes/26/164/f#self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business: 0

--- a/statutes/26/164/f.yaml
+++ b/statutes/26/164/f.yaml
@@ -1,91 +1,88 @@
 format: rulespec/v1
 imports:
-  - us:statutes/26/1401#self_employment_oasdi_tax
-  - us:statutes/26/1401#self_employment_hospital_insurance_tax
+- us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax
+- us:statutes/26/1401/b/1#self_employment_income_tax
 module:
   proof_validation:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/164
-  summary: |-
-    (f) Deduction for one-half of self-employment taxes (1) In general In the case of an individual, in addition to the taxes described in subsection (a), there shall be allowed as a deduction for the taxable year an amount equal to one-half of the taxes imposed by section 1401 (other than the taxes imposed by section 1401(b)(2)) for such taxable year. (2) Deduction treated as attributable to trade or business For purposes of this chapter, the deduction allowed by paragraph (1) shall be treated as attributable to a trade or business carried on by the taxpayer which does not consist of the performance of services by the taxpayer as an employee.
+  summary: (f) Deduction for one-half of self-employment taxes (1) In the case of
+    an an individual, in addition to the taxes described in subsection (a), there
+    shall be allowed as a deduction for the taxable year an amount equal to one-half
+    of the taxes imposed by section 1401 (other than the taxes imposed by section
+    1401(b)(2)) for such taxable year. (2) Deduction treated as attributable to trade
+    or business For purposes of this chapter, the deduction allowed by paragraph (1)
+    shall be treated as attributable to a trade or business carried on by the taxpayer
+    which does not consist of the performance of services by the taxpayer as an employee.
 rules:
-  - name: self_employment_tax_deduction_fraction
-    kind: parameter
-    dtype: Rate
-    source: 26 USC 164(f)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/statute/26/164
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          1 / 2
-
-  - name: self_employment_tax_deduction
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 26 USC 164(f)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/164
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/164
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/1401#self_employment_oasdi_tax
-              output: self_employment_oasdi_tax
-              hash: sha256:a844cf97fb59ac576f3b4f44a604c9658bbdd6cc5b4c84d136ac066d8166948b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/1401#self_employment_hospital_insurance_tax
-              output: self_employment_hospital_insurance_tax
-              hash: sha256:a844cf97fb59ac576f3b4f44a604c9658bbdd6cc5b4c84d136ac066d8166948b
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          if taxpayer_is_individual:
-              (self_employment_oasdi_tax + self_employment_hospital_insurance_tax)
-              * self_employment_tax_deduction_fraction
-          else:
-              0
-
-  - name: self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 26 USC 164(f)(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us/statute/26/164
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/164/f#self_employment_tax_deduction
-              output: self_employment_tax_deduction
-              hash: sha256:local
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          self_employment_tax_deduction
+- name: self_employment_tax_deduction_fraction
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 164(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/164
+          span: 26 USC 164(f)(1), "one-half"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 1 / 2
+- name: self_employment_tax_deduction
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 164(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/164
+          span: 26 USC 164(f)(1)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/164
+          span: 26 USC 164(f)(1), "In the case of an individual"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax
+          output: old_age_survivors_and_disability_insurance_tax
+          hash: sha256:069cdd781afab99ae6644e2df92b23bbf58ebdbcc60f4fcdc577a436ed2a3df2
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/1401/b/1#self_employment_income_tax
+          output: self_employment_income_tax
+          hash: sha256:1254c5c0873aa5e91f3d53a986e7e091650f11d366b567859388a96dda40382d
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if taxpayer_is_individual: (old_age_survivors_and_disability_insurance_tax
+      + self_employment_income_tax) * self_employment_tax_deduction_fraction else:
+      0'
+- name: self_employment_tax_deduction_attributable_to_nonemployee_trade_or_business
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 164(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/164
+          span: 26 USC 164(f)(2)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: self_employment_tax_deduction


### PR DESCRIPTION
## Summary
- Regenerate 26 USC 164(f) through axiom-encode encode --apply using encoder 0.2.146.
- Replace parent 1401 tax imports with child 1401(a) OASDI and 1401(b)(1) Medicare SECA imports.
- Keep the deduction person-scoped and update companion tests with transitive 1402(a) / 1402(b) inputs.

## Validation
- axiom-encode test statutes/26/164/f.test.yaml --root /private/tmp/rulespec-us-164-f-seca-wage-base-v8 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --json
- axiom-encode proof-validate statutes/26/164/f.yaml --json
- axiom-encode validate statutes/26/164/f.yaml --skip-reviewers --json
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-164-f-seca-wage-base-v8 --base-ref origin/main --json
- git diff --check

## Notes
- Generated-only change; manifest is signed by axiom-encode encode --apply.
- Part of #48. A follow-up 32(c)(2) regeneration attempt was blocked by source-scope validation before applying any files, so this PR only carries the clean 164(f) regeneration.
