### PR TITLE
Add generated 3121(b)(1) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/1.yaml",
+      "sha256": "001f26c1ea50e28c4a36bec7525c28d189a6538fd7625707ee3180174bc17f31"
+    },
+    {
+      "path": "statutes/26/3121/b/1.test.yaml",
+      "sha256": "3df445be96f82af13b1476764ad61c641ee700ee06c23efe4fdc6af0840aa52f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4b7a2374104d92748b788cb8fa4ce2f60f72ce3b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.170",
+    "version_commit": "4b7a2374104d92748b788cb8fa4ce2f60f72ce3b"
+  },
+  "axiom_encode_version": "0.2.170",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(1)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-1-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "da98fb7b404da21c5f18474a2c46d6cd2cd44c16c99d0e0609def0c8424ae2af",
+  "generated_at": "2026-05-24T22:32:55.836066+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-1-20260524/openai-gpt-5.5/statutes/26/3121/b/1.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-1-20260524",
+  "generated_output_sha256": "001f26c1ea50e28c4a36bec7525c28d189a6538fd7625707ee3180174bc17f31",
+  "generation_prompt_sha256": "a5758d9dae8d526cf37f943a595a45a868e681c22da626b5fe9d08ff6d1352d6",
+  "model": "gpt-5.5",
+  "run_id": "2d8f9141",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5d08b94bee010127915e56da204ffed2772cea9e7abe1cbe7150e6c8a4e3f8ad"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-1-20260524/traces/openai-gpt-5.5/26-USC-3121-b-1.json",
+  "trace_sha256": "6bbac1b54044bdd206161865c3dc5f3a15f2a1fab249d885c16915c6d913fcf7"
+}

--- a/statutes/26/3121/b/1.test.yaml
+++ b/statutes/26/3121/b/1.test.yaml
@@ -1,0 +1,108 @@
+- name: qualifying_worker_from_named_origin_service_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: true
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: false
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: true
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: true
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - holds
+- name: qualifying_worker_from_other_foreign_country_service_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: true
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: false
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: true
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: true
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: true
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - holds
+- name: service_not_by_foreign_agricultural_worker_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: false
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: false
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: true
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: true
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_lawfully_admitted_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: true
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: false
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: false
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: true
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: true
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_from_covered_foreign_origin_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: true
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: false
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: false
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: true
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: true
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_temporary_or_not_for_agricultural_labor_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/1#input.service_performed_by_foreign_agricultural_worker: true
+      us:statutes/26/3121/b/1#input.worker_lawfully_admitted_to_united_states: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_bahamas_jamaica_or_other_british_west_indies: true
+      us:statutes/26/3121/b/1#input.worker_admitted_from_other_foreign_country_or_possession: false
+      us:statutes/26/3121/b/1#input.worker_admitted_on_temporary_basis: false
+      us:statutes/26/3121/b/1#input.worker_admitted_to_perform_agricultural_labor: false
+  output:
+    us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/1.yaml
+++ b/statutes/26/3121/b/1.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (1) service performed by foreign agricultural workers lawfully admitted to the United States from the Bahamas, Jamaica, and the other British West Indies, or from any other foreign country or possession thereof, on a temporary basis to perform agricultural labor;
+rules:
+  - name: foreign_agricultural_worker_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by foreign agricultural workers"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "lawfully admitted to the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "from the Bahamas, Jamaica, and the other British West Indies, or from any other foreign country or possession thereof"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "on a temporary basis"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "to perform agricultural labor"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_foreign_agricultural_worker
+          and worker_lawfully_admitted_to_united_states
+          and (worker_admitted_from_bahamas_jamaica_or_other_british_west_indies or worker_admitted_from_other_foreign_country_or_possession)
+          and worker_admitted_on_temporary_basis
+          and worker_admitted_to_perform_agricultural_labor


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(b)(1) foreign agricultural worker service excluded from employment
- add generated boundary tests for covered origins, noncovered origin, lawful admission, temporary basis, and agricultural-labor purpose
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-1-20260524/statutes/26/3121/b/1.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-b-1-20260524/statutes/26/3121/b/1.test.yaml --root /private/tmp/rulespec-us-3121-b-1-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-1-20260524/statutes/26/3121/b/1.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-1-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage after encoder #182: generated 3121(b)(1) output is known_not_comparable; overall tax counts are comparable=225, known_not_comparable=597, unmapped=3.