### PR TITLE
Add generated 3121(b)(10) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/10.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/10.yaml",
+      "sha256": "e494aacf077618d703c49aa8c4598045149ed908f14a9dc3d9099cf42a1a758a"
+    },
+    {
+      "path": "statutes/26/3121/b/10.test.yaml",
+      "sha256": "f723e6e63fca7a12cd2c12431f718016495052f62b332dbe4d6e5d81eddf3054"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.178",
+    "version_commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c"
+  },
+  "axiom_encode_version": "0.2.178",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(10)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-10-v3-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "36e20d6445163c6ba064880069cc2c1c5e939a7cbaf6b8d26d95c4d294b21635",
+  "generated_at": "2026-05-25T00:49:56.747622+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-10-v3-20260525/openai-gpt-5.5/statutes/26/3121/b/10.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-10-v3-20260525",
+  "generated_output_sha256": "e494aacf077618d703c49aa8c4598045149ed908f14a9dc3d9099cf42a1a758a",
+  "generation_prompt_sha256": "4aa75bb867e61fe0284a3868dba7be75bb46c706fd30f7e5ce69da7c4bde3722",
+  "model": "gpt-5.5",
+  "run_id": "1f14b862",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8af0013c4976fbd1706fcb8026ee10b3475178f96e3d16ed8facebbcb18c73cd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-10-v3-20260525/traces/openai-gpt-5.5/26-USC-3121-b-10.json",
+  "trace_sha256": "7c2414f86ba4bde9cfa7aab063f722b8f1de84a1cdbba0231537b45ded724496"
+}

--- a/statutes/26/3121/b/10.test.yaml
+++ b/statutes/26/3121/b/10.test.yaml
@@ -1,0 +1,84 @@
+- name: qualifying_student_service_in_employ_of_school_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/10#input.service_performed_in_employ_of_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.service_performed_in_employ_of_organization_described_in_section_509_a_3: false
+      ? us:statutes/26/3121/b/10#input.organization_organized_and_operated_exclusively_for_benefit_functions_or_purposes_of_school_college_or_university
+      : false
+      ? us:statutes/26/3121/b/10#input.organization_operated_supervised_or_controlled_by_or_in_connection_with_school_college_or_university
+      : false
+      us:statutes/26/3121/b/10#input.student_enrolled_and_regularly_attending_classes_at_such_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.employer_is_state_or_political_subdivision_school_college_or_university: false
+      ? us:statutes/26/3121/b/10#input.services_performed_by_student_referred_to_in_section_218_c_5_of_social_security_act_are_covered_under_section_218_agreement
+      : false
+  output:
+    us:statutes/26/3121/b/10#student_service_for_school_or_supporting_organization_excluded_from_employment:
+    - holds
+- name: qualifying_student_service_in_employ_of_section_509_supporting_organization_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/10#input.service_performed_in_employ_of_school_college_or_university: false
+      us:statutes/26/3121/b/10#input.service_performed_in_employ_of_organization_described_in_section_509_a_3: true
+      ? us:statutes/26/3121/b/10#input.organization_organized_and_operated_exclusively_for_benefit_functions_or_purposes_of_school_college_or_university
+      : true
+      ? us:statutes/26/3121/b/10#input.organization_operated_supervised_or_controlled_by_or_in_connection_with_school_college_or_university
+      : true
+      us:statutes/26/3121/b/10#input.student_enrolled_and_regularly_attending_classes_at_such_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.employer_is_state_or_political_subdivision_school_college_or_university: false
+      ? us:statutes/26/3121/b/10#input.services_performed_by_student_referred_to_in_section_218_c_5_of_social_security_act_are_covered_under_section_218_agreement
+      : false
+  output:
+    us:statutes/26/3121/b/10#student_service_for_school_or_supporting_organization_excluded_from_employment:
+    - holds
+- name: section_218_state_school_covered_student_service_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/10#input.service_performed_in_employ_of_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.service_performed_in_employ_of_organization_described_in_section_509_a_3: false
+      ? us:statutes/26/3121/b/10#input.organization_organized_and_operated_exclusively_for_benefit_functions_or_purposes_of_school_college_or_university
+      : false
+      ? us:statutes/26/3121/b/10#input.organization_operated_supervised_or_controlled_by_or_in_connection_with_school_college_or_university
+      : false
+      us:statutes/26/3121/b/10#input.student_enrolled_and_regularly_attending_classes_at_such_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.employer_is_state_or_political_subdivision_school_college_or_university: true
+      ? us:statutes/26/3121/b/10#input.services_performed_by_student_referred_to_in_section_218_c_5_of_social_security_act_are_covered_under_section_218_agreement
+      : true
+  output:
+    us:statutes/26/3121/b/10#student_service_for_school_or_supporting_organization_excluded_from_employment:
+    - not_holds
+- name: service_not_by_enrolled_regularly_attending_student_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/10#input.service_performed_in_employ_of_school_college_or_university: true
+      us:statutes/26/3121/b/10#input.service_performed_in_employ_of_organization_described_in_section_509_a_3: false
+      ? us:statutes/26/3121/b/10#input.organization_organized_and_operated_exclusively_for_benefit_functions_or_purposes_of_school_college_or_university
+      : false
+      ? us:statutes/26/3121/b/10#input.organization_operated_supervised_or_controlled_by_or_in_connection_with_school_college_or_university
+      : false
+      us:statutes/26/3121/b/10#input.student_enrolled_and_regularly_attending_classes_at_such_school_college_or_university: false
+      us:statutes/26/3121/b/10#input.employer_is_state_or_political_subdivision_school_college_or_university: false
+      ? us:statutes/26/3121/b/10#input.services_performed_by_student_referred_to_in_section_218_c_5_of_social_security_act_are_covered_under_section_218_agreement
+      : false
+  output:
+    us:statutes/26/3121/b/10#student_service_for_school_or_supporting_organization_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/10.yaml
+++ b/statutes/26/3121/b/10.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (10) service performed in the employ of— (A) a school, college, or university, or (B) an organization described in section 509(a)(3) if the organization is organized, and at all times thereafter is operated, exclusively for the benefit of, to perform the functions of, or to carry out the purposes of a school, college, or university and is operated, supervised, or controlled by or in connection with such school, college, or university, unless it is a school, college, or university of a State or a political subdivision thereof and the services performed in its employ by a student referred to in section 218(c)(5) of the Social Security Act are covered under the agreement between the Commissioner of Social Security and such State entered into pursuant to section 218 of such Act; if such service is performed by a student who is enrolled and regularly attending classes at such school, college, or university;
+rules:
+  - name: student_service_for_school_or_supporting_organization_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of— (A) a school, college, or university"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "(B) an organization described in section 509(a)(3)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the organization is organized, and at all times thereafter is operated, exclusively for the benefit of, to perform the functions of, or to carry out the purposes of a school, college, or university"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "and is operated, supervised, or controlled by or in connection with such school, college, or university"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "unless it is a school, college, or university of a State or a political subdivision thereof and the services performed in its employ by a student referred to in section 218(c)(5) of the Social Security Act are covered under the agreement between the Commissioner of Social Security and such State entered into pursuant to section 218 of such Act"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if such service is performed by a student who is enrolled and regularly attending classes at such school, college, or university"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            service_performed_in_employ_of_school_college_or_university
+            or (
+              service_performed_in_employ_of_organization_described_in_section_509_a_3
+              and organization_organized_and_operated_exclusively_for_benefit_functions_or_purposes_of_school_college_or_university
+              and organization_operated_supervised_or_controlled_by_or_in_connection_with_school_college_or_university
+            )
+          )
+          and student_enrolled_and_regularly_attending_classes_at_such_school_college_or_university
+          and not (
+            employer_is_state_or_political_subdivision_school_college_or_university
+            and services_performed_by_student_referred_to_in_section_218_c_5_of_social_security_act_are_covered_under_section_218_agreement
+          )


### PR DESCRIPTION
## Summary

- Add signed generated RuleSpec for 26 USC 3121(b)(10).
- Encode student service in the employ of schools and section-described supporting organizations as one Payment-level employment exclusion.
- Keep the Social Security Act section 218 covered-state-school carve-out as a source-stated boundary exception.

## Provenance

Generated by `axiom-encode` 0.2.178 from current encoder main using `openai:gpt-5.5` with signed apply. Encoder PR #189 was needed so the section 509(a)(3) supporting-organization branch stayed executable instead of deferred.

## Checks

- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-10-v3-20260525/statutes/26/3121/b/10.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-10-v3-20260525/statutes/26/3121/b/10.test.yaml --root /private/tmp/rulespec-us-3121-b-10-v3-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-10-v3-20260525/statutes/26/3121/b/10.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-10-v3-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <temp copy containing rulespec-us/> --oracle policyengine --program tax --json`

PE coverage summary after this output: `225 comparable / 620 known_not_comparable / 3 unmapped`, with `0` untested comparable outputs.