### PR TITLE
Encode section 3121(a)(11) moving expense exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/11.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/11.yaml",
+      "sha256": "596db745d34031621db79f38310e0c46c41f08f3c81b90b47bd4927a6890f460"
+    },
+    {
+      "path": "statutes/26/3121/a/11.test.yaml",
+      "sha256": "6577c37762eef3db9cb6d95ce064ca2ed580462da2004ab24d985835033cdfcd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7c12b240b19be2898e84611c644b9cd8374bbb70",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.161",
+    "version_commit": "7c12b240b19be2898e84611c644b9cd8374bbb70"
+  },
+  "axiom_encode_version": "0.2.161",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(11)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-11-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "4e3c0a7b391116e5cf001f12a27993dfb7389198042141cc1efc639bc512559a",
+  "generated_at": "2026-05-24T20:42:18.940442+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-11-20260524/openai-gpt-5.5/statutes/26/3121/a/11.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-11-20260524",
+  "generated_output_sha256": "596db745d34031621db79f38310e0c46c41f08f3c81b90b47bd4927a6890f460",
+  "generation_prompt_sha256": "5b5c92c181e0d2c6d3cfd7f8e07d141ac2460ed76a418905e5ea6a560148bf94",
+  "model": "gpt-5.5",
+  "run_id": "bfb68539",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e879fa38f540a3be15735e948f5c394674f8f957bdcb7d17436edd90d2c8a1ad"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-11-20260524/traces/openai-gpt-5.5/26-USC-3121-a-11.json",
+  "trace_sha256": "1912554cafa41f33b7cc68c543b611330330bac93ec0267cf743c831f9a7e80f"
+}

--- a/statutes/26/3121/a/11.test.yaml
+++ b/statutes/26/3121/a/11.test.yaml
@@ -1,0 +1,57 @@
+- name: qualifying_remuneration_with_reasonable_section_217_belief_excluded_to_corresponding_deduction_extent
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/11#input.remuneration_paid_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/11#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : true
+      ? us:statutes/26/3121/a/11#input.remuneration_amount_corresponding_to_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 1200
+  output:
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_excluded_from_wages:
+    - 1200
+- name: remuneration_not_paid_to_or_on_behalf_of_employee_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/11#input.remuneration_paid_to_or_on_behalf_of_employee: false
+      ? us:statutes/26/3121/a/11#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : true
+      ? us:statutes/26/3121/a/11#input.remuneration_amount_corresponding_to_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 1200
+  output:
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_excluded_from_wages:
+    - 0
+- name: no_reasonable_belief_of_corresponding_section_217_deduction_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/11#input.remuneration_paid_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/11#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : false
+      ? us:statutes/26/3121/a/11#input.remuneration_amount_corresponding_to_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 1200
+  output:
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/11.yaml
+++ b/statutes/26/3121/a/11.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (11) remuneration paid to or on behalf of an employee if (and to the extent that) at the time of the payment of such remuneration it is reasonable to believe that a corresponding deduction is allowable under section 217 (determined without regard to section 274(n));
+rules:
+  - name: moving_expense_deduction_reasonable_belief_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid to or on behalf of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "at the time of the payment of such remuneration it is reasonable to believe that a corresponding deduction is allowable under section 217 (determined without regard to section 274(n))"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_paid_to_or_on_behalf_of_employee
+          and reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+
+  - name: moving_expense_deduction_reasonable_belief_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid to or on behalf of an employee if (and to the extent that)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "a corresponding deduction is allowable under section 217 (determined without regard to section 274(n))"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/11#moving_expense_deduction_reasonable_belief_exclusion_applies
+              output: moving_expense_deduction_reasonable_belief_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if moving_expense_deduction_reasonable_belief_exclusion_applies: remuneration_amount_corresponding_to_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for the 26 USC 3121(a)(11) moving-expense wage exclusion
- add generated companion tests for the reasonable-belief predicate and excluded amount
- add signed encoding manifest

## Generated provenance
- axiom-encode commit: `7c12b240b19be2898e84611c644b9cd8374bbb70`
- axiom-encode version: `0.2.161`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/11.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/11.test.yaml --root /private/tmp/rulespec-us-3121-a-11-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/11.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-11-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage check after axiom-encode #173: all changed outputs are `known_not_comparable`