### PR TITLE
Encode section 3121(a)(10) home worker exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/10.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/10.yaml",
+      "sha256": "ead5106ab2534f4a233c87c4eccc8b9435ad4dd69ce3d3ebcadaf227cf89be83"
+    },
+    {
+      "path": "statutes/26/3121/a/10.test.yaml",
+      "sha256": "2f103da979a806c70b10e400230967332f4d16b5082362f39b6067feeeca3e0d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7e6ccb4b627190c589f6da8e4897cf094f77a194",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.160",
+    "version_commit": "7e6ccb4b627190c589f6da8e4897cf094f77a194"
+  },
+  "axiom_encode_version": "0.2.160",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(10)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-10-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "0c6a87ba42bd20be283d0992bde91a10409523e1ff1dd5cea8a9ab0d49673b71",
+  "generated_at": "2026-05-24T20:29:28.318565+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-10-20260524/openai-gpt-5.5/statutes/26/3121/a/10.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-10-20260524",
+  "generated_output_sha256": "ead5106ab2534f4a233c87c4eccc8b9435ad4dd69ce3d3ebcadaf227cf89be83",
+  "generation_prompt_sha256": "b96d9d583b01de8f943ebf05b62e1cab33b815bd7092db7f1f8e5a3ad6a7dc17",
+  "model": "gpt-5.5",
+  "run_id": "fb4a2b15",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e9e4c84494ea4b5b76f16a647342fa3c73db5384d842f0917fb47568985da839"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-10-20260524/traces/openai-gpt-5.5/26-USC-3121-a-10.json",
+  "trace_sha256": "3dbf340ed89670d3fa6a395f99fc781fd77bf178d1ac2197a8920743293d565a"
+}

--- a/statutes/26/3121/a/10.test.yaml
+++ b/statutes/26/3121/a/10.test.yaml
@@ -1,0 +1,73 @@
+- name: qualifying_home_worker_remuneration_under_threshold_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/10#input.remuneration_amount: 80
+      us:statutes/26/3121/a/10#input.remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/10#input.service_is_described_in_subsection_d_3_C_relating_to_home_workers: true
+      us:statutes/26/3121/a/10#input.cash_remuneration_paid_in_calendar_year_by_employer_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/10#home_worker_cash_remuneration_annual_threshold: 100
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_excluded_from_wages:
+    - 80
+- name: cash_remuneration_equal_to_threshold_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/10#input.remuneration_amount: 100
+      us:statutes/26/3121/a/10#input.remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/10#input.service_is_described_in_subsection_d_3_C_relating_to_home_workers: true
+      us:statutes/26/3121/a/10#input.cash_remuneration_paid_in_calendar_year_by_employer_to_employee_for_such_service: 100
+  output:
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_excluded_from_wages:
+    - 0
+- name: non_home_worker_service_not_excluded_even_under_threshold
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/10#input.remuneration_amount: 80
+      us:statutes/26/3121/a/10#input.remuneration_paid_by_employer_to_employee: true
+      us:statutes/26/3121/a/10#input.service_is_described_in_subsection_d_3_C_relating_to_home_workers: false
+      us:statutes/26/3121/a/10#input.cash_remuneration_paid_in_calendar_year_by_employer_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_excluded_from_wages:
+    - 0
+- name: remuneration_not_paid_by_employer_to_employee_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/10#input.remuneration_amount: 80
+      us:statutes/26/3121/a/10#input.remuneration_paid_by_employer_to_employee: false
+      us:statutes/26/3121/a/10#input.service_is_described_in_subsection_d_3_C_relating_to_home_workers: true
+      us:statutes/26/3121/a/10#input.cash_remuneration_paid_in_calendar_year_by_employer_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/10.yaml
+++ b/statutes/26/3121/a/10.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (10) remuneration paid by an employer in any calendar year to an employee for service described in subsection (d)(3)(C) (relating to home workers), if the cash remuneration paid in such year by the employer to the employee for such service is less than $100;
+rules:
+  - name: home_worker_cash_remuneration_annual_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "less than $100"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          100
+
+  - name: home_worker_low_cash_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid by an employer in any calendar year to an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "for service described in subsection (d)(3)(C) (relating to home workers)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the cash remuneration paid in such year by the employer to the employee for such service is less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/10#home_worker_cash_remuneration_annual_threshold
+              output: home_worker_cash_remuneration_annual_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_paid_by_employer_to_employee
+          and service_is_described_in_subsection_d_3_C_relating_to_home_workers
+          and cash_remuneration_paid_in_calendar_year_by_employer_to_employee_for_such_service < home_worker_cash_remuneration_annual_threshold
+
+  - name: home_worker_low_cash_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid by an employer in any calendar year to an employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/10#home_worker_low_cash_remuneration_exclusion_applies
+              output: home_worker_low_cash_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if home_worker_low_cash_remuneration_exclusion_applies: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for the 26 USC 3121(a)(10) home-worker wage exclusion
- add generated companion tests for the $100 cash-remuneration threshold and exclusion amount
- add signed encoding manifest

## Generated provenance
- axiom-encode commit: `7e6ccb4b627190c589f6da8e4897cf094f77a194`
- axiom-encode version: `0.2.160`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/10.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/10.test.yaml --root /private/tmp/rulespec-us-3121-a-10-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/10.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-10-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage check after axiom-encode #172: all changed outputs are `known_not_comparable`