### PR TITLE
Add generated 3121(l) foreign affiliate agreement rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/l.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/l.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/l.yaml",
+      "sha256": "c81d073c64d315efec292be74e9d19f9b4d89578140066df87334b7ec28df43a"
+    },
+    {
+      "path": "statutes/26/3121/l.test.yaml",
+      "sha256": "28f06b757978df0a1d78e877ba84cf47dc4ec701f34cdc20b3208c2142ea5bc1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6cc00b17540e3517dfcdf381c04a315b12737fd8",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.192",
+    "version_commit": "6cc00b17540e3517dfcdf381c04a315b12737fd8"
+  },
+  "axiom_encode_version": "0.2.192",
+  "backend": "openai",
+  "citation": "26 USC 3121(l)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-l-20260525-v3/_eval_workspaces/openai-gpt-5.5/26-USC-3121-l/workspace/context-manifest.json",
+  "context_manifest_sha256": "5d4edef9cac65666b41f7cc6c14b5e71a5cc797051cdc2fd7952b99b2ac06445",
+  "generated_at": "2026-05-25T05:17:18.010015+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-l-20260525-v3/openai-gpt-5.5/statutes/26/3121/l.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-l-20260525-v3",
+  "generated_output_sha256": "c81d073c64d315efec292be74e9d19f9b4d89578140066df87334b7ec28df43a",
+  "generation_prompt_sha256": "92dd118955bcc4ae29b1c618dbf6b08c8054eca94311c479c6578b03a900fbb6",
+  "model": "gpt-5.5",
+  "run_id": "c86e52b1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "12724bb2a66cee276251a8f1a1f7a88f0a9e453dbcbb1980e63d652035bf5365"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-l-20260525-v3/traces/openai-gpt-5.5/26-USC-3121-l.json",
+  "trace_sha256": "0da16dc45119deaffb6cd06d75e844eb78b79ec05644c69178a6fa94da238e22"
+}

--- a/statutes/26/3121/l.test.yaml
+++ b/statutes/26/3121/l.test.yaml
@@ -1,0 +1,106 @@
+- name: corporation_interest_threshold_makes_foreign_affiliate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: false
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3121/h#input.employer_is_partnership: false
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0
+    us:statutes/26/3121/h#input.employer_is_trust: false
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: true
+    us:statutes/26/3121/l#input.entity_is_foreign_entity: true
+    us:statutes/26/3121/l#input.foreign_entity_is_corporation: true
+    us:statutes/26/3121/l#input.american_employer_interest_in_foreign_entity_voting_stock: 0.1
+    us:statutes/26/3121/l#input.american_employer_interest_in_foreign_entity_profits: 0
+    us:statutes/26/3121/l#input.agreement_amended_to_include_services_for_other_affiliate: true
+    ? us:statutes/26/3121/l#input.amendment_executed_after_first_month_following_first_calendar_quarter_for_which_agreement_is_in_effect
+    : true
+    us:statutes/26/3121/l#input.period_is_after_calendar_quarter_in_which_amendment_is_executed: true
+    us:statutes/26/3121/l#input.foreign_entity_ceases_to_be_foreign_affiliate_at_any_time_in_calendar_quarter: true
+    us:statutes/26/3121/l#input.period_is_end_of_that_calendar_quarter: true
+    us:statutes/26/3121/l#input.agreement_under_this_subsection: true
+    us:statutes/26/3121/l#input.attempted_termination_is_on_or_after_stated_no_termination_date: true
+    us:statutes/26/3121/l#input.overpayment_under_agreement_cannot_be_adjusted: true
+    us:statutes/26/3121/l#input.years_between_overpayment_and_claim_filing: 2
+  output:
+    us:statutes/26/3121/l#ten_percent_interest_in_foreign_entity: holds
+    us:statutes/26/3121/l#foreign_affiliate: holds
+    us:statutes/26/3121/l#agreement_effective_for_other_affiliate_after_late_amendment_quarter: holds
+    us:statutes/26/3121/l#agreement_effective_period_terminates_for_entity_ceasing_to_be_foreign_affiliate: holds
+    us:statutes/26/3121/l#agreement_may_not_be_terminated_after_stated_date: holds
+    us:statutes/26/3121/l#overpayment_payable_by_secretary_when_unadjustable_and_timely_claimed: holds
+- name: noncorporation_profit_interest_below_threshold_and_late_claim_do_not_qualify
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/h#input.employer_is_united_states_or_instrumentality_thereof: false
+    us:statutes/26/3121/h#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3121/h#input.employer_is_partnership: false
+    us:statutes/26/3121/h#input.partnership_partners_resident_of_united_states_fraction: 0
+    us:statutes/26/3121/h#input.employer_is_trust: false
+    us:statutes/26/3121/h#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3121/h#input.corporation_employer_organized_under_laws_of_united_states_or_state: true
+    us:statutes/26/3121/l#input.entity_is_foreign_entity: true
+    us:statutes/26/3121/l#input.foreign_entity_is_corporation: false
+    us:statutes/26/3121/l#input.american_employer_interest_in_foreign_entity_voting_stock: 0
+    us:statutes/26/3121/l#input.american_employer_interest_in_foreign_entity_profits: 0.09
+    us:statutes/26/3121/l#input.agreement_amended_to_include_services_for_other_affiliate: true
+    ? us:statutes/26/3121/l#input.amendment_executed_after_first_month_following_first_calendar_quarter_for_which_agreement_is_in_effect
+    : true
+    us:statutes/26/3121/l#input.period_is_after_calendar_quarter_in_which_amendment_is_executed: false
+    us:statutes/26/3121/l#input.foreign_entity_ceases_to_be_foreign_affiliate_at_any_time_in_calendar_quarter: false
+    us:statutes/26/3121/l#input.period_is_end_of_that_calendar_quarter: true
+    us:statutes/26/3121/l#input.agreement_under_this_subsection: true
+    us:statutes/26/3121/l#input.attempted_termination_is_on_or_after_stated_no_termination_date: false
+    us:statutes/26/3121/l#input.overpayment_under_agreement_cannot_be_adjusted: true
+    us:statutes/26/3121/l#input.years_between_overpayment_and_claim_filing: 3
+  output:
+    us:statutes/26/3121/l#ten_percent_interest_in_foreign_entity: not_holds
+    us:statutes/26/3121/l#foreign_affiliate: not_holds
+    us:statutes/26/3121/l#agreement_effective_for_other_affiliate_after_late_amendment_quarter: not_holds
+    us:statutes/26/3121/l#agreement_effective_period_terminates_for_entity_ceasing_to_be_foreign_affiliate: not_holds
+    us:statutes/26/3121/l#agreement_may_not_be_terminated_after_stated_date: not_holds
+    us:statutes/26/3121/l#overpayment_payable_by_secretary_when_unadjustable_and_timely_claimed: not_holds
+- name: coverage_and_trust_fund_wage_treatment_apply_for_qualifying_person
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/l#input.agreement_entered_into_pursuant_to_this_subsection: true
+    us:statutes/26/3121/l#input.employee_is_citizen_or_resident_of_united_states: true
+    us:statutes/26/3121/l#input.employee_performs_services_on_or_after_effective_date_of_agreement: true
+    us:statutes/26/3121/l#input.employee_is_employee_of_foreign_affiliate_specified_in_agreement: true
+    us:statutes/26/3121/l#input.employee_performs_services_outside_united_states: true
+    us:statutes/26/3121/l#input.service_would_be_excluded_from_employment_if_performed_in_united_states: false
+    us:statutes/26/3121/l#input.remuneration_would_be_excluded_from_wages_if_service_performed_in_united_states: false
+    us:statutes/26/3121/l#input.remuneration_paid_for_services_covered_by_foreign_affiliate_agreement: true
+    us:statutes/26/3121/l#input.remuneration_would_be_wages_if_services_constituted_employment: true
+    us:statutes/26/3121/l#input.remuneration_reported_to_secretary_under_agreement_or_regulations: true
+  output:
+    us:statutes/26/3121/l#foreign_affiliate_agreement_coverage_applies: holds
+    us:statutes/26/3121/l#remuneration_considered_wages_subject_to_chapter_taxes_for_trust_fund_purposes: holds
+- name: excluded_service_blocks_agreement_coverage_but_not_trust_fund_wage_treatment_when_trust_fund_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/l#input.agreement_entered_into_pursuant_to_this_subsection: true
+    us:statutes/26/3121/l#input.employee_is_citizen_or_resident_of_united_states: true
+    us:statutes/26/3121/l#input.employee_performs_services_on_or_after_effective_date_of_agreement: true
+    us:statutes/26/3121/l#input.employee_is_employee_of_foreign_affiliate_specified_in_agreement: true
+    us:statutes/26/3121/l#input.employee_performs_services_outside_united_states: true
+    us:statutes/26/3121/l#input.service_would_be_excluded_from_employment_if_performed_in_united_states: true
+    us:statutes/26/3121/l#input.remuneration_would_be_excluded_from_wages_if_service_performed_in_united_states: false
+    us:statutes/26/3121/l#input.remuneration_paid_for_services_covered_by_foreign_affiliate_agreement: true
+    us:statutes/26/3121/l#input.remuneration_would_be_wages_if_services_constituted_employment: true
+    us:statutes/26/3121/l#input.remuneration_reported_to_secretary_under_agreement_or_regulations: true
+  output:
+    us:statutes/26/3121/l#foreign_affiliate_agreement_coverage_applies: not_holds
+    us:statutes/26/3121/l#remuneration_considered_wages_subject_to_chapter_taxes_for_trust_fund_purposes: holds

--- a/statutes/26/3121/l.yaml
+++ b/statutes/26/3121/l.yaml
@@ -1,0 +1,279 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (l) Agreements entered into by American employers with respect to foreign affiliates (1) Agreement with respect to certain employees of foreign affiliate The Secretary shall, at the American employer’s request, enter into an agreement (in such manner and form as may be prescribed by the Secretary) with any American employer (as defined in subsection (h)) who desires to have the insurance system established by title II of the Social Security Act extended to service performed outside the United States in the employ of any 1 or more of such employer’s foreign affiliates (as defined in paragraph (6)) by all employees who are citizens or residents of the United States, except that the agreement shall not apply to any service performed by, or remuneration paid to, an employee if such service or remuneration would be excluded from the term “employment” or “wages”, as defined in this section, had the service been performed in the United States. Such agreement may be amended at any time so as to be made applicable, in the same manner and under the same conditions, with respect to any other foreign affiliate of such American employer. Such agreement shall be applicable with respect to citizens or residents of the United States who, on or after the effective date of the agreement, are employees of and perform services outside the United States for any foreign affiliate specified in the agreement. Such agreement shall provide— (A) that the American employer shall pay to the Secretary, at such time or times as the Secretary may by regulations prescribe, amounts equivalent to the sum of the taxes which would be imposed by sections 3101 and 3111 (including amounts equivalent to the interest, additions to the taxes, additional amounts, and penalties which would be applicable) with respect to the remuneration which would be wages if the services covered by the agreement constituted employment as defined in this section; and (B) that the American employer will comply with such regulations relating to payments and reports as the Secretary may prescribe to carry out the purposes of this subsection. (2) Effective period of agreement An agreement entered into pursuant to paragraph (1) shall be in effect for the period beginning with the first day of the calendar quarter in which such agreement is entered into or the first day of the succeeding calendar quarter, as may be specified in the agreement; except that in case such agreement is amended to include the services performed for any other affiliate and such amendment is executed after the first month following the first calendar quarter for which the agreement is in effect, the agreement shall be in effect with respect to service performed for such other affiliate only after the calendar quarter in which such amendment is executed. Notwithstanding any other provision of this subsection, the period for which any such agreement is effective with respect to any foreign entity shall terminate at the end of any calendar quarter in which the foreign entity, at any time in such quarter, ceases to be a foreign affiliate as defined in paragraph (6). (3) No termination of agreement No agreement under this subsection may be terminated, either in its entirety or with respect to any foreign affiliate, on or after June 15, 1989 . (4) Deposits in trust funds For purposes of section 201 of the Social Security Act, relating to appropriations to the Federal Old-Age and Survivors Insurance Trust Fund and the Federal Disability Insurance Trust Fund, such remuneration— (A) paid for services covered by an agreement entered into pursuant to paragraph (1) as would be wages if the services constituted employment, and (B) as is reported to the Secretary pursuant to the provisions of such agreement or of the regulations issued under this subsection, shall be considered wages subject to the taxes imposed by this chapter. (5) Overpayments and underpayments (A) If more or less than the correct amount due under an agreement entered into pursuant to this subsection is paid with respect to any payment of remuneration, proper adjustments with respect to the amounts due under such agreement shall be made, without interest, in such manner and at such times as may be required by regulations prescribed by the Secretary. (B) If an overpayment cannot be adjusted under subparagraph (A), the amount thereof shall be paid by the Secretary, through the Fiscal Service of the Treasury Department, but only if a claim for such overpayment is filed with the Secretary within two years from the time such overpayment was made. (6) Foreign affiliate defined For purposes of this subsection and section 210(a) of the Social Security Act— (A) In general A foreign affiliate of an American employer is any foreign entity in which such American employer has not less than a 10-percent interest. (B) Determination of 10-percent interest For purposes of subparagraph (A), an American employer has a 10-percent interest in any entity if such employer has such an interest directly (or through one or more entities)— (i) in the case of a corporation, in the voting stock thereof, and (ii) in the case of any other entity, in the profits thereof. (7) American employer as separate entity Each American employer which enters into an agreement pursuant to paragraph (1) of this subsection shall, for purposes of this subsection and section 6413(c)(2)(C), relating to special refunds in the case of employees of certain foreign entities, be considered an employer in its capacity as a party to such agreement separate and distinct from its identity as a person employing individuals on its own account. (8) Regulations Regulations of the Secretary to carry out the purposes of this subsection shall be designed to make the requirements imposed on American employers with respect to services covered by an agreement entered into pursuant to this subsection the same, so far as practicable, as those imposed upon employers pursuant to this title with respect to the taxes imposed by this chapter.
+  deferred_outputs:
+    - output: us:statutes/26/3121/l#american_employer_payment_due_under_foreign_affiliate_agreement
+      reason: The required payment amount is defined by reference to the taxes that would be imposed by sections 3101 and 3111, but the copied RuleSpec context for 26 USC 3101 and 26 USC 3111 has no executable tax outputs.
+    - output: us:statutes/26/3121/l#american_employer_separate_entity_for_special_refunds
+      reason: The separate-entity rule is expressly for purposes of section 6413(c)(2)(C), but no copied RuleSpec context provides that cited special-refund rule.
+imports:
+  - us:statutes/26/3121/h#american_employer
+rules:
+  - name: foreign_affiliate_interest_threshold
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 26 USC 3121(l)(6)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: not less than a 10-percent interest
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.10
+
+  - name: overpayment_claim_filing_year_limit
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: 26 USC 3121(l)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: within two years from the time such overpayment was made
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2
+
+  - name: ten_percent_interest_in_foreign_entity
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if such employer has such an interest directly (or through one or more entities)— (i) in the case of a corporation, in the voting stock thereof, and (ii) in the case of any other entity, in the profits thereof
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/l#foreign_affiliate_interest_threshold
+              output: foreign_affiliate_interest_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            foreign_entity_is_corporation
+            and american_employer_interest_in_foreign_entity_voting_stock >= foreign_affiliate_interest_threshold
+          )
+          or (
+            not foreign_entity_is_corporation
+            and american_employer_interest_in_foreign_entity_profits >= foreign_affiliate_interest_threshold
+          )
+
+  - name: foreign_affiliate
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(6)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: A foreign affiliate of an American employer is any foreign entity in which such American employer has not less than a 10-percent interest.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/h#american_employer
+              output: american_employer
+              hash: sha256:7fe5e86e5ea35041490b0a4c90cbb4d96badfd74b5da2fd235863b6c820b277e
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/l#ten_percent_interest_in_foreign_entity
+              output: ten_percent_interest_in_foreign_entity
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          american_employer
+          and entity_is_foreign_entity
+          and ten_percent_interest_in_foreign_entity
+
+  - name: foreign_affiliate_agreement_coverage_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Such agreement shall be applicable with respect to citizens or residents of the United States who, on or after the effective date of the agreement, are employees of and perform services outside the United States for any foreign affiliate specified in the agreement.
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: except that the agreement shall not apply to any service performed by, or remuneration paid to, an employee if such service or remuneration would be excluded from the term “employment” or “wages”, as defined in this section, had the service been performed in the United States
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          agreement_entered_into_pursuant_to_this_subsection
+          and employee_is_citizen_or_resident_of_united_states
+          and employee_performs_services_on_or_after_effective_date_of_agreement
+          and employee_is_employee_of_foreign_affiliate_specified_in_agreement
+          and employee_performs_services_outside_united_states
+          and not service_would_be_excluded_from_employment_if_performed_in_united_states
+          and not remuneration_would_be_excluded_from_wages_if_service_performed_in_united_states
+
+  - name: agreement_effective_for_other_affiliate_after_late_amendment_quarter
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: in case such agreement is amended to include the services performed for any other affiliate and such amendment is executed after the first month following the first calendar quarter for which the agreement is in effect
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the agreement shall be in effect with respect to service performed for such other affiliate only after the calendar quarter in which such amendment is executed
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          agreement_amended_to_include_services_for_other_affiliate
+          and amendment_executed_after_first_month_following_first_calendar_quarter_for_which_agreement_is_in_effect
+          and period_is_after_calendar_quarter_in_which_amendment_is_executed
+
+  - name: agreement_effective_period_terminates_for_entity_ceasing_to_be_foreign_affiliate
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: in which the foreign entity, at any time in such quarter, ceases to be a foreign affiliate as defined in paragraph (6)
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the period for which any such agreement is effective with respect to any foreign entity shall terminate at the end of any calendar quarter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          foreign_entity_ceases_to_be_foreign_affiliate_at_any_time_in_calendar_quarter
+          and period_is_end_of_that_calendar_quarter
+
+  - name: agreement_may_not_be_terminated_after_stated_date
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: No agreement under this subsection may be terminated, either in its entirety or with respect to any foreign affiliate, on or after June 15, 1989.
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          agreement_under_this_subsection
+          and attempted_termination_is_on_or_after_stated_no_termination_date
+
+  - name: remuneration_considered_wages_subject_to_chapter_taxes_for_trust_fund_purposes
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: paid for services covered by an agreement entered into pursuant to paragraph (1) as would be wages if the services constituted employment
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as is reported to the Secretary pursuant to the provisions of such agreement or of the regulations issued under this subsection
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall be considered wages subject to the taxes imposed by this chapter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          remuneration_paid_for_services_covered_by_foreign_affiliate_agreement
+          and remuneration_would_be_wages_if_services_constituted_employment
+          and remuneration_reported_to_secretary_under_agreement_or_regulations
+
+  - name: overpayment_payable_by_secretary_when_unadjustable_and_timely_claimed
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(l)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: If an overpayment cannot be adjusted under subparagraph (A)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: but only if a claim for such overpayment is filed with the Secretary within two years from the time such overpayment was made
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/l#overpayment_claim_filing_year_limit
+              output: overpayment_claim_filing_year_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          overpayment_under_agreement_cannot_be_adjusted
+          and years_between_overpayment_and_claim_filing <= overpayment_claim_filing_year_limit


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3121(l), covering foreign-affiliate agreement definitions and related timing/payment predicates.
- Include generated parameters for the 10-percent foreign-affiliate interest threshold and the two-year overpayment claim filing limit.
- Include the signed encoding manifest.

## Notes
- Generated with `axiom-encode 0.2.192` / `gpt-5.5` in run `c86e52b1`.
- The raw model artifact required the encoder-side mixed-output-entity test repair added in TheAxiomFoundation/axiom-encode#202.
- The associated PolicyEngine oracle classification for 3121(l) was added in TheAxiomFoundation/axiom-encode#203.
- Deferred outputs remain for the payment amount tied to unavailable 3101/3111 executable tax outputs and the 6413(c)(2)(C) special-refund separate-entity rule.

## Verification
- `uv run axiom-encode validate /private/tmp/rulespec-us-3121-l-20260525/statutes/26/3121/l.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3121-l-20260525/statutes/26/3121/l.test.yaml --root /private/tmp/rulespec-us-3121-l-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-l-20260525/statutes/26/3121/l.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-l-20260525 --base-ref origin/main --json`
- PolicyEngine oracle coverage: 899 total outputs, 225 comparable, 671 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
