### PR TITLE
Encode section 3121(a)(6) state unemployment exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/6.yaml",
+      "sha256": "b011eca0cf58d600895824cfd6396bc4f974f1216148a3144afe619d380adc26"
+    },
+    {
+      "path": "statutes/26/3121/a/6.test.yaml",
+      "sha256": "842cd6d2553ff273ce506977120c05bc9d9e3113605d3868858585b85fe39c3c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6a1c232a5ac3939327496f50f8479346a4c1d3e9",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.157",
+    "version_commit": "6a1c232a5ac3939327496f50f8479346a4c1d3e9"
+  },
+  "axiom_encode_version": "0.2.157",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(6)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-6-main-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "1617d0a116b3d243fe2685c1a01fc806d22e06eab191f26a33c8d876b5daa950",
+  "generated_at": "2026-05-24T19:47:26.730416+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-6-main-20260524/openai-gpt-5.5/statutes/26/3121/a/6.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-6-main-20260524",
+  "generated_output_sha256": "b011eca0cf58d600895824cfd6396bc4f974f1216148a3144afe619d380adc26",
+  "generation_prompt_sha256": "9cc97714c33e6e18c9b30b3de76e98daf5696bec2be3c60a96a61b972f501b9f",
+  "model": "gpt-5.5",
+  "run_id": "cd519b99",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b208e2b774eb1c601b57c1c0bbb7f0bee2e94d1cb5c93617f4e863bc6ab4cc82"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-6-main-20260524/traces/openai-gpt-5.5/26-USC-3121-a-6.json",
+  "trace_sha256": "3e451b58ab2568b60e69beedb264c1b60b25a83ca12edfc22e4c3ebd03056210"
+}

--- a/statutes/26/3121/a/6.test.yaml
+++ b/statutes/26/3121/a/6.test.yaml
@@ -1,0 +1,72 @@
+- name: qualifying state unemployment payment for domestic service is excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/6#input.payment_amount: 120
+      us:statutes/26/3121/a/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3121/a/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+  output:
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_excluded_from_wages:
+    - 120
+- name: qualifying state unemployment payment for agricultural labor is excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/6#input.payment_amount: 80
+      us:statutes/26/3121/a/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3121/a/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_agricultural_labor: true
+  output:
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_excluded_from_wages:
+    - 80
+- name: deduction from remuneration prevents state unemployment payment exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/6#input.payment_amount: 120
+      us:statutes/26/3121/a/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: false
+      us:statutes/26/3121/a/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+  output:
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_excluded_from_wages:
+    - 0
+- name: payment not required under state unemployment law is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/6#input.payment_amount: 120
+      us:statutes/26/3121/a/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3121/a/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: false
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/a/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+  output:
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/6.yaml
+++ b/statutes/26/3121/a/6.yaml
@@ -1,0 +1,75 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (6) the payment by an employer (without deduction from the remuneration of the employee)— (A) of the tax imposed upon an employee under section 3101, or (B) of any payment required from an employee under a State unemployment compensation law, with respect to remuneration paid to an employee for domestic service in a private home of the employer or for agricultural labor;
+  deferred_outputs:
+    - output: us:statutes/26/3121/a/6#employee_section_3101_tax_domestic_or_agricultural_payment_exclusion_applies
+      reason: The source's subparagraph (A) depends on identifying "the tax imposed upon an employee under section 3101"; the copied RuleSpec context for 26 USC 3101 is marked entity_not_supported and exports no executable section 3101 tax concept.
+    - output: us:statutes/26/3121/a/6#employee_section_3101_tax_domestic_or_agricultural_payment_excluded_from_wages
+      reason: The amount excluded under subparagraph (A) cannot be computed without an executable source-backed concept for the employee tax imposed under section 3101; the copied 26 USC 3101 context is entity_not_supported.
+rules:
+  - name: state_unemployment_domestic_or_agricultural_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the payment by an employer (without deduction from the remuneration of the employee)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "of any payment required from an employee under a State unemployment compensation law"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "with respect to remuneration paid to an employee for domestic service in a private home of the employer or for agricultural labor"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer_without_deduction_from_employee_remuneration
+          and payment_required_from_employee_under_state_unemployment_compensation_law
+          and (remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer or remuneration_paid_to_employee_for_agricultural_labor)
+
+  - name: state_unemployment_domestic_or_agricultural_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the payment by an employer (without deduction from the remuneration of the employee)— ... (B) of any payment required from an employee under a State unemployment compensation law"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "with respect to remuneration paid to an employee for domestic service in a private home of the employer or for agricultural labor"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/6#state_unemployment_domestic_or_agricultural_payment_exclusion_applies
+              output: state_unemployment_domestic_or_agricultural_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if state_unemployment_domestic_or_agricultural_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec artifacts for section 3121(a)(6)
- encode the state unemployment compensation payment exclusion for domestic service and agricultural labor
- defer the section 3101 employee-tax branch because section 3101 is currently entity-not-supported

## Verification
- axiom-encode encode "26 USC 3121(a)(6)" --backend openai --model gpt-5.5 --mode repo-augmented --apply
- uv run axiom-encode validate statutes/26/3121/a/6.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3121/a/6.test.yaml --root /private/tmp/rulespec-us-3121-a-6-v2-20260524 --json
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-6-v2-20260524 --base-ref origin/main --json