### PR TITLE
Add generated 3121(b)(5) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/5.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/5.yaml",
+      "sha256": "c8f07d805b01a2a9e8fa9a5291f40c9d9d20ef003dd14c581349b8aa1d4e91e1"
+    },
+    {
+      "path": "statutes/26/3121/b/5.test.yaml",
+      "sha256": "7fc851c950d182e00929937f2a1bcb2afc202b43bae779fdf8b1ad6f81e63ffa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "291819b1407799bb7fa9f1a747f8e07d97344e53",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.173",
+    "version_commit": "291819b1407799bb7fa9f1a747f8e07d97344e53"
+  },
+  "axiom_encode_version": "0.2.173",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(5)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-5-20260524-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "44a3cad6d074cffacd1fd951d0590118cd08386677675f37ca1e7f133c6648d9",
+  "generated_at": "2026-05-24T23:14:41.834978+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-5-20260524-v2/openai-gpt-5.5/statutes/26/3121/b/5.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-5-20260524-v2",
+  "generated_output_sha256": "c8f07d805b01a2a9e8fa9a5291f40c9d9d20ef003dd14c581349b8aa1d4e91e1",
+  "generation_prompt_sha256": "0955c330f8b7b4611cd62014ccc4af542bf6eea9a29353f51df3176ec88004be",
+  "model": "gpt-5.5",
+  "run_id": "0569e39f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dea8c3054931bbb750c806c2a97be52283bc3578c8775931a3c92e50bf51f2b0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-5-20260524-v2/traces/openai-gpt-5.5/26-USC-3121-b-5.json",
+  "trace_sha256": "d94cdc1ab87e117b343126b658b0d4e8affae906c445ef850f774b0aa0118eed"
+}

--- a/statutes/26/3121/b/5.test.yaml
+++ b/statutes/26/3121/b/5.test.yaml
@@ -1,0 +1,226 @@
+- name: qualifying_continuous_federal_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/5#input.continuously_performing_service_described_in_subparagraph_a_since_relevant_date: true
+      us:statutes/26/3121/b/5#input.returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_detail_or_transfer_to_international_organization: false
+      us:statutes/26/3121/b/5#input.reemployed_or_reinstated_after_american_institute_in_taiwan_employment: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights: false
+      ? us:statutes/26/3121/b/5#input.returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+      : false
+      us:statutes/26/3121/b/5#input.receiving_annuity_from_civil_service_retirement_and_disability_fund: false
+      ? us:statutes/26/3121/b/5#input.receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+      : false
+      us:statutes/26/3121/b/5#input.service_in_position_placed_in_executive_schedule: false
+      ? us:statutes/26/3121/b/5#input.service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+      : false
+      ? us:statutes/26/3121/b/5#input.service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+      : false
+      us:statutes/26/3121/b/5#input.other_service_in_legislative_branch_of_federal_government: false
+      us:statutes/26/3121/b/5#input.individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date: false
+      us:statutes/26/3121/b/5#input.individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date: false
+      ? us:statutes/26/3121/b/5#input.individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+      : false
+      us:statutes/26/3121/b/5#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/5#input.service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6: true
+      us:statutes/26/3121/b/5#input.service_performed_as_president_or_vice_president: false
+      us:statutes/26/3121/b/5#input.service_performed_as_specified_federal_judicial_officer: false
+      us:statutes/26/3121/b/5#input.service_performed_as_member_delegate_or_resident_commissioner_of_congress: false
+  output:
+    us:statutes/26/3121/b/5#federal_service_continuity_treated_as_service_described_in_subparagraph_a:
+    - holds
+    us:statutes/26/3121/b/5#federal_retirement_annuity_or_benefits_status_applies:
+    - not_holds
+    us:statutes/26/3121/b/5#executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies:
+    - not_holds
+    us:statutes/26/3121/b/5#legislative_branch_service_exception_applies:
+    - not_holds
+    us:statutes/26/3121/b/5#federal_retirement_election_service_exception_applies:
+    - not_holds
+    us:statutes/26/3121/b/5#federal_employment_service_excluded_from_employment:
+    - holds
+- name: qualifying_continuous_federal_service_excluded_scalar_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3121/b/5#separation_period_less_than_consecutive_days_for_continuity: 366
+- name: qualifying_federal_annuitant_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/5#input.continuously_performing_service_described_in_subparagraph_a_since_relevant_date: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_detail_or_transfer_to_international_organization: false
+      us:statutes/26/3121/b/5#input.reemployed_or_reinstated_after_american_institute_in_taiwan_employment: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights: false
+      ? us:statutes/26/3121/b/5#input.returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+      : false
+      us:statutes/26/3121/b/5#input.receiving_annuity_from_civil_service_retirement_and_disability_fund: true
+      ? us:statutes/26/3121/b/5#input.receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+      : false
+      us:statutes/26/3121/b/5#input.service_in_position_placed_in_executive_schedule: false
+      ? us:statutes/26/3121/b/5#input.service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+      : false
+      ? us:statutes/26/3121/b/5#input.service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+      : false
+      us:statutes/26/3121/b/5#input.other_service_in_legislative_branch_of_federal_government: false
+      us:statutes/26/3121/b/5#input.individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date: false
+      us:statutes/26/3121/b/5#input.individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date: false
+      ? us:statutes/26/3121/b/5#input.individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+      : false
+      us:statutes/26/3121/b/5#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/5#input.service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6: true
+      us:statutes/26/3121/b/5#input.service_performed_as_president_or_vice_president: false
+      us:statutes/26/3121/b/5#input.service_performed_as_specified_federal_judicial_officer: false
+      us:statutes/26/3121/b/5#input.service_performed_as_member_delegate_or_resident_commissioner_of_congress: false
+  output:
+    us:statutes/26/3121/b/5#federal_retirement_annuity_or_benefits_status_applies:
+    - holds
+    us:statutes/26/3121/b/5#federal_employment_service_excluded_from_employment:
+    - holds
+- name: executive_schedule_exception_blocks_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/5#input.continuously_performing_service_described_in_subparagraph_a_since_relevant_date: true
+      us:statutes/26/3121/b/5#input.returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_detail_or_transfer_to_international_organization: false
+      us:statutes/26/3121/b/5#input.reemployed_or_reinstated_after_american_institute_in_taiwan_employment: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights: false
+      ? us:statutes/26/3121/b/5#input.returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+      : false
+      us:statutes/26/3121/b/5#input.receiving_annuity_from_civil_service_retirement_and_disability_fund: false
+      ? us:statutes/26/3121/b/5#input.receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+      : false
+      us:statutes/26/3121/b/5#input.service_in_position_placed_in_executive_schedule: true
+      ? us:statutes/26/3121/b/5#input.service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+      : false
+      ? us:statutes/26/3121/b/5#input.service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+      : false
+      us:statutes/26/3121/b/5#input.other_service_in_legislative_branch_of_federal_government: false
+      us:statutes/26/3121/b/5#input.individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date: false
+      us:statutes/26/3121/b/5#input.individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date: false
+      ? us:statutes/26/3121/b/5#input.individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+      : false
+      us:statutes/26/3121/b/5#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/5#input.service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6: true
+      us:statutes/26/3121/b/5#input.service_performed_as_president_or_vice_president: false
+      us:statutes/26/3121/b/5#input.service_performed_as_specified_federal_judicial_officer: false
+      us:statutes/26/3121/b/5#input.service_performed_as_member_delegate_or_resident_commissioner_of_congress: false
+  output:
+    us:statutes/26/3121/b/5#executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies:
+    - holds
+    us:statutes/26/3121/b/5#federal_employment_service_excluded_from_employment:
+    - not_holds
+- name: legislative_branch_exception_blocks_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/5#input.continuously_performing_service_described_in_subparagraph_a_since_relevant_date: true
+      us:statutes/26/3121/b/5#input.returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_detail_or_transfer_to_international_organization: false
+      us:statutes/26/3121/b/5#input.reemployed_or_reinstated_after_american_institute_in_taiwan_employment: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights: false
+      ? us:statutes/26/3121/b/5#input.returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+      : false
+      us:statutes/26/3121/b/5#input.receiving_annuity_from_civil_service_retirement_and_disability_fund: false
+      ? us:statutes/26/3121/b/5#input.receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+      : false
+      us:statutes/26/3121/b/5#input.service_in_position_placed_in_executive_schedule: false
+      ? us:statutes/26/3121/b/5#input.service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+      : false
+      ? us:statutes/26/3121/b/5#input.service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+      : false
+      us:statutes/26/3121/b/5#input.other_service_in_legislative_branch_of_federal_government: true
+      us:statutes/26/3121/b/5#input.individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date: true
+      us:statutes/26/3121/b/5#input.individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date: false
+      ? us:statutes/26/3121/b/5#input.individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+      : false
+      us:statutes/26/3121/b/5#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/5#input.service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6: true
+      us:statutes/26/3121/b/5#input.service_performed_as_president_or_vice_president: false
+      us:statutes/26/3121/b/5#input.service_performed_as_specified_federal_judicial_officer: false
+      us:statutes/26/3121/b/5#input.service_performed_as_member_delegate_or_resident_commissioner_of_congress: false
+  output:
+    us:statutes/26/3121/b/5#legislative_branch_service_exception_applies:
+    - holds
+    us:statutes/26/3121/b/5#federal_employment_service_excluded_from_employment:
+    - not_holds
+- name: federal_retirement_election_exception_blocks_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/5#input.continuously_performing_service_described_in_subparagraph_a_since_relevant_date: true
+      us:statutes/26/3121/b/5#input.returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_detail_or_transfer_to_international_organization: false
+      us:statutes/26/3121/b/5#input.reemployed_or_reinstated_after_american_institute_in_taiwan_employment: false
+      us:statutes/26/3121/b/5#input.returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights: false
+      ? us:statutes/26/3121/b/5#input.returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+      : false
+      us:statutes/26/3121/b/5#input.receiving_annuity_from_civil_service_retirement_and_disability_fund: false
+      ? us:statutes/26/3121/b/5#input.receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+      : false
+      us:statutes/26/3121/b/5#input.service_in_position_placed_in_executive_schedule: false
+      ? us:statutes/26/3121/b/5#input.service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+      : false
+      ? us:statutes/26/3121/b/5#input.service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+      : false
+      us:statutes/26/3121/b/5#input.other_service_in_legislative_branch_of_federal_government: false
+      us:statutes/26/3121/b/5#input.individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date: false
+      us:statutes/26/3121/b/5#input.individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date: false
+      ? us:statutes/26/3121/b/5#input.individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+      : false
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+      : true
+      ? us:statutes/26/3121/b/5#input.service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+      : false
+      us:statutes/26/3121/b/5#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/5#input.service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6: true
+      us:statutes/26/3121/b/5#input.service_performed_as_president_or_vice_president: false
+      us:statutes/26/3121/b/5#input.service_performed_as_specified_federal_judicial_officer: false
+      us:statutes/26/3121/b/5#input.service_performed_as_member_delegate_or_resident_commissioner_of_congress: false
+  output:
+    us:statutes/26/3121/b/5#federal_retirement_election_service_exception_applies:
+    - holds
+    us:statutes/26/3121/b/5#federal_employment_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/5.yaml
+++ b/statutes/26/3121/b/5.yaml
@@ -1,0 +1,274 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (5) service performed in the employ of the United States or any instrumentality of the United States, if such service— (A) would be excluded from the term “employment” for purposes of this title if the provisions of paragraphs (5) and (6) of this subsection as in effect in January 1983 had remained in effect, and (B) is performed by an individual who— (i) has been continuously performing service described in subparagraph (A) since December 31, 1983, and for purposes of this clause— (I) if an individual performing service described in subparagraph (A) returns to the performance of such service after being separated therefrom for a period of less than 366 consecutive days ... then such service shall be considered continuous, (II) if an individual ... returns ... after being detailed or transferred to an international organization ... then the service performed for that organization shall be considered service described in subparagraph (A), (III) if an individual ... is reemployed or reinstated after being separated ... for the purpose of accepting employment with the American Institute in Taiwan ... then the service performed for that Institute shall be considered service described in subparagraph (A), (IV) if an individual ... returns ... after performing service as a member of a uniformed service ... and after exercising restoration or reemployment rights ... then the service so performed as a member of a uniformed service shall be considered service described in subparagraph (A), and (V) if an individual ... returns ... after employment (by a tribal organization) to which section 104(e)(2) of the Indian Self-Determination Act applies, then the service performed for that tribal organization shall be considered service described in subparagraph (A); or (ii) is receiving an annuity from the Civil Service Retirement and Disability Fund, or benefits ... under another retirement system established by a law of the United States for employees of the Federal Government ...; except that this paragraph shall not apply with respect to any such service performed on or after any date on which such individual performs— (C) service performed as the President or Vice President of the United States, (D) service performed— (i) in a position placed in the Executive Schedule under sections 5312 through 5317 of title 5, United States Code, (ii) as a noncareer appointee in the Senior Executive Service or a noncareer member of the Senior Foreign Service, or (iii) in a position to which the individual is appointed by the President (or his designee) or the Vice President under section 105(a)(1), 106(a)(1), or 107(a)(1) or (b)(1) of title 3, United States Code, if the maximum rate of basic pay for such position is at or above the rate for level V of the Executive Schedule, (E) service performed as specified Federal judges and judicial officers, (F) service performed as a Member, Delegate, or Resident Commissioner of or to the Congress, (G) any other service in the legislative branch of the Federal Government if clauses (i), (ii), or (iii) apply, with the stated retirement-system subject-to rule, or (H) service performed by an individual on or after the effective date of an election to become subject to FERS, specified CIA/FERS open enrollment systems, or the Foreign Service Pension System.
+rules:
+  - name: separation_period_less_than_consecutive_days_for_continuity
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 3121(b)(5)(B)(i)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "after being separated therefrom for a period of less than 366 consecutive days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          366
+
+  - name: federal_service_continuity_treated_as_service_described_in_subparagraph_a
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)(B)(i)(I)-(V)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "has been continuously performing service described in subparagraph (A) since December 31, 1983"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "returns to the performance of such service after being separated therefrom for a period of less than 366 consecutive days ... then such service shall be considered continuous"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed for that organization shall be considered service described in subparagraph (A)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed for that Institute shall be considered service described in subparagraph (A)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service so performed as a member of a uniformed service shall be considered service described in subparagraph (A)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed for that tribal organization shall be considered service described in subparagraph (A)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          continuously_performing_service_described_in_subparagraph_a_since_relevant_date
+          or returned_to_service_after_separation_for_less_than_continuity_threshold_consecutive_days
+          or returned_to_service_after_detail_or_transfer_to_international_organization
+          or reemployed_or_reinstated_after_american_institute_in_taiwan_employment
+          or returned_to_service_after_uniformed_service_with_restoration_or_reemployment_rights
+          or returned_to_service_after_tribal_organization_employment_to_which_indian_self_determination_act_applies
+
+  - name: federal_retirement_annuity_or_benefits_status_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is receiving an annuity from the Civil Service Retirement and Disability Fund"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or benefits (for service as an employee) under another retirement system established by a law of the United States for employees of the Federal Government (other than for members of the uniformed service)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          receiving_annuity_from_civil_service_retirement_and_disability_fund
+          or receiving_employee_service_benefits_under_other_federal_employee_retirement_system_other_than_uniformed_service
+
+  - name: executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed— (i) in a position placed in the Executive Schedule under sections 5312 through 5317 of title 5, United States Code"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "as a noncareer appointee in the Senior Executive Service or a noncareer member of the Senior Foreign Service"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in a position to which the individual is appointed by the President (or his designee) or the Vice President ... if the maximum rate of basic pay for such position is at or above the rate for level V of the Executive Schedule"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_position_placed_in_executive_schedule
+          or service_as_noncareer_senior_executive_service_appointee_or_noncareer_senior_foreign_service_member
+          or service_in_presidential_or_vice_presidential_appointed_position_with_basic_pay_at_or_above_level_v_executive_schedule
+
+  - name: legislative_branch_service_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)(G)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any other service in the legislative branch of the Federal Government if such service—"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is performed by an individual who was not subject to subchapter III of chapter 83 of title 5 ... or to another retirement system ... on December 31, 1983"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is performed by an individual who has, at any time after December 31, 1983, received a lump-sum payment under section 8342(a) of title 5 ... or under the corresponding provision"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is performed by an individual after such individual has otherwise ceased to be subject to subchapter III of chapter 83 of title 5 ... while performing service in the legislative branch"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          other_service_in_legislative_branch_of_federal_government
+          and (
+            individual_was_not_subject_to_specified_federal_employee_retirement_system_on_relevant_date
+            or individual_received_lump_sum_payment_under_specified_retirement_system_after_relevant_date
+            or individual_ceased_to_be_subject_to_specified_retirement_system_while_performing_legislative_branch_service_after_relevant_date
+          )
+
+  - name: federal_retirement_election_service_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)(H)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual— (i) on or after the effective date of an election ... to become subject to the Federal Employees’ Retirement System"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or (ii) on or after the effective date of an election ... to become subject to the Foreign Service Pension System"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_on_or_after_effective_date_of_election_to_become_subject_to_federal_employees_retirement_system
+          or service_on_or_after_effective_date_of_election_to_become_subject_to_foreign_service_pension_system
+
+  - name: federal_employment_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of the United States or any instrumentality of the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "would be excluded from the term “employment” for purposes of this title if the provisions of paragraphs (5) and (6) of this subsection as in effect in January 1983 had remained in effect"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/5#federal_service_continuity_treated_as_service_described_in_subparagraph_a
+              output: federal_service_continuity_treated_as_service_described_in_subparagraph_a
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/5#federal_retirement_annuity_or_benefits_status_applies
+              output: federal_retirement_annuity_or_benefits_status_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that this paragraph shall not apply with respect to any such service performed on or after any date on which such individual performs— (C) service performed as the President or Vice President of the United States"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/5#executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies
+              output: executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(E) service performed as the Chief Justice of the United States, an Associate Justice of the Supreme Court ... or United States bankruptcy judge"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(F) service performed as a Member, Delegate, or Resident Commissioner of or to the Congress"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/5#legislative_branch_service_exception_applies
+              output: legislative_branch_service_exception_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/5#federal_retirement_election_service_exception_applies
+              output: federal_retirement_election_service_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_united_states_or_instrumentality
+          and service_would_have_been_excluded_under_january_1983_paragraphs_5_and_6
+          and (
+            federal_service_continuity_treated_as_service_described_in_subparagraph_a
+            or federal_retirement_annuity_or_benefits_status_applies
+          )
+          and not service_performed_as_president_or_vice_president
+          and not executive_schedule_or_noncareer_or_presidential_appointment_service_exception_applies
+          and not service_performed_as_specified_federal_judicial_officer
+          and not service_performed_as_member_delegate_or_resident_commissioner_of_congress
+          and not legislative_branch_service_exception_applies
+          and not federal_retirement_election_service_exception_applies


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(b)(5) federal-service employment exclusions
- model continuity, retirement-annuity/benefit status, federal-service exceptions, and final exclusion gate
- include signed encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-5-v2-20260524/statutes/26/3121/b/5.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-b-5-v2-20260524/statutes/26/3121/b/5.test.yaml --root /private/tmp/rulespec-us-3121-b-5-v2-20260524 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-5-v2-20260524/statutes/26/3121/b/5.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-5-v2-20260524 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root <tmp alias root> --oracle policyengine --program tax --json

PolicyEngine coverage: generated 3121(b)(5) outputs are known_not_comparable; overall tax counts are comparable=225, known_not_comparable=608, unmapped=3.

Depends on encoder prompt fix TheAxiomFoundation/axiom-encode#184, merged.