### PR TITLE
Add generated 3121(w) church election rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/w.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/w.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/w.yaml",
+      "sha256": "2babfbda7f9ce6c45e8691d47c77aec2fa61e59fe2688a0ffe297ba271f8f4a0"
+    },
+    {
+      "path": "statutes/26/3121/w.test.yaml",
+      "sha256": "c7123d6cd3cf9df44578fbc639e6e3c4207c3ba9349e8f74bc7e7e53394f825e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "53c0c81cecbd9a4814b4fff05fc5d9b825597641",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.201",
+    "version_commit": "53c0c81cecbd9a4814b4fff05fc5d9b825597641"
+  },
+  "axiom_encode_version": "0.2.201",
+  "backend": "openai",
+  "citation": "26 USC 3121(w)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-w-20260525-apply-v201-rerun1/_eval_workspaces/openai-gpt-5.5/26-USC-3121-w/workspace/context-manifest.json",
+  "context_manifest_sha256": "cb9472ff4e08e23e29f17b030a2755c65f97d2e9739e701a5bb83b83404a68ab",
+  "generated_at": "2026-05-25T07:39:06.711351+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-w-20260525-apply-v201-rerun1/openai-gpt-5.5/statutes/26/3121/w.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-w-20260525-apply-v201-rerun1",
+  "generated_output_sha256": "2babfbda7f9ce6c45e8691d47c77aec2fa61e59fe2688a0ffe297ba271f8f4a0",
+  "generation_prompt_sha256": "8bee3fe11b78224bd7335780cf474827a4c91d82a5f07961a41a40d377589bbb",
+  "model": "gpt-5.5",
+  "run_id": "b8727965",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "836be2edcd507b48b5fbc82cb9e3ee65715caa01e79ee17022325a6bfb09d5f0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-w-20260525-apply-v201-rerun1/traces/openai-gpt-5.5/26-USC-3121-w.json",
+  "trace_sha256": "42b9cdf5c5ca6e074e312256b0833f2e12589ee4705c169266a1d401f4730808"
+}

--- a/statutes/26/3121/w.test.yaml
+++ b/statutes/26/3121/w.test.yaml
@@ -1,0 +1,136 @@
+- name: church_election_excludes_services_when_all_conditions_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/w#input.employer_is_church: true
+    us:statutes/26/3121/w#input.employer_is_convention_or_association_of_churches: false
+    ? us:statutes/26/3121/w#input.elementary_or_secondary_school_controlled_operated_or_principally_supported_by_church_or_church_association
+    : false
+    us:statutes/26/3121/w#input.church_controlled_tax_exempt_organization_described_in_section_501_c_3: false
+    us:statutes/26/3121/w#input.offers_goods_services_or_facilities_for_sale_to_general_public_other_than_incidental_basis: false
+    us:statutes/26/3121/w#input.goods_services_or_facilities_sold_at_nominal_charge_substantially_less_than_cost: false
+    us:statutes/26/3121/w#input.governmental_support_fraction: 0
+    ? us:statutes/26/3121/w#input.receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses
+    : 0
+    us:statutes/26/3121/w#input.election_made_within_statutory_time_period: true
+    us:statutes/26/3121/w#input.election_made_in_accordance_with_secretary_procedures: true
+    us:statutes/26/3121/w#input.organization_states_religious_opposition_to_employer_tax_payment: true
+    us:statutes/26/3121/w#input.years_information_required_under_section_6051_not_furnished_to_secretary: 0
+    us:statutes/26/3121/w#input.secretary_requested_previously_unfurnished_information: false
+    us:statutes/26/3121/w#input.furnished_all_previously_unfurnished_information_for_period_covered_by_election: false
+    us:statutes/26/3121/w#input.church_or_organization_revoked_election_under_secretary_regulations: false
+    us:statutes/26/3121/w#input.service_performed_after_statutory_service_start_date: true
+    us:statutes/26/3121/w#input.service_performed_by_current_or_future_employee: true
+  output:
+    us:statutes/26/3121/w#church: holds
+    us:statutes/26/3121/w#disqualified_public_commercial_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#qualified_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#election_available_to_church_or_qualified_organization: holds
+    us:statutes/26/3121/w#secretary_revocation_for_information_failure: not_holds
+    us:statutes/26/3121/w#election_revoked: not_holds
+    us:statutes/26/3121/w#secretary_revocation_retroactive_to_information_failure_period_start: not_holds
+    us:statutes/26/3121/w#services_excluded_from_employment_by_church_election: holds
+- name: qualified_church_controlled_organization_with_nominal_public_sales_is_not_disqualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/w#input.employer_is_church: false
+    us:statutes/26/3121/w#input.employer_is_convention_or_association_of_churches: false
+    ? us:statutes/26/3121/w#input.elementary_or_secondary_school_controlled_operated_or_principally_supported_by_church_or_church_association
+    : false
+    us:statutes/26/3121/w#input.church_controlled_tax_exempt_organization_described_in_section_501_c_3: true
+    us:statutes/26/3121/w#input.offers_goods_services_or_facilities_for_sale_to_general_public_other_than_incidental_basis: true
+    us:statutes/26/3121/w#input.goods_services_or_facilities_sold_at_nominal_charge_substantially_less_than_cost: true
+    us:statutes/26/3121/w#input.governmental_support_fraction: 0.3
+    ? us:statutes/26/3121/w#input.receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses
+    : 0
+    us:statutes/26/3121/w#input.election_made_within_statutory_time_period: true
+    us:statutes/26/3121/w#input.election_made_in_accordance_with_secretary_procedures: true
+    us:statutes/26/3121/w#input.organization_states_religious_opposition_to_employer_tax_payment: true
+    us:statutes/26/3121/w#input.years_information_required_under_section_6051_not_furnished_to_secretary: 0
+    us:statutes/26/3121/w#input.secretary_requested_previously_unfurnished_information: false
+    us:statutes/26/3121/w#input.furnished_all_previously_unfurnished_information_for_period_covered_by_election: true
+    us:statutes/26/3121/w#input.church_or_organization_revoked_election_under_secretary_regulations: false
+    us:statutes/26/3121/w#input.service_performed_after_statutory_service_start_date: true
+    us:statutes/26/3121/w#input.service_performed_by_current_or_future_employee: true
+  output:
+    us:statutes/26/3121/w#church: not_holds
+    us:statutes/26/3121/w#disqualified_public_commercial_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#qualified_church_controlled_organization: holds
+    us:statutes/26/3121/w#election_available_to_church_or_qualified_organization: holds
+    us:statutes/26/3121/w#secretary_revocation_for_information_failure: not_holds
+    us:statutes/26/3121/w#election_revoked: not_holds
+    us:statutes/26/3121/w#secretary_revocation_retroactive_to_information_failure_period_start: not_holds
+    us:statutes/26/3121/w#services_excluded_from_employment_by_church_election: holds
+- name: public_commercial_church_controlled_organization_above_support_threshold_is_not_qualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/w#input.employer_is_church: false
+    us:statutes/26/3121/w#input.employer_is_convention_or_association_of_churches: false
+    ? us:statutes/26/3121/w#input.elementary_or_secondary_school_controlled_operated_or_principally_supported_by_church_or_church_association
+    : false
+    us:statutes/26/3121/w#input.church_controlled_tax_exempt_organization_described_in_section_501_c_3: true
+    us:statutes/26/3121/w#input.offers_goods_services_or_facilities_for_sale_to_general_public_other_than_incidental_basis: true
+    us:statutes/26/3121/w#input.goods_services_or_facilities_sold_at_nominal_charge_substantially_less_than_cost: false
+    us:statutes/26/3121/w#input.governmental_support_fraction: 0.26
+    ? us:statutes/26/3121/w#input.receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses
+    : 0
+    us:statutes/26/3121/w#input.election_made_within_statutory_time_period: true
+    us:statutes/26/3121/w#input.election_made_in_accordance_with_secretary_procedures: true
+    us:statutes/26/3121/w#input.organization_states_religious_opposition_to_employer_tax_payment: true
+    us:statutes/26/3121/w#input.years_information_required_under_section_6051_not_furnished_to_secretary: 0
+    us:statutes/26/3121/w#input.secretary_requested_previously_unfurnished_information: false
+    us:statutes/26/3121/w#input.furnished_all_previously_unfurnished_information_for_period_covered_by_election: true
+    us:statutes/26/3121/w#input.church_or_organization_revoked_election_under_secretary_regulations: false
+    us:statutes/26/3121/w#input.service_performed_after_statutory_service_start_date: true
+    us:statutes/26/3121/w#input.service_performed_by_current_or_future_employee: true
+  output:
+    us:statutes/26/3121/w#church: not_holds
+    us:statutes/26/3121/w#disqualified_public_commercial_church_controlled_organization: holds
+    us:statutes/26/3121/w#qualified_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#election_available_to_church_or_qualified_organization: not_holds
+    us:statutes/26/3121/w#secretary_revocation_for_information_failure: not_holds
+    us:statutes/26/3121/w#election_revoked: not_holds
+    us:statutes/26/3121/w#secretary_revocation_retroactive_to_information_failure_period_start: not_holds
+    us:statutes/26/3121/w#services_excluded_from_employment_by_church_election: not_holds
+- name: secretary_information_failure_revokes_election_and_blocks_service_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/w#input.employer_is_church: true
+    us:statutes/26/3121/w#input.employer_is_convention_or_association_of_churches: false
+    ? us:statutes/26/3121/w#input.elementary_or_secondary_school_controlled_operated_or_principally_supported_by_church_or_church_association
+    : false
+    us:statutes/26/3121/w#input.church_controlled_tax_exempt_organization_described_in_section_501_c_3: false
+    us:statutes/26/3121/w#input.offers_goods_services_or_facilities_for_sale_to_general_public_other_than_incidental_basis: false
+    us:statutes/26/3121/w#input.goods_services_or_facilities_sold_at_nominal_charge_substantially_less_than_cost: false
+    us:statutes/26/3121/w#input.governmental_support_fraction: 0
+    ? us:statutes/26/3121/w#input.receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses
+    : 0
+    us:statutes/26/3121/w#input.election_made_within_statutory_time_period: true
+    us:statutes/26/3121/w#input.election_made_in_accordance_with_secretary_procedures: true
+    us:statutes/26/3121/w#input.organization_states_religious_opposition_to_employer_tax_payment: true
+    us:statutes/26/3121/w#input.years_information_required_under_section_6051_not_furnished_to_secretary: 2
+    us:statutes/26/3121/w#input.secretary_requested_previously_unfurnished_information: true
+    us:statutes/26/3121/w#input.furnished_all_previously_unfurnished_information_for_period_covered_by_election: false
+    us:statutes/26/3121/w#input.church_or_organization_revoked_election_under_secretary_regulations: false
+    us:statutes/26/3121/w#input.service_performed_after_statutory_service_start_date: true
+    us:statutes/26/3121/w#input.service_performed_by_current_or_future_employee: true
+  output:
+    us:statutes/26/3121/w#church: holds
+    us:statutes/26/3121/w#disqualified_public_commercial_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#qualified_church_controlled_organization: not_holds
+    us:statutes/26/3121/w#election_available_to_church_or_qualified_organization: holds
+    us:statutes/26/3121/w#secretary_revocation_for_information_failure: holds
+    us:statutes/26/3121/w#election_revoked: holds
+    us:statutes/26/3121/w#secretary_revocation_retroactive_to_information_failure_period_start: holds
+    us:statutes/26/3121/w#services_excluded_from_employment_by_church_election: not_holds

--- a/statutes/26/3121/w.yaml
+++ b/statutes/26/3121/w.yaml
@@ -1,0 +1,291 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    Churches and qualified church-controlled organizations may elect to exclude services from employment for title II of the Social Security Act and this chapter if opposed for religious reasons to the employer tax; the election timing, duration, revocation rules, and definitions of “church” and “qualified church-controlled organization” are stated in 26 USC 3121(w).
+rules:
+  - name: information_failure_revocation_period_years
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: 26 USC 3121(w)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: for a period of 2 years or more
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2
+
+  - name: disqualifying_public_support_threshold
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 26 USC 3121(w)(3)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: more than 25 percent of its support
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.25
+
+  - name: church
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_church
+          or employer_is_convention_or_association_of_churches
+          or elementary_or_secondary_school_controlled_operated_or_principally_supported_by_church_or_church_association
+
+  - name: disqualified_public_commercial_church_controlled_organization
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: offers goods, services, or facilities for sale, other than on an incidental basis, to the general public
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: other than goods, services, or facilities which are sold at a nominal charge
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: normally receives more than 25 percent of its support
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#disqualifying_public_support_threshold
+              output: disqualifying_public_support_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          offers_goods_services_or_facilities_for_sale_to_general_public_other_than_incidental_basis
+          and not goods_services_or_facilities_sold_at_nominal_charge_substantially_less_than_cost
+          and (
+            governmental_support_fraction > disqualifying_public_support_threshold
+            or receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses > disqualifying_public_support_threshold
+            or governmental_support_fraction + receipts_support_fraction_from_admissions_sales_services_or_facilities_in_non_unrelated_trades_or_businesses > disqualifying_public_support_threshold
+          )
+
+  - name: qualified_church_controlled_organization
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#disqualified_public_commercial_church_controlled_organization
+              output: disqualified_public_commercial_church_controlled_organization
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          church_controlled_tax_exempt_organization_described_in_section_501_c_3
+          and not disqualified_public_commercial_church_controlled_organization
+
+  - name: election_available_to_church_or_qualified_organization
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: opposed for religious reasons to the payment of the tax imposed under section 3111
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#church
+              output: church
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#qualified_church_controlled_organization
+              output: qualified_church_controlled_organization
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (church or qualified_church_controlled_organization)
+          and election_made_within_statutory_time_period
+          and election_made_in_accordance_with_secretary_procedures
+          and organization_states_religious_opposition_to_employer_tax_payment
+
+  - name: secretary_revocation_for_information_failure
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: fails to furnish the information required under section 6051 to the Secretary for a period of 2 years or more
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#information_failure_revocation_period_years
+              output: information_failure_revocation_period_years
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          years_information_required_under_section_6051_not_furnished_to_secretary >= information_failure_revocation_period_years
+          and secretary_requested_previously_unfurnished_information
+          and not furnished_all_previously_unfurnished_information_for_period_covered_by_election
+
+  - name: election_revoked
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#secretary_revocation_for_information_failure
+              output: secretary_revocation_for_information_failure
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          church_or_organization_revoked_election_under_secretary_regulations
+          or secretary_revocation_for_information_failure
+
+  - name: secretary_revocation_retroactive_to_information_failure_period_start
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall apply retroactively to the beginning of the 2-year period
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#secretary_revocation_for_information_failure
+              output: secretary_revocation_for_information_failure
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          secretary_revocation_for_information_failure
+
+  - name: services_excluded_from_employment_by_church_election
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(w)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall apply to current and future employees, and shall apply to service performed after December 31, 1983
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#election_available_to_church_or_qualified_organization
+              output: election_available_to_church_or_qualified_organization
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/w#election_revoked
+              output: election_revoked
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          election_available_to_church_or_qualified_organization
+          and service_performed_after_statutory_service_start_date
+          and service_performed_by_current_or_future_employee
+          and not election_revoked


### PR DESCRIPTION
## Summary
- Adds generated rules and tests for `26 USC 3121(w)` church and qualified church-controlled organization elections.
- Includes signed apply manifest from `axiom-encode encode --apply`.

## Provenance
- Encoder for generation: `axiom-encode` `0.2.201`
- Encoder commit for generation: `53c0c81cecbd9a4814b4fff05fc5d9b825597641`
- Model: `gpt-5.5`
- Run ID: `b8727965`
- Dirty tracked encoder state: `false`

## Local validation
- `uv run axiom-encode validate statutes/26/3121/w.yaml --skip-reviewers --json`
- `uv run axiom-encode test statutes/26/3121/w.test.yaml --root . --json` (`4` cases)
- `uv run axiom-encode proof-validate statutes/26/3121/w.yaml` (`25` atoms)
- `uv run axiom-encode guard-generated --repo . --base-ref origin/main --json`

## PolicyEngine oracle coverage
After encoder registry PRs through `axiom-encode` `0.2.202` (`d0a4fbe857404bd5f032943667aba0aceb5cdd75`), on a copied rulespec tree:
- Total outputs: `928`
- Comparable: `225`
- Known not comparable: `700`
- Legacy unmapped: `3`
- Untested comparable: `0`
