### PR TITLE
Add generated 3121(b)(12) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/12.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/12.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/12.yaml",
+      "sha256": "b118e9148b4245cdfc1c97d2bc915c9bf73c9de914f756dcacc5ce58cb17ae56"
+    },
+    {
+      "path": "statutes/26/3121/b/12.test.yaml",
+      "sha256": "8693a22ee0fe4edec087b94c67c3b401ec3113f6e3011ef78d35c4f56257d530"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.178",
+    "version_commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c"
+  },
+  "axiom_encode_version": "0.2.178",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(12)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-12-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "e5a0b6ccf2236374250b388a100775b2098300a77ad777e52607b9dd76b81572",
+  "generated_at": "2026-05-25T00:59:29.463604+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-12-20260525/openai-gpt-5.5/statutes/26/3121/b/12.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-12-20260525",
+  "generated_output_sha256": "b118e9148b4245cdfc1c97d2bc915c9bf73c9de914f756dcacc5ce58cb17ae56",
+  "generation_prompt_sha256": "8b0b54767645c09a0b2df3d4575bb2fa92755426f802304e0c91b509b6edcb5c",
+  "model": "gpt-5.5",
+  "run_id": "6a9d5f6f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4968069837c5411d64421a32b052c16f31f473dff98d103e703813eebec14f4f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-12-20260525/traces/openai-gpt-5.5/26-USC-3121-b-12.json",
+  "trace_sha256": "73e184772ebd8e2730ec3f02b728a40b0a6c8a63c6164e9b8ed31f312fa33c11"
+}

--- a/statutes/26/3121/b/12.test.yaml
+++ b/statutes/26/3121/b/12.test.yaml
@@ -1,0 +1,64 @@
+- name: qualifying_foreign_government_instrumentality_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+      ? us:statutes/26/3121/b/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+      : true
+      ? us:statutes/26/3121/b/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+      : true
+  output:
+    us:statutes/26/3121/b/12#foreign_government_instrumentality_service_excluded_from_employment:
+    - holds
+- name: service_not_in_employ_of_wholly_owned_foreign_government_instrumentality_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: false
+      ? us:statutes/26/3121/b/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+      : true
+      ? us:statutes/26/3121/b/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+      : true
+  output:
+    us:statutes/26/3121/b/12#foreign_government_instrumentality_service_excluded_from_employment:
+    - not_holds
+- name: service_not_of_similar_character_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+      ? us:statutes/26/3121/b/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+      : false
+      ? us:statutes/26/3121/b/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+      : true
+  output:
+    us:statutes/26/3121/b/12#foreign_government_instrumentality_service_excluded_from_employment:
+    - not_holds
+- name: secretary_of_state_does_not_certify_equivalent_exemption_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+      ? us:statutes/26/3121/b/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+      : true
+      ? us:statutes/26/3121/b/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+      : false
+  output:
+    us:statutes/26/3121/b/12#foreign_government_instrumentality_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/12.yaml
+++ b/statutes/26/3121/b/12.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (12) service performed in the employ of an instrumentality wholly owned by a foreign government— (A) if the service is of a character similar to that performed in foreign countries by employees of the United States Government or of an instrumentality thereof; and (B) if the Secretary of State shall certify to the Secretary of the Treasury that the foreign government, with respect to whose instrumentality and employees thereof exemption is claimed, grants an equivalent exemption with respect to similar service performed in the foreign country by employees of the United States Government and of instrumentalities thereof;
+rules:
+  - name: foreign_government_instrumentality_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in the employ of an instrumentality wholly owned by a foreign government"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the service is of a character similar to that performed in foreign countries by employees of the United States Government or of an instrumentality thereof"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if the Secretary of State shall certify to the Secretary of the Treasury that the foreign government, with respect to whose instrumentality and employees thereof exemption is claimed, grants an equivalent exemption with respect to similar service performed in the foreign country by employees of the United States Government and of instrumentalities thereof"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government
+          and service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+          and secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees


### PR DESCRIPTION
## Summary

- Add signed generated RuleSpec for 26 USC 3121(b)(12).
- Encode the foreign-government-instrumentality employment service exclusion with source-stated similarity and reciprocal-exemption certification conditions.

## Provenance

Generated by `axiom-encode` 0.2.178 from current encoder main using `openai:gpt-5.5` with signed apply.

## Checks

- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-12-20260525/statutes/26/3121/b/12.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-12-20260525/statutes/26/3121/b/12.test.yaml --root /private/tmp/rulespec-us-3121-b-12-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-12-20260525/statutes/26/3121/b/12.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-12-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <temp copy containing rulespec-us/> --oracle policyengine --program tax --json`

PE coverage summary after this output: `225 comparable / 622 known_not_comparable / 3 unmapped`, with `0` untested comparable outputs.