### PR TITLE
Add generated 3121(a)(18) wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/18.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/18.yaml",
+      "sha256": "29d47b60c8e9af5eaac037561a2e8bd69622abd00aa0cda41f657378c69a6c6c"
+    },
+    {
+      "path": "statutes/26/3121/a/18.test.yaml",
+      "sha256": "20043290083c1412e5436200987059dd095500371058f9334764a02dcb62afc2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b620ca9ca9c295af1ebd3e12c2f032e7dfb5c6a8",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.164",
+    "version_commit": "b620ca9ca9c295af1ebd3e12c2f032e7dfb5c6a8"
+  },
+  "axiom_encode_version": "0.2.164",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(18)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-18-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "6e5d3797eaf199d34c228d615366afbd44d5f66c8612344232c43ea78643d469",
+  "generated_at": "2026-05-24T21:21:16.491371+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-18-20260524/openai-gpt-5.5/statutes/26/3121/a/18.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-18-20260524",
+  "generated_output_sha256": "29d47b60c8e9af5eaac037561a2e8bd69622abd00aa0cda41f657378c69a6c6c",
+  "generation_prompt_sha256": "5a8f3e65f7bb24e4750c159a9323254ee370ad82ed7065cc1e1a009a5fac4090",
+  "model": "gpt-5.5",
+  "run_id": "09999f48",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "803a5df3091e59a8141fa819c869ee53f4e38e57d82d6f3fd7b35399dd5d18dd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-18-20260524/traces/openai-gpt-5.5/26-USC-3121-a-18.json",
+  "trace_sha256": "24c5c5309c93f56d35b622aa56c26106201de83278b0dd267b627c0dac6f1458"
+}

--- a/statutes/26/3121/a/18.test.yaml
+++ b/statutes/26/3121/a/18.test.yaml
@@ -1,0 +1,54 @@
+- name: qualifying_employee_payment_or_benefit_excluded_from_wages
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/18#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3121/a/18#input.reasonable_to_believe_at_time_of_payment_or_furnishing_employee_can_exclude_under_section_127_129_134_b_4_or_134_b_5
+      : true
+      us:statutes/26/3121/a/18#input.payment_or_benefit_amount_excludable_from_income_under_section_127_129_134_b_4_or_134_b_5: 1500
+  output:
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_reasonable_belief_applies:
+    - holds
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_excluded_from_wages:
+    - 1500
+- name: payment_or_benefit_not_to_or_for_employee_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/18#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: false
+      ? us:statutes/26/3121/a/18#input.reasonable_to_believe_at_time_of_payment_or_furnishing_employee_can_exclude_under_section_127_129_134_b_4_or_134_b_5
+      : true
+      us:statutes/26/3121/a/18#input.payment_or_benefit_amount_excludable_from_income_under_section_127_129_134_b_4_or_134_b_5: 1500
+  output:
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_reasonable_belief_applies:
+    - not_holds
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_excluded_from_wages:
+    - 0
+- name: no_reasonable_belief_of_income_exclusion_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/18#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3121/a/18#input.reasonable_to_believe_at_time_of_payment_or_furnishing_employee_can_exclude_under_section_127_129_134_b_4_or_134_b_5
+      : false
+      us:statutes/26/3121/a/18#input.payment_or_benefit_amount_excludable_from_income_under_section_127_129_134_b_4_or_134_b_5: 1500
+  output:
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_reasonable_belief_applies:
+    - not_holds
+    us:statutes/26/3121/a/18#employee_benefit_income_exclusion_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/18.yaml
+++ b/statutes/26/3121/a/18.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (18) any payment made, or benefit furnished, to or for the benefit of an employee if at the time of such payment or such furnishing it is reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5);
+rules:
+  - name: employee_benefit_income_exclusion_reasonable_belief_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made, or benefit furnished, to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "at the time of such payment or such furnishing it is reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_or_benefit_furnished_to_or_for_benefit_of_employee
+          and reasonable_to_believe_at_time_of_payment_or_furnishing_employee_can_exclude_under_section_127_129_134_b_4_or_134_b_5
+
+  - name: employee_benefit_income_exclusion_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made, or benefit furnished, to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if at the time of such payment or such furnishing it is reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/18#employee_benefit_income_exclusion_reasonable_belief_applies
+              output: employee_benefit_income_exclusion_reasonable_belief_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if employee_benefit_income_exclusion_reasonable_belief_applies: payment_or_benefit_amount_excludable_from_income_under_section_127_129_134_b_4_or_134_b_5 else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for section 3121(a)(18) employee benefit income-exclusion wage treatment
- add generated tests for qualifying payment, non-employee benefit, and no-reasonable-belief cases
- include signed axiom-encode apply manifest

## Generated provenance
- tool: axiom-encode encode --apply
- encoder version: 0.2.164
- model: gpt-5.5
- run id: 09999f48

## Local checks
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-18-20260524/statutes/26/3121/a/18.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-a-18-20260524/statutes/26/3121/a/18.test.yaml --root /private/tmp/rulespec-us-3121-a-18-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-a-18-20260524/statutes/26/3121/a/18.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-18-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a18.6wZwqq --oracle policyengine --program tax --json