### PR TITLE
Add generated 3121(r) religious order election rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/r.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/r.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/r.yaml",
+      "sha256": "8a989feccfbad2103ad98e111ea654768d3c919bfd11f6fa42086ba5996bdc75"
+    },
+    {
+      "path": "statutes/26/3121/r.test.yaml",
+      "sha256": "b2e2aabaf9c72b91e69adf7166b97740ccd4818b828028195120d306c006b5e5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ee3036c2ca4d8aaee71d09dba20dd9f16f84dbc6",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.200",
+    "version_commit": "ee3036c2ca4d8aaee71d09dba20dd9f16f84dbc6"
+  },
+  "axiom_encode_version": "0.2.200",
+  "backend": "openai",
+  "citation": "26 USC 3121(r)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-r-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-r/workspace/context-manifest.json",
+  "context_manifest_sha256": "968fb64058d9c96b1f001ac73337b90797d1883439690c7124b0cbea6d23c592",
+  "generated_at": "2026-05-25T07:07:00.283117+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-r-20260525-v2/openai-gpt-5.5/statutes/26/3121/r.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-r-20260525-v2",
+  "generated_output_sha256": "8a989feccfbad2103ad98e111ea654768d3c919bfd11f6fa42086ba5996bdc75",
+  "generation_prompt_sha256": "15e1c4b3d80cad82a5d0e0252e7b72ae6c6f3406853cf26de0ca62163e64bd57",
+  "model": "gpt-5.5",
+  "run_id": "7a17a004",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3af4df55eff6a7b775dea8e577276acbf21b515f852eb814b1374916f67401d9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-r-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-r.json",
+  "trace_sha256": "b9124f01f8ac2437bf5836f4b5a7a9a66f3b3421368e6f428ca93775dcc456c1"
+}

--- a/statutes/26/3121/r.test.yaml
+++ b/statutes/26/3121/r.test.yaml
@@ -1,0 +1,88 @@
+- name: qualifying_individual_is_member_and_retroactive_election_applies_to_pre_filing_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: true
+    ? us:statutes/26/3121/r#input.performs_tasks_usually_required_and_to_extent_usually_required_of_active_member_of_religious_order
+    : true
+    us:statutes/26/3121/r#input.considered_retired_because_of_old_age_or_total_disability: false
+    us:statutes/26/3121/r#input.certificate_designated_retroactive_beginning_under_clause_iii: true
+    us:statutes/26/3121/r#input.services_performed_before_quarter_in_which_certificate_is_filed: true
+    us:statutes/26/3121/r#input.individual_was_member_at_time_services_were_performed: true
+    us:statutes/26/3121/r#input.individual_living_on_first_day_of_quarter_in_which_certificate_is_filed: true
+  output:
+    us:statutes/26/3121/r#member: holds
+    us:statutes/26/3121/r#retroactive_election_applies_to_pre_filing_service: holds
+- name: retired_individual_is_not_member_and_pre_filing_service_not_covered_when_not_living_on_filing_quarter_first_day
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: true
+    ? us:statutes/26/3121/r#input.performs_tasks_usually_required_and_to_extent_usually_required_of_active_member_of_religious_order
+    : true
+    us:statutes/26/3121/r#input.considered_retired_because_of_old_age_or_total_disability: true
+    us:statutes/26/3121/r#input.certificate_designated_retroactive_beginning_under_clause_iii: true
+    us:statutes/26/3121/r#input.services_performed_before_quarter_in_which_certificate_is_filed: true
+    us:statutes/26/3121/r#input.individual_was_member_at_time_services_were_performed: true
+    us:statutes/26/3121/r#input.individual_living_on_first_day_of_quarter_in_which_certificate_is_filed: false
+  output:
+    us:statutes/26/3121/r#member: not_holds
+    us:statutes/26/3121/r#retroactive_election_applies_to_pre_filing_service: not_holds
+- name: valid_retroactive_certificate_makes_election_in_effect_and_sets_prior_quarter_tax_timing_rules
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/r#input.entity_is_religious_order_whose_members_are_required_to_take_vow_of_poverty_or_autonomous_subdivision_of_such_order
+    : true
+    us:statutes/26/3121/r#input.certificate_filed_in_form_and_manner_and_with_official_prescribed_by_regulations_under_chapter: true
+    us:statutes/26/3121/r#input.certificate_elects_social_security_title_ii_insurance_system_extended_to_member_duty_services: true
+    us:statutes/26/3121/r#input.certificate_provides_election_irrevocable: true
+    us:statutes/26/3121/r#input.certificate_provides_election_applies_to_all_current_and_future_covered_members: true
+    us:statutes/26/3121/r#input.certificate_provides_member_duty_services_deemed_performed_as_employee_of_order_or_subdivision: true
+    us:statutes/26/3121/r#input.certificate_provides_member_wages_determined_as_provided_in_subsection_i_4: true
+    us:statutes/26/3121/r#input.current_period_on_or_after_designated_beginning_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_filing_calendar_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_succeeding_filing_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_preceding_filing_quarter: true
+    us:statutes/26/3121/r#input.designated_beginning_quarter_precedes_filing_quarter_by_calendar_quarters: 20
+    us:statutes/26/3121/r#input.certificate_of_election_filed_pursuant_to_subsection_r: true
+    us:statutes/26/3121/r#input.certificate_effective_for_one_or_more_calendar_quarters_prior_to_filing_quarter: true
+  output:
+    us:statutes/26/3121/r#certificate_of_election_by_religious_order_valid: holds
+    us:statutes/26/3121/r#retroactive_designation_within_allowed_quarter_limit: holds
+    us:statutes/26/3121/r#election_of_coverage_in_effect: holds
+    us:statutes/26/3121/r#retroactive_prior_quarter_return_and_payment_due_date_rule_applies: holds
+    us:statutes/26/3121/r#retroactive_election_tax_assessment_minimum_years: 3
+- name: certificate_missing_irrevocability_and_too_early_retroactive_designation_does_not_make_election_in_effect
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3121/r#input.entity_is_religious_order_whose_members_are_required_to_take_vow_of_poverty_or_autonomous_subdivision_of_such_order
+    : true
+    us:statutes/26/3121/r#input.certificate_filed_in_form_and_manner_and_with_official_prescribed_by_regulations_under_chapter: true
+    us:statutes/26/3121/r#input.certificate_elects_social_security_title_ii_insurance_system_extended_to_member_duty_services: true
+    us:statutes/26/3121/r#input.certificate_provides_election_irrevocable: false
+    us:statutes/26/3121/r#input.certificate_provides_election_applies_to_all_current_and_future_covered_members: true
+    us:statutes/26/3121/r#input.certificate_provides_member_duty_services_deemed_performed_as_employee_of_order_or_subdivision: true
+    us:statutes/26/3121/r#input.certificate_provides_member_wages_determined_as_provided_in_subsection_i_4: true
+    us:statutes/26/3121/r#input.current_period_on_or_after_designated_beginning_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_filing_calendar_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_succeeding_filing_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_preceding_filing_quarter: true
+    us:statutes/26/3121/r#input.designated_beginning_quarter_precedes_filing_quarter_by_calendar_quarters: 21
+    us:statutes/26/3121/r#input.certificate_of_election_filed_pursuant_to_subsection_r: true
+    us:statutes/26/3121/r#input.certificate_effective_for_one_or_more_calendar_quarters_prior_to_filing_quarter: false
+  output:
+    us:statutes/26/3121/r#certificate_of_election_by_religious_order_valid: not_holds
+    us:statutes/26/3121/r#retroactive_designation_within_allowed_quarter_limit: not_holds
+    us:statutes/26/3121/r#election_of_coverage_in_effect: not_holds
+    us:statutes/26/3121/r#retroactive_prior_quarter_return_and_payment_due_date_rule_applies: not_holds
+    us:statutes/26/3121/r#retroactive_election_tax_assessment_minimum_years: 0

--- a/statutes/26/3121/r.yaml
+++ b/statutes/26/3121/r.yaml
@@ -1,0 +1,374 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: "(r) Election of coverage by religious orders (1) Certificate of election\
+    \ by order A religious order whose members are required to take a vow of poverty,\
+    \ or any autonomous subdivision of such order, may file a certificate (in such\
+    \ form and manner, and with such official, as may be prescribed by regulations\
+    \ under this chapter) electing to have the insurance system established by title\
+    \ II of the Social Security Act extended to services performed by its members\
+    \ in the exercise of duties required by such order or such subdivision thereof.\
+    \ Such certificate of election shall provide that\u2014 (A) such election of coverage\
+    \ by such order or subdivision shall be irrevocable; (B) such election shall apply\
+    \ to all current and future members of such order, or in the case of a subdivision\
+    \ thereof to all current and future members of such order who belong to such subdivision;\
+    \ (C) all services performed by a member of such an order or subdivision in the\
+    \ exercise of duties required by such order or subdivision shall be deemed to\
+    \ have been performed by such member as an employee of such order or subdivision;\
+    \ and (D) the wages of each member, upon which such order or subdivision shall\
+    \ pay the taxes imposed by sections 3101 and 3111, will be determined as provided\
+    \ in subsection (i)(4). (2) Definition of member For purposes of this subsection,\
+    \ a member of a religious order means any individual who is subject to a vow of\
+    \ poverty as a member of such order and who performs tasks usually required (and\
+    \ to the extent usually required) of an active member of such order and who is\
+    \ not considered retired because of old age or total disability. (3) Effective\
+    \ date for election (A) A certificate of election of coverage shall be in effect,\
+    \ for purposes of subsection (b)(8) and for purposes of section 210(a)(8) of the\
+    \ Social Security Act, for the period beginning with whichever of the following\
+    \ may be designated by the order or subdivision thereof: (i) the first day of\
+    \ the calendar quarter in which the certificate is filed, (ii) the first day of\
+    \ the calendar quarter succeeding such quarter, or (iii) the first day of any\
+    \ calendar quarter preceding the calendar quarter in which the certificate is\
+    \ filed, except that such date may not be earlier than the first day of the twentieth\
+    \ calendar quarter preceding the quarter in which such certificate is filed. Whenever\
+    \ a date is designated under clause (iii), the election shall apply to services\
+    \ performed before the quarter in which the certificate is filed only if the member\
+    \ performing such services was a member at the time such services were performed\
+    \ and is living on the first day of the quarter in which such certificate is filed.\
+    \ (B) If a certificate of election filed pursuant to this subsection is effective\
+    \ for one or more calendar quarters prior to the quarter in which such certificate\
+    \ is filed, then\u2014 (i) for purposes of computing interest and for purposes\
+    \ of section 6651 (relating to addition to tax for failure to file tax return),\
+    \ the due date for the return and payment of the tax for such prior calendar quarters\
+    \ resulting from the filing of such certificate shall be the last day of the calendar\
+    \ month following the calendar quarter in which the certificate is filed; and\
+    \ (ii) the statutory period for the assessment of such tax shall not expire before\
+    \ the expiration of 3 years from such due date. [(4) Repealed. Pub. L. 98\u2013\
+    21, title I, \xA7 102(b)(3)(B) , Apr. 20, 1983 , 97 Stat. 71 ]"
+rules:
+- name: retroactive_designation_max_preceding_calendar_quarters
+  kind: parameter
+  dtype: Count
+  period: Year
+  source: 26 USC 3121(r)(3)(A)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: such date may not be earlier than the first day of the twentieth
+            calendar quarter preceding the quarter in which such certificate is filed
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '20'
+- name: minimum_assessment_period_years_for_retroactive_election_tax
+  kind: parameter
+  dtype: Count
+  period: Year
+  source: 26 USC 3121(r)(3)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the statutory period for the assessment of such tax shall not expire
+            before the expiration of 3 years from such due date
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '3'
+- name: member
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: a member of a religious order means any individual who is subject
+            to a vow of poverty as a member of such order
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: and who performs tasks usually required (and to the extent usually
+            required) of an active member of such order
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: and who is not considered retired because of old age or total disability
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'individual_subject_to_vow_of_poverty_as_member_of_religious_order
+
+      and performs_tasks_usually_required_and_to_extent_usually_required_of_active_member_of_religious_order
+
+      and not considered_retired_because_of_old_age_or_total_disability'
+- name: certificate_of_election_by_religious_order_valid
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: A religious order whose members are required to take a vow of poverty,
+            or any autonomous subdivision of such order, may file a certificate
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: in such form and manner, and with such official, as may be prescribed
+            by regulations under this chapter
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: electing to have the insurance system established by title II of
+            the Social Security Act extended to services performed by its members
+            in the exercise of duties required by such order or such subdivision thereof
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: "Such certificate of election shall provide that\u2014 (A) such\
+            \ election of coverage by such order or subdivision shall be irrevocable"
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: such election shall apply to all current and future members of
+            such order, or in the case of a subdivision thereof to all current and
+            future members of such order who belong to such subdivision
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: all services performed by a member of such an order or subdivision
+            in the exercise of duties required by such order or subdivision shall
+            be deemed to have been performed by such member as an employee of such
+            order or subdivision
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the wages of each member, upon which such order or subdivision
+            shall pay the taxes imposed by sections 3101 and 3111, will be determined
+            as provided in subsection (i)(4)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'entity_is_religious_order_whose_members_are_required_to_take_vow_of_poverty_or_autonomous_subdivision_of_such_order
+
+      and certificate_filed_in_form_and_manner_and_with_official_prescribed_by_regulations_under_chapter
+
+      and certificate_elects_social_security_title_ii_insurance_system_extended_to_member_duty_services
+
+      and certificate_provides_election_irrevocable
+
+      and certificate_provides_election_applies_to_all_current_and_future_covered_members
+
+      and certificate_provides_member_duty_services_deemed_performed_as_employee_of_order_or_subdivision
+
+      and certificate_provides_member_wages_determined_as_provided_in_subsection_i_4'
+- name: retroactive_designation_within_allowed_quarter_limit
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(3)(A)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the first day of any calendar quarter preceding the calendar quarter
+            in which the certificate is filed
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: except that such date may not be earlier than the first day of
+            the twentieth calendar quarter preceding the quarter in which such certificate
+            is filed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#retroactive_designation_max_preceding_calendar_quarters
+          output: retroactive_designation_max_preceding_calendar_quarters
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'certificate_designates_first_day_of_calendar_quarter_preceding_filing_quarter
+
+      and designated_beginning_quarter_precedes_filing_quarter_by_calendar_quarters
+      <= retroactive_designation_max_preceding_calendar_quarters'
+- name: election_of_coverage_in_effect
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: A certificate of election of coverage shall be in effect, for purposes
+            of subsection (b)(8) and for purposes of section 210(a)(8) of the Social
+            Security Act, for the period beginning with whichever of the following
+            may be designated by the order or subdivision thereof
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the first day of the calendar quarter in which the certificate
+            is filed
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the first day of the calendar quarter succeeding such quarter
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the first day of any calendar quarter preceding the calendar quarter
+            in which the certificate is filed, except that such date may not be earlier
+            than the first day of the twentieth calendar quarter preceding the quarter
+            in which such certificate is filed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#certificate_of_election_by_religious_order_valid
+          output: certificate_of_election_by_religious_order_valid
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#retroactive_designation_within_allowed_quarter_limit
+          output: retroactive_designation_within_allowed_quarter_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "certificate_of_election_by_religious_order_valid\nand current_period_on_or_after_designated_beginning_quarter\n\
+      and (\n  certificate_designates_first_day_of_filing_calendar_quarter\n  or certificate_designates_first_day_of_calendar_quarter_succeeding_filing_quarter\n\
+      \  or retroactive_designation_within_allowed_quarter_limit\n)"
+- name: retroactive_election_applies_to_pre_filing_service
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: Whenever a date is designated under clause (iii), the election
+            shall apply to services performed before the quarter in which the certificate
+            is filed
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: only if the member performing such services was a member at the
+            time such services were performed
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: and is living on the first day of the quarter in which such certificate
+            is filed
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'certificate_designated_retroactive_beginning_under_clause_iii
+
+      and services_performed_before_quarter_in_which_certificate_is_filed
+
+      and individual_was_member_at_time_services_were_performed
+
+      and individual_living_on_first_day_of_quarter_in_which_certificate_is_filed'
+- name: retroactive_prior_quarter_return_and_payment_due_date_rule_applies
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3121(r)(3)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: If a certificate of election filed pursuant to this subsection
+            is effective for one or more calendar quarters prior to the quarter in
+            which such certificate is filed
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the due date for the return and payment of the tax for such prior
+            calendar quarters resulting from the filing of such certificate shall
+            be the last day of the calendar month following the calendar quarter in
+            which the certificate is filed
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'certificate_of_election_filed_pursuant_to_subsection_r
+
+      and certificate_effective_for_one_or_more_calendar_quarters_prior_to_filing_quarter'
+- name: retroactive_election_tax_assessment_minimum_years
+  kind: derived
+  entity: Employer
+  dtype: Count
+  period: Year
+  source: 26 USC 3121(r)(3)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: If a certificate of election filed pursuant to this subsection
+            is effective for one or more calendar quarters prior to the quarter in
+            which such certificate is filed
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: the statutory period for the assessment of such tax shall not expire
+            before the expiration of 3 years from such due date
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#minimum_assessment_period_years_for_retroactive_election_tax
+          output: minimum_assessment_period_years_for_retroactive_election_tax
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if certificate_of_election_filed_pursuant_to_subsection_r and certificate_effective_for_one_or_more_calendar_quarters_prior_to_filing_quarter:
+      minimum_assessment_period_years_for_retroactive_election_tax else: 0'


### PR DESCRIPTION
## Summary
- Adds generated rules and tests for `26 USC 3121(r)` religious order election coverage.
- Includes signed apply manifest from `axiom-encode encode --apply`.

## Provenance
- Encoder: `axiom-encode` `0.2.200`
- Encoder commit: `ee3036c2ca4d8aaee71d09dba20dd9f16f84dbc6`
- Model: `gpt-5.5`
- Run ID: `7a17a004`
- Dirty tracked encoder state: `false`

## Local validation
- `uv run axiom-encode validate statutes/26/3121/r.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/r.test.yaml --root . --json` (`4` cases)
- `uv run axiom-encode proof-validate statutes/26/3121/r.yaml` (`29` atoms)
- `uv run axiom-encode guard-generated --repo . --base-ref origin/main --json`

## PolicyEngine oracle coverage
On a copied rulespec tree:
- Total outputs: `918`
- Comparable: `225`
- Known not comparable: `690`
- Legacy unmapped: `3`
- Untested comparable: `0`
