### PR TITLE
Add generated 3121(b)(13) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/13.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/13.yaml",
+      "sha256": "a791ff439b24e483f59ea43e2876c84ca327e164a3f6f92b59150309e270cefc"
+    },
+    {
+      "path": "statutes/26/3121/b/13.test.yaml",
+      "sha256": "f1b6f165dee8392adfec8f212491f2d3eaa3a9bd396cd9a4f3831df799a8cd16"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.178",
+    "version_commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c"
+  },
+  "axiom_encode_version": "0.2.178",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(13)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-13-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "96b1b2d275718bacdca5dae1966ee0c1da7d9e49d6db97f93a8fa530c0f45568",
+  "generated_at": "2026-05-25T01:05:26.026564+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-13-20260525/openai-gpt-5.5/statutes/26/3121/b/13.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-13-20260525",
+  "generated_output_sha256": "a791ff439b24e483f59ea43e2876c84ca327e164a3f6f92b59150309e270cefc",
+  "generation_prompt_sha256": "ac7eaa8b36a898382bb607a9c72c2398a6596912c3942bcc474eea49be696741",
+  "model": "gpt-5.5",
+  "run_id": "9a104599",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "754689c4ec55758ae6de642d0645c9431777177f9bd493f1804d31fa848776fd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-13-20260525/traces/openai-gpt-5.5/26-USC-3121-b-13.json",
+  "trace_sha256": "cbebb5cdc2b35aeb11fc95c9406e7996040dd20496528146391b0b5fa39b338e"
+}

--- a/statutes/26/3121/b/13.test.yaml
+++ b/statutes/26/3121/b/13.test.yaml
@@ -1,0 +1,75 @@
+- name: qualifying_student_nurse_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/13#input.service_performed_as_student_nurse: true
+      us:statutes/26/3121/b/13#input.service_performed_in_employ_of_hospital_or_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.individual_enrolled_and_regularly_attending_classes_in_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3121/b/13#student_nurse_service_excluded_from_employment:
+    - holds
+- name: service_not_as_student_nurse_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/13#input.service_performed_as_student_nurse: false
+      us:statutes/26/3121/b/13#input.service_performed_in_employ_of_hospital_or_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.individual_enrolled_and_regularly_attending_classes_in_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3121/b/13#student_nurse_service_excluded_from_employment:
+    - not_holds
+- name: service_not_in_employ_of_hospital_or_nurses_training_school_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/13#input.service_performed_as_student_nurse: true
+      us:statutes/26/3121/b/13#input.service_performed_in_employ_of_hospital_or_nurses_training_school: false
+      us:statutes/26/3121/b/13#input.individual_enrolled_and_regularly_attending_classes_in_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3121/b/13#student_nurse_service_excluded_from_employment:
+    - not_holds
+- name: individual_not_enrolled_and_regularly_attending_nurses_training_school_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/13#input.service_performed_as_student_nurse: true
+      us:statutes/26/3121/b/13#input.service_performed_in_employ_of_hospital_or_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.individual_enrolled_and_regularly_attending_classes_in_nurses_training_school: false
+      us:statutes/26/3121/b/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3121/b/13#student_nurse_service_excluded_from_employment:
+    - not_holds
+- name: nurses_training_school_not_chartered_or_approved_under_state_law_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/13#input.service_performed_as_student_nurse: true
+      us:statutes/26/3121/b/13#input.service_performed_in_employ_of_hospital_or_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.individual_enrolled_and_regularly_attending_classes_in_nurses_training_school: true
+      us:statutes/26/3121/b/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: false
+  output:
+    us:statutes/26/3121/b/13#student_nurse_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/13.yaml
+++ b/statutes/26/3121/b/13.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (13) service performed as a student nurse in the employ of a hospital or a nurses’ training school by an individual who is enrolled and is regularly attending classes in a nurses’ training school chartered or approved pursuant to State law;
+rules:
+  - name: student_nurse_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed as a student nurse"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in the employ of a hospital or a nurses’ training school"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by an individual who is enrolled and is regularly attending classes in a nurses’ training school"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "nurses’ training school chartered or approved pursuant to State law"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_as_student_nurse
+          and service_performed_in_employ_of_hospital_or_nurses_training_school
+          and individual_enrolled_and_regularly_attending_classes_in_nurses_training_school
+          and nurses_training_school_chartered_or_approved_pursuant_to_state_law


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec for 26 USC 3121(b)(13), the student nurse employment exclusion.
- Includes generated tests and signed encoding manifest.
- Generated with axiom-encode 0.2.178 using openai:gpt-5.5.

## Validation
- `uv run axiom-encode validate statutes/26/3121/b/13.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/b/13.test.yaml --root /private/tmp/rulespec-us-3121-b-13-20260525 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/b/13.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-13-20260525 --base-ref origin/main --json`
- PE oracle coverage with this branch: 225 comparable / 623 known_not_comparable / 3 unmapped; 0 untested comparable.

## Notes
PolicyEngine does not expose section 3121(b) child-fragment service-classification predicates one-to-one, so this output is classified as known_not_comparable rather than a numeric PE comparison.