### PR TITLE
Add generated 3121(a)(22) wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/22.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/22.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/22.yaml",
+      "sha256": "e4f85cd1bbd51f46252346fbf59d0996c888df8c76ceef9ecc733d38c2d325d3"
+    },
+    {
+      "path": "statutes/26/3121/a/22.test.yaml",
+      "sha256": "762198c38bc1f5e06639f29e7fe34115b2dfcf0387956a9df1a7afc222e242ed"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f3c0cd4f56850f6417e718e7ad20ced98d5aab93",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.169",
+    "version_commit": "f3c0cd4f56850f6417e718e7ad20ced98d5aab93"
+  },
+  "axiom_encode_version": "0.2.169",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(22)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-a-22-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-22/workspace/context-manifest.json",
+  "context_manifest_sha256": "d91e9e3074b7deba1bea7ce8e3f2f7bc3d5f75d10662b6a8f67b31ee8727acfb",
+  "generated_at": "2026-05-24T22:22:17.193714+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-a-22-20260524/openai-gpt-5.5/statutes/26/3121/a/22.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-a-22-20260524",
+  "generated_output_sha256": "e4f85cd1bbd51f46252346fbf59d0996c888df8c76ceef9ecc733d38c2d325d3",
+  "generation_prompt_sha256": "77103bec7c8d187bd9940be0694070d390f4fd63af0dfdc2c717a24aba1f14aa",
+  "model": "gpt-5.5",
+  "run_id": "b2dbdba9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c8046b8cfe68353b0dca07b69eb33079e7a3c9999d89acf0951e6c1048ed6edf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-a-22-20260524/traces/openai-gpt-5.5/26-USC-3121-a-22.json",
+  "trace_sha256": "d6c037dd7e30a80c015df5ec7ad660ad2529945a5378250d0bcba8f317f2b3a5"
+}

--- a/statutes/26/3121/a/22.test.yaml
+++ b/statutes/26/3121/a/22.test.yaml
@@ -1,0 +1,92 @@
+- name: incentive_stock_option_share_transfer_remuneration_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/22#input.remuneration_amount: 2500
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
+      us:statutes/26/3121/a/22#input.share_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: true
+      us:statutes/26/3121/a/22#input.share_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_disposition_by_individual_of_stock_described_in_subparagraph_A: false
+  output:
+    us:statutes/26/3121/a/22#stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_disposition_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_excluded_from_wages:
+    - 2500
+- name: employee_stock_purchase_plan_share_transfer_remuneration_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/22#input.remuneration_amount: 1800
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
+      us:statutes/26/3121/a/22#input.share_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3121/a/22#input.share_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: true
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_disposition_by_individual_of_stock_described_in_subparagraph_A: false
+  output:
+    us:statutes/26/3121/a/22#stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_disposition_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_excluded_from_wages:
+    - 1800
+- name: disposition_of_stock_described_in_subparagraph_A_remuneration_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/22#input.remuneration_amount: 3200
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
+      us:statutes/26/3121/a/22#input.share_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3121/a/22#input.share_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_disposition_by_individual_of_stock_described_in_subparagraph_A: true
+  output:
+    us:statutes/26/3121/a/22#stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_disposition_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_excluded_from_wages:
+    - 3200
+- name: unrelated_remuneration_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/22#input.remuneration_amount: 900
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
+      us:statutes/26/3121/a/22#input.share_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3121/a/22#input.share_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      us:statutes/26/3121/a/22#input.remuneration_on_account_of_disposition_by_individual_of_stock_described_in_subparagraph_A: false
+  output:
+    us:statutes/26/3121/a/22#stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_disposition_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/22.yaml
+++ b/statutes/26/3121/a/22.yaml
@@ -1,0 +1,120 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (22) remuneration on account of— (A) a transfer of a share of stock to any individual pursuant to an exercise of an incentive stock option (as defined in section 422(b)) or under an employee stock purchase plan (as defined in section 423(b)), or (B) any disposition by the individual of such stock; or
+rules:
+  - name: stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(22)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration on account of— (A) a transfer of a share of stock to any individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "pursuant to an exercise of an incentive stock option (as defined in section 422(b))"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or under an employee stock purchase plan (as defined in section 423(b))"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_on_account_of_transfer_of_share_of_stock_to_individual
+          and (share_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b or share_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b)
+
+  - name: stock_disposition_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(22)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration on account of—"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(B) any disposition by the individual of such stock"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_on_account_of_disposition_by_individual_of_stock_described_in_subparagraph_A
+
+  - name: stock_option_transfer_or_disposition_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(22)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration on account of— (A) a transfer of a share of stock to any individual pursuant to an exercise of an incentive stock option (as defined in section 422(b)) or under an employee stock purchase plan (as defined in section 423(b)), or (B) any disposition by the individual of such stock"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/22#stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies
+              output: stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/22#stock_disposition_remuneration_exclusion_applies
+              output: stock_disposition_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies
+          or stock_disposition_remuneration_exclusion_applies
+
+  - name: stock_option_transfer_or_disposition_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(22)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "remuneration on account of— (A) a transfer of a share of stock to any individual pursuant to an exercise of an incentive stock option (as defined in section 422(b)) or under an employee stock purchase plan (as defined in section 423(b)), or (B) any disposition by the individual of such stock"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/22#stock_option_transfer_or_disposition_remuneration_exclusion_applies
+              output: stock_option_transfer_or_disposition_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if stock_option_transfer_or_disposition_remuneration_exclusion_applies: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(22) stock-option and stock-disposition wage exclusions
- add generated tests for incentive stock option, employee stock purchase plan, stock disposition, and unrelated remuneration cases
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-22-20260524/statutes/26/3121/a/22.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-a-22-20260524/statutes/26/3121/a/22.test.yaml --root /private/tmp/rulespec-us-3121-a-22-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-a-22-20260524/statutes/26/3121/a/22.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-a-22-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage after encoder #181: generated 3121(a)(22) outputs are known_not_comparable; overall tax counts are comparable=225, known_not_comparable=596, unmapped=3.