### PR TITLE
Add generated 3121(b)(19) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/19.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/19.yaml",
+      "sha256": "43daf96c3196978a75863ff394162b2f56b4fd99e910307fe134888a013384ce"
+    },
+    {
+      "path": "statutes/26/3121/b/19.test.yaml",
+      "sha256": "8b460921b2fc182c96b8843d6af242f4748a88c8fba18f50dd8eeb9326fc260d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(19)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-19-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "411e94f972646c08a83fb6f0538d1dc74c1207956852f94b96742adcbc2b878e",
+  "generated_at": "2026-05-25T02:20:47.486688+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-19-20260525/openai-gpt-5.5/statutes/26/3121/b/19.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-19-20260525",
+  "generated_output_sha256": "43daf96c3196978a75863ff394162b2f56b4fd99e910307fe134888a013384ce",
+  "generation_prompt_sha256": "23a4b5ca84a6ec2704e04bb3b8b81a72790104a96b19be4cb46cc3907a087754",
+  "model": "gpt-5.5",
+  "run_id": "7ae3ca91",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9e91b93ab82ad763ee5de4f16016c2df632f6e901ee1fec6a9a5582e61ff230c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-19-20260525/traces/openai-gpt-5.5/26-USC-3121-b-19.json",
+  "trace_sha256": "82c167c172c2dd159c783fb741451d486cd52da39b1ffe375b8684a9eb4ef518"
+}

--- a/statutes/26/3121/b/19.test.yaml
+++ b/statutes/26/3121/b/19.test.yaml
@@ -1,0 +1,80 @@
+- name: qualifying_nonresident_alien_nonimmigrant_purpose_service_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/19#input.service_performed_by_nonresident_alien_individual: true
+      us:statutes/26/3121/b/19#input.service_performed_for_period_individual_temporarily_present_in_united_states: true
+      ? us:statutes/26/3121/b/19#input.individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+      : true
+      us:statutes/26/3121/b/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q: true
+  output:
+    us:statutes/26/3121/b/19#nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment:
+    - holds
+- name: service_not_performed_by_nonresident_alien_individual_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/19#input.service_performed_by_nonresident_alien_individual: false
+      us:statutes/26/3121/b/19#input.service_performed_for_period_individual_temporarily_present_in_united_states: true
+      ? us:statutes/26/3121/b/19#input.individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+      : true
+      us:statutes/26/3121/b/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q: true
+  output:
+    us:statutes/26/3121/b/19#nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment:
+    - not_holds
+- name: service_not_for_period_of_temporary_presence_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/19#input.service_performed_by_nonresident_alien_individual: true
+      us:statutes/26/3121/b/19#input.service_performed_for_period_individual_temporarily_present_in_united_states: false
+      ? us:statutes/26/3121/b/19#input.individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+      : true
+      us:statutes/26/3121/b/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q: true
+  output:
+    us:statutes/26/3121/b/19#nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment:
+    - not_holds
+- name: individual_not_temporarily_present_as_covered_nonimmigrant_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/19#input.service_performed_by_nonresident_alien_individual: true
+      us:statutes/26/3121/b/19#input.service_performed_for_period_individual_temporarily_present_in_united_states: true
+      ? us:statutes/26/3121/b/19#input.individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+      : false
+      us:statutes/26/3121/b/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q: true
+  output:
+    us:statutes/26/3121/b/19#nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment:
+    - not_holds
+- name: service_not_performed_to_carry_out_applicable_nonimmigrant_purpose_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/19#input.service_performed_by_nonresident_alien_individual: true
+      us:statutes/26/3121/b/19#input.service_performed_for_period_individual_temporarily_present_in_united_states: true
+      ? us:statutes/26/3121/b/19#input.individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+      : true
+      us:statutes/26/3121/b/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q: false
+  output:
+    us:statutes/26/3121/b/19#nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/19.yaml
+++ b/statutes/26/3121/b/19.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (19) Service which is performed by a nonresident alien individual for the period he is temporarily present in the United States as a nonimmigrant under subparagraph (F), (J), (M), or (Q) of section 101(a)(15) of the Immigration and Nationality Act, as amended, and which is performed to carry out the purpose specified in subparagraph (F), (J), (M), or (Q), as the case may be;
+rules:
+  - name: nonresident_alien_nonimmigrant_purpose_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "Service which is performed by a nonresident alien individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "for the period he is temporarily present in the United States"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "as a nonimmigrant under subparagraph (F), (J), (M), or (Q) of section 101(a)(15) of the Immigration and Nationality Act, as amended"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "which is performed to carry out the purpose specified in subparagraph (F), (J), (M), or (Q), as the case may be"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_nonresident_alien_individual
+          and service_performed_for_period_individual_temporarily_present_in_united_states
+          and individual_temporarily_present_as_nonimmigrant_under_subparagraph_f_j_m_or_q_of_section_101_a_15
+          and service_performed_to_carry_out_purpose_specified_in_applicable_subparagraph_f_j_m_or_q


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(19)` nonresident-alien F/J/M/Q nonimmigrant purpose service exclusion
- include generated tests for all four statutory conditions
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-19-20260525/statutes/26/3121/b/19.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-19-20260525/statutes/26/3121/b/19.test.yaml --root /private/tmp/rulespec-us-3121-b-19-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-19-20260525/statutes/26/3121/b/19.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-19-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `857` total tax outputs, `225` comparable, `629` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(19)` output is known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.