### PR TITLE
Add generated 3121(b)(6) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/6.yaml",
+      "sha256": "2cd042b8dbd66930d961827fd3c0d7720decb56ade0d5cf905f60f2650ae7551"
+    },
+    {
+      "path": "statutes/26/3121/b/6.test.yaml",
+      "sha256": "bd4435b616333af9bf3d4f4b9cfd7d9e249c3da783b84ccd2f7f086fbfd86d61"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "291819b1407799bb7fa9f1a747f8e07d97344e53",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.173",
+    "version_commit": "291819b1407799bb7fa9f1a747f8e07d97344e53"
+  },
+  "axiom_encode_version": "0.2.173",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(6)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-6-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "bc078e945493a6f2589d2fc8bb9b90768b655d9d9ce8b3cc94da587ad1ee9fb9",
+  "generated_at": "2026-05-24T23:21:23.104108+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-6-20260524/openai-gpt-5.5/statutes/26/3121/b/6.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-6-20260524",
+  "generated_output_sha256": "2cd042b8dbd66930d961827fd3c0d7720decb56ade0d5cf905f60f2650ae7551",
+  "generation_prompt_sha256": "3f259c49414ec758fd9c8558959369a3478c2224c5f9e9fd2ebbe2fb787e7ebb",
+  "model": "gpt-5.5",
+  "run_id": "260ecc77",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1649b67db08a5d954c06a2dcc8c675441c6b4e8eb62ffd1622ede7e5be01cd66"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-6-20260524/traces/openai-gpt-5.5/26-USC-3121-b-6.json",
+  "trace_sha256": "f655e7b8dcb9fc96afb82e29d35a88db8fa085423e74ae273f21607b3b5d2a73"
+}

--- a/statutes/26/3121/b/6.test.yaml
+++ b/statutes/26/3121/b/6.test.yaml
@@ -1,0 +1,80 @@
+- name: federal_penal_institution_inmate_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/6#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/6#input.service_performed_in_penal_institution_of_united_states_by_inmate: true
+      us:statutes/26/3121/b/6#input.individual_is_employee_included_under_section_5351_2_of_title_5: false
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_intern: false
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_resident_in_training: false
+      ? us:statutes/26/3121/b/6#input.individual_employee_serving_on_temporary_basis_in_fire_storm_earthquake_flood_or_similar_emergency
+      : false
+  output:
+    us:statutes/26/3121/b/6#section_5351_student_hospital_employee_branch_applies:
+    - not_holds
+    us:statutes/26/3121/b/6#federal_penal_student_or_emergency_service_excluded_from_employment:
+    - holds
+- name: federal_section_5351_student_hospital_employee_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/6#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/6#input.service_performed_in_penal_institution_of_united_states_by_inmate: false
+      us:statutes/26/3121/b/6#input.individual_is_employee_included_under_section_5351_2_of_title_5: true
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_intern: false
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_resident_in_training: false
+      ? us:statutes/26/3121/b/6#input.individual_employee_serving_on_temporary_basis_in_fire_storm_earthquake_flood_or_similar_emergency
+      : false
+  output:
+    us:statutes/26/3121/b/6#section_5351_student_hospital_employee_branch_applies:
+    - holds
+    us:statutes/26/3121/b/6#federal_penal_student_or_emergency_service_excluded_from_employment:
+    - holds
+- name: federal_temporary_emergency_employee_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/6#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/6#input.service_performed_in_penal_institution_of_united_states_by_inmate: false
+      us:statutes/26/3121/b/6#input.individual_is_employee_included_under_section_5351_2_of_title_5: false
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_intern: false
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_resident_in_training: false
+      ? us:statutes/26/3121/b/6#input.individual_employee_serving_on_temporary_basis_in_fire_storm_earthquake_flood_or_similar_emergency
+      : true
+  output:
+    us:statutes/26/3121/b/6#section_5351_student_hospital_employee_branch_applies:
+    - not_holds
+    us:statutes/26/3121/b/6#federal_penal_student_or_emergency_service_excluded_from_employment:
+    - holds
+- name: medical_or_dental_intern_exception_blocks_section_5351_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/6#input.service_performed_in_employ_of_united_states_or_instrumentality: true
+      us:statutes/26/3121/b/6#input.service_performed_in_penal_institution_of_united_states_by_inmate: false
+      us:statutes/26/3121/b/6#input.individual_is_employee_included_under_section_5351_2_of_title_5: true
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_intern: true
+      us:statutes/26/3121/b/6#input.service_performed_as_medical_or_dental_resident_in_training: false
+      ? us:statutes/26/3121/b/6#input.individual_employee_serving_on_temporary_basis_in_fire_storm_earthquake_flood_or_similar_emergency
+      : false
+  output:
+    us:statutes/26/3121/b/6#section_5351_student_hospital_employee_branch_applies:
+    - not_holds
+    us:statutes/26/3121/b/6#federal_penal_student_or_emergency_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/6.yaml
+++ b/statutes/26/3121/b/6.yaml
@@ -1,0 +1,74 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (6) service performed in the employ of the United States or any instrumentality of the United States if such service is performed— (A) in a penal institution of the United States by an inmate thereof; (B) by any individual as an employee included under section 5351(2) of title 5 , United States Code (relating to certain interns, student nurses, and other student employees of hospitals of the Federal Government), other than as a medical or dental intern or a medical or dental resident in training; or (C) by any individual as an employee serving on a temporary basis in case of fire, storm, earthquake, flood, or other similar emergency;
+rules:
+  - name: section_5351_student_hospital_employee_branch_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by any individual as an employee included under section 5351(2) of title 5 , United States Code (relating to certain interns, student nurses, and other student employees of hospitals of the Federal Government)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than as a medical or dental intern or a medical or dental resident in training"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_is_employee_included_under_section_5351_2_of_title_5
+          and not service_performed_as_medical_or_dental_intern
+          and not service_performed_as_medical_or_dental_resident_in_training
+
+  - name: federal_penal_student_or_emergency_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of the United States or any instrumentality of the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in a penal institution of the United States by an inmate thereof"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/6#section_5351_student_hospital_employee_branch_applies
+              output: section_5351_student_hospital_employee_branch_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by any individual as an employee serving on a temporary basis in case of fire, storm, earthquake, flood, or other similar emergency"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_united_states_or_instrumentality
+          and (
+            service_performed_in_penal_institution_of_united_states_by_inmate
+            or section_5351_student_hospital_employee_branch_applies
+            or individual_employee_serving_on_temporary_basis_in_fire_storm_earthquake_flood_or_similar_emergency
+          )


### PR DESCRIPTION
Generated by signed axiom-encode apply for 26 USC 3121(b)(6) using gpt-5.5 and encoder 0.2.173.\n\nLocal checks:\n- axiom-encode validate statutes/26/3121/b/6.yaml --skip-reviewers --json\n- axiom-encode test statutes/26/3121/b/6.test.yaml --root /private/tmp/rulespec-us-3121-b-6-20260524 --json\n- axiom-encode proof-validate statutes/26/3121/b/6.yaml\n- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-6-20260524 --base-ref origin/main --json\n- axiom-encode oracle-coverage --oracle policyengine --program tax: 225 comparable / 610 known_not_comparable / 3 unmapped\n\nNo hand edits to generated RuleSpec artifacts.