### PR TITLE
Add generated 3121(c) employment pay-period rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/c.yaml",
+      "sha256": "52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6"
+    },
+    {
+      "path": "statutes/26/3121/c.test.yaml",
+      "sha256": "7f636df892b6af9bea91c9ba71267302c8d6620f434bb8d5a6e523b07266cb2b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8c8193a9e338842d9ed9ccd7aa755122f36ad1cc",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.183",
+    "version_commit": "8c8193a9e338842d9ed9ccd7aa755122f36ad1cc"
+  },
+  "axiom_encode_version": "0.2.183",
+  "backend": "openai",
+  "citation": "26 USC 3121(c)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-c-v2-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "8c210c70efda17e98ee57014c75dd2e7ee0c78656f873c0a4b61c6406d410079",
+  "generated_at": "2026-05-25T02:50:50.948619+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-c-v2-20260525/openai-gpt-5.5/statutes/26/3121/c.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-c-v2-20260525",
+  "generated_output_sha256": "52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6",
+  "generation_prompt_sha256": "dec803719972716fe0e7cabb576b18810571fe50670a23a21fdf26bda84e7fd6",
+  "model": "gpt-5.5",
+  "run_id": "cbfa3f0e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bcbeccbbb10e9772579c49c2c2ae749159cef725d11ddf2a6ce6c17af8f20331"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-c-v2-20260525/traces/openai-gpt-5.5/26-USC-3121-c.json",
+  "trace_sha256": "e0411004444633a613394e07a0dda131ea425a6aff6740c659db7a0655c175c5"
+}

--- a/statutes/26/3121/c.test.yaml
+++ b/statutes/26/3121/c.test.yaml
@@ -1,0 +1,64 @@
+- name: one_half_or_more_employment_services_makes_all_services_deemed_employment
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:statutes/26/3121/c#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3121/c#input.pay_period_consecutive_days: 31
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.5
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.5
+    us:statutes/26/3121/c#input.any_service_in_pay_period_excepted_by_subsection_b_9: false
+  output:
+    us:statutes/26/3121/c#pay_period_under_subsection_c: holds
+    us:statutes/26/3121/c#all_services_for_pay_period_deemed_employment: holds
+    us:statutes/26/3121/c#no_services_for_pay_period_deemed_employment: not_holds
+- name: more_than_one_half_nonemployment_services_makes_no_services_deemed_employment
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-02-01'
+    end: '2026-02-28'
+  input:
+    us:statutes/26/3121/c#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3121/c#input.pay_period_consecutive_days: 15
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.4
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
+    us:statutes/26/3121/c#input.any_service_in_pay_period_excepted_by_subsection_b_9: false
+  output:
+    us:statutes/26/3121/c#pay_period_under_subsection_c: holds
+    us:statutes/26/3121/c#all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3121/c#no_services_for_pay_period_deemed_employment: holds
+- name: period_longer_than_31_consecutive_days_is_not_pay_period_under_subsection_c
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-03-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3121/c#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3121/c#input.pay_period_consecutive_days: 32
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.6
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.4
+    us:statutes/26/3121/c#input.any_service_in_pay_period_excepted_by_subsection_b_9: false
+  output:
+    us:statutes/26/3121/c#pay_period_under_subsection_c: not_holds
+    us:statutes/26/3121/c#all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3121/c#no_services_for_pay_period_deemed_employment: not_holds
+- name: subsection_b_9_excepted_service_makes_subsection_c_inapplicable
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-04-01'
+    end: '2026-04-30'
+  input:
+    us:statutes/26/3121/c#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3121/c#input.pay_period_consecutive_days: 30
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.6
+    us:statutes/26/3121/c#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
+    us:statutes/26/3121/c#input.any_service_in_pay_period_excepted_by_subsection_b_9: true
+  output:
+    us:statutes/26/3121/c#pay_period_under_subsection_c: holds
+    us:statutes/26/3121/c#all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3121/c#no_services_for_pay_period_deemed_employment: not_holds

--- a/statutes/26/3121/c.yaml
+++ b/statutes/26/3121/c.yaml
@@ -1,0 +1,156 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (c) Included and excluded service For purposes of this chapter, if the services performed during one-half or more of any pay period by an employee for the person employing him constitute employment, all the services of such employee for such period shall be deemed to be employment; but if the services performed during more than one-half of any such pay period by an employee for the person employing him do not constitute employment, then none of the services of such employee for such period shall be deemed to be employment. As used in this subsection, the term “pay period” means a period (of not more than 31 consecutive days) for which a payment of remuneration is ordinarily made to the employee by the person employing him. This subsection shall not be applicable with respect to services performed in a pay period by an employee for the person employing him, where any of such service is excepted by subsection (b)(9).
+rules:
+  - name: pay_period_max_consecutive_days
+    kind: parameter
+    dtype: Count
+    period: Day
+    source: 26 USC 3121(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “pay period” means a period (of not more than 31 consecutive days)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          31
+
+  - name: one_half_services_threshold
+    kind: parameter
+    dtype: Rate
+    period: Day
+    source: 26 USC 3121(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the services performed during one-half or more of any pay period
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1 / 2
+
+  - name: pay_period_under_subsection_c
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3121(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “pay period” means a period (of not more than 31 consecutive days) for which a payment of remuneration is ordinarily made to the employee by the person employing him
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/c#pay_period_max_consecutive_days
+              output: pay_period_max_consecutive_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer
+          and pay_period_consecutive_days <= pay_period_max_consecutive_days
+
+  - name: all_services_for_pay_period_deemed_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3121(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the services performed during one-half or more of any pay period by an employee for the person employing him constitute employment
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: all the services of such employee for such period shall be deemed to be employment
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: This subsection shall not be applicable with respect to services performed in a pay period by an employee for the person employing him, where any of such service is excepted by subsection (b)(9).
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/c#pay_period_under_subsection_c
+              output: pay_period_under_subsection_c
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/c#one_half_services_threshold
+              output: one_half_services_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          pay_period_under_subsection_c
+          and services_performed_for_employer_during_pay_period_that_constitute_employment_fraction >= one_half_services_threshold
+          and not any_service_in_pay_period_excepted_by_subsection_b_9
+
+  - name: no_services_for_pay_period_deemed_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3121(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the services performed during more than one-half of any such pay period by an employee for the person employing him do not constitute employment
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: then none of the services of such employee for such period shall be deemed to be employment
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: This subsection shall not be applicable with respect to services performed in a pay period by an employee for the person employing him, where any of such service is excepted by subsection (b)(9).
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/c#pay_period_under_subsection_c
+              output: pay_period_under_subsection_c
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/c#one_half_services_threshold
+              output: one_half_services_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          pay_period_under_subsection_c
+          and services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction > one_half_services_threshold
+          and not any_service_in_pay_period_excepted_by_subsection_b_9


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(c) pay-period included/excluded service deeming rules
- include generated tests and signed encoding manifest
- generated with axiom-encode 0.2.183 / gpt-5.5 after encoder PR #194 classified 3121(c) PE oracle outputs

## Verification
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-c-v2-20260525/statutes/26/3121/c.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-c-v2-20260525/statutes/26/3121/c.test.yaml --root /private/tmp/rulespec-us-3121-c-v2-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-c-v2-20260525/statutes/26/3121/c.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-c-v2-20260525 --base-ref origin/main --json
- PE oracle coverage: 866 total tax outputs, 225 comparable, 638 known-not-comparable, 3 legacy unmapped, 0 untested comparable