### PR TITLE
Add generated 3121(b)(3) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/3.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/3.yaml",
+      "sha256": "1c3e16528185e5ddff5af9e31460fb2c22bd47512cc66ddc8cc01dac2dc805bb"
+    },
+    {
+      "path": "statutes/26/3121/b/3.test.yaml",
+      "sha256": "2a3231321f0de855fd84d487acf2b7983f21bfa5cd9ceb2d807d52b4542e6f34"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b0b5d978e3f9c0a9765b943ada309adeec49834a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.172",
+    "version_commit": "b0b5d978e3f9c0a9765b943ada309adeec49834a"
+  },
+  "axiom_encode_version": "0.2.172",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(3)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-3-20260524-rerun/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "adbb7218692fe4acbfe7fb101af25ba172897f986ab698b7b0c9df3540e88afb",
+  "generated_at": "2026-05-24T22:56:03.560737+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-3-20260524-rerun/openai-gpt-5.5/statutes/26/3121/b/3.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-3-20260524-rerun",
+  "generated_output_sha256": "1c3e16528185e5ddff5af9e31460fb2c22bd47512cc66ddc8cc01dac2dc805bb",
+  "generation_prompt_sha256": "78bdebaab4a8b6ea44707c9dda4d09e0f39788eedb5ce559e851c50d77d044d3",
+  "model": "gpt-5.5",
+  "run_id": "291b31d2",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "820babaa49b82074569c9b3d22ffb65491353bb3a2fe5823eeb71d2acc17ab47"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-3-20260524-rerun/traces/openai-gpt-5.5/26-USC-3121-b-3.json",
+  "trace_sha256": "385adf5c6e989b58e465f5d4487453dd475d00e539956b94c7c1da783509f459"
+}

--- a/statutes/26/3121/b/3.test.yaml
+++ b/statutes/26/3121/b/3.test.yaml
@@ -1,0 +1,108 @@
+- name: child_under_18_employed_by_parent_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/3#input.service_performed_by_child_under_age_18: true
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_father_or_mother: true
+      us:statutes/26/3121/b/3#input.service_not_in_course_of_employer_trade_or_business: false
+      us:statutes/26/3121/b/3#input.domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/b/3#input.individual_under_age_21: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_spouse: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_son_or_daughter: false
+      us:statutes/26/3121/b/3#input.employer_is_surviving_spouse: false
+      us:statutes/26/3121/b/3#input.employer_is_divorced_individual_and_has_not_remarried: false
+      ? us:statutes/26/3121/b/3#input.employer_has_spouse_living_in_home_incapable_of_caring_for_child_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_living_in_home: false
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_has_not_attained_age_18: false
+      ? us:statutes/26/3121/b/3#input.employer_child_stepchild_requires_adult_personal_care_and_supervision_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+  output:
+    us:statutes/26/3121/b/3#family_employment_service_excluded_from_employment:
+    - holds
+- name: nonbusiness_service_by_under_21_individual_employed_by_parent_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/3#input.service_performed_by_child_under_age_18: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_father_or_mother: true
+      us:statutes/26/3121/b/3#input.service_not_in_course_of_employer_trade_or_business: true
+      us:statutes/26/3121/b/3#input.domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/b/3#input.individual_under_age_21: true
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_spouse: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_son_or_daughter: false
+      us:statutes/26/3121/b/3#input.employer_is_surviving_spouse: true
+      us:statutes/26/3121/b/3#input.employer_is_divorced_individual_and_has_not_remarried: false
+      ? us:statutes/26/3121/b/3#input.employer_has_spouse_living_in_home_incapable_of_caring_for_child_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_living_in_home: true
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_has_not_attained_age_18: true
+      ? us:statutes/26/3121/b/3#input.employer_child_stepchild_requires_adult_personal_care_and_supervision_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+  output:
+    us:statutes/26/3121/b/3#family_employment_service_excluded_from_employment:
+    - holds
+- name: domestic_service_for_son_or_daughter_without_exception_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/3#input.service_performed_by_child_under_age_18: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_father_or_mother: false
+      us:statutes/26/3121/b/3#input.service_not_in_course_of_employer_trade_or_business: false
+      us:statutes/26/3121/b/3#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/b/3#input.individual_under_age_21: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_spouse: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_son_or_daughter: true
+      us:statutes/26/3121/b/3#input.employer_is_surviving_spouse: false
+      us:statutes/26/3121/b/3#input.employer_is_divorced_individual_and_has_not_remarried: false
+      ? us:statutes/26/3121/b/3#input.employer_has_spouse_living_in_home_incapable_of_caring_for_child_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_living_in_home: true
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_has_not_attained_age_18: true
+      ? us:statutes/26/3121/b/3#input.employer_child_stepchild_requires_adult_personal_care_and_supervision_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+  output:
+    us:statutes/26/3121/b/3#domestic_service_for_son_or_daughter_exception_applies:
+    - not_holds
+    us:statutes/26/3121/b/3#family_employment_service_excluded_from_employment:
+    - holds
+- name: domestic_service_for_son_or_daughter_exception_blocks_subparagraph_b_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/3#input.service_performed_by_child_under_age_18: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_father_or_mother: false
+      us:statutes/26/3121/b/3#input.service_not_in_course_of_employer_trade_or_business: false
+      us:statutes/26/3121/b/3#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/b/3#input.individual_under_age_21: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_spouse: false
+      us:statutes/26/3121/b/3#input.individual_in_employ_of_son_or_daughter: true
+      us:statutes/26/3121/b/3#input.employer_is_surviving_spouse: true
+      us:statutes/26/3121/b/3#input.employer_is_divorced_individual_and_has_not_remarried: false
+      ? us:statutes/26/3121/b/3#input.employer_has_spouse_living_in_home_incapable_of_caring_for_child_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_living_in_home: true
+      us:statutes/26/3121/b/3#input.employer_child_stepchild_has_not_attained_age_18: true
+      ? us:statutes/26/3121/b/3#input.employer_child_stepchild_requires_adult_personal_care_and_supervision_for_at_least_4_continuous_weeks_in_calendar_quarter
+      : false
+  output:
+    us:statutes/26/3121/b/3#domestic_service_for_son_or_daughter_exception_applies:
+    - holds
+    us:statutes/26/3121/b/3#family_employment_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/3.yaml
+++ b/statutes/26/3121/b/3.yaml
@@ -1,0 +1,120 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (3) (A) service performed by a child under the age of 18 in the employ of his father or mother; (B) service not in the course of the employer’s trade or business, or domestic service in a private home of the employer, performed by an individual under the age of 21 in the employ of his father or mother, or performed by an individual in the employ of his spouse or son or daughter; except that the provisions of this subparagraph shall not be applicable to such domestic service performed by an individual in the employ of his son or daughter if— (i) the employer is a surviving spouse or a divorced individual and has not remarried, or has a spouse living in the home who has a mental or physical condition which results in such spouse’s being incapable of caring for a son, daughter, stepson, or stepdaughter (referred to in clause (ii)) for at least 4 continuous weeks in the calendar quarter in which the service is rendered, and (ii) a son, daughter, stepson, or stepdaughter of such employer is living in the home, and (iii) the son, daughter, stepson, or stepdaughter (referred to in clause (ii)) has not attained age 18 or has a mental or physical condition which requires the personal care and supervision of an adult for at least 4 continuous weeks in the calendar quarter in which the service is rendered;
+rules:
+  - name: domestic_service_for_son_or_daughter_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(3)(B), exception clauses (i)-(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that the provisions of this subparagraph shall not be applicable to such domestic service performed by an individual in the employ of his son or daughter if—"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the employer is a surviving spouse or a divorced individual and has not remarried"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or has a spouse living in the home who has a mental or physical condition which results in such spouse’s being incapable of caring for a son, daughter, stepson, or stepdaughter ... for at least 4 continuous weeks in the calendar quarter in which the service is rendered"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "a son, daughter, stepson, or stepdaughter of such employer is living in the home"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the son, daughter, stepson, or stepdaughter ... has not attained age 18 or has a mental or physical condition which requires the personal care and supervision of an adult for at least 4 continuous weeks in the calendar quarter in which the service is rendered"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          domestic_service_in_private_home_of_employer
+          and individual_in_employ_of_son_or_daughter
+          and (
+            employer_is_surviving_spouse
+            or employer_is_divorced_individual_and_has_not_remarried
+            or employer_has_spouse_living_in_home_incapable_of_caring_for_child_for_at_least_4_continuous_weeks_in_calendar_quarter
+          )
+          and employer_child_stepchild_living_in_home
+          and (
+            employer_child_stepchild_has_not_attained_age_18
+            or employer_child_stepchild_requires_adult_personal_care_and_supervision_for_at_least_4_continuous_weeks_in_calendar_quarter
+          )
+  - name: family_employment_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by a child under the age of 18 in the employ of his father or mother"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service not in the course of the employer’s trade or business"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "domestic service in a private home of the employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "performed by an individual under the age of 21 in the employ of his father or mother"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "performed by an individual in the employ of his spouse or son or daughter"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/3#domestic_service_for_son_or_daughter_exception_applies
+              output: domestic_service_for_son_or_daughter_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            service_performed_by_child_under_age_18
+            and individual_in_employ_of_father_or_mother
+          )
+          or (
+            (
+              service_not_in_course_of_employer_trade_or_business
+              or domestic_service_in_private_home_of_employer
+            )
+            and (
+              (
+                individual_under_age_21
+                and individual_in_employ_of_father_or_mother
+              )
+              or individual_in_employ_of_spouse
+              or individual_in_employ_of_son_or_daughter
+            )
+            and not domestic_service_for_son_or_daughter_exception_applies
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(b)(3) family employment service exclusions
- split out the domestic-service-for-son-or-daughter exception predicate and final family employment exclusion predicate
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-3-20260524/statutes/26/3121/b/3.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-b-3-20260524/statutes/26/3121/b/3.test.yaml --root /private/tmp/rulespec-us-3121-b-3-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-3-20260524/statutes/26/3121/b/3.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-3-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage: generated 3121(b)(3) outputs are known_not_comparable; overall tax counts are comparable=225, known_not_comparable=600, unmapped=3.

Depends on encoder validator fix TheAxiomFoundation/axiom-encode#183, merged.