### PR TITLE
Add generated 3121(n) uniformed service member rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/n.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/n.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/n.yaml",
+      "sha256": "bc7c567f659adac073f8f981aeee4b05b923be056d34e2bda291f6a9751334c8"
+    },
+    {
+      "path": "statutes/26/3121/n.test.yaml",
+      "sha256": "d3f60563fc27293dd4ff6b74430fed6f58dbe7e881d33978b86e76b0f8900017"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1d8a27e851c2cf328d0d064f77aee023e81785ce",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.195",
+    "version_commit": "1d8a27e851c2cf328d0d064f77aee023e81785ce"
+  },
+  "axiom_encode_version": "0.2.195",
+  "backend": "openai",
+  "citation": "26 USC 3121(n)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-n-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-n/workspace/context-manifest.json",
+  "context_manifest_sha256": "5a953b7f927b086b40d9ed8755a9002114f2fe70db19aa30ad04cd1e0af00c3e",
+  "generated_at": "2026-05-25T05:57:14.932013+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-n-20260525-v2/openai-gpt-5.5/statutes/26/3121/n.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-n-20260525-v2",
+  "generated_output_sha256": "bc7c567f659adac073f8f981aeee4b05b923be056d34e2bda291f6a9751334c8",
+  "generation_prompt_sha256": "d5e724ebb9c2b09618e43371256d4ef33571e67ed2b75fcaba22712ad3cd2d78",
+  "model": "gpt-5.5",
+  "run_id": "705e5ec9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8a3b91e9e9d2f7ddca54db22d2e76ca31fe5fda919b72e06eb1e04ccac66e877"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-n-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-n.json",
+  "trace_sha256": "ec97484f8ffe4980e37891b02bebfffbd04a4b1a249fca694de86a9dd6914eab"
+}

--- a/statutes/26/3121/n.test.yaml
+++ b/statutes/26/3121/n.test.yaml
@@ -1,0 +1,117 @@
+- name: appointed_or_enlisted_component_member_is_member_of_uniformed_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/n#input.temporary_member_of_coast_guard_reserve: false
+    us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard: true
+    ? us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+    : false
+    ? us:statutes/26/3121/n#input.commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+    : false
+    us:statutes/26/3121/n#input.serving_in_army_or_air_force_under_call_or_conscription: false
+    ? us:statutes/26/3121/n#input.retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+    : false
+    us:statutes/26/3121/n#input.member_of_fleet_reserve_or_fleet_marine_corps_reserve: false
+    us:statutes/26/3121/n#input.cadet_or_midshipman_at_specified_united_states_service_academy: false
+    ? us:statutes/26/3121/n#input.member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+    : false
+    us:statutes/26/3121/n#input.ordered_to_annual_training_duty: false
+    us:statutes/26/3121/n#input.annual_training_duty_days_ordered: 0
+    us:statutes/26/3121/n#input.performing_authorized_travel_to_or_from_annual_training_duty: false
+    ? us:statutes/26/3121/n#input.en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+    : false
+    us:statutes/26/3121/n#input.provisionally_accepted_for_active_duty: false
+    us:statutes/26/3121/n#input.selected_under_military_selective_service_act_for_active_military_naval_or_air_service: false
+    us:statutes/26/3121/n#input.ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty: false
+  output:
+    us:statutes/26/3121/n#member_of_uniformed_service: holds
+- name: reserve_officers_training_corps_ordered_to_fourteen_days_is_member
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/n#input.temporary_member_of_coast_guard_reserve: false
+    us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard: false
+    ? us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+    : false
+    ? us:statutes/26/3121/n#input.commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+    : false
+    us:statutes/26/3121/n#input.serving_in_army_or_air_force_under_call_or_conscription: false
+    ? us:statutes/26/3121/n#input.retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+    : false
+    us:statutes/26/3121/n#input.member_of_fleet_reserve_or_fleet_marine_corps_reserve: false
+    us:statutes/26/3121/n#input.cadet_or_midshipman_at_specified_united_states_service_academy: false
+    ? us:statutes/26/3121/n#input.member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+    : true
+    us:statutes/26/3121/n#input.ordered_to_annual_training_duty: true
+    us:statutes/26/3121/n#input.annual_training_duty_days_ordered: 14
+    us:statutes/26/3121/n#input.performing_authorized_travel_to_or_from_annual_training_duty: false
+    ? us:statutes/26/3121/n#input.en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+    : false
+    us:statutes/26/3121/n#input.provisionally_accepted_for_active_duty: false
+    us:statutes/26/3121/n#input.selected_under_military_selective_service_act_for_active_military_naval_or_air_service: false
+    us:statutes/26/3121/n#input.ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty: false
+  output:
+    us:statutes/26/3121/n#reserve_officers_training_corps_annual_training_duty_minimum_days: 14
+    us:statutes/26/3121/n#member_of_uniformed_service: holds
+- name: final_acceptance_selective_service_person_ordered_to_proceed_is_member
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/n#input.temporary_member_of_coast_guard_reserve: false
+    us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard: false
+    ? us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+    : false
+    ? us:statutes/26/3121/n#input.commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+    : false
+    us:statutes/26/3121/n#input.serving_in_army_or_air_force_under_call_or_conscription: false
+    ? us:statutes/26/3121/n#input.retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+    : false
+    us:statutes/26/3121/n#input.member_of_fleet_reserve_or_fleet_marine_corps_reserve: false
+    us:statutes/26/3121/n#input.cadet_or_midshipman_at_specified_united_states_service_academy: false
+    ? us:statutes/26/3121/n#input.member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+    : false
+    us:statutes/26/3121/n#input.ordered_to_annual_training_duty: false
+    us:statutes/26/3121/n#input.annual_training_duty_days_ordered: 0
+    us:statutes/26/3121/n#input.performing_authorized_travel_to_or_from_annual_training_duty: false
+    ? us:statutes/26/3121/n#input.en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+    : true
+    us:statutes/26/3121/n#input.provisionally_accepted_for_active_duty: false
+    us:statutes/26/3121/n#input.selected_under_military_selective_service_act_for_active_military_naval_or_air_service: true
+    us:statutes/26/3121/n#input.ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty: true
+  output:
+    us:statutes/26/3121/n#member_of_uniformed_service: holds
+- name: temporary_coast_guard_reserve_member_is_not_member_of_uniformed_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/n#input.temporary_member_of_coast_guard_reserve: true
+    us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard: true
+    ? us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+    : false
+    ? us:statutes/26/3121/n#input.commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+    : false
+    us:statutes/26/3121/n#input.serving_in_army_or_air_force_under_call_or_conscription: false
+    ? us:statutes/26/3121/n#input.retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+    : false
+    us:statutes/26/3121/n#input.member_of_fleet_reserve_or_fleet_marine_corps_reserve: false
+    us:statutes/26/3121/n#input.cadet_or_midshipman_at_specified_united_states_service_academy: false
+    ? us:statutes/26/3121/n#input.member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+    : false
+    us:statutes/26/3121/n#input.ordered_to_annual_training_duty: false
+    us:statutes/26/3121/n#input.annual_training_duty_days_ordered: 0
+    us:statutes/26/3121/n#input.performing_authorized_travel_to_or_from_annual_training_duty: false
+    ? us:statutes/26/3121/n#input.en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+    : false
+    us:statutes/26/3121/n#input.provisionally_accepted_for_active_duty: false
+    us:statutes/26/3121/n#input.selected_under_military_selective_service_act_for_active_military_naval_or_air_service: false
+    us:statutes/26/3121/n#input.ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty: false
+  output:
+    us:statutes/26/3121/n#member_of_uniformed_service: not_holds

--- a/statutes/26/3121/n.yaml
+++ b/statutes/26/3121/n.yaml
@@ -1,0 +1,124 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (n) Member of a uniformed service For purposes of this chapter, the term “member of a uniformed service” means any person appointed, enlisted, or inducted in a component of the Army, Navy, Air Force, Marine Corps, or Coast Guard (including a reserve component as defined in section 101(27) of title 38 , United States Code), or in one of those services without specification of component, or as a commissioned officer of the Coast and Geodetic Survey, the National Oceanic and Atmospheric Administration Corps, or the Regular or Reserve Corps 2 2 See Change of Name note below. of the Public Health Service, and any person serving in the Army or Air Force under call or conscription. The term includes— (1) a retired member of any of those services; (2) a member of the Fleet Reserve or Fleet Marine Corps Reserve; (3) a cadet at the United States Military Academy, a midshipman at the United States Naval Academy, and a cadet at the United States Coast Guard Academy or United States Air Force Academy; (4) a member of the Reserve Officers’ Training Corps, the Naval Reserve Officers’ Training Corps, or the Air Force Reserve Officers’ Training Corps, when ordered to annual training duty for fourteen days or more, and while performing authorized travel to and from that duty; and (5) any person while en route to or from, or at, a place for final acceptance or for entry upon active duty in the military, naval, or air service— (A) who has been provisionally accepted for such duty; or (B) who, under the Military Selective Service Act, has been selected for active military, naval, or air service; and has been ordered or directed to proceed to such place. The term does not include a temporary member of the Coast Guard Reserve.
+rules:
+  - name: reserve_officers_training_corps_annual_training_duty_minimum_days
+    kind: parameter
+    dtype: Count
+    period: Day
+    source: 26 USC 3121(n)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: ordered to annual training duty for fourteen days or more
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          14
+
+  - name: member_of_uniformed_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(n)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “member of a uniformed service” means any person appointed, enlisted, or inducted in a component of the Army, Navy, Air Force, Marine Corps, or Coast Guard (including a reserve component as defined in section 101(27) of title 38 , United States Code)
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: or in one of those services without specification of component
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: or as a commissioned officer of the Coast and Geodetic Survey, the National Oceanic and Atmospheric Administration Corps, or the Regular or Reserve Corps of the Public Health Service
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: and any person serving in the Army or Air Force under call or conscription
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term includes— (1) a retired member of any of those services
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: (2) a member of the Fleet Reserve or Fleet Marine Corps Reserve
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: (3) a cadet at the United States Military Academy, a midshipman at the United States Naval Academy, and a cadet at the United States Coast Guard Academy or United States Air Force Academy
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: (4) a member of the Reserve Officers’ Training Corps, the Naval Reserve Officers’ Training Corps, or the Air Force Reserve Officers’ Training Corps, when ordered to annual training duty for fourteen days or more, and while performing authorized travel to and from that duty
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/n#reserve_officers_training_corps_annual_training_duty_minimum_days
+              output: reserve_officers_training_corps_annual_training_duty_minimum_days
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: (5) any person while en route to or from, or at, a place for final acceptance or for entry upon active duty in the military, naval, or air service— (A) who has been provisionally accepted for such duty; or (B) who, under the Military Selective Service Act, has been selected for active military, naval, or air service; and has been ordered or directed to proceed to such place
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: The term does not include a temporary member of the Coast Guard Reserve.
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          not temporary_member_of_coast_guard_reserve
+          and (
+            appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard
+            or appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+            or commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+            or serving_in_army_or_air_force_under_call_or_conscription
+            or retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+            or member_of_fleet_reserve_or_fleet_marine_corps_reserve
+            or cadet_or_midshipman_at_specified_united_states_service_academy
+            or (
+              member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+              and ordered_to_annual_training_duty
+              and annual_training_duty_days_ordered >= reserve_officers_training_corps_annual_training_duty_minimum_days
+            )
+            or (
+              member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+              and ordered_to_annual_training_duty
+              and annual_training_duty_days_ordered >= reserve_officers_training_corps_annual_training_duty_minimum_days
+              and performing_authorized_travel_to_or_from_annual_training_duty
+            )
+            or (
+              en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+              and (
+                provisionally_accepted_for_active_duty
+                or selected_under_military_selective_service_act_for_active_military_naval_or_air_service
+              )
+              and ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty
+            )
+          )


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec coverage for 26 USC 3121(n), defining `member_of_uniformed_service` for FICA purposes.
- Adds the section-specific ROTC annual training duty threshold and four companion tests covering inclusion, threshold, final-acceptance/selective-service path, and the temporary Coast Guard Reserve exclusion.
- Includes the signed generation manifest.

## Provenance
- Generated with `axiom-encode 0.2.195`
- Model: `gpt-5.5`
- Run ID: `705e5ec9`
- Encoder commit: `1d8a27e851c2cf328d0d064f77aee023e81785ce`
- Dirty tracked encoder state: `false`

## Validation
- `uv run axiom-encode validate .../statutes/26/3121/n.yaml --skip-reviewers --json`
- `uv run axiom-encode test .../statutes/26/3121/n.test.yaml --root ... --json`
- `uv run axiom-encode proof-validate .../statutes/26/3121/n.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --json`
- PE oracle coverage: 901 total outputs, 225 comparable, 673 known-not-comparable, 3 legacy unmapped, 0 untested comparable
