### PR TITLE
Encode section 3121(a)(12) tip exclusions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/12.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/12.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/12.yaml",
+      "sha256": "bbf63b231fba02ff3ed6363afa6a11a9d2f236b7ed48b1e21dfb0989f9db4265"
+    },
+    {
+      "path": "statutes/26/3121/a/12.test.yaml",
+      "sha256": "a2c9f52b980e7f846fa5c91594eaddb1467d8a6425391d7ad80de5e119d940ba"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fec9b6a7ec707ba0a17063902ab40c8476216635",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.162",
+    "version_commit": "fec9b6a7ec707ba0a17063902ab40c8476216635"
+  },
+  "axiom_encode_version": "0.2.162",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(12)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-12-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "f6f520968821ffe33c84dcd1740391918e4ce82fb411465386b9ca910c76ee5a",
+  "generated_at": "2026-05-24T20:52:52.431658+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-12-20260524/openai-gpt-5.5/statutes/26/3121/a/12.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-12-20260524",
+  "generated_output_sha256": "bbf63b231fba02ff3ed6363afa6a11a9d2f236b7ed48b1e21dfb0989f9db4265",
+  "generation_prompt_sha256": "e2f36b99ab7cf18a10d72693dba2ae3b4d272b2de80f9135eeef086871ad20cd",
+  "model": "gpt-5.5",
+  "run_id": "756d085f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "869eb17055d51efb8d74ba2f329a8305d89ade5c181c98d66619cfdc5e2b110b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-12-20260524/traces/openai-gpt-5.5/26-USC-3121-a-12.json",
+  "trace_sha256": "fde3dff05bf4ab466bbd84821d39d9d2b61b2e882fc83ba24f13a3fab9d96681"
+}

--- a/statutes/26/3121/a/12.test.yaml
+++ b/statutes/26/3121/a/12.test.yaml
@@ -1,0 +1,100 @@
+- name: noncash_tips_are_excluded
+  period:
+    period_kind: custom
+    name: calendar_month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/12#input.tips_paid_in_medium_other_than_cash: true
+      us:statutes/26/3121/a/12#input.tip_amount: 15
+      us:statutes/26/3121/a/12#input.cash_tips_received_by_employee_in_calendar_month_in_course_of_employment_by_employer: false
+      us:statutes/26/3121/a/12#input.monthly_cash_tips_amount: 0
+      us:statutes/26/3121/a/12#input.cash_tip_amount_for_payment: 0
+  output:
+    us:statutes/26/3121/a/12#noncash_tip_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/12#noncash_tips_excluded_from_wages:
+    - 15
+    us:statutes/26/3121/a/12#low_monthly_cash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#low_monthly_cash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#tips_excluded_from_wages:
+    - 15
+- name: cash_tips_below_monthly_threshold_are_excluded
+  period:
+    period_kind: custom
+    name: calendar_month
+    start: '2026-02-01'
+    end: '2026-02-28'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/12#input.tips_paid_in_medium_other_than_cash: false
+      us:statutes/26/3121/a/12#input.tip_amount: 0
+      us:statutes/26/3121/a/12#input.cash_tips_received_by_employee_in_calendar_month_in_course_of_employment_by_employer: true
+      us:statutes/26/3121/a/12#input.monthly_cash_tips_amount: 19
+      us:statutes/26/3121/a/12#input.cash_tip_amount_for_payment: 19
+  output:
+    us:statutes/26/3121/a/12#noncash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#noncash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#low_monthly_cash_tip_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/12#low_monthly_cash_tips_excluded_from_wages:
+    - 19
+    us:statutes/26/3121/a/12#tips_excluded_from_wages:
+    - 19
+- name: cash_tips_equal_to_monthly_threshold_are_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_month
+    start: '2026-03-01'
+    end: '2026-03-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/12#input.tips_paid_in_medium_other_than_cash: false
+      us:statutes/26/3121/a/12#input.tip_amount: 0
+      us:statutes/26/3121/a/12#input.cash_tips_received_by_employee_in_calendar_month_in_course_of_employment_by_employer: true
+      us:statutes/26/3121/a/12#input.monthly_cash_tips_amount: 20
+      us:statutes/26/3121/a/12#input.cash_tip_amount_for_payment: 20
+  output:
+    us:statutes/26/3121/a/12#noncash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#noncash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#low_monthly_cash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#low_monthly_cash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#tips_excluded_from_wages:
+    - 0
+- name: cash_tips_not_received_in_course_of_employment_by_employer_are_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_month
+    start: '2026-04-01'
+    end: '2026-04-30'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/12#input.tips_paid_in_medium_other_than_cash: false
+      us:statutes/26/3121/a/12#input.tip_amount: 0
+      us:statutes/26/3121/a/12#input.cash_tips_received_by_employee_in_calendar_month_in_course_of_employment_by_employer: false
+      us:statutes/26/3121/a/12#input.monthly_cash_tips_amount: 19
+      us:statutes/26/3121/a/12#input.cash_tip_amount_for_payment: 19
+  output:
+    us:statutes/26/3121/a/12#noncash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#noncash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#low_monthly_cash_tip_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/12#low_monthly_cash_tips_excluded_from_wages:
+    - 0
+    us:statutes/26/3121/a/12#tips_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/12.yaml
+++ b/statutes/26/3121/a/12.yaml
@@ -1,0 +1,160 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (12) (A) tips paid in any medium other than cash; (B) cash tips received by an employee in any calendar month in the course of his employment by an employer unless the amount of such cash tips is $20 or more;
+rules:
+  - name: monthly_cash_tip_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(12)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "unless the amount of such cash tips is $20 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: noncash_tip_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3121(a)(12)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "tips paid in any medium other than cash"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          tips_paid_in_medium_other_than_cash
+
+  - name: noncash_tips_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 26 USC 3121(a)(12)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "tips paid in any medium other than cash"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/12#noncash_tip_exclusion_applies
+              output: noncash_tip_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if noncash_tip_exclusion_applies: tip_amount else: 0
+
+  - name: low_monthly_cash_tip_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3121(a)(12)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash tips received by an employee in any calendar month in the course of his employment by an employer"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "unless the amount of such cash tips is $20 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/12#monthly_cash_tip_threshold
+              output: monthly_cash_tip_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cash_tips_received_by_employee_in_calendar_month_in_course_of_employment_by_employer
+          and monthly_cash_tips_amount < monthly_cash_tip_threshold
+
+  - name: low_monthly_cash_tips_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 26 USC 3121(a)(12)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash tips received by an employee in any calendar month in the course of his employment by an employer unless the amount of such cash tips is $20 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/12#low_monthly_cash_tip_exclusion_applies
+              output: low_monthly_cash_tip_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if low_monthly_cash_tip_exclusion_applies: cash_tip_amount_for_payment else: 0
+
+  - name: tips_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 26 USC 3121(a)(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(A) tips paid in any medium other than cash; (B) cash tips received by an employee in any calendar month in the course of his employment by an employer unless the amount of such cash tips is $20 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/12#noncash_tips_excluded_from_wages
+              output: noncash_tips_excluded_from_wages
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/12#low_monthly_cash_tips_excluded_from_wages
+              output: low_monthly_cash_tips_excluded_from_wages
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          noncash_tips_excluded_from_wages + low_monthly_cash_tips_excluded_from_wages


### PR DESCRIPTION
## Summary
- add generated RuleSpec for the 26 USC 3121(a)(12) noncash and low-monthly-cash tip wage exclusions
- add generated companion tests for noncash tips, below-threshold cash tips, threshold edge, and non-employment cash tips
- add signed encoding manifest

## Generated provenance
- axiom-encode commit: `fec9b6a7ec707ba0a17063902ab40c8476216635`
- axiom-encode version: `0.2.162`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/12.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/12.test.yaml --root /private/tmp/rulespec-us-3121-a-12-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/12.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-12-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage check after axiom-encode #174: all changed outputs are `known_not_comparable`