### PR TITLE
Add generated 3121(a)(21) wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/21.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/21.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/21.yaml",
+      "sha256": "8dffc9240c36ea7fae1f592e44fe13f9883a9d2aecc3787a22cb4c09c10def2a"
+    },
+    {
+      "path": "statutes/26/3121/a/21.test.yaml",
+      "sha256": "05d836afccf3c13018c6ffbcc59fed72c8cb8453d9de38f5344fd1eb559205eb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a98f1c7f53098f34ed598e596dd2bed3054634",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.168",
+    "version_commit": "07a98f1c7f53098f34ed598e596dd2bed3054634"
+  },
+  "axiom_encode_version": "0.2.168",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(21)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-21-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-21/workspace/context-manifest.json",
+  "context_manifest_sha256": "2e433c340de1ec9ddde338d9d641a851ab80ec792a30bde9e3e71a5bb08114ba",
+  "generated_at": "2026-05-24T22:08:26.309944+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-21-20260524/openai-gpt-5.5/statutes/26/3121/a/21.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-21-20260524",
+  "generated_output_sha256": "8dffc9240c36ea7fae1f592e44fe13f9883a9d2aecc3787a22cb4c09c10def2a",
+  "generation_prompt_sha256": "1ae30e16a723fdf98bd05bde845c40decafaf46b05b87967dc3c2dcfe0e3e750",
+  "model": "gpt-5.5",
+  "run_id": "ec9a5b9e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4c73de4de4a2bab0bd808051a01b354e8d317e1c7016ee095392d0cd9c08822c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-21-20260524/traces/openai-gpt-5.5/26-USC-3121-a-21.json",
+  "trace_sha256": "200aaa5eff224336115d236bfaba91af10983e46c8b6c0dbd7ce67f3be40799a"
+}

--- a/statutes/26/3121/a/21.test.yaml
+++ b/statutes/26/3121/a/21.test.yaml
@@ -1,0 +1,51 @@
+- name: tribal_member_section_7873_no_tax_remuneration_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/21#input.payment_recipient_is_member_of_indian_tribe: true
+      us:statutes/26/3121/a/21#input.remuneration_on_which_no_tax_is_imposed_by_this_chapter_by_reason_of_section_7873: true
+      us:statutes/26/3121/a/21#input.remuneration_amount: 2500
+  output:
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_excluded_from_wages:
+    - 2500
+- name: non_tribal_member_section_7873_no_tax_remuneration_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/21#input.payment_recipient_is_member_of_indian_tribe: false
+      us:statutes/26/3121/a/21#input.remuneration_on_which_no_tax_is_imposed_by_this_chapter_by_reason_of_section_7873: true
+      us:statutes/26/3121/a/21#input.remuneration_amount: 2500
+  output:
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_excluded_from_wages:
+    - 0
+- name: tribal_member_remuneration_not_no_tax_by_section_7873_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/21#input.payment_recipient_is_member_of_indian_tribe: true
+      us:statutes/26/3121/a/21#input.remuneration_on_which_no_tax_is_imposed_by_this_chapter_by_reason_of_section_7873: false
+      us:statutes/26/3121/a/21#input.remuneration_amount: 2500
+  output:
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/21.yaml
+++ b/statutes/26/3121/a/21.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (21) in the case of a member of an Indian tribe, any remuneration on which no tax is imposed by this chapter by reason of section 7873 (relating to income derived by Indians from exercise of fishing rights);
+rules:
+  - name: indian_fishing_rights_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(21)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in the case of a member of an Indian tribe"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any remuneration on which no tax is imposed by this chapter by reason of section 7873 (relating to income derived by Indians from exercise of fishing rights)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_recipient_is_member_of_indian_tribe
+          and remuneration_on_which_no_tax_is_imposed_by_this_chapter_by_reason_of_section_7873
+
+  - name: indian_fishing_rights_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(21)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any remuneration on which no tax is imposed by this chapter by reason of section 7873"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in the case of a member of an Indian tribe"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/21#indian_fishing_rights_remuneration_exclusion_applies
+              output: indian_fishing_rights_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if indian_fishing_rights_remuneration_exclusion_applies: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for section 3121(a)(21) Indian fishing-rights remuneration wage exclusion
- add generated tests for tribal-member, non-tribal-member, and non-section-7873 cases
- include signed axiom-encode apply manifest

## Generated provenance
- tool: axiom-encode encode --apply
- encoder version: 0.2.168
- model: gpt-5.5
- run id: ec9a5b9e

## Local checks
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-21-20260524/statutes/26/3121/a/21.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-a-21-20260524/statutes/26/3121/a/21.test.yaml --root /private/tmp/rulespec-us-3121-a-21-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-a-21-20260524/statutes/26/3121/a/21.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-21-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a21.kMigS0 --oracle policyengine --program tax --json