### PR TITLE
Regenerate section 3241(b) payroll table

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6"
+      "sha256": "83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
@@ -10,44 +10,44 @@
     },
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "099430a27bdcb6939ffa3847e26670040822c24ef8bd0bdc23edeb8d54da1343"
+      "sha256": "c36a57c70aecdeb20efcf49c1e010585607a5011790b34467e22ff1a7a8fc500"
     },
     {
       "path": "statutes/26/3211.yaml",
-      "sha256": "78056274fbb0b5817ce14a220c01c5bc1d726447a21cc2a10e92f651081016a5"
+      "sha256": "e3dbd4938b1c0a8797d0459c476624804d0716c579d6730635ccf3a9a943ca89"
     },
     {
       "path": "statutes/26/3221.yaml",
-      "sha256": "8ace6fdedbb8b9a7382830f796fe92250f843cfb16835770877f6189fb239c8c"
+      "sha256": "40cf7f7ae4e094f278416573b412671c47b6c389e3489c63fb7f9989df2f3848"
     }
   ],
   "axiom_encode_git": {
-    "commit": "064da3238bf19c707fa3e46e58a316a0cc973d1f",
+    "commit": "e006935ecc6750ab697660f0bafc08a8888b33be",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.141",
-    "version_commit": "064da3238bf19c707fa3e46e58a316a0cc973d1f"
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.155",
+    "version_commit": "e006935ecc6750ab697660f0bafc08a8888b33be"
   },
-  "axiom_encode_version": "0.2.141",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.155",
+  "backend": "openai",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3241b-final-v4/_eval_workspaces/codex-gpt-5.3-codex-spark/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "aaca5ae48294bfe787b42cf0240d7255429d8dd980199970839c03e7a0fac703",
-  "generated_at": "2026-05-24T14:09:51.383248+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3241b-final-v4/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3241b-final-v4",
-  "generated_output_sha256": "640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6",
-  "generation_prompt_sha256": "604e0e97108f4c7c4ad516b64fb2a4bc752b3a37c557cef099142dfd7da7ac44",
-  "model": "gpt-5.3-codex-spark",
-  "run_id": "07ed0b25",
-  "runner": "codex-gpt-5.3-codex-spark",
+  "context_manifest_file": "/private/tmp/axiom-encode-3241b-apply-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "858aeb8456f9c38204e8a246207e98eabb7b75c39dcc1e715e02049024cb4700",
+  "generated_at": "2026-05-24T19:20:55.471236+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3241b-apply-20260524/openai-gpt-5.5/statutes/26/3241/b.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3241b-apply-20260524",
+  "generated_output_sha256": "83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20",
+  "generation_prompt_sha256": "f615a100bd6d1ed336cbef74a778d28da0732ecf2628ddd3610c5165983d542c",
+  "model": "gpt-5.5",
+  "run_id": "2213422f",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0a9561a46efca507d2848acb6a4ec5e1c2595adad9fe41f1e05c67effc4788b9"
+    "value": "054de4f3216deb6586319d4a06c02e7b9417dcff0df7dd4e13914e151326ca3a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3241b-final-v4/traces/codex-gpt-5.3-codex-spark/26-USC-3241-b.json",
-  "trace_sha256": "6c611e9f81820b83eb9c308fbff3ffc6e2880a8995c6a3d0efdd1b10f15c1c22"
+  "trace_file": "/private/tmp/axiom-encode-3241b-apply-20260524/traces/openai-gpt-5.5/26-USC-3241-b.json",
+  "trace_sha256": "ffb6bcdb7adb5f85af0f232ca94380eea5a6fbc62f30bcfd1dfdf84ddcae2141"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -36,7 +36,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
               output: applicable_percentage_for_section_3201_b
-              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
+              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3211.yaml
+++ b/statutes/26/3211.yaml
@@ -37,7 +37,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
+              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3221.yaml
+++ b/statutes/26/3221.yaml
@@ -21,7 +21,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:640ef05f2e05870f1d82f8b704eb44d1628e11553d0913f5e9c0334cd4f09ea6
+              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -4,133 +4,123 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3241
-  summary: (b) Tax rate schedule | Average account benefits ratio | Applicable percentage
-    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) |
-    | | ------------------------------ | ------------------------------------------------------
-    | ----------------------------------------- | --- | | At least | But less than
-    | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 |
-    3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1
-    | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5
-    | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0
-    | .............. | 8.2 | 0 |
+  summary: |-
+    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 | 3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1 | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5 | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0 | .............. | 8.2 | 0 |
 rules:
-- name: average_account_benefits_ratio_band
-  kind: derived
-  entity: TaxUnit
-  dtype: Integer
-  period: Year
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'if average_account_benefits_ratio < 2.5: 1 else: if average_account_benefits_ratio
-      >= 2.5 and average_account_benefits_ratio < 3.0: 2 else: if average_account_benefits_ratio
-      >= 3.0 and average_account_benefits_ratio < 3.5: 3 else: if average_account_benefits_ratio
-      >= 3.5 and average_account_benefits_ratio < 4.0: 4 else: if average_account_benefits_ratio
-      >= 4.0 and average_account_benefits_ratio < 6.1: 5 else: if average_account_benefits_ratio
-      >= 6.1 and average_account_benefits_ratio < 6.5: 6 else: if average_account_benefits_ratio
-      >= 6.5 and average_account_benefits_ratio < 7.0: 7 else: if average_account_benefits_ratio
-      >= 7.0 and average_account_benefits_ratio < 7.5: 8 else: if average_account_benefits_ratio
-      >= 7.5 and average_account_benefits_ratio < 8.0: 9 else: if average_account_benefits_ratio
-      >= 8.0 and average_account_benefits_ratio < 8.5: 10 else: if average_account_benefits_ratio
-      >= 8.5 and average_account_benefits_ratio < 9.0: 11 else: 12'
-- name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
-  kind: parameter
-  dtype: Rate
-  indexed_by: average_account_benefits_ratio_band
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].values
-        kind: parameter_table
-        source:
-          corpus_citation_path: us/statute/26/3241
-          table:
-            header: Applicable percentage for sections 3211(b) and 3221(b)
-            row_key: average_account_benefits_ratio_band
-            column_key: applicable_percentage
-  versions:
-  - effective_from: '1990-01-01'
-    values:
-      1: 0.221
-      2: 0.181
-      3: 0.151
-      4: 0.141
-      5: 0.131
-      6: 0.126
-      7: 0.121
-      8: 0.116
-      9: 0.111
-      10: 0.101
-      11: 0.091
-      12: 0.082
-- name: applicable_percentage_for_section_3201_b_by_ratio_band
-  kind: parameter
-  dtype: Rate
-  indexed_by: average_account_benefits_ratio_band
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].values
-        kind: parameter_table
-        source:
-          corpus_citation_path: us/statute/26/3241
-          table:
-            header: Applicable percentage for section 3201(b)
-            row_key: average_account_benefits_ratio_band
-            column_key: applicable_percentage
-  versions:
-  - effective_from: '1990-01-01'
-    values:
-      1: 0.049
-      2: 0.049
-      3: 0.049
-      4: 0.049
-      5: 0.049
-      6: 0.044
-      7: 0.039
-      8: 0.034
-      9: 0.029
-      10: 0.019
-      11: 0.009
-      12: 0
-- name: applicable_percentage_for_sections_3211_b_and_3221_b
-  kind: derived
-  entity: TaxUnit
-  dtype: Rate
-  period: Year
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: '1990-01-01'
-    formula: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
-- name: applicable_percentage_for_section_3201_b
-  kind: derived
-  entity: TaxUnit
-  dtype: Rate
-  period: Year
-  source: 26 USC 3241(b)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3241
-  versions:
-  - effective_from: '1990-01-01'
-    formula: applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b), tax rate schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3241
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if average_account_benefits_ratio < 2.5: 1 else: if average_account_benefits_ratio >= 2.5 and average_account_benefits_ratio < 3.0: 2 else: if average_account_benefits_ratio >= 3.0 and average_account_benefits_ratio < 3.5: 3 else: if average_account_benefits_ratio >= 3.5 and average_account_benefits_ratio < 4.0: 4 else: if average_account_benefits_ratio >= 4.0 and average_account_benefits_ratio < 6.1: 5 else: if average_account_benefits_ratio >= 6.1 and average_account_benefits_ratio < 6.5: 6 else: if average_account_benefits_ratio >= 6.5 and average_account_benefits_ratio < 7.0: 7 else: if average_account_benefits_ratio >= 7.0 and average_account_benefits_ratio < 7.5: 8 else: if average_account_benefits_ratio >= 7.5 and average_account_benefits_ratio < 8.0: 9 else: if average_account_benefits_ratio >= 8.0 and average_account_benefits_ratio < 8.5: 10 else: if average_account_benefits_ratio >= 8.5 and average_account_benefits_ratio < 9.0: 11 else: 12
+
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/3241
+              table:
+                header: Tax rate schedule
+                row_key: Average account benefits ratio
+                column_key: Applicable percentage for sections 3211(b) and 3221(b)
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.221
+          2: 0.181
+          3: 0.151
+          4: 0.141
+          5: 0.131
+          6: 0.126
+          7: 0.121
+          8: 0.116
+          9: 0.111
+          10: 0.101
+          11: 0.091
+          12: 0.082
+
+  - name: applicable_percentage_for_section_3201_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b), applicable percentage for section 3201(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/3241
+              table:
+                header: Tax rate schedule
+                row_key: Average account benefits ratio
+                column_key: Applicable percentage for section 3201(b)
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+          3: 0.049
+          4: 0.049
+          5: 0.049
+          6: 0.044
+          7: 0.039
+          8: 0.034
+          9: 0.029
+          10: 0.019
+          11: 0.009
+          12: 0
+
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3241
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
+
+  - name: applicable_percentage_for_section_3201_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 3241(b), applicable percentage for section 3201(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3241
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]


### PR DESCRIPTION
## Summary
- regenerate the section 3241(b) payroll tax rate table with the current encoder from generated output
- refresh dependent import hashes in sections 3201, 3211, and 3221
- update the signed apply manifest for the generated artifacts

## Verification
- axiom-encode encode "26 USC 3241(b)" --backend openai --model gpt-5.5 --mode repo-augmented --apply
- uv run axiom-encode validate statutes/26/3241/b.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3241/b.test.yaml --root /private/tmp/rulespec-us-3241b-clean-20260524 --json
- uv run axiom-encode validate statutes/26/3201.yaml --skip-reviewers --json
- uv run axiom-encode validate statutes/26/3211.yaml --skip-reviewers --json
- uv run axiom-encode validate statutes/26/3221.yaml --skip-reviewers --json
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3241b-clean-20260524 --base-ref origin/main --json