### PR TITLE
Add generated 3121(b)(8) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/8.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/8.yaml",
+      "sha256": "436867089b46a894287c1cc7509f36abf7e80d4d93f5e32cb0a31738f730710c"
+    },
+    {
+      "path": "statutes/26/3121/b/8.test.yaml",
+      "sha256": "97647e5b254a05dc28a7638168c1aca5e5968c875930a8be45c7e3d5049f5f94"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b9b940a055222e3d8a487d703753a949953b4dd3",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.176",
+    "version_commit": "b9b940a055222e3d8a487d703753a949953b4dd3"
+  },
+  "axiom_encode_version": "0.2.176",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(8)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-8-v2-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "e68cca8ce671b11957de5b881993af30393a928ee7ef4124b9193d00a83d86c7",
+  "generated_at": "2026-05-25T00:20:49.155134+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-8-v2-20260524/openai-gpt-5.5/statutes/26/3121/b/8.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-8-v2-20260524",
+  "generated_output_sha256": "436867089b46a894287c1cc7509f36abf7e80d4d93f5e32cb0a31738f730710c",
+  "generation_prompt_sha256": "78f1c986a357b111be22ad80a8a5208be60d483a070ee84d9875c8bbc414cf83",
+  "model": "gpt-5.5",
+  "run_id": "1dd5f836",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ffb4573f9e2df51e38c6a226aafc558ae3451545a56b653350ec91294876e3c6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-8-v2-20260524/traces/openai-gpt-5.5/26-USC-3121-b-8.json",
+  "trace_sha256": "bd30b1dd8f54a94da7d6ed0449b0e3e73b49a83cd4230389175f4e199275eb2c"
+}

--- a/statutes/26/3121/b/8.test.yaml
+++ b/statutes/26/3121/b/8.test.yaml
@@ -1,0 +1,88 @@
+- name: minister_service_excluded_and_not_blocked_by_religious_order_elections
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/8#input.service_performed_by_duly_ordained_commissioned_or_licensed_minister_of_church_in_exercise_of_ministry
+      : true
+      us:statutes/26/3121/b/8#input.service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order: false
+      us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_order: true
+      ? us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision_to_which_member_belongs
+      : true
+      us:statutes/26/3121/b/8#input.service_performed_in_employ_of_church_or_qualified_church_controlled_organization: true
+      us:statutes/26/3121/b/8#input.church_or_organization_has_election_under_subsection_w_in_effect: true
+      us:statutes/26/3121/b/8#input.service_in_unrelated_trade_or_business_within_meaning_of_section_513_a: false
+  output:
+    us:statutes/26/3121/b/8#minister_or_religious_order_service_excluded_from_employment:
+    - holds
+    us:statutes/26/3121/b/8#church_election_service_excluded_from_employment:
+    - holds
+- name: religious_order_member_service_excluded_when_no_subsection_r_election_and_unrelated_trade_blocks_church_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/8#input.service_performed_by_duly_ordained_commissioned_or_licensed_minister_of_church_in_exercise_of_ministry
+      : false
+      us:statutes/26/3121/b/8#input.service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order: true
+      us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_order: false
+      ? us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision_to_which_member_belongs
+      : false
+      us:statutes/26/3121/b/8#input.service_performed_in_employ_of_church_or_qualified_church_controlled_organization: true
+      us:statutes/26/3121/b/8#input.church_or_organization_has_election_under_subsection_w_in_effect: true
+      us:statutes/26/3121/b/8#input.service_in_unrelated_trade_or_business_within_meaning_of_section_513_a: true
+  output:
+    us:statutes/26/3121/b/8#minister_or_religious_order_service_excluded_from_employment:
+    - holds
+    us:statutes/26/3121/b/8#church_election_service_excluded_from_employment:
+    - not_holds
+- name: subsection_r_order_election_blocks_religious_order_member_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/8#input.service_performed_by_duly_ordained_commissioned_or_licensed_minister_of_church_in_exercise_of_ministry
+      : false
+      us:statutes/26/3121/b/8#input.service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order: true
+      us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_order: true
+      ? us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision_to_which_member_belongs
+      : false
+      us:statutes/26/3121/b/8#input.service_performed_in_employ_of_church_or_qualified_church_controlled_organization: false
+      us:statutes/26/3121/b/8#input.church_or_organization_has_election_under_subsection_w_in_effect: true
+      us:statutes/26/3121/b/8#input.service_in_unrelated_trade_or_business_within_meaning_of_section_513_a: false
+  output:
+    us:statutes/26/3121/b/8#minister_or_religious_order_service_excluded_from_employment:
+    - not_holds
+    us:statutes/26/3121/b/8#church_election_service_excluded_from_employment:
+    - not_holds
+- name: subsection_r_autonomous_subdivision_election_blocks_religious_order_member_branch_and_no_subsection_w_election_blocks_church_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/b/8#input.service_performed_by_duly_ordained_commissioned_or_licensed_minister_of_church_in_exercise_of_ministry
+      : false
+      us:statutes/26/3121/b/8#input.service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order: true
+      us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_order: false
+      ? us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision_to_which_member_belongs
+      : true
+      us:statutes/26/3121/b/8#input.service_performed_in_employ_of_church_or_qualified_church_controlled_organization: true
+      us:statutes/26/3121/b/8#input.church_or_organization_has_election_under_subsection_w_in_effect: false
+      us:statutes/26/3121/b/8#input.service_in_unrelated_trade_or_business_within_meaning_of_section_513_a: false
+  output:
+    us:statutes/26/3121/b/8#minister_or_religious_order_service_excluded_from_employment:
+    - not_holds
+    us:statutes/26/3121/b/8#church_election_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/8.yaml
+++ b/statutes/26/3121/b/8.yaml
@@ -1,0 +1,78 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (8) (A) service performed by a duly ordained, commissioned, or licensed minister of a church in the exercise of his ministry or by a member of a religious order in the exercise of duties required by such order, except that this subparagraph shall not apply to service performed by a member of such an order in the exercise of such duties, if an election of coverage under subsection (r) is in effect with respect to such order, or with respect to the autonomous subdivision thereof to which such member belongs; (B) service performed in the employ of a church or qualified church-controlled organization if such church or organization has in effect an election under subsection (w), other than service in an unrelated trade or business (within the meaning of section 513(a));
+rules:
+  - name: minister_or_religious_order_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(8)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by a duly ordained, commissioned, or licensed minister of a church in the exercise of his ministry"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or by a member of a religious order in the exercise of duties required by such order"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "except that this subparagraph shall not apply to service performed by a member of such an order in the exercise of such duties, if an election of coverage under subsection (r) is in effect with respect to such order"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or with respect to the autonomous subdivision thereof to which such member belongs"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_duly_ordained_commissioned_or_licensed_minister_of_church_in_exercise_of_ministry
+          or (
+            service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order
+            and not election_of_coverage_under_subsection_r_in_effect_with_respect_to_order
+            and not election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision_to_which_member_belongs
+          )
+
+  - name: church_election_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(8)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of a church or qualified church-controlled organization"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if such church or organization has in effect an election under subsection (w)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than service in an unrelated trade or business (within the meaning of section 513(a))"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_church_or_qualified_church_controlled_organization
+          and church_or_organization_has_election_under_subsection_w_in_effect
+          and not service_in_unrelated_trade_or_business_within_meaning_of_section_513_a


### PR DESCRIPTION
## Summary

- Add signed generated RuleSpec for 26 USC 3121(b)(8).
- Encode minister/religious-order service and church/QCCO election service exclusions.
- Keep the 513(a) unrelated-trade-or-business carve-out as a source-stated boundary predicate rather than deferring the branch.

## Provenance

Generated by `axiom-encode` 0.2.176 from merged encoder PR #187 using `openai:gpt-5.5` with signed apply.

## Checks

- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-8-v2-20260524/statutes/26/3121/b/8.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-8-v2-20260524/statutes/26/3121/b/8.test.yaml --root /private/tmp/rulespec-us-3121-b-8-v2-20260524 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-8-v2-20260524/statutes/26/3121/b/8.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-8-v2-20260524 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <temp copy containing rulespec-us/> --oracle policyengine --program tax --json`