### PR TITLE
Encode section 3121(a)(7) service remuneration exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/7.yaml",
+      "sha256": "10cf29a985dedec36b3e3978e5cd2a58c2bc10a74763835428b09f9a2754db6d"
+    },
+    {
+      "path": "statutes/26/3121/a/7.test.yaml",
+      "sha256": "a9a3f9b521c43dd0a522b0fa70c92c9545886c6868b0df320b29de7ce81fa311"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c2c265a7addb98ce1dc8fa3e46c39a9ae028262b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.159",
+    "version_commit": "c2c265a7addb98ce1dc8fa3e46c39a9ae028262b"
+  },
+  "axiom_encode_version": "0.2.159",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(7)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-7-main-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "0c8f081cad3fae51871e851b50fe74e77a62c76625510e7f4cf9c70c2c43768a",
+  "generated_at": "2026-05-24T20:11:37.528720+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-7-main-20260524/openai-gpt-5.5/statutes/26/3121/a/7.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-7-main-20260524",
+  "generated_output_sha256": "10cf29a985dedec36b3e3978e5cd2a58c2bc10a74763835428b09f9a2754db6d",
+  "generation_prompt_sha256": "72335b6a9b7cc3497678d14d86e35cc24ff90652bf152f14cbc582591d0d005e",
+  "model": "gpt-5.5",
+  "run_id": "34ca3422",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "146fb1e0ff2088025ee0dc2cdf31f0a660af7b7cbdfe2e8a87ad21630264dec4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-7-main-20260524/traces/openai-gpt-5.5/26-USC-3121-a-7.json",
+  "trace_sha256": "dfb8115ebfdefd160ac25aec8f4dac02142c74a067c5b20ce581a666852925da"
+}

--- a/statutes/26/3121/a/7.test.yaml
+++ b/statutes/26/3121/a/7.test.yaml
@@ -1,0 +1,116 @@
+- name: noncash domestic service remuneration is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/7#input.payment_amount: 500
+      us:statutes/26/3121/a/7#input.remuneration_paid_in_medium_other_than_cash_to_employee: true
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_by_employer_to_employee: false
+      us:statutes/26/3121/a/7#input.service_not_in_course_of_employer_trade_or_business: false
+      us:statutes/26/3121/a/7#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/a/7#input.service_described_in_subsection_g_5: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_domestic_service: 0
+      us:statutes/26/3121/a/7#input.applicable_dollar_threshold_as_defined_in_subsection_x_for_year: 2600
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_nontrade_service: 0
+  output:
+    us:statutes/26/3121/a/7#noncash_private_or_nonbusiness_service_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/7#domestic_cash_below_applicable_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_service_for_subparagraph_c:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_below_statutory_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#private_or_nonbusiness_service_remuneration_excluded_from_wages:
+    - 500
+- name: cash domestic service below applicable threshold is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/7#input.payment_amount: 2000
+      us:statutes/26/3121/a/7#input.remuneration_paid_in_medium_other_than_cash_to_employee: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/7#input.service_not_in_course_of_employer_trade_or_business: false
+      us:statutes/26/3121/a/7#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/a/7#input.service_described_in_subsection_g_5: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_domestic_service: 2000
+      us:statutes/26/3121/a/7#input.applicable_dollar_threshold_as_defined_in_subsection_x_for_year: 2600
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_nontrade_service: 0
+  output:
+    us:statutes/26/3121/a/7#noncash_private_or_nonbusiness_service_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#domestic_cash_below_applicable_threshold_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/7#cash_nontrade_service_for_subparagraph_c:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_below_statutory_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#private_or_nonbusiness_service_remuneration_excluded_from_wages:
+    - 2000
+- name: cash nontrade service below one hundred dollar threshold is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/7#input.payment_amount: 90
+      us:statutes/26/3121/a/7#input.remuneration_paid_in_medium_other_than_cash_to_employee: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/7#input.service_not_in_course_of_employer_trade_or_business: true
+      us:statutes/26/3121/a/7#input.domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/a/7#input.service_described_in_subsection_g_5: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_domestic_service: 0
+      us:statutes/26/3121/a/7#input.applicable_dollar_threshold_as_defined_in_subsection_x_for_year: 2600
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_nontrade_service: 90
+  output:
+    us:statutes/26/3121/a/7#noncash_private_or_nonbusiness_service_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#domestic_cash_below_applicable_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_service_for_subparagraph_c:
+    - holds
+    us:statutes/26/3121/a/7#cash_nontrade_below_statutory_threshold_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/7#private_or_nonbusiness_service_remuneration_excluded_from_wages:
+    - 90
+- name: subsection_g_5_service_is_not_cash_nontrade_service_for_subparagraph_c
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/7#input.payment_amount: 90
+      us:statutes/26/3121/a/7#input.remuneration_paid_in_medium_other_than_cash_to_employee: false
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/7#input.service_not_in_course_of_employer_trade_or_business: true
+      us:statutes/26/3121/a/7#input.domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/a/7#input.service_described_in_subsection_g_5: true
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_domestic_service: 0
+      us:statutes/26/3121/a/7#input.applicable_dollar_threshold_as_defined_in_subsection_x_for_year: 2600
+      us:statutes/26/3121/a/7#input.cash_remuneration_paid_in_year_by_employer_to_employee_for_nontrade_service: 90
+  output:
+    us:statutes/26/3121/a/7#noncash_private_or_nonbusiness_service_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#domestic_cash_below_applicable_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_service_for_subparagraph_c:
+    - not_holds
+    us:statutes/26/3121/a/7#cash_nontrade_below_statutory_threshold_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/7#private_or_nonbusiness_service_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/7.yaml
+++ b/statutes/26/3121/a/7.yaml
@@ -1,0 +1,174 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (7) (A) remuneration paid in any medium other than cash to an employee for service not in the course of the employer’s trade or business or for domestic service in a private home of the employer; (B) cash remuneration paid by an employer in any calendar year to an employee for domestic service in a private home of the employer (including domestic service on a farm operated for profit), if the cash remuneration paid in such year by the employer to the employee for such service is less than the applicable dollar threshold (as defined in subsection (x)) for such year; (C) cash remuneration paid by an employer in any calendar year to an employee for service not in the course of the employer’s trade or business, if the cash remuneration paid in such year by the employer to the employee for such service is less than $100. As used in this subparagraph, the term “service not in the course of the employer’s trade or business” does not include domestic service in a private home of the employer and does not include service described in subsection (g)(5);
+rules:
+  - name: cash_nontrade_service_statutory_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(7)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is less than $100"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          100
+
+  - name: noncash_private_or_nonbusiness_service_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(7)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid in any medium other than cash to an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "for service not in the course of the employer’s trade or business or for domestic service in a private home of the employer"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_paid_in_medium_other_than_cash_to_employee
+          and (service_not_in_course_of_employer_trade_or_business or domestic_service_in_private_home_of_employer)
+
+  - name: domestic_cash_below_applicable_threshold_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(7)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash remuneration paid by an employer in any calendar year to an employee for domestic service in a private home of the employer (including domestic service on a farm operated for profit)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the cash remuneration paid in such year by the employer to the employee for such service is less than the applicable dollar threshold (as defined in subsection (x)) for such year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cash_remuneration_paid_by_employer_to_employee
+          and domestic_service_in_private_home_of_employer
+          and cash_remuneration_paid_in_year_by_employer_to_employee_for_domestic_service < applicable_dollar_threshold_as_defined_in_subsection_x_for_year
+
+  - name: cash_nontrade_service_for_subparagraph_c
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(7)(C), flush language
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "As used in this subparagraph, the term “service not in the course of the employer’s trade or business” does not include domestic service in a private home of the employer and does not include service described in subsection (g)(5)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_not_in_course_of_employer_trade_or_business
+          and not domestic_service_in_private_home_of_employer
+          and not service_described_in_subsection_g_5
+
+  - name: cash_nontrade_below_statutory_threshold_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(7)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash remuneration paid by an employer in any calendar year to an employee for service not in the course of the employer’s trade or business"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the cash remuneration paid in such year by the employer to the employee for such service is less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/7#cash_nontrade_service_for_subparagraph_c
+              output: cash_nontrade_service_for_subparagraph_c
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/7#cash_nontrade_service_statutory_threshold
+              output: cash_nontrade_service_statutory_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cash_remuneration_paid_by_employer_to_employee
+          and cash_nontrade_service_for_subparagraph_c
+          and cash_remuneration_paid_in_year_by_employer_to_employee_for_nontrade_service < cash_nontrade_service_statutory_threshold
+
+  - name: private_or_nonbusiness_service_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid in any medium other than cash ...; cash remuneration ... if ... less than the applicable dollar threshold ...; cash remuneration ... if ... less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/7#noncash_private_or_nonbusiness_service_exclusion_applies
+              output: noncash_private_or_nonbusiness_service_exclusion_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/7#domestic_cash_below_applicable_threshold_exclusion_applies
+              output: domestic_cash_below_applicable_threshold_exclusion_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/7#cash_nontrade_below_statutory_threshold_exclusion_applies
+              output: cash_nontrade_below_statutory_threshold_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if noncash_private_or_nonbusiness_service_exclusion_applies or domestic_cash_below_applicable_threshold_exclusion_applies or cash_nontrade_below_statutory_threshold_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(7) noncash, domestic-service, and nontrade-service wage exclusions
- add generated companion tests and signed encoding manifest

## Generated provenance
- axiom-encode commit: `c2c265a7addb98ce1dc8fa3e46c39a9ae028262b`
- axiom-encode version: `0.2.159`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/7.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/7.test.yaml --root /private/tmp/rulespec-us-3121-a-7-v2-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/7.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-7-v2-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage classification check: all changed outputs `known_not_comparable`