### PR TITLE
Add generated 3121(a)(20) wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/20.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/20.yaml",
+      "sha256": "ea275b0a0f469c2b51b32c7f31084b76a1e116cad034b3998d7f1d0006f5c48f"
+    },
+    {
+      "path": "statutes/26/3121/a/20.test.yaml",
+      "sha256": "9499d269ffb04eb299ecf67ec12153204a17ea3474fcfe3c0c00f6d29ea0ef0d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4807b48d1c0116b5c36bedcf7d2c83c8bff9a983",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.167",
+    "version_commit": "4807b48d1c0116b5c36bedcf7d2c83c8bff9a983"
+  },
+  "axiom_encode_version": "0.2.167",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(20)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-20-final-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "6662d73efb6888ef22d8b065e7359539ee56ff5be82d860b0ee14ab233b81795",
+  "generated_at": "2026-05-24T21:56:06.648245+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-20-final-20260524/openai-gpt-5.5/statutes/26/3121/a/20.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-20-final-20260524",
+  "generated_output_sha256": "ea275b0a0f469c2b51b32c7f31084b76a1e116cad034b3998d7f1d0006f5c48f",
+  "generation_prompt_sha256": "74ea6067680e24b71f8cdec39d3245d7f583a584ab79443097b44e1df0865dc0",
+  "model": "gpt-5.5",
+  "run_id": "bf112fcb",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fcda0533e9f8fe72bad7051faec280580684d6424688d5b2ad6c715e13041780"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-20-final-20260524/traces/openai-gpt-5.5/26-USC-3121-a-20.json",
+  "trace_sha256": "afdbecd86817beb1446539a3a2c56b1d723d7d7cbf14f179c5171e9afbda7b16"
+}

--- a/statutes/26/3121/a/20.test.yaml
+++ b/statutes/26/3121/a/20.test.yaml
@@ -1,0 +1,108 @@
+- name: qualifying_benefit_with_reasonable_section_74_c_belief_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/20#input.benefit_amount: 500
+      us:statutes/26/3121/a/20#input.benefit_provided_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+      : true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+      : false
+  output:
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_applies:
+    - holds
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_excluded_from_wages:
+    - 500
+- name: qualifying_benefit_with_reasonable_section_108_f_4_belief_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/20#input.benefit_amount: 800
+      us:statutes/26/3121/a/20#input.benefit_provided_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+      : true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+      : false
+  output:
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_applies:
+    - holds
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_excluded_from_wages:
+    - 800
+- name: qualifying_benefit_with_reasonable_section_117_or_132_belief_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/20#input.benefit_amount: 1200
+      us:statutes/26/3121/a/20#input.benefit_provided_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+      : true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+      : true
+  output:
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_applies:
+    - holds
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_excluded_from_wages:
+    - 1200
+- name: benefit_without_any_reasonable_exclusion_belief_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/20#input.benefit_amount: 500
+      us:statutes/26/3121/a/20#input.benefit_provided_to_or_on_behalf_of_employee: true
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+      : false
+    - us:statutes/26/3121/a/20#input.benefit_amount: 700
+      us:statutes/26/3121/a/20#input.benefit_provided_to_or_on_behalf_of_employee: false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+      : false
+      ? us:statutes/26/3121/a/20#input.reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+      : true
+  output:
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_applies:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_excluded_from_wages:
+    - 0
+    - 0

--- a/statutes/26/3121/a/20.yaml
+++ b/statutes/26/3121/a/20.yaml
@@ -1,0 +1,70 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (20) any benefit provided to or on behalf of an employee if at the time such benefit is provided it is reasonable to believe that the employee will be able to exclude such benefit from income under section 74(c), 108(f)(4), 117, or 132;
+rules:
+  - name: benefit_income_exclusion_reasonable_belief_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(20)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any benefit provided to or on behalf of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "at the time such benefit is provided it is reasonable to believe that the employee will be able to exclude such benefit from income under section 74(c), 108(f)(4), 117, or 132"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          benefit_provided_to_or_on_behalf_of_employee
+          and reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_74_c
+          or benefit_provided_to_or_on_behalf_of_employee
+          and reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_108_f_4
+          or benefit_provided_to_or_on_behalf_of_employee
+          and reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_117
+          or benefit_provided_to_or_on_behalf_of_employee
+          and reasonable_to_believe_at_time_benefit_provided_employee_can_exclude_benefit_from_income_under_section_132
+
+  - name: benefit_income_exclusion_reasonable_belief_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(20)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any benefit provided to or on behalf of an employee if"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "it is reasonable to believe that the employee will be able to exclude such benefit from income under section 74(c), 108(f)(4), 117, or 132"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/20#benefit_income_exclusion_reasonable_belief_applies
+              output: benefit_income_exclusion_reasonable_belief_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if benefit_income_exclusion_reasonable_belief_applies: benefit_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for section 3121(a)(20) benefit reasonable-belief income-exclusion wage treatment
- add generated tests covering listed income-exclusion sections and negative cases
- include signed axiom-encode apply manifest

## Generated provenance
- tool: axiom-encode encode --apply
- encoder version: 0.2.167
- model: gpt-5.5
- run id: bf112fcb

## Local checks
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-20-retry-20260524/statutes/26/3121/a/20.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-a-20-retry-20260524/statutes/26/3121/a/20.test.yaml --root /private/tmp/rulespec-us-3121-a-20-retry-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-a-20-retry-20260524/statutes/26/3121/a/20.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-20-retry-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a20.LoXv14 --oracle policyengine --program tax --json