### PR TITLE
Encode section 3121(a)(16) exempt organization exclusion

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/16.yaml",
+      "sha256": "f7cdf1f5bc2e2e5639da0e3ef31cc120d3168ee79640bdbab70ae3abf492e060"
+    },
+    {
+      "path": "statutes/26/3121/a/16.test.yaml",
+      "sha256": "6e11a015685d342ef21db394fe48965ece6d1f526fbfc43c8980952cc9c8b00e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "63043ccbba5456cf49d99725b0d3cc8b00dbc60f",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.163",
+    "version_commit": "63043ccbba5456cf49d99725b0d3cc8b00dbc60f"
+  },
+  "axiom_encode_version": "0.2.163",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(16)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-16-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "8163463fbedf66006b1266c6f9f2d9ec6a6f7e19e0099638ebbf4e34dcd2dffd",
+  "generated_at": "2026-05-24T21:05:47.171942+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-16-20260524/openai-gpt-5.5/statutes/26/3121/a/16.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-16-20260524",
+  "generated_output_sha256": "f7cdf1f5bc2e2e5639da0e3ef31cc120d3168ee79640bdbab70ae3abf492e060",
+  "generation_prompt_sha256": "654a90e7c0d2a7b70956cecbba23dbb678086b672bf38ecde0336f5002008b78",
+  "model": "gpt-5.5",
+  "run_id": "7f1dd492",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a0c125fcd89bed68034e7b858be451386bc350f8b71692d37376e5a9d0ef3b31"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-16-20260524/traces/openai-gpt-5.5/26-USC-3121-a-16.json",
+  "trace_sha256": "a0e2b829bfb50f0ba4323727813ea591be289d62907069fb50dd5f1eba27d84b"
+}

--- a/statutes/26/3121/a/16.test.yaml
+++ b/statutes/26/3121/a/16.test.yaml
@@ -1,0 +1,116 @@
+- name: qualifying_section_501a_organization_remuneration_under_threshold_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/16#input.remuneration_amount: 80
+      ? us:statutes/26/3121/a/16#input.remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+      : true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_501_a: true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_521: false
+      us:statutes/26/3121/a/16#input.organization_described_in_section_401_a: false
+      us:statutes/26/3121/a/16#input.remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/16#exempt_organization_remuneration_annual_threshold: 100
+    us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_excluded_from_wages:
+    - 80
+- name: qualifying_section_521_organization_remuneration_under_threshold_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/16#input.remuneration_amount: 90
+      ? us:statutes/26/3121/a/16#input.remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+      : true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_501_a: false
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_521: true
+      us:statutes/26/3121/a/16#input.organization_described_in_section_401_a: false
+      us:statutes/26/3121/a/16#input.remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service: 90
+  output:
+    us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_excluded_from_wages:
+    - 90
+- name: section_401a_organization_carveout_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/16#input.remuneration_amount: 80
+      ? us:statutes/26/3121/a/16#input.remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+      : true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_501_a: true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_521: false
+      us:statutes/26/3121/a/16#input.organization_described_in_section_401_a: true
+      us:statutes/26/3121/a/16#input.remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion:
+    - not_holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_excluded_from_wages:
+    - 0
+- name: remuneration_equal_to_threshold_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/16#input.remuneration_amount: 100
+      ? us:statutes/26/3121/a/16#input.remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+      : true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_501_a: true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_521: false
+      us:statutes/26/3121/a/16#input.organization_described_in_section_401_a: false
+      us:statutes/26/3121/a/16#input.remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service: 100
+  output:
+    us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_excluded_from_wages:
+    - 0
+- name: remuneration_not_for_service_in_employ_of_organization_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/16#input.remuneration_amount: 80
+      ? us:statutes/26/3121/a/16#input.remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+      : false
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_501_a: true
+      us:statutes/26/3121/a/16#input.organization_exempt_from_income_tax_under_section_521: false
+      us:statutes/26/3121/a/16#input.organization_described_in_section_401_a: false
+      us:statutes/26/3121/a/16#input.remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service: 80
+  output:
+    us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion:
+    - holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/16#exempt_organization_low_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/16.yaml
+++ b/statutes/26/3121/a/16.yaml
@@ -1,0 +1,110 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (16) remuneration paid by an organization exempt from income tax under section 501(a) (other than an organization described in section 401(a)) or under section 521 in any calendar year to an employee for service rendered in the employ of such organization, if the remuneration paid in such year by the organization to the employee for such service is less than $100; [
+rules:
+  - name: exempt_organization_remuneration_annual_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(a)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "less than $100"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          100
+
+  - name: qualifying_exempt_organization_for_low_remuneration_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "organization exempt from income tax under section 501(a) (other than an organization described in section 401(a)) or under section 521"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (organization_exempt_from_income_tax_under_section_501_a or organization_exempt_from_income_tax_under_section_521)
+          and not organization_described_in_section_401_a
+
+  - name: exempt_organization_low_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid by an organization exempt from income tax under section 501(a) (other than an organization described in section 401(a)) or under section 521 in any calendar year to an employee for service rendered in the employ of such organization"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the remuneration paid in such year by the organization to the employee for such service is less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/16#exempt_organization_remuneration_annual_threshold
+              output: exempt_organization_remuneration_annual_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/16#qualifying_exempt_organization_for_low_remuneration_exclusion
+              output: qualifying_exempt_organization_for_low_remuneration_exclusion
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_paid_by_organization_to_employee_for_service_rendered_in_employ_of_organization
+          and qualifying_exempt_organization_for_low_remuneration_exclusion
+          and remuneration_paid_in_calendar_year_by_organization_to_employee_for_such_service < exempt_organization_remuneration_annual_threshold
+
+  - name: exempt_organization_low_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration paid by an organization exempt from income tax under section 501(a) (other than an organization described in section 401(a)) or under section 521 in any calendar year to an employee for service rendered in the employ of such organization, if the remuneration paid in such year by the organization to the employee for such service is less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/16#exempt_organization_low_remuneration_exclusion_applies
+              output: exempt_organization_low_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if exempt_organization_low_remuneration_exclusion_applies: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for the 26 USC 3121(a)(16) exempt-organization low-remuneration wage exclusion
- add generated companion tests for 501(a), 521, 401(a) carveout, threshold edge, and service-employment predicate cases
- add signed encoding manifest

## Generated provenance
- axiom-encode commit: `63043ccbba5456cf49d99725b0d3cc8b00dbc60f`
- axiom-encode version: `0.2.163`
- model: `gpt-5.5`

## Local gates
- `uv run axiom-encode validate statutes/26/3121/a/16.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/a/16.test.yaml --root /private/tmp/rulespec-us-3121-a-16-20260524 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/a/16.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-16-20260524 --base-ref origin/main --json`
- local PolicyEngine oracle coverage check after axiom-encode #175: all changed outputs are `known_not_comparable`