### PR TITLE
Add generated 3121(e) citizenship definition rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/e.yaml",
+      "sha256": "b286b2f9be5205b579cbbb0a52d3b1f771ea135c86fe9a18b94575053a47fc1e"
+    },
+    {
+      "path": "statutes/26/3121/e.test.yaml",
+      "sha256": "6342e7af324cd96bf5099e21b46f2c20cae69302aa6392e6a96a1a15bcc46155"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b60d4ffc121f7fb4c85b5bbf3974476813ca5fae",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.185",
+    "version_commit": "b60d4ffc121f7fb4c85b5bbf3974476813ca5fae"
+  },
+  "axiom_encode_version": "0.2.185",
+  "backend": "openai",
+  "citation": "26 USC 3121(e)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-e-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "d9a598f422fe6a81a9dc881a5b2f74c33ff825a17291aa3017fba13ac1bd278b",
+  "generated_at": "2026-05-25T03:25:22.366348+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-e-20260525-v2/openai-gpt-5.5/statutes/26/3121/e.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-e-20260525-v2",
+  "generated_output_sha256": "b286b2f9be5205b579cbbb0a52d3b1f771ea135c86fe9a18b94575053a47fc1e",
+  "generation_prompt_sha256": "5e7e48f92813fcb5c8464d4831cb983f786cbc7de7d8813bd1e467f6bd8de1db",
+  "model": "gpt-5.5",
+  "run_id": "951fde49",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6646c2ebee30dcfadc84c0611281c645ad72e151570812f1056d7b6fb444a994"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-e-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-e.json",
+  "trace_sha256": "8f8e42f3a4ab14671c7f08e71a0dd17fdd5e25d601f70799666f0580fef22114"
+}

--- a/statutes/26/3121/e.test.yaml
+++ b/statutes/26/3121/e.test.yaml
@@ -1,0 +1,40 @@
+- name: puerto_rico_citizen_not_otherwise_us_citizen_is_considered_us_citizen_for_section
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/e#input.citizen_of_commonwealth_of_puerto_rico: true
+    us:statutes/26/3121/e#input.otherwise_citizen_of_united_states: false
+  output:
+    us:statutes/26/3121/e#citizen_of_united_states_for_section: holds
+- name: otherwise_us_citizen_is_citizen_for_section
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/e#input.citizen_of_commonwealth_of_puerto_rico: false
+    us:statutes/26/3121/e#input.otherwise_citizen_of_united_states: true
+  output:
+    us:statutes/26/3121/e#citizen_of_united_states_for_section: holds
+- name: puerto_rico_citizen_who_is_also_otherwise_us_citizen_remains_citizen_for_section
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/e#input.citizen_of_commonwealth_of_puerto_rico: true
+    us:statutes/26/3121/e#input.otherwise_citizen_of_united_states: true
+  output:
+    us:statutes/26/3121/e#citizen_of_united_states_for_section: holds
+- name: neither_puerto_rico_citizen_nor_otherwise_us_citizen_is_not_citizen_for_section
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/e#input.citizen_of_commonwealth_of_puerto_rico: false
+    us:statutes/26/3121/e#input.otherwise_citizen_of_united_states: false
+  output:
+    us:statutes/26/3121/e#citizen_of_united_states_for_section: not_holds

--- a/statutes/26/3121/e.yaml
+++ b/statutes/26/3121/e.yaml
@@ -1,0 +1,31 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (e) State, United States, and citizen For purposes of this chapter— (1) State The term “State” includes the District of Columbia, the Commonwealth of Puerto Rico, the Virgin Islands, Guam, and American Samoa. (2) United States The term “United States” when used in a geographical sense includes the Commonwealth of Puerto Rico, the Virgin Islands, Guam, and American Samoa. An individual who is a citizen of the Commonwealth of Puerto Rico (but not otherwise a citizen of the United States) shall be considered, for purposes of this section, as a citizen of the United States.
+rules:
+  - name: citizen_of_united_states_for_section
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(e)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: An individual who is a citizen of the Commonwealth of Puerto Rico (but not otherwise a citizen of the United States) shall be considered, for purposes of this section, as a citizen of the United States.
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          otherwise_citizen_of_united_states
+          or (
+            citizen_of_commonwealth_of_puerto_rico
+            and not otherwise_citizen_of_united_states
+          )


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(e)'s Puerto Rico citizenship treatment for section 3121.
- Include generated tests for Puerto Rico citizens, otherwise-US citizens, combined citizenship, and neither-citizenship cases.
- Include the signed encoding manifest.

## Notes
- Generated with `axiom-encode 0.2.185` / `gpt-5.5` in run `951fde49`.
- The associated PolicyEngine oracle classification for section 3121(e) was added in TheAxiomFoundation/axiom-encode#196.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-e-20260525/statutes/26/3121/e.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-e-20260525/statutes/26/3121/e.test.yaml --root /private/tmp/rulespec-us-3121-e-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-e-20260525/statutes/26/3121/e.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-e-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage: 868 total outputs, 225 comparable, 640 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
