### PR TITLE
Add generated 3121(b)(21) employment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/b/21.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/b/21.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/b/21.yaml",
+      "sha256": "85a0e485ee69209a75ae314ffaff52aceefe22a5233929e3279fb18172c701e4"
+    },
+    {
+      "path": "statutes/26/3121/b/21.test.yaml",
+      "sha256": "d033f14df0ff10aca5ebda415cd8ef660085487e159cdf8e20dbc6a1b2c047b7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e865d95f63d697d41793ad9866ceaa592f734df",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.182",
+    "version_commit": "2e865d95f63d697d41793ad9866ceaa592f734df"
+  },
+  "axiom_encode_version": "0.2.182",
+  "backend": "openai",
+  "citation": "26 USC 3121(b)(21)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-b-21-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-b-21/workspace/context-manifest.json",
+  "context_manifest_sha256": "cd2f55f6562373d69e62c729be7c3973b79062aadf9ca9bc4702aff2e6a1bf5b",
+  "generated_at": "2026-05-25T02:31:06.848245+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-b-21-20260525/openai-gpt-5.5/statutes/26/3121/b/21.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-b-21-20260525",
+  "generated_output_sha256": "85a0e485ee69209a75ae314ffaff52aceefe22a5233929e3279fb18172c701e4",
+  "generation_prompt_sha256": "6d7a233a1ea18a0c8b84ebb825df80b1081e39d441e7c9a90ab7f853d2563c00",
+  "model": "gpt-5.5",
+  "run_id": "81ee4de8",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc69f9c6c5a51cc136038c33b2afcc29643df67a8b582a4d3538f13717a3fb61"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-b-21-20260525/traces/openai-gpt-5.5/26-USC-3121-b-21.json",
+  "trace_sha256": "d02e90a6a0200ab70eace3bf41cda6c4666104454b108d0fdbc59ce450d78493"
+}

--- a/statutes/26/3121/b/21.test.yaml
+++ b/statutes/26/3121/b/21.test.yaml
@@ -1,0 +1,56 @@
+- name: qualifying_minor_domestic_private_home_service_not_principal_occupation_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/21#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/b/21#input.individual_under_age_18_during_any_portion_of_year: true
+      us:statutes/26/3121/b/21#input.service_not_principal_occupation_of_employee: true
+  output:
+    us:statutes/26/3121/b/21#minor_domestic_private_home_service_not_principal_occupation_excluded_from_employment:
+    - holds
+- name: non_domestic_private_home_service_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/21#input.domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3121/b/21#input.individual_under_age_18_during_any_portion_of_year: true
+      us:statutes/26/3121/b/21#input.service_not_principal_occupation_of_employee: true
+  output:
+    us:statutes/26/3121/b/21#minor_domestic_private_home_service_not_principal_occupation_excluded_from_employment:
+    - not_holds
+- name: individual_not_under_age_18_during_year_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/21#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/b/21#input.individual_under_age_18_during_any_portion_of_year: false
+      us:statutes/26/3121/b/21#input.service_not_principal_occupation_of_employee: true
+  output:
+    us:statutes/26/3121/b/21#minor_domestic_private_home_service_not_principal_occupation_excluded_from_employment:
+    - not_holds
+- name: service_is_principal_occupation_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/21#input.domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3121/b/21#input.individual_under_age_18_during_any_portion_of_year: true
+      us:statutes/26/3121/b/21#input.service_not_principal_occupation_of_employee: false
+  output:
+    us:statutes/26/3121/b/21#minor_domestic_private_home_service_not_principal_occupation_excluded_from_employment:
+    - not_holds

--- a/statutes/26/3121/b/21.yaml
+++ b/statutes/26/3121/b/21.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (21) domestic service in a private home of the employer which— (A) is performed in any year by an individual under the age of 18 during any portion of such year; and (B) is not the principal occupation of such employee; or
+rules:
+  - name: minor_domestic_private_home_service_not_principal_occupation_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(21)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "domestic service in a private home of the employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is performed in any year by an individual under the age of 18 during any portion of such year"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "is not the principal occupation of such employee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          domestic_service_in_private_home_of_employer
+          and individual_under_age_18_during_any_portion_of_year
+          and service_not_principal_occupation_of_employee


### PR DESCRIPTION
## Summary
- add generated RuleSpec for `26 USC 3121(b)(21)` minor domestic-service private-home exclusion
- include generated tests for each of the three statutory conditions
- include signed axiom-encode apply manifest from axiom-encode 0.2.182 / gpt-5.5

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-b-21-20260525/statutes/26/3121/b/21.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-b-21-20260525/statutes/26/3121/b/21.test.yaml --root /private/tmp/rulespec-us-3121-b-21-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-b-21-20260525/statutes/26/3121/b/21.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-b-21-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root <physical temp root>/rulespec-us --oracle policyengine --program tax --json`

PE oracle coverage with this branch: `861` total tax outputs, `225` comparable, `633` known-not-comparable, `3` unmapped, `0` untested comparable. The new `3121(b)(21)` output is known-not-comparable because PolicyEngine does not expose section 3121(b) employment-definition child-fragment predicates one-to-one.