### PR TITLE
Add generated 3121(b)(11) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/11.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/11.yaml",
+      "sha256": "23d73c08527d8107bea47e13b7615d7aae330520a507f08019f651c284c6586b"
+    },
+    {
+      "path": "statutes/26/3121/b/11.test.yaml",
+      "sha256": "a9b0374e86a19f7baca57847b570831dd2bad70e8e5374b315fbb35544b43c4a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.178",
+    "version_commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c"
+  },
+  "axiom_encode_version": "0.2.178",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(11)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-11-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "1e82817acad84be2f52d6ae489e6b9a842dea151c356de0f09b136362854f1e7",
+  "generated_at": "2026-05-25T00:54:20.455083+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-11-20260525/openai-gpt-5.5/statutes/26/3121/b/11.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-11-20260525",
+  "generated_output_sha256": "23d73c08527d8107bea47e13b7615d7aae330520a507f08019f651c284c6586b",
+  "generation_prompt_sha256": "cf8439f12e7b42011d2aa6006719d8a2b3c55ba6970f71f045f3af50a8b9ec67",
+  "model": "gpt-5.5",
+  "run_id": "7b71c406",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7d190566bf4347b0498d81cf5cd9583c4471469aed32c0318a1cf8723dace9e9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-11-20260525/traces/openai-gpt-5.5/26-USC-3121-b-11.json",
+  "trace_sha256": "c8b48cf3d4021297cf851cbe250cc549692a02f31b04451f7f17c17b075e4c98"
+}

--- a/statutes/26/3121/b/11.test.yaml
+++ b/statutes/26/3121/b/11.test.yaml
@@ -1,0 +1,24 @@
+- name: service_in_employ_of_foreign_government_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/11#input.service_performed_in_employ_of_foreign_government: true
+  output:
+    us:statutes/26/3121/b/11#foreign_government_employment_service_excluded_from_employment:
+    - holds
+- name: service_not_in_employ_of_foreign_government_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/11#input.service_performed_in_employ_of_foreign_government: false
+  output:
+    us:statutes/26/3121/b/11#foreign_government_employment_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/11.yaml
+++ b/statutes/26/3121/b/11.yaml
@@ -1,0 +1,32 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (11) service performed in the employ of a foreign government (including service as a consular or other officer or employee or a nondiplomatic representative);
+rules:
+  - name: foreign_government_employment_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of a foreign government"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "including service as a consular or other officer or employee or a nondiplomatic representative"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_foreign_government


### PR DESCRIPTION
## Summary

- Add signed generated RuleSpec for 26 USC 3121(b)(11).
- Encode the foreign-government employment service exclusion as a Payment-level employment exclusion.

## Provenance

Generated by `axiom-encode` 0.2.178 from current encoder main using `openai:gpt-5.5` with signed apply.

## Checks

- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-11-20260525/statutes/26/3121/b/11.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-11-20260525/statutes/26/3121/b/11.test.yaml --root /private/tmp/rulespec-us-3121-b-11-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-11-20260525/statutes/26/3121/b/11.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-11-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <temp copy containing rulespec-us/> --oracle policyengine --program tax --json`

PE coverage summary after this output: `225 comparable / 621 known_not_comparable / 3 unmapped`, with `0` untested comparable outputs.