### PR TITLE
Add generated 3121(b)(9) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/9.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/9.yaml",
+      "sha256": "e3927d932b47f951c70774dd7d06ca64311f1de12102820c50a0b46301754ddc"
+    },
+    {
+      "path": "statutes/26/3121/b/9.test.yaml",
+      "sha256": "6949e8f56827db24d44317ecdf39193061fce02c258b528ce376370e6a577447"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b9b940a055222e3d8a487d703753a949953b4dd3",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.176",
+    "version_commit": "b9b940a055222e3d8a487d703753a949953b4dd3"
+  },
+  "axiom_encode_version": "0.2.176",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(9)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-9-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "24a40a8bca5334038ceedfa0139fbc104f135f1188acba36586007fc95d99f3b",
+  "generated_at": "2026-05-25T00:26:02.931319+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-9-20260524/openai-gpt-5.5/statutes/26/3121/b/9.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-9-20260524",
+  "generated_output_sha256": "e3927d932b47f951c70774dd7d06ca64311f1de12102820c50a0b46301754ddc",
+  "generation_prompt_sha256": "f3364f4fd8db6239b73f07c0bf072c5fd26e565b8d446efef264cff17707d152",
+  "model": "gpt-5.5",
+  "run_id": "a53ada0c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "319141a01f3af55c96e17786a3ca68734f46219c5efb4934baa88222b62ffa9a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-9-20260524/traces/openai-gpt-5.5/26-USC-3121-b-9.json",
+  "trace_sha256": "c72b3ffc707dfcf35e76d5fe6283147474e2ef68e57fdfd8204f9e8ff8a024d0"
+}

--- a/statutes/26/3121/b/9.test.yaml
+++ b/statutes/26/3121/b/9.test.yaml
@@ -1,0 +1,39 @@
+- name: employee_under_section_3231_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_under_section_3231: true
+      us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_representative_under_section_3231: false
+  output:
+    us:statutes/26/3121/b/9#employee_or_employee_representative_service_excluded_from_employment:
+    - holds
+- name: employee_representative_under_section_3231_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_under_section_3231: false
+      us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_representative_under_section_3231: true
+  output:
+    us:statutes/26/3121/b/9#employee_or_employee_representative_service_excluded_from_employment:
+    - holds
+- name: service_not_by_employee_or_employee_representative_under_section_3231_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_under_section_3231: false
+      us:statutes/26/3121/b/9#input.service_performed_by_individual_as_employee_representative_under_section_3231: false
+  output:
+    us:statutes/26/3121/b/9#employee_or_employee_representative_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/9.yaml
+++ b/statutes/26/3121/b/9.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (9) service performed by an individual as an employee or employee representative as defined in section 3231;
+rules:
+  - name: employee_or_employee_representative_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual as an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "or employee representative as defined in section 3231"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_individual_as_employee_under_section_3231
+          or service_performed_by_individual_as_employee_representative_under_section_3231


### PR DESCRIPTION
## Summary

- Add signed generated RuleSpec for 26 USC 3121(b)(9).
- Encode the railroad employee / employee-representative service exclusion as a Payment-level employment exclusion.
- Keep section 3231 status as source-stated boundary predicates.

## Provenance

Generated by `axiom-encode` 0.2.176 from current encoder main using `openai:gpt-5.5` with signed apply.

## Checks

- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-9-20260524/statutes/26/3121/b/9.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-9-20260524/statutes/26/3121/b/9.test.yaml --root /private/tmp/rulespec-us-3121-b-9-20260524 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-9-20260524/statutes/26/3121/b/9.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-9-20260524 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <temp copy containing rulespec-us/> --oracle policyengine --program tax --json`

PE coverage summary after this output: `225 comparable / 619 known_not_comparable / 3 unmapped`, with `0` untested comparable outputs.