### PR TITLE
Add generated 3121(b)(4) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/4.yaml",
+      "sha256": "e00ef8456bf279835f64bb6ebfc182473a6fa1d3aa371ac313b6f883177ea93f"
+    },
+    {
+      "path": "statutes/26/3121/b/4.test.yaml",
+      "sha256": "6a7f7fcc3c40703face22b4b90685049af2987f1b1f912db057e778f859a5722"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b0b5d978e3f9c0a9765b943ada309adeec49834a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.172",
+    "version_commit": "b0b5d978e3f9c0a9765b943ada309adeec49834a"
+  },
+  "axiom_encode_version": "0.2.172",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(4)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-4-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "b564c367b1ac2df265efad5703c7c85ea93f8317cecc9287604de42d7b15fa12",
+  "generated_at": "2026-05-24T23:00:20.320307+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-4-20260524/openai-gpt-5.5/statutes/26/3121/b/4.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-4-20260524",
+  "generated_output_sha256": "e00ef8456bf279835f64bb6ebfc182473a6fa1d3aa371ac313b6f883177ea93f",
+  "generation_prompt_sha256": "56f9b4890a41c8c556ae02906c3fc95e7b39277349e886cb8ae50f397d5621bc",
+  "model": "gpt-5.5",
+  "run_id": "3f22ce96",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "680023b9439b41f3a9ff2a751493efce03ea3e0e5a136b3ee101f3b6c4bf1eb1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-4-20260524/traces/openai-gpt-5.5/26-USC-3121-b-4.json",
+  "trace_sha256": "2ed991bbf56633174d8559f414b970bfb21dfc0ad38f1127ee44cb74f001ee83"
+}

--- a/statutes/26/3121/b/4.test.yaml
+++ b/statutes/26/3121/b/4.test.yaml
@@ -1,0 +1,85 @@
+- name: nonamerican_vessel_service_by_non_citizen_outside_united_states_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_vessel_not_american_vessel: true
+      us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_aircraft_not_american_aircraft: false
+      ? us:statutes/26/3121/b/4#input.individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+      : true
+      us:statutes/26/3121/b/4#input.individual_not_citizen_of_united_states: true
+      us:statutes/26/3121/b/4#input.employer_not_american_employer: false
+  output:
+    us:statutes/26/3121/b/4#foreign_vessel_or_aircraft_service_excluded_from_employment:
+    - holds
+- name: nonamerican_aircraft_service_for_nonamerican_employer_outside_united_states_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_vessel_not_american_vessel: false
+      us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_aircraft_not_american_aircraft: true
+      ? us:statutes/26/3121/b/4#input.individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+      : true
+      us:statutes/26/3121/b/4#input.individual_not_citizen_of_united_states: false
+      us:statutes/26/3121/b/4#input.employer_not_american_employer: true
+  output:
+    us:statutes/26/3121/b/4#foreign_vessel_or_aircraft_service_excluded_from_employment:
+    - holds
+- name: service_not_on_nonamerican_vessel_or_nonamerican_aircraft_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_vessel_not_american_vessel: false
+      us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_aircraft_not_american_aircraft: false
+      ? us:statutes/26/3121/b/4#input.individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+      : true
+      us:statutes/26/3121/b/4#input.individual_not_citizen_of_united_states: true
+      us:statutes/26/3121/b/4#input.employer_not_american_employer: false
+  output:
+    us:statutes/26/3121/b/4#foreign_vessel_or_aircraft_service_excluded_from_employment:
+    - not_holds
+- name: individual_not_employed_on_and_in_connection_with_vessel_or_aircraft_outside_united_states_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_vessel_not_american_vessel: true
+      us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_aircraft_not_american_aircraft: false
+      ? us:statutes/26/3121/b/4#input.individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+      : false
+      us:statutes/26/3121/b/4#input.individual_not_citizen_of_united_states: true
+      us:statutes/26/3121/b/4#input.employer_not_american_employer: false
+  output:
+    us:statutes/26/3121/b/4#foreign_vessel_or_aircraft_service_excluded_from_employment:
+    - not_holds
+- name: united_states_citizen_with_american_employer_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_vessel_not_american_vessel: true
+      us:statutes/26/3121/b/4#input.service_performed_on_or_in_connection_with_aircraft_not_american_aircraft: false
+      ? us:statutes/26/3121/b/4#input.individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+      : true
+      us:statutes/26/3121/b/4#input.individual_not_citizen_of_united_states: false
+      us:statutes/26/3121/b/4#input.employer_not_american_employer: false
+  output:
+    us:statutes/26/3121/b/4#foreign_vessel_or_aircraft_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/4.yaml
+++ b/statutes/26/3121/b/4.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (4) service performed by an individual on or in connection with a vessel not an American vessel, or on or in connection with an aircraft not an American aircraft, if (A) the individual is employed on and in connection with such vessel or aircraft, when outside the United States and (B)(i) such individual is not a citizen of the United States or (ii) the employer is not an American employer;
+rules:
+  - name: foreign_vessel_or_aircraft_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual on or in connection with a vessel not an American vessel"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or on or in connection with an aircraft not an American aircraft"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the individual is employed on and in connection with such vessel or aircraft, when outside the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "such individual is not a citizen of the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the employer is not an American employer"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            service_performed_on_or_in_connection_with_vessel_not_american_vessel
+            or service_performed_on_or_in_connection_with_aircraft_not_american_aircraft
+          )
+          and individual_employed_on_and_in_connection_with_such_vessel_or_aircraft_when_outside_united_states
+          and (
+            individual_not_citizen_of_united_states
+            or employer_not_american_employer
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(b)(4) foreign vessel or aircraft service excluded from employment
- add generated tests for non-American vessel/aircraft, outside-US employment, citizenship, and American-employer boundaries
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-4-20260524/statutes/26/3121/b/4.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-b-4-20260524/statutes/26/3121/b/4.test.yaml --root /private/tmp/rulespec-us-3121-b-4-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-4-20260524/statutes/26/3121/b/4.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-4-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage: generated 3121(b)(4) output is known_not_comparable; overall tax counts are comparable=225, known_not_comparable=601, unmapped=3.