### PR TITLE
Add generated 3121(b)(20) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/20.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/20.yaml",
+      "sha256": "2dcd60ad243ef88c716126c5cdf99b3659f5f265550c63f0c8e79a6c7075594d"
+    },
+    {
+      "path": "statutes/26/3121/b/20.test.yaml",
+      "sha256": "62a90ae7cfc1daa14ae67ab08233213b80bde071411bf120b5973c7e724aa57e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(20)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-20-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "67c48f85d3101805d57ddbe37f1517c179f074c705c9e44a9937eed86fc30402",
+  "generated_at": "2026-05-25T02:25:47.341785+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-20-20260525/openai-gpt-5.5/statutes/26/3121/b/20.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-20-20260525",
+  "generated_output_sha256": "2dcd60ad243ef88c716126c5cdf99b3659f5f265550c63f0c8e79a6c7075594d",
+  "generation_prompt_sha256": "ed82d2c07503524eac94be56b0dd17676d2117107117af405955d37689466e10",
+  "model": "gpt-5.5",
+  "run_id": "ddfd963f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "718f87aa43cc931ed6f66b09c15662375220e885def456e4adbf372e4468189d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-20-20260525/traces/openai-gpt-5.5/26-USC-3121-b-20.json",
+  "trace_sha256": "44df1b4fd8483084718c02dea66733bc995bd7063b6d950385e417167fbe8f59"
+}

--- a/statutes/26/3121/b/20.test.yaml
+++ b/statutes/26/3121/b/20.test.yaml
@@ -1,0 +1,92 @@
+- name: qualifying_fishing_boat_share_service_with_no_cash_remuneration_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: false
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 0
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: false
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: false
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment:
+    - holds
+- name: qualifying_fishing_boat_share_service_with_permitted_additional_duties_cash_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: false
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 100
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: true
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: true
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment:
+    - holds
+- name: paragraph_3_A_service_carveout_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: true
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 0
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: false
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: false
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment:
+    - not_holds
+- name: disqualifying_cash_remuneration_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: false
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 101
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: true
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: true
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/20.yaml
+++ b/statutes/26/3121/b/20.yaml
@@ -1,0 +1,111 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (20) service (other than service described in paragraph (3)(A)) performed by an individual on a boat engaged in catching fish or other forms of aquatic animal life under an arrangement with the owner or operator of such boat pursuant to which— (A) such individual does not receive any cash remuneration other than as provided in subparagraph (B) and other than cash remuneration— (i) which does not exceed $100 per trip; (ii) which is contingent on a minimum catch; and (iii) which is paid solely for additional duties (such as mate, engineer, or cook) for which additional cash remuneration is traditional in the industry, (B) such individual receives a share of the boat’s (or the boats’ in the case of a fishing operation involving more than one boat) catch of fish or other forms of aquatic animal life or a share of the proceeds from the sale of such catch, and (C) the amount of such individual’s share depends on the amount of the boat’s (or the boats’ in the case of a fishing operation involving more than one boat) catch of fish or other forms of aquatic animal life, but only if the operating crew of such boat (or each boat from which the individual receives a share in the case of a fishing operation involving more than one boat) is normally made up of fewer than 10 individuals;
+rules:
+  - name: permitted_additional_duties_cash_remuneration_per_trip_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3121(b)(20)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "which does not exceed $100 per trip"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          100
+
+  - name: operating_crew_size_must_be_fewer_than
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3121(b)(20)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "normally made up of fewer than 10 individuals"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: fishing_boat_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(20)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "service (other than service described in paragraph (3)(A))"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "performed by an individual on a boat engaged in catching fish or other forms of aquatic animal life"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under an arrangement with the owner or operator of such boat"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "such individual does not receive any cash remuneration other than as provided in subparagraph (B)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "cash remuneration— (i) which does not exceed $100 per trip; (ii) which is contingent on a minimum catch; and (iii) which is paid solely for additional duties (such as mate, engineer, or cook) for which additional cash remuneration is traditional in the industry"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "such individual receives a share of the boat’s (or the boats’ in the case of a fishing operation involving more than one boat) catch of fish or other forms of aquatic animal life or a share of the proceeds from the sale of such catch"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the amount of such individual’s share depends on the amount of the boat’s (or the boats’ in the case of a fishing operation involving more than one boat) catch of fish or other forms of aquatic animal life"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "but only if the operating crew of such boat (or each boat from which the individual receives a share in the case of a fishing operation involving more than one boat) is normally made up of fewer than 10 individuals"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          not service_described_in_paragraph_3_A
+          and service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+          and service_performed_under_arrangement_with_owner_or_operator_of_boat
+          and (
+            individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds
+            or (
+              cash_remuneration_per_trip <= permitted_additional_duties_cash_remuneration_per_trip_limit
+              and cash_remuneration_contingent_on_minimum_catch
+              and cash_remuneration_paid_solely_for_additional_duties
+              and additional_cash_remuneration_for_duties_traditional_in_industry
+            )
+          )
+          and individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch
+          and individual_share_amount_depends_on_amount_of_boat_catch
+          and operating_crew_normally_made_up_of_individual_count < operating_crew_size_must_be_fewer_than


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(20)` fishing-boat share-arrangement service exclusion
- encode the `$100` per-trip additional-duty cash limit and fewer-than-10 crew threshold as generated parameters
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-20-20260525/statutes/26/3121/b/20.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-20-20260525/statutes/26/3121/b/20.test.yaml --root /private/tmp/rulespec-us-3121-b-20-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-20-20260525/statutes/26/3121/b/20.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-20-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `860` total tax outputs, `225` comparable, `632` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(20)` outputs are known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.