### PR TITLE
Add generated 3121(q) tip remuneration rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/q.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/q.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/q.yaml",
+      "sha256": "47c1be6595a8d86dedd4a3b492fca478ff803c9a40bb4298cfc159ec06741e40"
+    },
+    {
+      "path": "statutes/26/3121/q.test.yaml",
+      "sha256": "6fa2b6fe3712be21abde4ac636544a9313c1ff80979c21313e2338d2cd68070a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "438a67a04d92afb0747c049a228c4191dbd31ea9",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.199",
+    "version_commit": "438a67a04d92afb0747c049a228c4191dbd31ea9"
+  },
+  "axiom_encode_version": "0.2.199",
+  "backend": "openai",
+  "citation": "26 USC 3121(q)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-q-20260525-v3/_eval_workspaces/openai-gpt-5.5/26-USC-3121-q/workspace/context-manifest.json",
+  "context_manifest_sha256": "ab925c50e7c1d2874ab8c0ede90f6668d8912ab245eeb6b17498345dbed799c7",
+  "generated_at": "2026-05-25T06:48:35.125690+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-q-20260525-v3/openai-gpt-5.5/statutes/26/3121/q.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-q-20260525-v3",
+  "generated_output_sha256": "47c1be6595a8d86dedd4a3b492fca478ff803c9a40bb4298cfc159ec06741e40",
+  "generation_prompt_sha256": "82c56e09dce4c380b1a169e045fe165357e0cc8c0d91dd54211a020457b0a241",
+  "model": "gpt-5.5",
+  "run_id": "c23ea05a",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5959e9fc2a03a42e213e7c6e6d8620c935efbd2c2956808841509b29f3c04495"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-q-20260525-v3/traces/openai-gpt-5.5/26-USC-3121-q.json",
+  "trace_sha256": "6fa4d050beffb08d77e5ec026429b5344d68ad3806b2904f6e4dfd3ea58455da"
+}

--- a/statutes/26/3121/q.test.yaml
+++ b/statutes/26/3121/q.test.yaml
@@ -1,0 +1,83 @@
+- name: tips_received_in_course_of_employment_are_remuneration_and_deemed_paid_by_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/q#input.employee_received_tips_in_course_of_employment: true
+  output:
+    us:statutes/26/3121/q#tips_remuneration_for_employment: holds
+    us:statutes/26/3121/q#tips_deemed_paid_by_employer_for_employer_taxes: holds
+- name: no_tips_received_in_course_of_employment_are_not_remuneration_under_this_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/q#input.employee_received_tips_in_course_of_employment: false
+  output:
+    us:statutes/26/3121/q#tips_remuneration_for_employment: not_holds
+    us:statutes/26/3121/q#tips_deemed_paid_by_employer_for_employer_taxes: not_holds
+- name: no_statement_branch_deems_tips_paid_at_time_received
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us:statutes/26/3121/q#input.employee_received_tips_in_course_of_employment: true
+    us:statutes/26/3121/q#input.no_written_statement_including_tips_furnished_to_employer: true
+    us:statutes/26/3121/q#input.day_is_time_tips_received: true
+  output:
+    us:statutes/26/3121/q#tips_remuneration_deemed_paid_when_received_if_no_statement_furnished: holds
+- name: no_statement_branch_does_not_apply_when_day_is_not_time_received
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-16'
+    end: '2026-01-16'
+  input:
+    us:statutes/26/3121/q#input.employee_received_tips_in_course_of_employment: true
+    us:statutes/26/3121/q#input.no_written_statement_including_tips_furnished_to_employer: true
+    us:statutes/26/3121/q#input.day_is_time_tips_received: false
+  output:
+    us:statutes/26/3121/q#tips_remuneration_deemed_paid_when_received_if_no_statement_furnished: not_holds
+- name: subtitle_f_notice_and_demand_timing_applies_for_no_statement
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-02-01'
+    end: '2026-02-01'
+  input:
+    us:statutes/26/3121/q#input.determining_employer_liability_for_employer_taxes_with_respect_to_tips: true
+    us:statutes/26/3121/q#input.no_written_statement_including_tips_furnished_to_employer: true
+    us:statutes/26/3121/q#input.written_statement_including_tips_furnished_to_employer_was_inaccurate_or_incomplete: false
+    us:statutes/26/3121/q#input.notice_and_demand_for_such_taxes_made_to_employer_by_secretary_on_day: true
+  output:
+    us:statutes/26/3121/q#tips_remuneration_deemed_paid_on_notice_and_demand_date_for_subtitle_f: holds
+- name: subtitle_f_notice_and_demand_timing_applies_for_inaccurate_or_incomplete_statement
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-02-02'
+    end: '2026-02-02'
+  input:
+    us:statutes/26/3121/q#input.determining_employer_liability_for_employer_taxes_with_respect_to_tips: true
+    us:statutes/26/3121/q#input.no_written_statement_including_tips_furnished_to_employer: false
+    us:statutes/26/3121/q#input.written_statement_including_tips_furnished_to_employer_was_inaccurate_or_incomplete: true
+    us:statutes/26/3121/q#input.notice_and_demand_for_such_taxes_made_to_employer_by_secretary_on_day: true
+  output:
+    us:statutes/26/3121/q#tips_remuneration_deemed_paid_on_notice_and_demand_date_for_subtitle_f: holds
+- name: subtitle_f_notice_and_demand_timing_does_not_apply_without_notice_and_demand
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-02-03'
+    end: '2026-02-03'
+  input:
+    us:statutes/26/3121/q#input.determining_employer_liability_for_employer_taxes_with_respect_to_tips: true
+    us:statutes/26/3121/q#input.no_written_statement_including_tips_furnished_to_employer: true
+    us:statutes/26/3121/q#input.written_statement_including_tips_furnished_to_employer_was_inaccurate_or_incomplete: false
+    us:statutes/26/3121/q#input.notice_and_demand_for_such_taxes_made_to_employer_by_secretary_on_day: false
+  output:
+    us:statutes/26/3121/q#tips_remuneration_deemed_paid_on_notice_and_demand_date_for_subtitle_f: not_holds

--- a/statutes/26/3121/q.yaml
+++ b/statutes/26/3121/q.yaml
@@ -1,0 +1,109 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (q) Tips included for both employee and employer taxes For purposes of this chapter, tips received by an employee in the course of his employment shall be considered remuneration for such employment (and deemed to have been paid by the employer for purposes of subsections (a) and (b) of section 3111). Such remuneration shall be deemed to be paid at the time a written statement including such tips is furnished to the employer pursuant to section 6053(a) or (if no statement including such tips is so furnished) at the time received; except that, in determining the employer’s liability in connection with the taxes imposed by section 3111 with respect to such tips in any case where no statement including such tips was so furnished (or to the extent that the statement so furnished was inaccurate or incomplete), such remuneration shall be deemed for purposes of subtitle F to be paid on the date on which notice and demand for such taxes is made to the employer by the Secretary.
+  deferred_outputs:
+    - output: us:statutes/26/3121/q#tips_remuneration_deemed_paid_when_written_statement_furnished
+      reason: The furnished-statement timing branch depends on whether a written statement including tips is furnished pursuant to section 6053(a), but no executable RuleSpec source for 26 USC 6053(a) is available.
+rules:
+  - name: tips_remuneration_for_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(q)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: tips received by an employee in the course of his employment shall be considered remuneration for such employment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employee_received_tips_in_course_of_employment
+
+  - name: tips_deemed_paid_by_employer_for_employer_taxes
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(q)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: tips received by an employee in the course of his employment shall be considered remuneration for such employment (and deemed to have been paid by the employer for purposes of subsections (a) and (b) of section 3111)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employee_received_tips_in_course_of_employment
+
+  - name: tips_remuneration_deemed_paid_when_received_if_no_statement_furnished
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3121(q)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if no statement including such tips is so furnished
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Such remuneration shall be deemed to be paid ... at the time received
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employee_received_tips_in_course_of_employment
+          and no_written_statement_including_tips_furnished_to_employer
+          and day_is_time_tips_received
+
+  - name: tips_remuneration_deemed_paid_on_notice_and_demand_date_for_subtitle_f
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3121(q)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: in determining the employer’s liability in connection with the taxes imposed by section 3111 with respect to such tips
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: in any case where no statement including such tips was so furnished (or to the extent that the statement so furnished was inaccurate or incomplete)
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: such remuneration shall be deemed for purposes of subtitle F to be paid on the date on which notice and demand for such taxes is made to the employer by the Secretary
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          determining_employer_liability_for_employer_taxes_with_respect_to_tips
+          and (
+            no_written_statement_including_tips_furnished_to_employer
+            or written_statement_including_tips_furnished_to_employer_was_inaccurate_or_incomplete
+          )
+          and notice_and_demand_for_such_taxes_made_to_employer_by_secretary_on_day


### PR DESCRIPTION
## Summary
- Add generated 26 USC 3121(q) tip-remuneration and employer/timing rules.
- Add generated companion tests and signed encoding manifest.

## Provenance
- Generated by `axiom-encode encode --apply`
- Encoder: `0.2.199` (`438a67a04d92afb0747c049a228c4191dbd31ea9`)
- Model: `gpt-5.5`
- Run ID: `c23ea05a`
- Tracked encoder dirty state: `false`

## Local validation
- `uv run axiom-encode validate statutes/26/3121/q.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/q.test.yaml --root /private/tmp/rulespec-us-3121-q-v3-20260525 --json` (7 cases)
- `uv run axiom-encode proof-validate statutes/26/3121/q.yaml` (7 atoms)
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-q-v3-20260525 --base-ref origin/main --json`

## PolicyEngine coverage
- `total_outputs`: 909
- `comparable`: 225
- `known_not_comparable`: 681
- `unmapped`: 3 legacy outputs
- `untested_comparable`: 0