### PR TITLE
Add generated 3121(b)(14) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/14.yaml",
+      "sha256": "a3528ac80074ad1b4efb25baafe227d9806debe074df9f8219493d87b750a9bb"
+    },
+    {
+      "path": "statutes/26/3121/b/14.test.yaml",
+      "sha256": "23582b8c6985c57ed3ce1a649a5801b25311345194f030ac5ee87f81f17393f7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.178",
+    "version_commit": "fdee8a317714e3ac0bb259f347bc2f7a05c7687c"
+  },
+  "axiom_encode_version": "0.2.178",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(14)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-14-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "ad3b2bf559ca91f1d62a40e4bf08028261586c3ad7ce414ac3aacbb11a09948b",
+  "generated_at": "2026-05-25T01:11:58.357570+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-14-20260525/openai-gpt-5.5/statutes/26/3121/b/14.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-14-20260525",
+  "generated_output_sha256": "a3528ac80074ad1b4efb25baafe227d9806debe074df9f8219493d87b750a9bb",
+  "generation_prompt_sha256": "d74269785bfd7275d3778de905a5f86f53fc19b16347205b5476b116f5529c7c",
+  "model": "gpt-5.5",
+  "run_id": "6d411082",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "284e6a076d5524f8112770e83d086514b0482f135919a64029339d34c07c7bd7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-14-20260525/traces/openai-gpt-5.5/26-USC-3121-b-14.json",
+  "trace_sha256": "be7d71bb1a0b753f1cebf49826ac4dde373429fdee700c2f362ca4cea08ee95d"
+}

--- a/statutes/26/3121/b/14.test.yaml
+++ b/statutes/26/3121/b/14.test.yaml
@@ -1,0 +1,76 @@
+- name: under_age_newspaper_delivery_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/14#input.individual_under_age_18: true
+      us:statutes/26/3121/b/14#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: true
+      us:statutes/26/3121/b/14#input.delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution: false
+      us:statutes/26/3121/b/14#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines: false
+      us:statutes/26/3121/b/14#input.newspapers_or_magazines_sold_to_ultimate_consumers: false
+      us:statutes/26/3121/b/14#input.arrangement_newspapers_or_magazines_sold_by_individual_at_fixed_price: false
+      ? us:statutes/26/3121/b/14#input.individual_compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+      : false
+  output:
+    us:statutes/26/3121/b/14#newspaper_delivery_or_sales_service_excluded_from_employment:
+    - holds
+- name: subsequent_delivery_point_carveout_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/14#input.individual_under_age_18: true
+      us:statutes/26/3121/b/14#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: true
+      us:statutes/26/3121/b/14#input.delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution: true
+      us:statutes/26/3121/b/14#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines: false
+      us:statutes/26/3121/b/14#input.newspapers_or_magazines_sold_to_ultimate_consumers: false
+      us:statutes/26/3121/b/14#input.arrangement_newspapers_or_magazines_sold_by_individual_at_fixed_price: false
+      ? us:statutes/26/3121/b/14#input.individual_compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+      : false
+  output:
+    us:statutes/26/3121/b/14#newspaper_delivery_or_sales_service_excluded_from_employment:
+    - not_holds
+- name: qualifying_newspaper_or_magazine_sale_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/14#input.individual_under_age_18: false
+      us:statutes/26/3121/b/14#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: false
+      us:statutes/26/3121/b/14#input.delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution: false
+      us:statutes/26/3121/b/14#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines: true
+      us:statutes/26/3121/b/14#input.newspapers_or_magazines_sold_to_ultimate_consumers: true
+      us:statutes/26/3121/b/14#input.arrangement_newspapers_or_magazines_sold_by_individual_at_fixed_price: true
+      ? us:statutes/26/3121/b/14#input.individual_compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+      : true
+  output:
+    us:statutes/26/3121/b/14#newspaper_delivery_or_sales_service_excluded_from_employment:
+    - holds
+- name: sale_not_to_ultimate_consumers_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/14#input.individual_under_age_18: false
+      us:statutes/26/3121/b/14#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: false
+      us:statutes/26/3121/b/14#input.delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution: false
+      us:statutes/26/3121/b/14#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines: true
+      us:statutes/26/3121/b/14#input.newspapers_or_magazines_sold_to_ultimate_consumers: false
+      us:statutes/26/3121/b/14#input.arrangement_newspapers_or_magazines_sold_by_individual_at_fixed_price: true
+      ? us:statutes/26/3121/b/14#input.individual_compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+      : true
+  output:
+    us:statutes/26/3121/b/14#newspaper_delivery_or_sales_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/14.yaml
+++ b/statutes/26/3121/b/14.yaml
@@ -1,0 +1,67 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (14) (A) service performed by an individual under the age of 18 in the delivery or distribution of newspapers or shopping news, not including delivery or distribution to any point for subsequent delivery or distribution; (B) service performed by an individual in, and at the time of, the sale of newspapers or magazines to ultimate consumers, under an arrangement under which the newspapers or magazines are to be sold by him at a fixed price, his compensation being based on the retention of the excess of such price over the amount at which the newspapers or magazines are charged to him, whether or not he is guaranteed a minimum amount of compensation for such service, or is entitled to be credited with the unsold newspapers or magazines turned back;
+rules:
+  - name: newspaper_delivery_or_sales_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual under the age of 18"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "in the delivery or distribution of newspapers or shopping news"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "not including delivery or distribution to any point for subsequent delivery or distribution"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual in, and at the time of, the sale of newspapers or magazines to ultimate consumers"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under an arrangement under which the newspapers or magazines are to be sold by him at a fixed price"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "his compensation being based on the retention of the excess of such price over the amount at which the newspapers or magazines are charged to him"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "whether or not he is guaranteed a minimum amount of compensation for such service, or is entitled to be credited with the unsold newspapers or magazines turned back"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            individual_under_age_18
+            and service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news
+            and not delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+          )
+          or (
+            service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines
+            and newspapers_or_magazines_sold_to_ultimate_consumers
+            and arrangement_newspapers_or_magazines_sold_by_individual_at_fixed_price
+            and individual_compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+          )


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec for 26 USC 3121(b)(14), the newspaper delivery and newspaper/magazine sale employment exclusion.
- Includes generated tests and signed encoding manifest.
- Generated with axiom-encode 0.2.178 using openai:gpt-5.5.

## Validation
- `uv run axiom-encode validate statutes/26/3121/b/14.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/b/14.test.yaml --root /private/tmp/rulespec-us-3121-b-14-20260525 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/b/14.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-14-20260525 --base-ref origin/main --json`
- PE oracle coverage with this branch: 225 comparable / 624 known_not_comparable / 3 unmapped; 0 untested comparable.

## Notes
PolicyEngine does not expose section 3121(b) employment-definition child-fragment service-classification predicates as one-to-one variables, so this output is classified as known_not_comparable rather than a numeric PE comparison.