### PR TITLE
Add generated 3121(p) Peace Corps service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/p.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/p.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/p.yaml",
+      "sha256": "cdaa5af6659860fecf0dde77518693f5c77fba19e6ee7fe1d327ead2a182f117"
+    },
+    {
+      "path": "statutes/26/3121/p.test.yaml",
+      "sha256": "22b2cb4dc8a9b6720f832a501f9ea5b5d5a5e8e5d85a0105b133af44aceddf13"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2e1629184b3d7951a5968d338c80ad40d2a6abc6",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.197",
+    "version_commit": "2e1629184b3d7951a5968d338c80ad40d2a6abc6"
+  },
+  "axiom_encode_version": "0.2.197",
+  "backend": "openai",
+  "citation": "26 USC 3121(p)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-p-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-p/workspace/context-manifest.json",
+  "context_manifest_sha256": "19d6c56ae6f96f72c02c0fb12e4cf176ab041f7e347761797815d30167c8d247",
+  "generated_at": "2026-05-25T06:26:38.292827+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-p-20260525-v2/openai-gpt-5.5/statutes/26/3121/p.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-p-20260525-v2",
+  "generated_output_sha256": "cdaa5af6659860fecf0dde77518693f5c77fba19e6ee7fe1d327ead2a182f117",
+  "generation_prompt_sha256": "7a78ca7e370af9133417a44ca2210c28da6fb4b915ade11a99118e6fae2fb4f5",
+  "model": "gpt-5.5",
+  "run_id": "dc8dcb28",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8fc95fa249c41d28b938f3567983a9b6fa28065d5cdffc7bf48ac69d9bf00098"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-p-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-p.json",
+  "trace_sha256": "43aa7fb522ff89bba564b54882876282e8b876c1ad0d48df73af9eaf529116fe"
+}

--- a/statutes/26/3121/p.test.yaml
+++ b/statutes/26/3121/p.test.yaml
@@ -1,0 +1,42 @@
+- name: peace_corps_volunteer_service_constitutes_employment_notwithstanding_subsection_b_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/p#input.service_performed_by_individual_as_peace_corps_volunteer_or_volunteer_leader_within_meaning_of_peace_corps_act
+      : true
+      us:statutes/26/3121/p#input.service_would_be_excluded_from_employment_under_subsection_b: true
+  output:
+    us:statutes/26/3121/p#peace_corps_volunteer_service_constitutes_employment:
+    - holds
+- name: peace_corps_volunteer_service_constitutes_employment_when_not_excluded_by_subsection_b
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/p#input.service_performed_by_individual_as_peace_corps_volunteer_or_volunteer_leader_within_meaning_of_peace_corps_act
+      : true
+      us:statutes/26/3121/p#input.service_would_be_excluded_from_employment_under_subsection_b: false
+  output:
+    us:statutes/26/3121/p#peace_corps_volunteer_service_constitutes_employment:
+    - holds
+- name: service_not_as_peace_corps_volunteer_or_leader_does_not_constitute_employment_under_subsection_p
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3121/p#input.service_performed_by_individual_as_peace_corps_volunteer_or_volunteer_leader_within_meaning_of_peace_corps_act
+      : false
+      us:statutes/26/3121/p#input.service_would_be_excluded_from_employment_under_subsection_b: true
+  output:
+    us:statutes/26/3121/p#peace_corps_volunteer_service_constitutes_employment:
+    - not_holds

--- a/statutes/26/3121/p.yaml
+++ b/statutes/26/3121/p.yaml
@@ -1,0 +1,41 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (p) Peace Corps volunteer service For purposes of this chapter, the term “employment” shall, notwithstanding the provisions of subsection (b) of this section, include service performed by an individual as a volunteer or volunteer leader within the meaning of the Peace Corps Act.
+rules:
+  - name: peace_corps_volunteer_service_constitutes_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(p)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “employment” shall, notwithstanding the provisions of subsection (b) of this section, include service performed by an individual as a volunteer or volunteer leader within the meaning of the Peace Corps Act
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: notwithstanding the provisions of subsection (b) of this section
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: service performed by an individual as a volunteer or volunteer leader within the meaning of the Peace Corps Act
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_individual_as_peace_corps_volunteer_or_volunteer_leader_within_meaning_of_peace_corps_act
+          and (
+            service_would_be_excluded_from_employment_under_subsection_b
+            or not service_would_be_excluded_from_employment_under_subsection_b
+          )


### PR DESCRIPTION
## Summary
- Add generated 26 USC 3121(p) Peace Corps volunteer-service employment inclusion rule.
- Add generated regression tests and signed encoding manifest.

## Provenance
- Generated by `axiom-encode encode --apply`
- Encoder: `0.2.197` (`2e1629184b3d7951a5968d338c80ad40d2a6abc6`)
- Model: `gpt-5.5`
- Run ID: `dc8dcb28`
- Tracked encoder dirty state: `false`

## Local validation
- `uv run axiom-encode validate statutes/26/3121/p.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/p.test.yaml --root /private/tmp/rulespec-us-3121-p-v2-20260525 --json` (3 cases)
- `uv run axiom-encode proof-validate statutes/26/3121/p.yaml` (3 atoms)
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-p-v2-20260525 --base-ref origin/main --json`

## PolicyEngine coverage
- `total_outputs`: 905
- `comparable`: 225
- `known_not_comparable`: 677
- `unmapped`: 3 legacy outputs
- `untested_comparable`: 0