### PR TITLE
Encode section 3121(a)(8) agricultural labor exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/8.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/8.yaml",
+      "sha256": "bb7f5f02128dd39a7bf00fdfa9a680b5d35f5668f9fab7c24603ba5c12e2d8af"
+    },
+    {
+      "path": "statutes/26/3121/a/8.test.yaml",
+      "sha256": "2ab437d7af8573814797fb977e96cea2e41fcfa1ad42dfe35e92497d56550336"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c2c265a7addb98ce1dc8fa3e46c39a9ae028262b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.159",
+    "version_commit": "c2c265a7addb98ce1dc8fa3e46c39a9ae028262b"
+  },
+  "axiom_encode_version": "0.2.159",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(8)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-8-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "d98c7696ea7ac43e12890a30302120323394e76877c197a306ac5b1a315cc25e",
+  "generated_at": "2026-05-24T20:16:20.229567+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-8-20260524/openai-gpt-5.5/statutes/26/3121/a/8.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-8-20260524",
+  "generated_output_sha256": "bb7f5f02128dd39a7bf00fdfa9a680b5d35f5668f9fab7c24603ba5c12e2d8af",
+  "generation_prompt_sha256": "a0d6f2a3e21bd9092ab171248542daeb079af4075d57d3a9a78c5bb5fa770d4a",
+  "model": "gpt-5.5",
+  "run_id": "5f3646cb",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8399bee2f7ded6753e5b110e124e92a1e4d531193cb9571ad52570a681db4fab"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-8-20260524/traces/openai-gpt-5.5/26-USC-3121-a-8.json",
+  "trace_sha256": "e1e1329fa10bd7b6e9d174fecd6a5b963fb08972495c7b9ca503640e6395c3bd"
+}

--- a/statutes/26/3121/a/8.test.yaml
+++ b/statutes/26/3121/a/8.test.yaml
@@ -1,0 +1,145 @@
+- name: noncash_agricultural_labor_remuneration_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/8#input.payment_amount: 500
+      us:statutes/26/3121/a/8#input.payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: true
+      us:statutes/26/3121/a/8#input.payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor: false
+      us:statutes/26/3121/a/8#input.cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year: 0
+      us:statutes/26/3121/a/8#input.employer_expenditures_for_agricultural_labor_in_calendar_year: 0
+      us:statutes/26/3121/a/8#input.employee_is_employed_as_hand_harvest_laborer: false
+      us:statutes/26/3121/a/8#input.employee_is_paid_on_piece_rate_basis: false
+      ? us:statutes/26/3121/a/8#input.operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+      : false
+      us:statutes/26/3121/a/8#input.employee_commutes_daily_from_permanent_residence_to_farm: false
+      us:statutes/26/3121/a/8#input.employee_weeks_employed_in_agriculture_during_preceding_calendar_year: 20
+  output:
+    us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#agricultural_labor_remuneration_excluded_from_wages:
+    - 500
+- name: cash_agricultural_labor_below_employee_and_employer_thresholds_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/8#input.payment_amount: 100
+      us:statutes/26/3121/a/8#input.payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: false
+      us:statutes/26/3121/a/8#input.payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor: true
+      us:statutes/26/3121/a/8#input.cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year: 100
+      us:statutes/26/3121/a/8#input.employer_expenditures_for_agricultural_labor_in_calendar_year: 2000
+      us:statutes/26/3121/a/8#input.employee_is_employed_as_hand_harvest_laborer: false
+      us:statutes/26/3121/a/8#input.employee_is_paid_on_piece_rate_basis: false
+      ? us:statutes/26/3121/a/8#input.operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+      : false
+      us:statutes/26/3121/a/8#input.employee_commutes_daily_from_permanent_residence_to_farm: false
+      us:statutes/26/3121/a/8#input.employee_weeks_employed_in_agriculture_during_preceding_calendar_year: 20
+  output:
+    us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/8#agricultural_labor_remuneration_excluded_from_wages:
+    - 100
+- name: cash_agricultural_labor_not_excluded_when_employee_threshold_met
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/8#input.payment_amount: 150
+      us:statutes/26/3121/a/8#input.payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: false
+      us:statutes/26/3121/a/8#input.payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor: true
+      us:statutes/26/3121/a/8#input.cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year: 150
+      us:statutes/26/3121/a/8#input.employer_expenditures_for_agricultural_labor_in_calendar_year: 2000
+      us:statutes/26/3121/a/8#input.employee_is_employed_as_hand_harvest_laborer: false
+      us:statutes/26/3121/a/8#input.employee_is_paid_on_piece_rate_basis: false
+      ? us:statutes/26/3121/a/8#input.operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+      : false
+      us:statutes/26/3121/a/8#input.employee_commutes_daily_from_permanent_residence_to_farm: false
+      us:statutes/26/3121/a/8#input.employee_weeks_employed_in_agriculture_during_preceding_calendar_year: 20
+  output:
+    us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#agricultural_labor_remuneration_excluded_from_wages:
+    - 0
+- name: employer_expenditure_threshold_blocks_cash_exclusion_without_hand_harvest_exception
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/8#input.payment_amount: 100
+      us:statutes/26/3121/a/8#input.payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: false
+      us:statutes/26/3121/a/8#input.payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor: true
+      us:statutes/26/3121/a/8#input.cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year: 100
+      us:statutes/26/3121/a/8#input.employer_expenditures_for_agricultural_labor_in_calendar_year: 2500
+      us:statutes/26/3121/a/8#input.employee_is_employed_as_hand_harvest_laborer: true
+      us:statutes/26/3121/a/8#input.employee_is_paid_on_piece_rate_basis: true
+      ? us:statutes/26/3121/a/8#input.operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+      : true
+      us:statutes/26/3121/a/8#input.employee_commutes_daily_from_permanent_residence_to_farm: true
+      us:statutes/26/3121/a/8#input.employee_weeks_employed_in_agriculture_during_preceding_calendar_year: 13
+  output:
+    us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies:
+    - holds
+    us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#agricultural_labor_remuneration_excluded_from_wages:
+    - 0
+- name: hand_harvest_exception_prevents_clause_ii_from_blocking_cash_exclusion
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/8#input.payment_amount: 100
+      us:statutes/26/3121/a/8#input.payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: false
+      us:statutes/26/3121/a/8#input.payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor: true
+      us:statutes/26/3121/a/8#input.cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year: 100
+      us:statutes/26/3121/a/8#input.employer_expenditures_for_agricultural_labor_in_calendar_year: 2500
+      us:statutes/26/3121/a/8#input.employee_is_employed_as_hand_harvest_laborer: true
+      us:statutes/26/3121/a/8#input.employee_is_paid_on_piece_rate_basis: true
+      ? us:statutes/26/3121/a/8#input.operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+      : true
+      us:statutes/26/3121/a/8#input.employee_commutes_daily_from_permanent_residence_to_farm: true
+      us:statutes/26/3121/a/8#input.employee_weeks_employed_in_agriculture_during_preceding_calendar_year: 12
+  output:
+    us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies:
+    - holds
+    us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies:
+    - not_holds
+    us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/8#agricultural_labor_remuneration_excluded_from_wages:
+    - 100

--- a/statutes/26/3121/a/8.yaml
+++ b/statutes/26/3121/a/8.yaml
@@ -1,0 +1,196 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (8) (A) remuneration paid in any medium other than cash for agricultural labor; (B) cash remuneration paid by an employer in any calendar year to an employee for agricultural labor unless— (i) the cash remuneration paid in such year by the employer to the employee for such labor is $150 or more, or (ii) the employer’s expenditures for agricultural labor in such year equal or exceed $2,500, except that clause (ii) shall not apply in determining whether remuneration paid to an employee constitutes “wages” under this section if such employee (I) is employed as a hand harvest laborer and is paid on a piece rate basis in an operation which has been, and is customarily and generally recognized as having been, paid on a piece rate basis in the region of employment, (II) commutes daily from his permanent residence to the farm on which he is so employed, and (III) has been employed in agriculture less than 13 weeks during the preceding calendar year; [
+rules:
+  - name: agricultural_labor_cash_remuneration_employee_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(8)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the cash remuneration paid in such year by the employer to the employee for such labor is $150 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          150
+
+  - name: agricultural_labor_employer_expenditure_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(8)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the employer’s expenditures for agricultural labor in such year equal or exceed $2,500"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2500
+
+  - name: hand_harvest_preceding_agriculture_weeks_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3121(a)(8)(B)(ii)(III)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "has been employed in agriculture less than 13 weeks during the preceding calendar year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          13
+
+  - name: hand_harvest_laborer_clause_ii_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(8)(B)(ii)(I)-(III)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that clause (ii) shall not apply in determining whether remuneration paid to an employee constitutes “wages” under this section if such employee (I) is employed as a hand harvest laborer and is paid on a piece rate basis in an operation which has been, and is customarily and generally recognized as having been, paid on a piece rate basis in the region of employment, (II) commutes daily from his permanent residence to the farm on which he is so employed, and (III) has been employed in agriculture less than 13 weeks during the preceding calendar year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#hand_harvest_preceding_agriculture_weeks_limit
+              output: hand_harvest_preceding_agriculture_weeks_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employee_is_employed_as_hand_harvest_laborer
+          and employee_is_paid_on_piece_rate_basis
+          and operation_has_been_and_is_customarily_and_generally_recognized_as_paid_on_piece_rate_basis_in_region_of_employment
+          and employee_commutes_daily_from_permanent_residence_to_farm
+          and employee_weeks_employed_in_agriculture_during_preceding_calendar_year < hand_harvest_preceding_agriculture_weeks_limit
+
+  - name: clause_ii_agricultural_labor_expenditure_test_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(8)(B)(ii), flush language exception
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the employer’s expenditures for agricultural labor in such year equal or exceed $2,500"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that clause (ii) shall not apply in determining whether remuneration paid to an employee constitutes “wages” under this section if such employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#agricultural_labor_employer_expenditure_threshold
+              output: agricultural_labor_employer_expenditure_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#hand_harvest_laborer_clause_ii_exception_applies
+              output: hand_harvest_laborer_clause_ii_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_expenditures_for_agricultural_labor_in_calendar_year >= agricultural_labor_employer_expenditure_threshold
+          and not hand_harvest_laborer_clause_ii_exception_applies
+
+  - name: cash_agricultural_labor_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(8)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash remuneration paid by an employer in any calendar year to an employee for agricultural labor unless— (i) the cash remuneration paid in such year by the employer to the employee for such labor is $150 or more, or (ii) the employer’s expenditures for agricultural labor in such year equal or exceed $2,500"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that clause (ii) shall not apply"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#agricultural_labor_cash_remuneration_employee_threshold
+              output: agricultural_labor_cash_remuneration_employee_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#clause_ii_agricultural_labor_expenditure_test_applies
+              output: clause_ii_agricultural_labor_expenditure_test_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor
+          and cash_remuneration_paid_by_employer_to_employee_for_agricultural_labor_in_calendar_year < agricultural_labor_cash_remuneration_employee_threshold
+          and not clause_ii_agricultural_labor_expenditure_test_applies
+
+  - name: agricultural_labor_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(8)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid in any medium other than cash for agricultural labor"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash remuneration paid by an employer in any calendar year to an employee for agricultural labor unless"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/8#cash_agricultural_labor_remuneration_exclusion_applies
+              output: cash_agricultural_labor_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_is_remuneration_paid_in_medium_other_than_cash_for_agricultural_labor: payment_amount else: if cash_agricultural_labor_remuneration_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(8) agricultural-labor wage exclusions
- add generated companion tests and signed encoding manifest

## Generated provenance
- axiom-encode commit: `c2c265a7addb98ce1dc8fa3e46c39a9ae028262b`
- axiom-encode version: `0.2.159`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/8.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/8.test.yaml --root /private/tmp/rulespec-us-3121-a-8-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/8.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-8-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage classification check after TheAxiomFoundation/axiom-encode#171: all changed outputs `known_not_comparable`