### PR TITLE
Add generated 3121(j) covered transportation service definitions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/j.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/j.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/j.yaml",
+      "sha256": "970f9cc106420ddef32fc17c6cf72890522afa9e1a16b5d2bbafb4ca10ad8baf"
+    },
+    {
+      "path": "statutes/26/3121/j.test.yaml",
+      "sha256": "1f38181031db8664184d2f4da3f1692e160644ddaffbfbc37a15c4765d7e0b77"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ffafa87b43192f1fa9f92fbb06c1fc8220589ff2",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.190",
+    "version_commit": "ffafa87b43192f1fa9f92fbb06c1fc8220589ff2"
+  },
+  "axiom_encode_version": "0.2.190",
+  "backend": "openai",
+  "citation": "26 USC 3121(j)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-j-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-j/workspace/context-manifest.json",
+  "context_manifest_sha256": "3f05474097c43013419303adfb7ddb1db3735f6c545c4f16e5d20d281b827d36",
+  "generated_at": "2026-05-25T04:45:48.078401+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-j-20260525-v2/openai-gpt-5.5/statutes/26/3121/j.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-j-20260525-v2",
+  "generated_output_sha256": "970f9cc106420ddef32fc17c6cf72890522afa9e1a16b5d2bbafb4ca10ad8baf",
+  "generation_prompt_sha256": "07e0f0121bbed86f2a07ca4c23bfa9c7f23e50e0d5700b84cd0dfb8531089222",
+  "model": "gpt-5.5",
+  "run_id": "acebac9e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "10480d7d0980ce73338f637c337f9711ad8ffe76a864f4aef0d7770c748bc7d9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-j-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-j.json",
+  "trace_sha256": "f664f27e8cded4874b35a9601b19f5074071fe8bbaf9f1fd8241b713b001e34d"
+}

--- a/statutes/26/3121/j.test.yaml
+++ b/statutes/26/3121/j.test.yaml
@@ -1,0 +1,117 @@
+- name: definitions_hold_for_retirement_system_acquisition_and_political_subdivision
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/j#input.pension_annuity_retirement_or_similar_fund_or_system: true
+    us:statutes/26/3121/j#input.established_by_state_or_political_subdivision: true
+    us:statutes/26/3121/j#input.covers_employees_of_state_or_political_subdivision_or_both: true
+    us:statutes/26/3121/j#input.covers_only_service_in_positions_connected_with_operation_of_public_transportation_system: false
+    us:statutes/26/3121/j#input.preacquisition_service_constituted_employment_under_this_chapter: true
+    ? us:statutes/26/3121/j#input.preacquisition_service_constituted_employment_under_subchapter_a_of_chapter_9_of_internal_revenue_code_of_1939
+    : false
+    us:statutes/26/3121/j#input.preacquisition_service_was_covered_by_agreement_pursuant_to_section_218_of_social_security_act: false
+    ? us:statutes/26/3121/j#input.some_preacquisition_employees_became_state_or_political_subdivision_employees_in_connection_with_and_at_time_of_acquisition
+    : true
+    us:statutes/26/3121/j#input.political_subdivision_under_other_law: false
+    us:statutes/26/3121/j#input.instrumentality_of_state: true
+    us:statutes/26/3121/j#input.instrumentality_of_one_or_more_political_subdivisions_of_state: false
+    us:statutes/26/3121/j#input.instrumentality_of_state_and_one_or_more_political_subdivisions: false
+  output:
+    us:statutes/26/3121/j#general_retirement_system_for_transportation_service: holds
+    us:statutes/26/3121/j#transportation_system_acquired_from_private_ownership: holds
+    us:statutes/26/3121/j#political_subdivision_for_transportation_service: holds
+- name: existing_system_historical_acquisition_is_covered_when_no_no_coverage_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/j#input.service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+    : true
+    ? us:statutes/26/3121/j#input.any_part_of_transportation_system_acquired_from_private_ownership_in_existing_system_historical_window
+    : true
+    ? us:statutes/26/3121/j#input.substantially_all_transportation_operation_service_covered_on_historical_reference_date_under_general_retirement_system_with_constitutionally_nonimpairable_benefits
+    : false
+    ? us:statutes/26/3121/j#input.no_part_of_transportation_system_operated_on_historical_reference_date_was_acquired_from_private_ownership_in_existing_system_historical_window
+    : false
+    ? us:statutes/26/3121/j#input.state_or_political_subdivision_made_later_acquisition_from_private_ownership_of_part_of_transportation_system
+    : false
+    ? us:statutes/26/3121/j#input.employee_became_state_or_political_subdivision_employee_in_connection_with_and_at_time_of_later_acquisition
+    : false
+    us:statutes/26/3121/j#input.employee_previously_rendered_employment_service_in_connection_with_operation_of_acquired_part: false
+    us:statutes/26/3121/j#input.service_has_commenced_under_third_calendar_quarter_timing_rule: false
+    ? us:statutes/26/3121/j#input.service_covered_on_commencement_day_by_general_retirement_system_without_special_provisions_for_acquired_employees
+    : false
+    ? us:statutes/26/3121/j#input.transportation_system_was_not_operated_by_state_or_political_subdivision_before_relevant_cutoff
+    : false
+    ? us:statutes/26/3121/j#input.at_time_of_first_later_acquisition_state_or_political_subdivision_lacked_general_retirement_system_covering_substantially_all_transportation_operation_service
+    : false
+  output:
+    us:statutes/26/3121/j#existing_transportation_system_no_coverage_case: not_holds
+    us:statutes/26/3121/j#post_cutoff_acquired_employee_transportation_service: not_holds
+    us:statutes/26/3121/j#newly_acquired_transportation_system_service: not_holds
+    us:statutes/26/3121/j#covered_transportation_service: holds
+- name: constitutionally_protected_general_retirement_system_blocks_existing_system_coverage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/j#input.service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+    : true
+    ? us:statutes/26/3121/j#input.any_part_of_transportation_system_acquired_from_private_ownership_in_existing_system_historical_window
+    : true
+    ? us:statutes/26/3121/j#input.substantially_all_transportation_operation_service_covered_on_historical_reference_date_under_general_retirement_system_with_constitutionally_nonimpairable_benefits
+    : true
+    ? us:statutes/26/3121/j#input.no_part_of_transportation_system_operated_on_historical_reference_date_was_acquired_from_private_ownership_in_existing_system_historical_window
+    : false
+    ? us:statutes/26/3121/j#input.state_or_political_subdivision_made_later_acquisition_from_private_ownership_of_part_of_transportation_system
+    : false
+    ? us:statutes/26/3121/j#input.employee_became_state_or_political_subdivision_employee_in_connection_with_and_at_time_of_later_acquisition
+    : false
+    us:statutes/26/3121/j#input.employee_previously_rendered_employment_service_in_connection_with_operation_of_acquired_part: false
+    us:statutes/26/3121/j#input.service_has_commenced_under_third_calendar_quarter_timing_rule: false
+    ? us:statutes/26/3121/j#input.service_covered_on_commencement_day_by_general_retirement_system_without_special_provisions_for_acquired_employees
+    : false
+    ? us:statutes/26/3121/j#input.transportation_system_was_not_operated_by_state_or_political_subdivision_before_relevant_cutoff
+    : false
+    ? us:statutes/26/3121/j#input.at_time_of_first_later_acquisition_state_or_political_subdivision_lacked_general_retirement_system_covering_substantially_all_transportation_operation_service
+    : false
+  output:
+    us:statutes/26/3121/j#existing_transportation_system_no_coverage_case: holds
+    us:statutes/26/3121/j#post_cutoff_acquired_employee_transportation_service: not_holds
+    us:statutes/26/3121/j#newly_acquired_transportation_system_service: not_holds
+    us:statutes/26/3121/j#covered_transportation_service: not_holds
+- name: later_acquired_employee_and_newly_acquired_system_coverage_paths_with_retirement_system_unless_carveout_false
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/j#input.service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+    : true
+    ? us:statutes/26/3121/j#input.any_part_of_transportation_system_acquired_from_private_ownership_in_existing_system_historical_window
+    : false
+    ? us:statutes/26/3121/j#input.substantially_all_transportation_operation_service_covered_on_historical_reference_date_under_general_retirement_system_with_constitutionally_nonimpairable_benefits
+    : false
+    ? us:statutes/26/3121/j#input.no_part_of_transportation_system_operated_on_historical_reference_date_was_acquired_from_private_ownership_in_existing_system_historical_window
+    : true
+    ? us:statutes/26/3121/j#input.state_or_political_subdivision_made_later_acquisition_from_private_ownership_of_part_of_transportation_system
+    : true
+    ? us:statutes/26/3121/j#input.employee_became_state_or_political_subdivision_employee_in_connection_with_and_at_time_of_later_acquisition
+    : true
+    us:statutes/26/3121/j#input.employee_previously_rendered_employment_service_in_connection_with_operation_of_acquired_part: true
+    us:statutes/26/3121/j#input.service_has_commenced_under_third_calendar_quarter_timing_rule: true
+    ? us:statutes/26/3121/j#input.service_covered_on_commencement_day_by_general_retirement_system_without_special_provisions_for_acquired_employees
+    : false
+    ? us:statutes/26/3121/j#input.transportation_system_was_not_operated_by_state_or_political_subdivision_before_relevant_cutoff
+    : true
+    ? us:statutes/26/3121/j#input.at_time_of_first_later_acquisition_state_or_political_subdivision_lacked_general_retirement_system_covering_substantially_all_transportation_operation_service
+    : true
+  output:
+    us:statutes/26/3121/j#existing_transportation_system_no_coverage_case: holds
+    us:statutes/26/3121/j#post_cutoff_acquired_employee_transportation_service: holds
+    us:statutes/26/3121/j#newly_acquired_transportation_system_service: holds
+    us:statutes/26/3121/j#covered_transportation_service: holds

--- a/statutes/26/3121/j.yaml
+++ b/statutes/26/3121/j.yaml
@@ -1,0 +1,258 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (j) Covered transportation service For purposes of this chapter— (1) Existing transportation systems—General rule Except as provided in paragraph (2), all service performed in the employ of a State or political subdivision in connection with its operation of a public transportation system shall constitute covered transportation service if any part of the transportation system was acquired from private ownership after 1936 and prior to 1951. (2) Existing transportation systems—Cases in which no transportation employees, or only certain employees, are covered Service performed in the employ of a State or political subdivision in connection with the operation of its public transportation system shall not constitute covered transportation service if— (A) any part of the transportation system was acquired from private ownership after 1936 and prior to 1951, and substantially all service in connection with the operation of the transportation system was, on December 31, 1950 , covered under a general retirement system providing benefits which, by reason of a provision of the State constitution dealing specifically with retirement systems of the State or political subdivisions thereof, cannot be diminished or impaired; or (B) no part of the transportation system operated by the State or political subdivision on December 31, 1950 , was acquired from private ownership after 1936 and prior to 1951; except that if such State or political subdivision makes an acquisition after 1950 from private ownership of any part of its transportation system, then, in the case of any employee who— (C) became an employee of such State or political subdivision in connection with and at the time of its acquisition after 1950 of such part, and (D) prior to such acquisition rendered service in employment (including as employment service covered by an agreement under section 218 of the Social Security Act) in connection with the operation of such part of the transportation system acquired by the State or political subdivision, the service of such employee in connection with the operation of the transportation system shall constitute covered transportation service, commencing with the first day of the third calendar quarter following the calendar quarter in which the acquisition of such part took place, unless on such first day such service of such employee is covered by a general retirement system which does not, with respect to such employee, contain special provisions applicable only to employees described in subparagraph (C). (3) Transportation systems acquired after 1950 All service performed in the employ of a State or political subdivision thereof in connection with its operation of a public transportation system shall constitute covered transportation service if the transportation system was not operated by the State or political subdivision prior to 1951 and, at the time of its first acquisition (after 1950) from private ownership of any part of its transportation system, the State or political subdivision did not have a general retirement system covering substantially all service performed in connection with the operation of the transportation system. (4) Definitions For purposes of this subsection— (A) The term “general retirement system” means any pension, annuity, retirement, or similar fund or system established by a State or by a political subdivision thereof for employees of the State, political subdivision, or both; but such term shall not include such a fund or system which covers only service performed in positions connected with the operation of its public transportation system. (B) A transportation system or a part thereof shall be considered to have been acquired by a State or political subdivision from private ownership if prior to the acquisition service performed by employees in connection with the operation of the system or part thereof acquired constituted employment under this chapter or subchapter A of chapter 9 of the Internal Revenue Code of 1939 or was covered by an agreement made pursuant to section 218 of the Social Security Act and some of such employees became employees of the State or political subdivision in connection with and at the time of such acquisition. (C) The term “political subdivision” includes an instrumentality of— (i) a State, (ii) one or more political subdivisions of a State, or (iii) a State and one or more of its political subdivisions.
+rules:
+  - name: general_retirement_system_for_transportation_service
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term “general retirement system” means any pension, annuity, retirement, or similar fund or system established by a State or by a political subdivision thereof for employees of the State, political subdivision, or both
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: but such term shall not include such a fund or system which covers only service performed in positions connected with the operation of its public transportation system
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          pension_annuity_retirement_or_similar_fund_or_system
+          and established_by_state_or_political_subdivision
+          and covers_employees_of_state_or_political_subdivision_or_both
+          and not covers_only_service_in_positions_connected_with_operation_of_public_transportation_system
+
+  - name: transportation_system_acquired_from_private_ownership
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(4)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: A transportation system or a part thereof shall be considered to have been acquired by a State or political subdivision from private ownership if prior to the acquisition service performed by employees in connection with the operation of the system or part thereof acquired constituted employment under this chapter or subchapter A of chapter 9 of the Internal Revenue Code of 1939 or was covered by an agreement made pursuant to section 218 of the Social Security Act
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: and some of such employees became employees of the State or political subdivision in connection with and at the time of such acquisition
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            preacquisition_service_constituted_employment_under_this_chapter
+            or preacquisition_service_constituted_employment_under_subchapter_a_of_chapter_9_of_internal_revenue_code_of_1939
+            or preacquisition_service_was_covered_by_agreement_pursuant_to_section_218_of_social_security_act
+          )
+          and some_preacquisition_employees_became_state_or_political_subdivision_employees_in_connection_with_and_at_time_of_acquisition
+
+  - name: political_subdivision_for_transportation_service
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(4)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term “political subdivision” includes an instrumentality of— (i) a State, (ii) one or more political subdivisions of a State, or (iii) a State and one or more of its political subdivisions.
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          political_subdivision_under_other_law
+          or instrumentality_of_state
+          or instrumentality_of_one_or_more_political_subdivisions_of_state
+          or instrumentality_of_state_and_one_or_more_political_subdivisions
+
+  - name: existing_transportation_system_no_coverage_case
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(2)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Service performed in the employ of a State or political subdivision in connection with the operation of its public transportation system shall not constitute covered transportation service if—
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any part of the transportation system was acquired from private ownership after 1936 and prior to 1951, and substantially all service in connection with the operation of the transportation system was, on December 31, 1950, covered under a general retirement system providing benefits which, by reason of a provision of the State constitution dealing specifically with retirement systems of the State or political subdivisions thereof, cannot be diminished or impaired
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: no part of the transportation system operated by the State or political subdivision on December 31, 1950, was acquired from private ownership after 1936 and prior to 1951
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+          and (
+            (
+              any_part_of_transportation_system_acquired_from_private_ownership_in_existing_system_historical_window
+              and substantially_all_transportation_operation_service_covered_on_historical_reference_date_under_general_retirement_system_with_constitutionally_nonimpairable_benefits
+            )
+            or no_part_of_transportation_system_operated_on_historical_reference_date_was_acquired_from_private_ownership_in_existing_system_historical_window
+          )
+
+  - name: post_cutoff_acquired_employee_transportation_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(2)(B)-(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: except that if such State or political subdivision makes an acquisition after 1950 from private ownership of any part of its transportation system
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: became an employee of such State or political subdivision in connection with and at the time of its acquisition after 1950 of such part
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: prior to such acquisition rendered service in employment (including as employment service covered by an agreement under section 218 of the Social Security Act) in connection with the operation of such part of the transportation system acquired by the State or political subdivision
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: commencing with the first day of the third calendar quarter following the calendar quarter in which the acquisition of such part took place
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: unless on such first day such service of such employee is covered by a general retirement system which does not, with respect to such employee, contain special provisions applicable only to employees described in subparagraph (C)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+          and no_part_of_transportation_system_operated_on_historical_reference_date_was_acquired_from_private_ownership_in_existing_system_historical_window
+          and state_or_political_subdivision_made_later_acquisition_from_private_ownership_of_part_of_transportation_system
+          and employee_became_state_or_political_subdivision_employee_in_connection_with_and_at_time_of_later_acquisition
+          and employee_previously_rendered_employment_service_in_connection_with_operation_of_acquired_part
+          and service_has_commenced_under_third_calendar_quarter_timing_rule
+          and not service_covered_on_commencement_day_by_general_retirement_system_without_special_provisions_for_acquired_employees
+
+  - name: newly_acquired_transportation_system_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: All service performed in the employ of a State or political subdivision thereof in connection with its operation of a public transportation system shall constitute covered transportation service
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the transportation system was not operated by the State or political subdivision prior to 1951
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: and, at the time of its first acquisition (after 1950) from private ownership of any part of its transportation system, the State or political subdivision did not have a general retirement system covering substantially all service performed in connection with the operation of the transportation system
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+          and transportation_system_was_not_operated_by_state_or_political_subdivision_before_relevant_cutoff
+          and at_time_of_first_later_acquisition_state_or_political_subdivision_lacked_general_retirement_system_covering_substantially_all_transportation_operation_service
+
+  - name: covered_transportation_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(j)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Except as provided in paragraph (2), all service performed in the employ of a State or political subdivision in connection with its operation of a public transportation system shall constitute covered transportation service if any part of the transportation system was acquired from private ownership after 1936 and prior to 1951.
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Service performed in the employ of a State or political subdivision in connection with the operation of its public transportation system shall not constitute covered transportation service if—
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the service of such employee in connection with the operation of the transportation system shall constitute covered transportation service
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: All service performed in the employ of a State or political subdivision thereof in connection with its operation of a public transportation system shall constitute covered transportation service
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/j#existing_transportation_system_no_coverage_case
+              output: existing_transportation_system_no_coverage_case
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/j#post_cutoff_acquired_employee_transportation_service
+              output: post_cutoff_acquired_employee_transportation_service
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/j#newly_acquired_transportation_system_service
+              output: newly_acquired_transportation_system_service
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            (
+              service_performed_in_employ_of_state_or_political_subdivision_in_connection_with_operation_of_public_transportation_system
+              and any_part_of_transportation_system_acquired_from_private_ownership_in_existing_system_historical_window
+              and not existing_transportation_system_no_coverage_case
+            )
+            or post_cutoff_acquired_employee_transportation_service
+            or newly_acquired_transportation_system_service
+          )


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(j) covered transportation service definitions.
- Include generated predicates for general retirement systems, transportation systems acquired from private ownership, political subdivisions, existing-system no-coverage cases, later-acquired employee coverage, newly acquired system coverage, and the composed covered-transportation-service rule.
- Include the signed encoding manifest.

## Notes
- Generated with `axiom-encode 0.2.190` / `gpt-5.5` in run `acebac9e`.
- The associated PolicyEngine oracle classification for section 3121(j) was added in TheAxiomFoundation/axiom-encode#201.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-j-20260525/statutes/26/3121/j.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-j-20260525/statutes/26/3121/j.test.yaml --root /private/tmp/rulespec-us-3121-j-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-j-20260525/statutes/26/3121/j.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-j-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage: 889 total outputs, 225 comparable, 661 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
