### PR TITLE
Add generated 3121(h) American employer definitions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/h.yaml",
+      "sha256": "7fe5e86e5ea35041490b0a4c90cbb4d96badfd74b5da2fd235863b6c820b277e"
+    },
+    {
+      "path": "statutes/26/3121/h.test.yaml",
+      "sha256": "d15c8c6f77edc338864beac058fc0e7d54aa14dab3490ba28607dc36e2552f67"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1188cf5808edab0cd03326ae17ce7cb1f407cd3e",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.188",
+    "version_commit": "1188cf5808edab0cd03326ae17ce7cb1f407cd3e"
+  },
+  "axiom_encode_version": "0.2.188",
+  "backend": "openai",
+  "citation": "26 USC 3121(h)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-h-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "ef3904fb3dfb6d3b6a95ac70b948f8bb1d130cc0e87af868de0d429302531af9",
+  "generated_at": "2026-05-25T04:10:23.373454+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-h-20260525-v2/openai-gpt-5.5/statutes/26/3121/h.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-h-20260525-v2",
+  "generated_output_sha256": "7fe5e86e5ea35041490b0a4c90cbb4d96badfd74b5da2fd235863b6c820b277e",
+  "generation_prompt_sha256": "e5ef99bfe8bdb4bf89011c460999ee3fd856b421e1c3f7e50bc84f20b1b1b82f",
+  "model": "gpt-5.5",
+  "run_id": "f9e01606",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "70ade810233014000ad9d847f40b52b936a37b1b7a073cea38f110452201976d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-h-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-h.json",
+  "trace_sha256": "860993fd74d48e8a77c246222589092a81c4829941e1317686b3e3a97a75fe56"
+}

--- a/statutes/26/3121/h.test.yaml
+++ b/statutes/26/3121/h.test.yaml
@@ -1,0 +1,60 @@
+- name: individual_resident_employer_is_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: false
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: true
+    us:statutes/26/3121/h#input.employer_is_partnership: false
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0
+    us:statutes/26/3121/h#input.employer_is_trust: false
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3121/h#american_employer: holds
+- name: partnership_with_two_thirds_resident_partners_is_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: false
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3121/h#input.employer_is_partnership: true
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0.6666666667
+    us:statutes/26/3121/h#input.employer_is_trust: false
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3121/h#american_employer: holds
+- name: united_states_trust_and_state_corporation_branches_are_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: true
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3121/h#input.employer_is_partnership: false
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0
+    us:statutes/26/3121/h#input.employer_is_trust: true
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: true
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: true
+  output:
+    us:statutes/26/3121/h#american_employer: holds
+- name: employer_with_no_qualifying_branch_is_not_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: false
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3121/h#input.employer_is_partnership: true
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0.5
+    us:statutes/26/3121/h#input.employer_is_trust: true
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3121/h#american_employer: not_holds

--- a/statutes/26/3121/h.yaml
+++ b/statutes/26/3121/h.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (h) American employer For purposes of this chapter, the term “American employer” means an employer which is— (1) the United States or any instrumentality thereof, (2) an individual who is a resident of the United States, (3) a partnership, if two-thirds or more of the partners are residents of the United States, (4) a trust, if all of the trustees are residents of the United States, or (5) a corporation organized under the laws of the United States or of any State.
+rules:
+  - name: partnership_resident_partner_fraction_threshold
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 26 USC 3121(h)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: two-thirds or more of the partners are residents of the United States
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2 / 3
+
+  - name: american_employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “American employer” means an employer which is— (1) the United States or any instrumentality thereof
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: an individual who is a resident of the United States
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: a partnership, if two-thirds or more of the partners are residents of the United States
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: a trust, if all of the trustees are residents of the United States
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: a corporation organized under the laws of the United States or of any State
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/h#partnership_resident_partner_fraction_threshold
+              output: partnership_resident_partner_fraction_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_united_states_or_instrumentality_thereof
+          or individual_employer_is_resident_of_united_states
+          or (
+            employer_is_partnership
+            and partnership_partners_resident_of_united_states_fraction >= partnership_resident_partner_fraction_threshold
+          )
+          or (
+            employer_is_trust
+            and all_trustees_are_residents_of_united_states
+          )
+          or corporation_employer_organized_under_laws_of_united_states_or_state


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(h)'s American employer definition.
- Include the partnership resident-partner threshold and generated tests for individual, partnership, United States/trust/corporation, and no-qualifying-branch cases.
- Include the signed encoding manifest.

## Notes
- Generated with `axiom-encode 0.2.188` / `gpt-5.5` in run `f9e01606`.
- The associated PolicyEngine oracle classification for section 3121(h) was added in TheAxiomFoundation/axiom-encode#199.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-h-20260525/statutes/26/3121/h.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-h-20260525/statutes/26/3121/h.test.yaml --root /private/tmp/rulespec-us-3121-h-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-h-20260525/statutes/26/3121/h.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-h-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage: 882 total outputs, 225 comparable, 654 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
