### PR TITLE
Add generated 3121(b)(16) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/16.yaml",
+      "sha256": "1ee6aa28ca6f539e8a4b613631fa1feb3883dbdce4b09d8816eee1441bdafcc2"
+    },
+    {
+      "path": "statutes/26/3121/b/16.test.yaml",
+      "sha256": "87a0f1c33334db31de2d255c676c9eb33c8964a0d528779dfae07149ffdc94d9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(16)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-16-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "00414d05c6b823b10923e948710af8a11bdb427a2f1c687c4a097903c449549f",
+  "generated_at": "2026-05-25T02:08:24.147340+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-16-20260525/openai-gpt-5.5/statutes/26/3121/b/16.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-16-20260525",
+  "generated_output_sha256": "1ee6aa28ca6f539e8a4b613631fa1feb3883dbdce4b09d8816eee1441bdafcc2",
+  "generation_prompt_sha256": "1af7d725da211b180e57bdff28912ea1268b21330f9682795468d928330cf0c9",
+  "model": "gpt-5.5",
+  "run_id": "012cba7f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2c97268709cab23004d7f584e8d7c9a4796530936b509e8a77c1874803ba2cd1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-16-20260525/traces/openai-gpt-5.5/26-USC-3121-b-16.json",
+  "trace_sha256": "c4dace3280f5592e15c70ac931498ae88cde04687774f69ea8a4638b89705ea1"
+}

--- a/statutes/26/3121/b/16.test.yaml
+++ b/statutes/26/3121/b/16.test.yaml
@@ -1,0 +1,75 @@
+- name: qualifying_agricultural_share_arrangement_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/16#input.service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land: true
+      us:statutes/26/3121/b/16#input.individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land: true
+      us:statutes/26/3121/b/16#input.commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant: true
+      us:statutes/26/3121/b/16#input.individual_share_depends_on_amount_of_commodities_produced: true
+  output:
+    us:statutes/26/3121/b/16#agricultural_commodity_share_arrangement_service_excluded_from_employment:
+    - holds
+- name: no_owner_or_tenant_land_arrangement_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/16#input.service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land: false
+      us:statutes/26/3121/b/16#input.individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land: true
+      us:statutes/26/3121/b/16#input.commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant: true
+      us:statutes/26/3121/b/16#input.individual_share_depends_on_amount_of_commodities_produced: true
+  output:
+    us:statutes/26/3121/b/16#agricultural_commodity_share_arrangement_service_excluded_from_employment:
+    - not_holds
+- name: individual_does_not_undertake_commodity_production_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/16#input.service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land: true
+      us:statutes/26/3121/b/16#input.individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land: false
+      us:statutes/26/3121/b/16#input.commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant: true
+      us:statutes/26/3121/b/16#input.individual_share_depends_on_amount_of_commodities_produced: true
+  output:
+    us:statutes/26/3121/b/16#agricultural_commodity_share_arrangement_service_excluded_from_employment:
+    - not_holds
+- name: commodities_or_proceeds_not_divided_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/16#input.service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land: true
+      us:statutes/26/3121/b/16#input.individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land: true
+      us:statutes/26/3121/b/16#input.commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant: false
+      us:statutes/26/3121/b/16#input.individual_share_depends_on_amount_of_commodities_produced: true
+  output:
+    us:statutes/26/3121/b/16#agricultural_commodity_share_arrangement_service_excluded_from_employment:
+    - not_holds
+- name: individual_share_not_dependent_on_amount_produced_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/16#input.service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land: true
+      us:statutes/26/3121/b/16#input.individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land: true
+      us:statutes/26/3121/b/16#input.commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant: true
+      us:statutes/26/3121/b/16#input.individual_share_depends_on_amount_of_commodities_produced: false
+  output:
+    us:statutes/26/3121/b/16#agricultural_commodity_share_arrangement_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/16.yaml
+++ b/statutes/26/3121/b/16.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (16) service performed by an individual under an arrangement with the owner or tenant of land pursuant to which— (A) such individual undertakes to produce agricultural or horticultural commodities (including livestock, bees, poultry, and fur-bearing animals and wildlife) on such land, (B) the agricultural or horticultural commodities produced by such individual, or the proceeds therefrom, are to be divided between such individual and such owner or tenant, and (C) the amount of such individual’s share depends on the amount of the agricultural or horticultural commodities produced;
+rules:
+  - name: agricultural_commodity_share_arrangement_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed by an individual under an arrangement with the owner or tenant of land"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "such individual undertakes to produce agricultural or horticultural commodities (including livestock, bees, poultry, and fur-bearing animals and wildlife) on such land"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the agricultural or horticultural commodities produced by such individual, or the proceeds therefrom, are to be divided between such individual and such owner or tenant"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the amount of such individual’s share depends on the amount of the agricultural or horticultural commodities produced"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_individual_under_arrangement_with_owner_or_tenant_of_land
+          and individual_undertakes_to_produce_agricultural_or_horticultural_commodities_on_such_land
+          and commodities_or_proceeds_are_to_be_divided_between_individual_and_owner_or_tenant
+          and individual_share_depends_on_amount_of_commodities_produced


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(16)` agricultural commodity share-arrangement service exclusion
- include generated tests for all four statutory conditions
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-16-20260525/statutes/26/3121/b/16.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-16-20260525/statutes/26/3121/b/16.test.yaml --root /private/tmp/rulespec-us-3121-b-16-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-16-20260525/statutes/26/3121/b/16.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-16-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `855` total tax outputs, `225` comparable, `627` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(16)` output is known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.