### PR TITLE
Add generated 3121(b)(15) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/15.yaml",
+      "sha256": "3296ab35494ad96aa49867df958dd73fc30c4185cbf06a8498bf735ce408af2e"
+    },
+    {
+      "path": "statutes/26/3121/b/15.test.yaml",
+      "sha256": "9f8bf969fa9196f8a084e5cd47b60f448825c17f88a6975f5dda775c583d4b9f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(15)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-15-v4-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "3b2e90d8eb232b3930c8903db463408981ce106a7a8432b46a5fc91282fd616b",
+  "generated_at": "2026-05-25T02:03:48.432008+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-15-v4-20260525/openai-gpt-5.5/statutes/26/3121/b/15.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-15-v4-20260525",
+  "generated_output_sha256": "3296ab35494ad96aa49867df958dd73fc30c4185cbf06a8498bf735ce408af2e",
+  "generation_prompt_sha256": "6c7bd01e5e2e375501b9e13817cc3c211afbd346a296b588af8d15f46dca8e0c",
+  "model": "gpt-5.5",
+  "run_id": "ef961dcd",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7bbb41432c044dec38d21c81ad3f93f6969289a1875a29caa57309e7823ac59a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-15-v4-20260525/traces/openai-gpt-5.5/26-USC-3121-b-15.json",
+  "trace_sha256": "64fe69aacddf25f67b6facc6c8615fcdf1b9e5493abecb986bbe196533de2e8d"
+}

--- a/statutes/26/3121/b/15.test.yaml
+++ b/statutes/26/3121/b/15.test.yaml
@@ -1,0 +1,75 @@
+- name: international_organization_service_excluded_when_not_employment_under_subsection_y
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: false
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/15#input.service_performed_in_employ_of_international_organization: true
+      ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+      : true
+      us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: false
+  output:
+    us:statutes/26/3121/b/15#international_organization_service_excluded_from_employment:
+    - holds
+- name: service_not_in_employ_of_international_organization_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : false
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: false
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/15#input.service_performed_in_employ_of_international_organization: false
+  output:
+    us:statutes/26/3121/b/15#international_organization_service_excluded_from_employment:
+    - not_holds
+- name: international_organization_service_that_constitutes_employment_under_subsection_y_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+    : true
+    ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+    : true
+    ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+    : true
+    us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/15#input.service_performed_in_employ_of_international_organization: true
+      ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+      : true
+      us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+      ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+      : true
+      ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+      : true
+      ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+      : true
+  output:
+    us:statutes/26/3121/b/15#international_organization_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/15.yaml
+++ b/statutes/26/3121/b/15.yaml
@@ -1,0 +1,41 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (15) service performed in the employ of an international organization, except service which constitutes “employment” under subsection (y);
+rules:
+  - name: international_organization_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: service performed in the employ of an international organization
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: except service which constitutes “employment” under subsection (y)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment
+              output: transferred_federal_employee_international_organization_service_constitutes_employment
+              hash: sha256:6a75fb832688d9d8a6c78d2c9c88b7b8a75bc059893339cf7b8b127e14847e25
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization
+          and not transferred_federal_employee_international_organization_service_constitutes_employment


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(15)` international-organization service exclusion
- import generated `3121(y)` employment carveout and test both exclusion and carveout behavior
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-15-v4-20260525/statutes/26/3121/b/15.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-15-v4-20260525/statutes/26/3121/b/15.test.yaml --root /private/tmp/rulespec-us-3121-b-15-v4-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-15-v4-20260525/statutes/26/3121/b/15.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-15-v4-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `854` total tax outputs, `225` comparable, `626` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(15)` output is known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.