### PR TITLE
Add generated 3121(d) employee definition rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/d.yaml",
+      "sha256": "eeb9f0d28957d7f3d29d97262ef031c1eccb8ef49dfcd16935206afbfc0724ff"
+    },
+    {
+      "path": "statutes/26/3121/d.test.yaml",
+      "sha256": "6ec656e02daa4f50738e1e64a4828b4b18461d31085ba7fdbc4fa10d656730ea"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8c8193a9e338842d9ed9ccd7aa755122f36ad1cc",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.183",
+    "version_commit": "8c8193a9e338842d9ed9ccd7aa755122f36ad1cc"
+  },
+  "axiom_encode_version": "0.2.183",
+  "backend": "openai",
+  "citation": "26 USC 3121(d)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-d-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "77cd9d057f7a722dc4d415395e5c546536b8f5fba65dd7d0d0511522fd00ea12",
+  "generated_at": "2026-05-25T02:56:03.301970+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-d-20260525/openai-gpt-5.5/statutes/26/3121/d.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-d-20260525",
+  "generated_output_sha256": "eeb9f0d28957d7f3d29d97262ef031c1eccb8ef49dfcd16935206afbfc0724ff",
+  "generation_prompt_sha256": "7e4a817295650886839c6ef42b8026d0a65406686402ab5ac383550ce212bc80",
+  "model": "gpt-5.5",
+  "run_id": "bf6c24f5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "88cd67e4be334c6ba6ae80bd45fd670e1031f3614377dd00cec8d035afa0c275"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-d-20260525/traces/openai-gpt-5.5/26-USC-3121-d.json",
+  "trace_sha256": "21f3d39faaa455dbaa43840d27e7c66c5657650116859cd9fbb934b6edf1f775"
+}

--- a/statutes/26/3121/d.test.yaml
+++ b/statutes/26/3121/d.test.yaml
@@ -1,0 +1,84 @@
+- name: statutory_service_worker_without_exceptions_is_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/d#input.officer_of_corporation: false
+    us:statutes/26/3121/d#input.common_law_employee_status: false
+    us:statutes/26/3121/d#input.performs_services_for_remuneration_for_person: true
+    us:statutes/26/3121/d#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: true
+    us:statutes/26/3121/d#input.full_time_life_insurance_salesman: false
+    us:statutes/26/3121/d#input.home_worker_performing_specified_work_on_furnished_returnable_materials_or_goods: false
+    ? us:statutes/26/3121/d#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3121/d#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: true
+    us:statutes/26/3121/d#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3121/d#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+    ? us:statutes/26/3121/d#input.services_included_under_agreement_entered_pursuant_to_section_218_or_218A_of_social_security_act
+    : false
+  output:
+    us:statutes/26/3121/d#employee: holds
+- name: substantial_investment_exception_blocks_statutory_service_worker_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/d#input.officer_of_corporation: false
+    us:statutes/26/3121/d#input.common_law_employee_status: false
+    us:statutes/26/3121/d#input.performs_services_for_remuneration_for_person: true
+    us:statutes/26/3121/d#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: true
+    us:statutes/26/3121/d#input.full_time_life_insurance_salesman: false
+    us:statutes/26/3121/d#input.home_worker_performing_specified_work_on_furnished_returnable_materials_or_goods: false
+    ? us:statutes/26/3121/d#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3121/d#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: true
+    us:statutes/26/3121/d#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: true
+    us:statutes/26/3121/d#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+    ? us:statutes/26/3121/d#input.services_included_under_agreement_entered_pursuant_to_section_218_or_218A_of_social_security_act
+    : false
+  output:
+    us:statutes/26/3121/d#employee: not_holds
+- name: single_transaction_exception_blocks_statutory_service_worker_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/d#input.officer_of_corporation: false
+    us:statutes/26/3121/d#input.common_law_employee_status: false
+    us:statutes/26/3121/d#input.performs_services_for_remuneration_for_person: true
+    us:statutes/26/3121/d#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: true
+    us:statutes/26/3121/d#input.full_time_life_insurance_salesman: false
+    us:statutes/26/3121/d#input.home_worker_performing_specified_work_on_furnished_returnable_materials_or_goods: false
+    ? us:statutes/26/3121/d#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3121/d#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: true
+    us:statutes/26/3121/d#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3121/d#input.services_are_single_transaction_not_part_of_continuing_relationship: true
+    ? us:statutes/26/3121/d#input.services_included_under_agreement_entered_pursuant_to_section_218_or_218A_of_social_security_act
+    : false
+  output:
+    us:statutes/26/3121/d#employee: not_holds
+- name: services_under_social_security_act_agreement_are_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/d#input.officer_of_corporation: false
+    us:statutes/26/3121/d#input.common_law_employee_status: false
+    us:statutes/26/3121/d#input.performs_services_for_remuneration_for_person: false
+    us:statutes/26/3121/d#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: false
+    us:statutes/26/3121/d#input.full_time_life_insurance_salesman: false
+    us:statutes/26/3121/d#input.home_worker_performing_specified_work_on_furnished_returnable_materials_or_goods: false
+    ? us:statutes/26/3121/d#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3121/d#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: false
+    us:statutes/26/3121/d#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3121/d#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+    ? us:statutes/26/3121/d#input.services_included_under_agreement_entered_pursuant_to_section_218_or_218A_of_social_security_act
+    : true
+  output:
+    us:statutes/26/3121/d#employee: holds

--- a/statutes/26/3121/d.yaml
+++ b/statutes/26/3121/d.yaml
@@ -1,0 +1,93 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (d) Employee For purposes of this chapter, the term “employee” means— (1) any officer of a corporation; or (2) any individual who, under the usual common law rules applicable in determining the employer-employee relationship, has the status of an employee; or (3) any individual (other than an individual who is an employee under paragraph (1) or (2)) who performs services for remuneration for any person— (A) as an agent-driver or commission-driver engaged in distributing meat products, vegetable products, fruit products, bakery products, beverages (other than milk), or laundry or dry-cleaning services, for his principal; (B) as a full-time life insurance salesman; (C) as a home worker performing work, according to specifications furnished by the person for whom the services are performed, on materials or goods furnished by such person which are required to be returned to such person or a person designated by him; or (D) as a traveling or city salesman, other than as an agent-driver or commission-driver, engaged upon a full-time basis in the solicitation on behalf of, and the transmission to, his principal (except for side-line sales activities on behalf of some other person) of orders from wholesalers, retailers, contractors, or operators of hotels, restaurants, or other similar establishments for merchandise for resale or supplies for use in their business operations; if the contract of service contemplates that substantially all of such services are to be performed personally by such individual; except that an individual shall not be included in the term “employee” under the provisions of this paragraph if such individual has a substantial investment in facilities used in connection with the performance of such services (other than in facilities for transportation), or if the services are in the nature of a single transaction not part of a continuing relationship with the person for whom the services are performed; or (4) any individual who performs services that are included under an agreement entered into pursuant to section 218 or 218A of the Social Security Act.
+rules:
+  - name: employee
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: For purposes of this chapter, the term “employee” means— (1) any officer of a corporation
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any individual who, under the usual common law rules applicable in determining the employer-employee relationship, has the status of an employee
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any individual (other than an individual who is an employee under paragraph (1) or (2)) who performs services for remuneration for any person
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as an agent-driver or commission-driver engaged in distributing meat products, vegetable products, fruit products, bakery products, beverages (other than milk), or laundry or dry-cleaning services, for his principal
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as a full-time life insurance salesman
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as a home worker performing work, according to specifications furnished by the person for whom the services are performed, on materials or goods furnished by such person which are required to be returned to such person or a person designated by him
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as a traveling or city salesman, other than as an agent-driver or commission-driver, engaged upon a full-time basis in the solicitation on behalf of, and the transmission to, his principal (except for side-line sales activities on behalf of some other person) of orders from wholesalers, retailers, contractors, or operators of hotels, restaurants, or other similar establishments for merchandise for resale or supplies for use in their business operations
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the contract of service contemplates that substantially all of such services are to be performed personally by such individual
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: except that an individual shall not be included in the term “employee” under the provisions of this paragraph if such individual has a substantial investment in facilities used in connection with the performance of such services (other than in facilities for transportation)
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: or if the services are in the nature of a single transaction not part of a continuing relationship with the person for whom the services are performed
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any individual who performs services that are included under an agreement entered into pursuant to section 218 or 218A of the Social Security Act
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          officer_of_corporation
+          or common_law_employee_status
+          or (
+            performs_services_for_remuneration_for_person
+            and not officer_of_corporation
+            and not common_law_employee_status
+            and (
+              agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal
+              or full_time_life_insurance_salesman
+              or home_worker_performing_specified_work_on_furnished_returnable_materials_or_goods
+              or traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+            )
+            and contract_contemplates_substantially_all_services_performed_personally_by_individual
+            and not individual_has_substantial_investment_in_nontransportation_facilities_used_in_services
+            and not services_are_single_transaction_not_part_of_continuing_relationship
+          )
+          or services_included_under_agreement_entered_pursuant_to_section_218_or_218A_of_social_security_act


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(d), defining `employee` for chapter 21.
- Include generated tests for statutory service worker inclusion, exception handling, and Social Security Act section 218/218A agreement inclusion.
- Include the signed encoding manifest for the generated files.

## Notes
- Generated with `axiom-encode 0.2.183` / `gpt-5.5` in run `bf6c24f5`.
- Revalidated after TheAxiomFoundation/axiom-encode#195 with current `axiom-encode 0.2.184`, which classifies the 3121(d) PolicyEngine oracle output as known-not-comparable.
- Two later 0.2.184 regeneration attempts deferred this section because of the external section 218/218A agreement dependency; this PR uses the earlier substantive signed generated output rather than publishing an empty deferred artifact.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-d-20260525/statutes/26/3121/d.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-d-20260525/statutes/26/3121/d.test.yaml --root /private/tmp/rulespec-us-3121-d-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-d-20260525/statutes/26/3121/d.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-d-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage with this branch: 867 total outputs, 225 comparable, 639 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
