### PR TITLE
Add generated 3121(b)(18) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/18.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/18.yaml",
+      "sha256": "57dfa47042074c31911c3cfaf4588ce8b31bac152a476f17ba2dc4682ffd4672"
+    },
+    {
+      "path": "statutes/26/3121/b/18.test.yaml",
+      "sha256": "044e65ca1a582f99f2d4bc613b41cd571f11b712aab974c13a8fad8177d3837a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(18)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-18-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "d9d8ae2d830b34877cc9eef39839a2a98a3555a39ca19f8729df41f36a8c8ce0",
+  "generated_at": "2026-05-25T02:16:39.119792+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-18-20260525/openai-gpt-5.5/statutes/26/3121/b/18.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-18-20260525",
+  "generated_output_sha256": "57dfa47042074c31911c3cfaf4588ce8b31bac152a476f17ba2dc4682ffd4672",
+  "generation_prompt_sha256": "19e04b247205b95229fdc00c8d00b9c3aefe83a39fc6f6385a39f100c78cf4e5",
+  "model": "gpt-5.5",
+  "run_id": "2d2c5c13",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "02bc058757b08a46e6cfb84aa8be2b1f30ec939a80c95518d9b82f7d5d79d46a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-18-20260525/traces/openai-gpt-5.5/26-USC-3121-b-18.json",
+  "trace_sha256": "29a5611e7ec6f776006676585724d9d91ea8c63ecee653234259f2f9d3f1f23c"
+}

--- a/statutes/26/3121/b/18.test.yaml
+++ b/statutes/26/3121/b/18.test.yaml
@@ -1,0 +1,96 @@
+- name: qualifying_guam_philippines_temporary_nonimmigrant_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: true
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: true
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: true
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: true
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: true
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - holds
+- name: service_not_performed_in_guam_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: false
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: true
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: true
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: true
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: true
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_resident_of_republic_of_philippines_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: true
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: false
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: true
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: true
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: true
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_in_guam_on_temporary_basis_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: true
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: true
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: false
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: true
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: true
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_nonimmigrant_alien_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: true
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: true
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: true
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: false
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: true
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - not_holds
+- name: worker_not_admitted_to_guam_pursuant_to_h_ii_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/18#input.service_performed_in_guam: true
+      us:statutes/26/3121/b/18#input.worker_resident_of_republic_of_philippines: true
+      us:statutes/26/3121/b/18#input.worker_in_guam_on_temporary_basis: true
+      us:statutes/26/3121/b/18#input.worker_is_nonimmigrant_alien: true
+      us:statutes/26/3121/b/18#input.worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii: false
+  output:
+    us:statutes/26/3121/b/18#guam_philippines_temporary_nonimmigrant_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/18.yaml
+++ b/statutes/26/3121/b/18.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (18) service performed in Guam by a resident of the Republic of the Philippines while in Guam on a temporary basis as a nonimmigrant alien admitted to Guam pursuant to section 101(a)(15)(H)(ii) of the Immigration and Nationality Act ( 8 U.S.C. 1101(a)(15)(H)(ii) );
+rules:
+  - name: guam_philippines_temporary_nonimmigrant_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service performed in Guam"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by a resident of the Republic of the Philippines"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "while in Guam on a temporary basis"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "as a nonimmigrant alien"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "admitted to Guam pursuant to section 101(a)(15)(H)(ii) of the Immigration and Nationality Act ( 8 U.S.C. 1101(a)(15)(H)(ii) )"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_guam
+          and worker_resident_of_republic_of_philippines
+          and worker_in_guam_on_temporary_basis
+          and worker_is_nonimmigrant_alien
+          and worker_admitted_to_guam_pursuant_to_immigration_and_nationality_act_section_101_a_15_H_ii


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(18)` Guam temporary Philippines-resident nonimmigrant service exclusion
- include generated tests for all five statutory conditions
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-18-20260525/statutes/26/3121/b/18.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-18-20260525/statutes/26/3121/b/18.test.yaml --root /private/tmp/rulespec-us-3121-b-18-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-18-20260525/statutes/26/3121/b/18.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-18-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `856` total tax outputs, `225` comparable, `628` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(18)` output is known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.