### PR TITLE
Add generated 3121(a)(19) wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/19.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/19.yaml",
+      "sha256": "66f0c23f0cd13fbfbbeab993ce52ac43c4fd800dd4edd9e5fd0b01be8e4e61b9"
+    },
+    {
+      "path": "statutes/26/3121/a/19.test.yaml",
+      "sha256": "460f7d97db2a6957e046fee4235816452fb53625edfaea76a916c74f09de7430"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d953ec20de8aad11cc8adaef472107a50c756dc2",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.165",
+    "version_commit": "d953ec20de8aad11cc8adaef472107a50c756dc2"
+  },
+  "axiom_encode_version": "0.2.165",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(19)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-19-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "08d188f34f15d8596d5b234f0393695171fae52beaadbc3f4ba0a396a02e22c9",
+  "generated_at": "2026-05-24T21:34:46.760831+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-19-20260524/openai-gpt-5.5/statutes/26/3121/a/19.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-19-20260524",
+  "generated_output_sha256": "66f0c23f0cd13fbfbbeab993ce52ac43c4fd800dd4edd9e5fd0b01be8e4e61b9",
+  "generation_prompt_sha256": "861804ede39d5f3e8606e9db3ea883ed7d0c38c876bc89d7444d98c584a9da7a",
+  "model": "gpt-5.5",
+  "run_id": "f2ed1b6b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a04017ca690603b56eb3ab0aad1e960447f8dd30330eaf86257b59ddf3755d9f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-19-20260524/traces/openai-gpt-5.5/26-USC-3121-a-19.json",
+  "trace_sha256": "09af4d780e190cbc764ac87e1d742431c55087453b8422f100b6698357276004"
+}

--- a/statutes/26/3121/a/19.test.yaml
+++ b/statutes/26/3121/a/19.test.yaml
@@ -1,0 +1,54 @@
+- name: qualifying_meals_or_lodging_with_section_119_reasonable_belief_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/19#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer: true
+      ? us:statutes/26/3121/a/19#input.reasonable_to_believe_at_time_of_furnishing_employee_will_be_able_to_exclude_items_from_income_under_section_119
+      : true
+      us:statutes/26/3121/a/19#input.value_of_meals_or_lodging_furnished: 500
+  output:
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_excluded_from_wages:
+    - 500
+- name: items_not_furnished_by_or_on_behalf_of_employer_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/19#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer: false
+      ? us:statutes/26/3121/a/19#input.reasonable_to_believe_at_time_of_furnishing_employee_will_be_able_to_exclude_items_from_income_under_section_119
+      : true
+      us:statutes/26/3121/a/19#input.value_of_meals_or_lodging_furnished: 500
+  output:
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_excluded_from_wages:
+    - 0
+- name: no_reasonable_belief_of_section_119_exclusion_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/19#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer: true
+      ? us:statutes/26/3121/a/19#input.reasonable_to_believe_at_time_of_furnishing_employee_will_be_able_to_exclude_items_from_income_under_section_119
+      : false
+      us:statutes/26/3121/a/19#input.value_of_meals_or_lodging_furnished: 500
+  output:
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/19.yaml
+++ b/statutes/26/3121/a/19.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (19) the value of any meals or lodging furnished by or on behalf of the employer if at the time of such furnishing it is reasonable to believe that the employee will be able to exclude such items from income under section 119;
+rules:
+  - name: meals_or_lodging_section_119_reasonable_belief_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the value of any meals or lodging furnished by or on behalf of the employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if at the time of such furnishing it is reasonable to believe that the employee will be able to exclude such items from income under section 119"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          meals_or_lodging_furnished_by_or_on_behalf_of_employer
+          and reasonable_to_believe_at_time_of_furnishing_employee_will_be_able_to_exclude_items_from_income_under_section_119
+
+  - name: meals_or_lodging_section_119_reasonable_belief_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the value of any meals or lodging furnished by or on behalf of the employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if at the time of such furnishing it is reasonable to believe that the employee will be able to exclude such items from income under section 119"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/19#meals_or_lodging_section_119_reasonable_belief_exclusion_applies
+              output: meals_or_lodging_section_119_reasonable_belief_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if meals_or_lodging_section_119_reasonable_belief_exclusion_applies: value_of_meals_or_lodging_furnished else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for section 3121(a)(19) employer-furnished meals/lodging section 119 reasonable-belief wage treatment
- add generated tests for qualifying furnishing, not by/on behalf of employer, and no-reasonable-belief cases
- include signed axiom-encode apply manifest

## Generated provenance
- tool: axiom-encode encode --apply
- encoder version: 0.2.165
- model: gpt-5.5
- run id: f2ed1b6b

## Local checks
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-19-20260524/statutes/26/3121/a/19.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-a-19-20260524/statutes/26/3121/a/19.test.yaml --root /private/tmp/rulespec-us-3121-a-19-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-a-19-20260524/statutes/26/3121/a/19.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-19-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a19.vX3SdQ --oracle policyengine --program tax --json