### PR TITLE
Add generated 3121(y) international organization employment rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/y.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/y.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/y.yaml",
+      "sha256": "6a75fb832688d9d8a6c78d2c9c88b7b8a75bc059893339cf7b8b127e14847e25"
+    },
+    {
+      "path": "statutes/26/3121/y.test.yaml",
+      "sha256": "7c0cf990aa1a5f5a4cc656c1288fb75ad5adb2dbd2a9dd1f1ffce1beec1da02a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "47b084ed0047b09f72d18ac81d403749c277a3ad",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.180",
+    "version_commit": "47b084ed0047b09f72d18ac81d403749c277a3ad"
+  },
+  "axiom_encode_version": "0.2.180",
+  "backend": "openai",
+  "citation": "26 USC 3121(y)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-y-v3-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-y/workspace/context-manifest.json",
+  "context_manifest_sha256": "d8060d879585be499c6fa499d9665890cd39a8003109836bc93495e3a1ae142a",
+  "generated_at": "2026-05-25T01:35:10.320972+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-y-v3-20260525/openai-gpt-5.5/statutes/26/3121/y.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-y-v3-20260525",
+  "generated_output_sha256": "6a75fb832688d9d8a6c78d2c9c88b7b8a75bc059893339cf7b8b127e14847e25",
+  "generation_prompt_sha256": "83f62d4b85015e6ce23db3397210cf1e1f298e9d7c96a7cf16a77c41775b9653",
+  "model": "gpt-5.5",
+  "run_id": "e239e8ca",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3ff4ad4001f64a915386b6ac03a87d2488696f1ae034f9ae070752c894a49d8a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-y-v3-20260525/traces/openai-gpt-5.5/26-USC-3121-y.json",
+  "trace_sha256": "7f6032235ccc0b096a47116fe56a798a4c14fed02dde3bc1c384558727f463d0"
+}

--- a/statutes/26/3121/y.test.yaml
+++ b/statutes/26/3121/y.test.yaml
@@ -1,0 +1,102 @@
+- name: qualifying_transferred_federal_employee_international_organization_service_constitutes_employment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: holds
+- name: service_not_in_employ_of_international_organization_does_not_constitute_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : false
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: not_holds
+- name: transfer_not_pursuant_to_section_3582_does_not_constitute_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: false
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: not_holds
+- name: no_immediately_prior_federal_agency_service_does_not_constitute_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : false
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: not_holds
+- name: prior_federal_agency_service_not_employment_for_oasdi_taxes_does_not_constitute_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : false
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: not_holds
+- name: no_reemployment_entitlement_after_separation_and_application_does_not_constitute_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : false
+  output:
+    us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment: not_holds

--- a/statutes/26/3121/y.yaml
+++ b/statutes/26/3121/y.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (y) Service in the employ of international organizations by certain transferred Federal employees (1) In general For purposes of this chapter, service performed in the employ of an international organization by an individual pursuant to a transfer of such individual to such international organization pursuant to section 3582 of title 5 , United States Code, shall constitute “employment” if— (A) immediately before such transfer, such individual performed service with a Federal agency which constituted “employment” under subsection (b) for purposes of the taxes imposed by sections 3101(a) and 3111(a), and (B) such individual would be entitled, upon separation from such international organization and proper application, to reemployment with such Federal agency under such section 3582. (2) Definitions For purposes of this subsection— (A) Federal agency The term “Federal agency” means an agency, as defined in section 3581(1) of title 5 , United States Code. (B) International organization The term “international organization” has the meaning provided such term by section 3581(3) of title 5 , United States Code.
+rules:
+  - name: transferred_federal_employee_international_organization_service_constitutes_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(y)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: service performed in the employ of an international organization by an individual
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: pursuant to a transfer of such individual to such international organization pursuant to section 3582 of title 5, United States Code
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: immediately before such transfer, such individual performed service with a Federal agency
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: which constituted “employment” under subsection (b) for purposes of the taxes imposed by sections 3101(a) and 3111(a)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: such individual would be entitled, upon separation from such international organization and proper application, to reemployment with such Federal agency under such section 3582
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term “Federal agency” means an agency, as defined in section 3581(1) of title 5, United States Code
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term “international organization” has the meaning provided such term by section 3581(3) of title 5, United States Code
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+          and transfer_to_international_organization_pursuant_to_section_3582_of_title_5
+          and immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+          and prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+          and individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec for 26 USC 3121(y), service in the employ of international organizations by certain transferred Federal employees.
- Includes generated tests and signed encoding manifest.
- Generated with axiom-encode 0.2.180 using openai:gpt-5.5.

## Validation
- `uv run axiom-encode validate statutes/26/3121/y.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/y.test.yaml --root /private/tmp/rulespec-us-3121-y-v2-20260525 --json`
- `uv run axiom-encode proof-validate statutes/26/3121/y.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-y-v2-20260525 --base-ref origin/main --json`
- PE oracle coverage with this branch: 225 comparable / 625 known_not_comparable / 3 unmapped; 0 untested comparable.

## Notes
This dependency is needed before regenerating 26 USC 3121(b)(15), whose exception turns on whether service constitutes employment under subsection (y).