### PR TITLE
Add generated 3121(b)(7) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/7.yaml",
+      "sha256": "728fa023b438b53e0ffd0b04a474b0d3a5ffdd9285c5bcf12979f5a91a6b8102"
+    },
+    {
+      "path": "statutes/26/3121/b/7.test.yaml",
+      "sha256": "34e4ad95747b47cfe07ad485bfaf81db33b43717e67c7749084878513993814d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7e021b467e3741d04d203d7d356aa44e3ad12408",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.175",
+    "version_commit": "7e021b467e3741d04d203d7d356aa44e3ad12408"
+  },
+  "axiom_encode_version": "0.2.175",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(7)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-7-v8-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "4d921918394f853515727c3270187d4fa2adc4321e2ef0741917cdce06b5bd81",
+  "generated_at": "2026-05-25T00:03:28.493947+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-7-v8-20260524/openai-gpt-5.5/statutes/26/3121/b/7.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-7-v8-20260524",
+  "generated_output_sha256": "728fa023b438b53e0ffd0b04a474b0d3a5ffdd9285c5bcf12979f5a91a6b8102",
+  "generation_prompt_sha256": "f95732fe9c561889dc572f6849ae6db04e36292f23e17ebe25ddce68c21cdfc7",
+  "model": "gpt-5.5",
+  "run_id": "79a690ea",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4b521fc9d248a2108feadb858cfdbe01cab8535668ee554b5c352df4cd3b5aca"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-7-v8-20260524/traces/openai-gpt-5.5/26-USC-3121-b-7.json",
+  "trace_sha256": "73f82e9122960cdf7063b2dac94e7a15292b6db13261ce569926c268569b5d1d"
+}

--- a/statutes/26/3121/b/7.test.yaml
+++ b/statutes/26/3121/b/7.test.yaml
@@ -1,0 +1,168 @@
+- name: ordinary_state_or_local_government_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/7#input.service_performed_in_employ_of_state_or_political_subdivision_or_wholly_owned_instrumentality
+      : true
+      us:statutes/26/3121/b/7#input.service_constitutes_covered_transportation_service_under_subsection_j: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_american_samoa_or_wholly_owned_instrumentality: false
+      ? us:statutes/26/3121/b/7#input.service_performed_by_officer_or_employee_of_that_government_or_subdivision_or_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_district_of_columbia_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_united_states_other_than_fers: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_or_penal_institution_by_patient_or_inmate: false
+      ? us:statutes/26/3121/b/7#input.district_of_columbia_section_5351_2_student_hospital_employee_service_other_than_medical_or_dental_intern_or_resident
+      : false
+      ? us:statutes/26/3121/b/7#input.service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      us:statutes/26/3121/b/7#input.service_by_district_of_columbia_board_committee_or_council_member_paid_on_fee_basis: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.employee_properly_classified_as_temporary_or_intermittent_employee: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_guam: false
+      us:statutes/26/3121/b/7#input.service_performed_by_elected_official: false
+      us:statutes/26/3121/b/7#input.service_performed_by_member_of_legislature: false
+      us:statutes/26/3121/b/7#input.service_included_under_agreement_entered_into_pursuant_to_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/b/7#input.service_in_employ_of_state_other_than_district_of_columbia_guam_or_american_samoa_or_subdivision_or_wholly_owned_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.individual_not_member_of_retirement_system_of_state_subdivision_or_instrumentality: false
+      us:statutes/26/3121/b/7#input.individual_employed_to_relieve_individual_from_unemployment: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_home_or_other_institution_by_patient_or_inmate: false
+      us:statutes/26/3121/b/7#input.election_official_or_worker_service_with_remuneration_less_than_applicable_threshold: false
+      ? us:statutes/26/3121/b/7#input.employee_position_compensated_solely_on_fee_basis_treated_as_trade_or_business_for_net_earnings_from_self_employment
+      : false
+  output:
+    us:statutes/26/3121/b/7#guam_american_samoa_officer_employee_service_exception_to_state_employment_exclusion:
+    - not_holds
+    us:statutes/26/3121/b/7#district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion:
+    - not_holds
+    us:statutes/26/3121/b/7#guam_temporary_or_intermitent_non_guam_retirement_service_exception_to_state_employment_exclusion:
+    - not_holds
+    us:statutes/26/3121/b/7#other_state_non_retirement_member_service_exception_to_state_employment_exclusion:
+    - not_holds
+    us:statutes/26/3121/b/7#state_or_local_government_service_excluded_from_employment:
+    - holds
+- name: covered_transportation_service_blocks_paragraph_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/7#input.service_performed_in_employ_of_state_or_political_subdivision_or_wholly_owned_instrumentality
+      : true
+      us:statutes/26/3121/b/7#input.service_constitutes_covered_transportation_service_under_subsection_j: true
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_american_samoa_or_wholly_owned_instrumentality: false
+      ? us:statutes/26/3121/b/7#input.service_performed_by_officer_or_employee_of_that_government_or_subdivision_or_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_district_of_columbia_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_united_states_other_than_fers: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_or_penal_institution_by_patient_or_inmate: false
+      ? us:statutes/26/3121/b/7#input.district_of_columbia_section_5351_2_student_hospital_employee_service_other_than_medical_or_dental_intern_or_resident
+      : false
+      ? us:statutes/26/3121/b/7#input.service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      us:statutes/26/3121/b/7#input.service_by_district_of_columbia_board_committee_or_council_member_paid_on_fee_basis: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.employee_properly_classified_as_temporary_or_intermittent_employee: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_guam: false
+      us:statutes/26/3121/b/7#input.service_performed_by_elected_official: false
+      us:statutes/26/3121/b/7#input.service_performed_by_member_of_legislature: false
+      us:statutes/26/3121/b/7#input.service_included_under_agreement_entered_into_pursuant_to_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/b/7#input.service_in_employ_of_state_other_than_district_of_columbia_guam_or_american_samoa_or_subdivision_or_wholly_owned_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.individual_not_member_of_retirement_system_of_state_subdivision_or_instrumentality: false
+      us:statutes/26/3121/b/7#input.individual_employed_to_relieve_individual_from_unemployment: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_home_or_other_institution_by_patient_or_inmate: false
+      us:statutes/26/3121/b/7#input.election_official_or_worker_service_with_remuneration_less_than_applicable_threshold: false
+      ? us:statutes/26/3121/b/7#input.employee_position_compensated_solely_on_fee_basis_treated_as_trade_or_business_for_net_earnings_from_self_employment
+      : false
+  output:
+    us:statutes/26/3121/b/7#state_or_local_government_service_excluded_from_employment:
+    - not_holds
+- name: district_of_columbia_patient_carveout_preserves_paragraph_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/7#input.service_performed_in_employ_of_state_or_political_subdivision_or_wholly_owned_instrumentality
+      : true
+      us:statutes/26/3121/b/7#input.service_constitutes_covered_transportation_service_under_subsection_j: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_american_samoa_or_wholly_owned_instrumentality: false
+      ? us:statutes/26/3121/b/7#input.service_performed_by_officer_or_employee_of_that_government_or_subdivision_or_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_district_of_columbia_or_wholly_owned_instrumentality: true
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_united_states_other_than_fers: true
+      us:statutes/26/3121/b/7#input.service_in_hospital_or_penal_institution_by_patient_or_inmate: true
+      ? us:statutes/26/3121/b/7#input.district_of_columbia_section_5351_2_student_hospital_employee_service_other_than_medical_or_dental_intern_or_resident
+      : false
+      ? us:statutes/26/3121/b/7#input.service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      us:statutes/26/3121/b/7#input.service_by_district_of_columbia_board_committee_or_council_member_paid_on_fee_basis: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.employee_properly_classified_as_temporary_or_intermittent_employee: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_guam: false
+      us:statutes/26/3121/b/7#input.service_performed_by_elected_official: false
+      us:statutes/26/3121/b/7#input.service_performed_by_member_of_legislature: false
+      us:statutes/26/3121/b/7#input.service_included_under_agreement_entered_into_pursuant_to_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/b/7#input.service_in_employ_of_state_other_than_district_of_columbia_guam_or_american_samoa_or_subdivision_or_wholly_owned_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.individual_not_member_of_retirement_system_of_state_subdivision_or_instrumentality: false
+      us:statutes/26/3121/b/7#input.individual_employed_to_relieve_individual_from_unemployment: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_home_or_other_institution_by_patient_or_inmate: false
+      us:statutes/26/3121/b/7#input.election_official_or_worker_service_with_remuneration_less_than_applicable_threshold: false
+      ? us:statutes/26/3121/b/7#input.employee_position_compensated_solely_on_fee_basis_treated_as_trade_or_business_for_net_earnings_from_self_employment
+      : false
+  output:
+    us:statutes/26/3121/b/7#district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion:
+    - not_holds
+    us:statutes/26/3121/b/7#state_or_local_government_service_excluded_from_employment:
+    - holds
+- name: other_state_non_retirement_member_service_blocks_paragraph_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/7#input.service_performed_in_employ_of_state_or_political_subdivision_or_wholly_owned_instrumentality
+      : true
+      us:statutes/26/3121/b/7#input.service_constitutes_covered_transportation_service_under_subsection_j: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_american_samoa_or_wholly_owned_instrumentality: false
+      ? us:statutes/26/3121/b/7#input.service_performed_by_officer_or_employee_of_that_government_or_subdivision_or_instrumentality
+      : false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_district_of_columbia_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_united_states_other_than_fers: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_or_penal_institution_by_patient_or_inmate: false
+      ? us:statutes/26/3121/b/7#input.district_of_columbia_section_5351_2_student_hospital_employee_service_other_than_medical_or_dental_intern_or_resident
+      : false
+      ? us:statutes/26/3121/b/7#input.service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      us:statutes/26/3121/b/7#input.service_by_district_of_columbia_board_committee_or_council_member_paid_on_fee_basis: false
+      us:statutes/26/3121/b/7#input.service_in_employ_of_government_of_guam_or_wholly_owned_instrumentality: false
+      us:statutes/26/3121/b/7#input.employee_properly_classified_as_temporary_or_intermittent_employee: false
+      us:statutes/26/3121/b/7#input.service_not_covered_by_retirement_system_established_by_law_of_guam: false
+      us:statutes/26/3121/b/7#input.service_performed_by_elected_official: false
+      us:statutes/26/3121/b/7#input.service_performed_by_member_of_legislature: false
+      us:statutes/26/3121/b/7#input.service_included_under_agreement_entered_into_pursuant_to_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/b/7#input.service_in_employ_of_state_other_than_district_of_columbia_guam_or_american_samoa_or_subdivision_or_wholly_owned_instrumentality
+      : true
+      us:statutes/26/3121/b/7#input.individual_not_member_of_retirement_system_of_state_subdivision_or_instrumentality: true
+      us:statutes/26/3121/b/7#input.individual_employed_to_relieve_individual_from_unemployment: false
+      us:statutes/26/3121/b/7#input.service_in_hospital_home_or_other_institution_by_patient_or_inmate: false
+      us:statutes/26/3121/b/7#input.election_official_or_worker_service_with_remuneration_less_than_applicable_threshold: false
+      ? us:statutes/26/3121/b/7#input.employee_position_compensated_solely_on_fee_basis_treated_as_trade_or_business_for_net_earnings_from_self_employment
+      : false
+  output:
+    us:statutes/26/3121/b/7#other_state_non_retirement_member_service_exception_to_state_employment_exclusion:
+    - holds
+    us:statutes/26/3121/b/7#state_or_local_government_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/7.yaml
+++ b/statutes/26/3121/b/7.yaml
@@ -1,0 +1,193 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (7) service performed in the employ of a State, or any political subdivision thereof, or any instrumentality of any one or more of the foregoing which is wholly owned thereby, except that this paragraph shall not apply in the case of— (A) service which, under subsection (j), constitutes covered transportation service, (B) service in the employ of the Government of Guam or the Government of American Samoa or any political subdivision thereof, or of any instrumentality of any one or more of the foregoing which is wholly owned thereby, performed by an officer or employee thereof (including a member of the legislature of any such Government or political subdivision), and, for purposes of this title with respect to the taxes imposed by this chapter— (i) any person whose service as such an officer or employee is not covered by a retirement system established by a law of the United States shall not, with respect to such service, be regarded as an employee of the United States or any agency or instrumentality thereof, and (ii) the remuneration for service described in clause (i) (including fees paid to a public official) shall be deemed to have been paid by the Government of Guam or the Government of American Samoa or by a political subdivision thereof or an instrumentality of any one or more of the foregoing which is wholly owned thereby, whichever is appropriate, (C) service performed in the employ of the District of Columbia or any instrumentality which is wholly owned thereby, if such service is not covered by a retirement system established by a law of the United States (other than the Federal Employees Retirement System provided in chapter 84 of title 5, United States Code); except that the provisions of this subparagraph shall not be applicable to service performed— (i) in a hospital or penal institution by a patient or inmate thereof; (ii) by any individual as an employee included under section 5351(2) of title 5 , United States Code (relating to certain interns, student nurses, and other student employees of hospitals of the District of Columbia Government), other than as a medical or dental intern or as a medical or dental resident in training; (iii) by any individual as an employee serving on a temporary basis in case of fire, storm, snow, earthquake, flood or other similar emergency; or (iv) by a member of a board, committee, or council of the District of Columbia, paid on a per diem, meeting, or other fee basis, (D) service performed in the employ of the Government of Guam (or any instrumentality which is wholly owned by such Government) by an employee properly classified as a temporary or intermittent employee, if such service is not covered by a retirement system established by a law of Guam; except that (i) the provisions of this subparagraph shall not be applicable to services performed by an elected official or a member of the legislature or in a hospital or penal institution by a patient or inmate thereof, and (ii) for purposes of this subparagraph, clauses (i) and (ii) of subparagraph (B) shall apply, (E) service included under an agreement entered into pursuant to section 218 of the Social Security Act, or (F) service in the employ of a State (other than the District of Columbia, Guam, or American Samoa), of any political subdivision thereof, or of any instrumentality of any one or more of the foregoing which is wholly owned thereby, by an individual who is not a member of a retirement system of such State, political subdivision, or instrumentality, except that the provisions of this subparagraph shall not be applicable to service performed— (i) by an individual who is employed to relieve such individual from unemployment; (ii) in a hospital, home, or other institution by a patient or inmate thereof; (iii) by any individual as an employee serving on a temporary basis in case of fire, storm, snow, earthquake, flood, or other similar emergency; (iv) by an election official or election worker if the remuneration paid in a calendar year for such service is less than $1,000 with respect to service performed during any calendar year commencing on or after January 1, 1995 , ending on or before December 31, 1999 , and the adjusted amount determined under section 218(c)(8)(B) of the Social Security Act for any calendar year commencing on or after January 1, 2000 , with respect to service performed during such calendar year; or (v) by an employee in a position compensated solely on a fee basis which is treated pursuant to section 1402(c)(2)(E) as a trade or business for purposes of inclusion of such fees in net earnings from self-employment; for purposes of this subparagraph, except as provided in regulations prescribed by the Secretary, the term “retirement system” has the meaning given such term by section 218(b)(4) of the Social Security Act;
+rules:
+  - name: election_worker_remuneration_threshold_for_calendar_years_before_adjustment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(b)(7)(F)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "less than $1,000 with respect to service performed during any calendar year commencing on or after January 1, 1995 , ending on or before December 31, 1999"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1000
+
+  - name: guam_american_samoa_officer_employee_service_exception_to_state_employment_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "this paragraph shall not apply in the case of— ... service in the employ of the Government of Guam or the Government of American Samoa or any political subdivision thereof, or of any instrumentality of any one or more of the foregoing which is wholly owned thereby, performed by an officer or employee thereof"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_government_of_guam_or_american_samoa_or_wholly_owned_instrumentality
+          and service_performed_by_officer_or_employee_of_that_government_or_subdivision_or_instrumentality
+
+  - name: district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of the District of Columbia or any instrumentality which is wholly owned thereby, if such service is not covered by a retirement system established by a law of the United States"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that the provisions of this subparagraph shall not be applicable to service performed— (i) in a hospital or penal institution by a patient or inmate thereof; (ii) by any individual as an employee included under section 5351(2) of title 5 ... other than as a medical or dental intern or as a medical or dental resident in training; (iii) by any individual as an employee serving on a temporary basis in case of fire, storm, snow, earthquake, flood or other similar emergency; or (iv) by a member of a board, committee, or council of the District of Columbia, paid on a per diem, meeting, or other fee basis"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_district_of_columbia_or_wholly_owned_instrumentality
+          and service_not_covered_by_retirement_system_established_by_law_of_united_states_other_than_fers
+          and not service_in_hospital_or_penal_institution_by_patient_or_inmate
+          and not district_of_columbia_section_5351_2_student_hospital_employee_service_other_than_medical_or_dental_intern_or_resident
+          and not service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+          and not service_by_district_of_columbia_board_committee_or_council_member_paid_on_fee_basis
+
+  - name: guam_temporary_or_intermitent_non_guam_retirement_service_exception_to_state_employment_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of the Government of Guam (or any instrumentality which is wholly owned by such Government) by an employee properly classified as a temporary or intermittent employee, if such service is not covered by a retirement system established by a law of Guam"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that (i) the provisions of this subparagraph shall not be applicable to services performed by an elected official or a member of the legislature or in a hospital or penal institution by a patient or inmate thereof"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_government_of_guam_or_wholly_owned_instrumentality
+          and employee_properly_classified_as_temporary_or_intermittent_employee
+          and service_not_covered_by_retirement_system_established_by_law_of_guam
+          and not service_performed_by_elected_official
+          and not service_performed_by_member_of_legislature
+          and not service_in_hospital_or_penal_institution_by_patient_or_inmate
+
+  - name: other_state_non_retirement_member_service_exception_to_state_employment_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service in the employ of a State (other than the District of Columbia, Guam, or American Samoa), of any political subdivision thereof, or of any instrumentality of any one or more of the foregoing which is wholly owned thereby, by an individual who is not a member of a retirement system of such State, political subdivision, or instrumentality"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that the provisions of this subparagraph shall not be applicable to service performed— (i) by an individual who is employed to relieve such individual from unemployment; (ii) in a hospital, home, or other institution by a patient or inmate thereof; (iii) by any individual as an employee serving on a temporary basis in case of fire, storm, snow, earthquake, flood, or other similar emergency; (iv) by an election official or election worker if the remuneration paid in a calendar year for such service is less than $1,000 ... and the adjusted amount determined under section 218(c)(8)(B) ...; or (v) by an employee in a position compensated solely on a fee basis which is treated pursuant to section 1402(c)(2)(E) as a trade or business for purposes of inclusion of such fees in net earnings from self-employment"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_state_other_than_district_of_columbia_guam_or_american_samoa_or_subdivision_or_wholly_owned_instrumentality
+          and individual_not_member_of_retirement_system_of_state_subdivision_or_instrumentality
+          and not individual_employed_to_relieve_individual_from_unemployment
+          and not service_in_hospital_home_or_other_institution_by_patient_or_inmate
+          and not service_by_temporary_emergency_employee_for_fire_storm_snow_earthquake_flood_or_similar_emergency
+          and not election_official_or_worker_service_with_remuneration_less_than_applicable_threshold
+          and not employee_position_compensated_solely_on_fee_basis_treated_as_trade_or_business_for_net_earnings_from_self_employment
+
+  - name: state_or_local_government_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of a State, or any political subdivision thereof, or any instrumentality of any one or more of the foregoing which is wholly owned thereby"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that this paragraph shall not apply in the case of— (A) service which, under subsection (j), constitutes covered transportation service"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/7#guam_american_samoa_officer_employee_service_exception_to_state_employment_exclusion
+              output: guam_american_samoa_officer_employee_service_exception_to_state_employment_exclusion
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/7#district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion
+              output: district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/7#guam_temporary_or_intermitent_non_guam_retirement_service_exception_to_state_employment_exclusion
+              output: guam_temporary_or_intermitent_non_guam_retirement_service_exception_to_state_employment_exclusion
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(E) service included under an agreement entered into pursuant to section 218 of the Social Security Act"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/7#other_state_non_retirement_member_service_exception_to_state_employment_exclusion
+              output: other_state_non_retirement_member_service_exception_to_state_employment_exclusion
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state_or_political_subdivision_or_wholly_owned_instrumentality
+          and not service_constitutes_covered_transportation_service_under_subsection_j
+          and not guam_american_samoa_officer_employee_service_exception_to_state_employment_exclusion
+          and not district_of_columbia_non_federal_retirement_service_exception_to_state_employment_exclusion
+          and not guam_temporary_or_intermitent_non_guam_retirement_service_exception_to_state_employment_exclusion
+          and not service_included_under_agreement_entered_into_pursuant_to_section_218_of_social_security_act
+          and not other_state_non_retirement_member_service_exception_to_state_employment_exclusion


### PR DESCRIPTION
Generated by signed axiom-encode apply for 26 USC 3121(b)(7) using gpt-5.5 and encoder 0.2.175.\n\nLocal checks:\n- axiom-encode validate statutes/26/3121/b/7.yaml --skip-reviewers --json\n- axiom-encode test statutes/26/3121/b/7.test.yaml --root /private/tmp/rulespec-us-3121-b-7-v8-20260524 --json\n- axiom-encode proof-validate statutes/26/3121/b/7.yaml\n- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-7-v8-20260524 --base-ref origin/main --json\n- axiom-encode oracle-coverage --oracle policyengine --program tax: 225 comparable / 616 known_not_comparable / 3 unmapped\n\nNo hand edits to generated RuleSpec artifacts.