### PR TITLE
Add generated 3121(f) vessel and aircraft definitions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/f.yaml",
+      "sha256": "339d2567923e0428f0cdbb4efa34900172ab3424eb5c58c374843bd3130d3361"
+    },
+    {
+      "path": "statutes/26/3121/f.test.yaml",
+      "sha256": "3f4b0b196fbb922c45a4431e199c3ee6418574566d077af29b1b821f04f2ab2d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed3e3187b396876229277820c9b86591526e6c53",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.186",
+    "version_commit": "ed3e3187b396876229277820c9b86591526e6c53"
+  },
+  "axiom_encode_version": "0.2.186",
+  "backend": "openai",
+  "citation": "26 USC 3121(f)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-f-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "14667750e843c0ebc9d104e1efbd228b2aec6753be915d7b44464da67b62568a",
+  "generated_at": "2026-05-25T03:38:04.757561+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-f-20260525-v2/openai-gpt-5.5/statutes/26/3121/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-f-20260525-v2",
+  "generated_output_sha256": "339d2567923e0428f0cdbb4efa34900172ab3424eb5c58c374843bd3130d3361",
+  "generation_prompt_sha256": "00f40ed0075bacb0439ccf1f39a2df84dc89fe2225fd330e1253f18f44beb094",
+  "model": "gpt-5.5",
+  "run_id": "d2a28dc3",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "44c887a0e8dea96e0828c587eb78efd58f5b9af864d01906fc248aa47d48623e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-f-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-f.json",
+  "trace_sha256": "374584175067dca98431d4465615ba0c818d3da4100063b76cd38165bf1d0f39"
+}

--- a/statutes/26/3121/f.test.yaml
+++ b/statutes/26/3121/f.test.yaml
@@ -1,0 +1,64 @@
+- name: vessel_documented_or_numbered_under_united_states_law_is_american_vessel
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/f#input.asset_is_vessel: true
+    us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: true
+    us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+    ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+    : false
+    us:statutes/26/3121/f#input.asset_is_aircraft: false
+    us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3121/f#american_vessel: holds
+    us:statutes/26/3121/f#american_aircraft: not_holds
+- name: undocumented_vessel_with_no_foreign_documentation_and_qualifying_crew_employment_is_american_vessel
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/f#input.asset_is_vessel: true
+    us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+    us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+    ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+    : true
+    us:statutes/26/3121/f#input.asset_is_aircraft: false
+    us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3121/f#american_vessel: holds
+    us:statutes/26/3121/f#american_aircraft: not_holds
+- name: foreign_documented_vessel_without_united_states_documentation_is_not_american_vessel
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/f#input.asset_is_vessel: true
+    us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+    us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: true
+    ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+    : true
+    us:statutes/26/3121/f#input.asset_is_aircraft: false
+    us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3121/f#american_vessel: not_holds
+    us:statutes/26/3121/f#american_aircraft: not_holds
+- name: aircraft_registered_under_united_states_law_is_american_aircraft
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/f#input.asset_is_vessel: false
+    us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+    us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+    ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+    : false
+    us:statutes/26/3121/f#input.asset_is_aircraft: true
+    us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: true
+  output:
+    us:statutes/26/3121/f#american_vessel: not_holds
+    us:statutes/26/3121/f#american_aircraft: holds

--- a/statutes/26/3121/f.yaml
+++ b/statutes/26/3121/f.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (f) American vessel and aircraft For purposes of this chapter, the term “American vessel” means any vessel documented or numbered under the laws of the United States; and includes any vessel which is neither documented or numbered under the laws of the United States nor documented under the laws of any foreign country, if its crew is employed solely by one or more citizens or residents of the United States or corporations organized under the laws of the United States or of any State; and the term “American aircraft” means an aircraft registered under the laws of the United States.
+rules:
+  - name: american_vessel
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “American vessel” means any vessel documented or numbered under the laws of the United States
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: includes any vessel which is neither documented or numbered under the laws of the United States nor documented under the laws of any foreign country, if its crew is employed solely by one or more citizens or residents of the United States or corporations organized under the laws of the United States or of any State
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          asset_is_vessel
+          and (
+            vessel_documented_or_numbered_under_laws_of_united_states
+            or (
+              not vessel_documented_or_numbered_under_laws_of_united_states
+              and
+              not vessel_documented_under_laws_of_any_foreign_country
+              and vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+            )
+          )
+
+  - name: american_aircraft
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “American aircraft” means an aircraft registered under the laws of the United States
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          asset_is_aircraft
+          and aircraft_registered_under_laws_of_united_states


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(f)'s American vessel and American aircraft definitions.
- Include generated tests for documented or numbered U.S. vessels, undocumented qualifying vessels, foreign-documented vessels, and registered U.S. aircraft.
- Include the signed encoding manifest.

## Notes
- Generated with `axiom-encode 0.2.186` / `gpt-5.5` in run `d2a28dc3`.
- The associated PolicyEngine oracle classification for section 3121(f) was added in TheAxiomFoundation/axiom-encode#197.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-f-20260525/statutes/26/3121/f.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-f-20260525/statutes/26/3121/f.test.yaml --root /private/tmp/rulespec-us-3121-f-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-f-20260525/statutes/26/3121/f.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-f-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage: 870 total outputs, 225 comparable, 642 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
