### PR TITLE
Add generated 3121(b)(2) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/2.yaml",
+      "sha256": "cdaed15e1ecbbb8286fe25a3ab843052230de551b38ad894c71f6669e60f0f22"
+    },
+    {
+      "path": "statutes/26/3121/b/2.test.yaml",
+      "sha256": "790c0f902e668adcf9990b0ffb28fb18858285a629610536b8f635245751d113"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "59e1b078ebeccc79b7425045c49e7efd9cc77557",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.171",
+    "version_commit": "59e1b078ebeccc79b7425045c49e7efd9cc77557"
+  },
+  "axiom_encode_version": "0.2.171",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(2)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-2-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "73c6d7ea53fa2180849e7060448eb88883f38a0f35467f876d517f753afd68df",
+  "generated_at": "2026-05-24T22:43:16.467150+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-2-20260524/openai-gpt-5.5/statutes/26/3121/b/2.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-2-20260524",
+  "generated_output_sha256": "cdaed15e1ecbbb8286fe25a3ab843052230de551b38ad894c71f6669e60f0f22",
+  "generation_prompt_sha256": "e4de4b6a2f84519f762cc8da0404e54759e11458db9036b5ea166a3c9d65a857",
+  "model": "gpt-5.5",
+  "run_id": "5f9eb5db",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a68eb741aa290754f731c6ae4e269392bc1840ba4081bd8566b0c77176d50649"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-2-20260524/traces/openai-gpt-5.5/26-USC-3121-b-2.json",
+  "trace_sha256": "088608b05223003bc07f6859b9e0d91c985811e27b91d4fa660d8035613f6b83"
+}

--- a/statutes/26/3121/b/2.test.yaml
+++ b/statutes/26/3121/b/2.test.yaml
@@ -1,0 +1,60 @@
+- name: qualifying_student_domestic_service_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/2#input.domestic_service_performed: true
+      us:statutes/26/3121/b/2#input.service_performed_in_local_college_club_or_local_chapter_of_college_fraternity_or_sorority: true
+      us:statutes/26/3121/b/2#input.student_enrolled_and_regularly_attending_classes_at_school_college_or_university: true
+  output:
+    us:statutes/26/3121/b/2#student_domestic_service_in_college_organization_excluded_from_employment:
+    - holds
+- name: non_domestic_service_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/2#input.domestic_service_performed: false
+      us:statutes/26/3121/b/2#input.service_performed_in_local_college_club_or_local_chapter_of_college_fraternity_or_sorority: true
+      us:statutes/26/3121/b/2#input.student_enrolled_and_regularly_attending_classes_at_school_college_or_university: true
+  output:
+    us:statutes/26/3121/b/2#student_domestic_service_in_college_organization_excluded_from_employment:
+    - not_holds
+- name: service_not_in_covered_college_organization_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/2#input.domestic_service_performed: true
+      us:statutes/26/3121/b/2#input.service_performed_in_local_college_club_or_local_chapter_of_college_fraternity_or_sorority: false
+      us:statutes/26/3121/b/2#input.student_enrolled_and_regularly_attending_classes_at_school_college_or_university: true
+  output:
+    us:statutes/26/3121/b/2#student_domestic_service_in_college_organization_excluded_from_employment:
+    - not_holds
+- name: student_not_enrolled_and_regularly_attending_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/2#input.domestic_service_performed: true
+      us:statutes/26/3121/b/2#input.service_performed_in_local_college_club_or_local_chapter_of_college_fraternity_or_sorority: true
+      us:statutes/26/3121/b/2#input.student_enrolled_and_regularly_attending_classes_at_school_college_or_university: false
+  output:
+    us:statutes/26/3121/b/2#student_domestic_service_in_college_organization_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/2.yaml
+++ b/statutes/26/3121/b/2.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (2) domestic service performed in a local college club, or local chapter of a college fraternity or sorority, by a student who is enrolled and is regularly attending classes at a school, college, or university;
+rules:
+  - name: student_domestic_service_in_college_organization_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "domestic service"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "performed in a local college club, or local chapter of a college fraternity or sorority"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by a student who is enrolled and is regularly attending classes at a school, college, or university"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          domestic_service_performed
+          and service_performed_in_local_college_club_or_local_chapter_of_college_fraternity_or_sorority
+          and student_enrolled_and_regularly_attending_classes_at_school_college_or_university


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(b)(2) student domestic service in college organizations excluded from employment
- add generated boundary tests for domestic service, covered college organization, and enrolled/regularly-attending student status
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-2-20260524/statutes/26/3121/b/2.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-b-2-20260524/statutes/26/3121/b/2.test.yaml --root /private/tmp/rulespec-us-3121-b-2-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-2-20260524/statutes/26/3121/b/2.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-2-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage: generated 3121(b)(2) output is known_not_comparable; overall tax counts are comparable=225, known_not_comparable=598, unmapped=3.