### PR TITLE
Add generated 3121(i) wage computation rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/i.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/i.yaml",
+      "sha256": "0b617c4fb8845e3fcd570ea0161867d3fcf4d2d797f68ffa96a3c7863b70b4d1"
+    },
+    {
+      "path": "statutes/26/3121/i.test.yaml",
+      "sha256": "0d1222b1923c702bdb0ecbbff957acbc519e3037b9b2364cc2e2375bbc0a6105"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d0a4fbe857404bd5f032943667aba0aceb5cdd75",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.202",
+    "version_commit": "d0a4fbe857404bd5f032943667aba0aceb5cdd75"
+  },
+  "axiom_encode_version": "0.2.202",
+  "backend": "openai",
+  "citation": "26 USC 3121(i)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-i-20260525-v2/_eval_workspaces/openai-gpt-5.5/26-USC-3121-i/workspace/context-manifest.json",
+  "context_manifest_sha256": "1dce2bd8f63081629d3d04fb743bda35069db6d83cd98938564083937de101be",
+  "generated_at": "2026-05-25T07:53:55.957476+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-i-20260525-v2/openai-gpt-5.5/statutes/26/3121/i.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-i-20260525-v2",
+  "generated_output_sha256": "0b617c4fb8845e3fcd570ea0161867d3fcf4d2d797f68ffa96a3c7863b70b4d1",
+  "generation_prompt_sha256": "632ae3fa80239e43ac6859dcfed03866610005e469ccbfb5ca92b430fadf99a2",
+  "model": "gpt-5.5",
+  "run_id": "ab644e9d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "360f51ec73c92469e098318cbdb2ad9d3bb38801a89f2ccaab616269f91d8bd3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-i-20260525-v2/traces/openai-gpt-5.5/26-USC-3121-i.json",
+  "trace_sha256": "9682b4f5500744e481de335a021fa0f39451587fc2946ae3b3cc3876f35600d2"
+}

--- a/statutes/26/3121/i.test.yaml
+++ b/statutes/26/3121/i.test.yaml
@@ -1,0 +1,209 @@
+- name: domestic_service_cash_remuneration_rounds_to_nearest_dollar
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/i#input.payment_amount: 12.49
+      us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: true
+      us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: true
+      us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: false
+      us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+    - us:statutes/26/3121/i#input.payment_amount: 12.5
+      us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: true
+      us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: true
+      us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: false
+      us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+    - us:statutes/26/3121/i#input.payment_amount: 9.75
+      us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: true
+      us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: false
+      us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: false
+      us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+  output:
+    us:statutes/26/3121/i#domestic_service_cash_remuneration_deemed_amount:
+    - 12
+    - 13
+    - 9.75
+    us:statutes/26/3121/i#retired_justice_or_judge_section_371_b_payment_excluded_from_wages:
+    - 0
+    - 0
+    - 0
+- name: domestic_service_cash_remuneration_rounds_to_nearest_dollar_scalar_outputs
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3121/i#domestic_service_fractional_dollar_rounding_threshold: 0.5
+    us:statutes/26/3121/i#domestic_service_fractional_dollar_rounding_increment: 1
+- name: uniformed_service_subsection_m_1_A_includes_only_basic_pay
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: false
+    us:statutes/26/3121/i#input.individual_performs_service_as_member_of_uniformed_service: true
+    us:statutes/26/3121/i#input.provisions_of_subsection_m_1_are_applicable_to_service: true
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_A_applies: true
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_B_applies: false
+    us:statutes/26/3121/i#input.basic_pay_described_in_chapter_3_and_section_1009_of_title_37: 50000
+    us:statutes/26/3121/i#input.compensation_for_service_determined_under_section_206_a_of_title_37: 3000
+    us:statutes/26/3121/n#input.temporary_member_of_coast_guard_reserve: false
+    us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_component_of_army_navy_air_force_marine_corps_or_coast_guard: true
+    ? us:statutes/26/3121/n#input.appointed_enlisted_or_inducted_in_army_navy_air_force_marine_corps_or_coast_guard_without_specification_of_component
+    : false
+    ? us:statutes/26/3121/n#input.commissioned_officer_of_coast_and_geodetic_survey_national_oceanic_and_atmospheric_administration_corps_or_public_health_service_regular_or_reserve_corps
+    : false
+    us:statutes/26/3121/n#input.serving_in_army_or_air_force_under_call_or_conscription: false
+    ? us:statutes/26/3121/n#input.retired_member_of_army_navy_air_force_marine_corps_coast_guard_coast_and_geodetic_survey_noaa_corps_or_public_health_service_corps
+    : false
+    us:statutes/26/3121/n#input.member_of_fleet_reserve_or_fleet_marine_corps_reserve: false
+    us:statutes/26/3121/n#input.cadet_or_midshipman_at_specified_united_states_service_academy: false
+    ? us:statutes/26/3121/n#input.member_of_reserve_officers_training_corps_naval_reserve_officers_training_corps_or_air_force_reserve_officers_training_corps
+    : false
+    us:statutes/26/3121/n#input.ordered_to_annual_training_duty: false
+    us:statutes/26/3121/n#input.annual_training_duty_days_ordered: 0
+    us:statutes/26/3121/n#input.performing_authorized_travel_to_or_from_annual_training_duty: false
+    ? us:statutes/26/3121/n#input.en_route_to_or_from_or_at_place_for_final_acceptance_or_entry_upon_active_duty_in_military_naval_or_air_service
+    : false
+    us:statutes/26/3121/n#input.provisionally_accepted_for_active_duty: false
+    us:statutes/26/3121/n#input.selected_under_military_selective_service_act_for_active_military_naval_or_air_service: false
+    us:statutes/26/3121/n#input.ordered_or_directed_to_proceed_to_place_for_final_acceptance_or_entry_upon_active_duty: false
+  output:
+    us:statutes/26/3121/i#uniformed_service_remuneration_included_before_subsection_a_1_limit: 50000
+- name: religious_order_member_remuneration_uses_monthly_floor
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:statutes/26/3121/i#input.individual_performs_service_in_exercise_of_duties_required_by_religious_order: true
+    ? us:statutes/26/3121/i#input.fair_market_value_of_board_lodging_clothing_and_other_perquisites_furnished_to_member_for_month
+    : 80
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: true
+    ? us:statutes/26/3121/r#input.performs_tasks_usually_required_and_to_extent_usually_required_of_active_member_of_religious_order
+    : true
+    us:statutes/26/3121/r#input.considered_retired_because_of_old_age_or_total_disability: false
+    ? us:statutes/26/3121/r#input.entity_is_religious_order_whose_members_are_required_to_take_vow_of_poverty_or_autonomous_subdivision_of_such_order
+    : true
+    us:statutes/26/3121/r#input.certificate_filed_in_form_and_manner_and_with_official_prescribed_by_regulations_under_chapter: true
+    us:statutes/26/3121/r#input.certificate_elects_social_security_title_ii_insurance_system_extended_to_member_duty_services: true
+    us:statutes/26/3121/r#input.certificate_provides_election_irrevocable: true
+    us:statutes/26/3121/r#input.certificate_provides_election_applies_to_all_current_and_future_covered_members: true
+    us:statutes/26/3121/r#input.certificate_provides_member_duty_services_deemed_performed_as_employee_of_order_or_subdivision: true
+    us:statutes/26/3121/r#input.certificate_provides_member_wages_determined_as_provided_in_subsection_i_4: true
+    us:statutes/26/3121/r#input.current_period_on_or_after_designated_beginning_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_filing_calendar_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_succeeding_filing_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_preceding_filing_quarter: false
+    us:statutes/26/3121/r#input.designated_beginning_quarter_precedes_filing_quarter_by_calendar_quarters: 0
+  output:
+    us:statutes/26/3121/i#religious_order_member_service_remuneration_before_subsection_a_1_limit: 100
+- name: religious_order_member_remuneration_uses_monthly_floor_scalar_outputs
+  period:
+    period_kind: custom
+    name: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:statutes/26/3121/i#input.individual_performs_service_in_exercise_of_duties_required_by_religious_order: true
+    ? us:statutes/26/3121/i#input.fair_market_value_of_board_lodging_clothing_and_other_perquisites_furnished_to_member_for_month
+    : 80
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: true
+    ? us:statutes/26/3121/r#input.performs_tasks_usually_required_and_to_extent_usually_required_of_active_member_of_religious_order
+    : true
+    us:statutes/26/3121/r#input.considered_retired_because_of_old_age_or_total_disability: false
+    ? us:statutes/26/3121/r#input.entity_is_religious_order_whose_members_are_required_to_take_vow_of_poverty_or_autonomous_subdivision_of_such_order
+    : true
+    us:statutes/26/3121/r#input.certificate_filed_in_form_and_manner_and_with_official_prescribed_by_regulations_under_chapter: true
+    us:statutes/26/3121/r#input.certificate_elects_social_security_title_ii_insurance_system_extended_to_member_duty_services: true
+    us:statutes/26/3121/r#input.certificate_provides_election_irrevocable: true
+    us:statutes/26/3121/r#input.certificate_provides_election_applies_to_all_current_and_future_covered_members: true
+    us:statutes/26/3121/r#input.certificate_provides_member_duty_services_deemed_performed_as_employee_of_order_or_subdivision: true
+    us:statutes/26/3121/r#input.certificate_provides_member_wages_determined_as_provided_in_subsection_i_4: true
+    us:statutes/26/3121/r#input.current_period_on_or_after_designated_beginning_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_filing_calendar_quarter: true
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_succeeding_filing_quarter: false
+    us:statutes/26/3121/r#input.certificate_designates_first_day_of_calendar_quarter_preceding_filing_quarter: false
+    us:statutes/26/3121/r#input.designated_beginning_quarter_precedes_filing_quarter_by_calendar_quarters: 0
+  output:
+    us:statutes/26/3121/i#religious_order_member_monthly_remuneration_floor: 100
+- name: retired_judge_section_371_b_payment_is_excluded_from_wages
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/i#input.payment_amount: 20000
+      us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: false
+      us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: false
+      us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: true
+      us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: true
+    - us:statutes/26/3121/i#input.payment_amount: 20000
+      us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: false
+      us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: false
+      us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: true
+      us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+  output:
+    us:statutes/26/3121/i#domestic_service_cash_remuneration_deemed_amount:
+    - 20000
+    - 20000
+    us:statutes/26/3121/i#retired_justice_or_judge_section_371_b_payment_excluded_from_wages:
+    - 20000
+    - 0
+- name: auto_zero_uniformed_service_remuneration_included_before_subsection_a_1_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: false
+    us:statutes/26/3121/i#input.basic_pay_described_in_chapter_3_and_section_1009_of_title_37: false
+    us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: false
+    us:statutes/26/3121/i#input.compensation_for_service_determined_under_section_206_a_of_title_37: false
+    ? us:statutes/26/3121/i#input.fair_market_value_of_board_lodging_clothing_and_other_perquisites_furnished_to_member_for_month
+    : 0
+    us:statutes/26/3121/i#input.individual_performs_service_as_member_of_uniformed_service: false
+    us:statutes/26/3121/i#input.individual_performs_service_in_exercise_of_duties_required_by_religious_order: false
+    us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: false
+    us:statutes/26/3121/i#input.payment_amount: 0
+    us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+    us:statutes/26/3121/i#input.provisions_of_subsection_m_1_are_applicable_to_service: false
+    us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: false
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_A_applies: false
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_B_applies: false
+  output:
+    us:statutes/26/3121/i#uniformed_service_remuneration_included_before_subsection_a_1_limit: 0
+- name: auto_zero_religious_order_member_service_remuneration_before_subsection_a_1_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/r#input.individual_subject_to_vow_of_poverty_as_member_of_religious_order: false
+    us:statutes/26/3121/i#input.basic_pay_described_in_chapter_3_and_section_1009_of_title_37: false
+    us:statutes/26/3121/i#input.cash_remuneration_for_domestic_service_described_in_subsection_a_7_B: false
+    us:statutes/26/3121/i#input.compensation_for_service_determined_under_section_206_a_of_title_37: false
+    ? us:statutes/26/3121/i#input.fair_market_value_of_board_lodging_clothing_and_other_perquisites_furnished_to_member_for_month
+    : 0
+    us:statutes/26/3121/i#input.individual_performs_service_as_member_of_uniformed_service: false
+    us:statutes/26/3121/i#input.individual_performs_service_in_exercise_of_duties_required_by_religious_order: false
+    us:statutes/26/3121/i#input.individual_performs_service_under_section_294_of_title_28: false
+    us:statutes/26/3121/i#input.payment_amount: 0
+    us:statutes/26/3121/i#input.payment_under_section_371_b_of_title_28_received_during_period_of_such_service: false
+    us:statutes/26/3121/i#input.provisions_of_subsection_m_1_are_applicable_to_service: false
+    us:statutes/26/3121/i#input.regulations_prescribe_nearest_dollar_computation_under_chapter: false
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_A_applies: false
+    us:statutes/26/3121/i#input.service_to_which_subsection_m_1_B_applies: false
+  output:
+    us:statutes/26/3121/i#religious_order_member_service_remuneration_before_subsection_a_1_limit: 0

--- a/statutes/26/3121/i.yaml
+++ b/statutes/26/3121/i.yaml
@@ -1,0 +1,208 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: '26 USC 3121(i) provides computation rules for wages in certain cases:
+    domestic service cash remuneration described in subsection (a)(7)(B) is computed
+    to the nearest dollar under prescribed regulations; uniformed-services remuneration
+    includes only specified basic pay or section 206(a) compensation, subject to subsection
+    (a)(1); Peace Corps volunteer service includes only amounts paid pursuant to specified
+    Peace Corps Act provisions, subject to subsection (a)(1); religious-order member
+    service with a subsection (r) election includes fair market value of board, lodging,
+    clothing, and other perquisites, not less than $100 a month, subject to subsection
+    (a)(1); and service by certain retired justices and judges excludes section 371(b)
+    payments received during the service period.'
+  deferred_outputs:
+  - output: us:statutes/26/3121/i#peace_corps_volunteer_service_remuneration_included_before_subsection_a_1_limit
+    reason: The Peace Corps volunteer-service wage rule depends on whether amounts
+      are paid pursuant to section 5(c) or 6(1) of the Peace Corps Act. No copied
+      RuleSpec source provides those upstream legal payment categories, and the prompt
+      identifies section 5(c) as a missing cited RuleSpec source.
+imports:
+- us:statutes/26/3121/n#member_of_uniformed_service
+- us:statutes/26/3121/r#member
+- us:statutes/26/3121/r#election_of_coverage_in_effect
+rules:
+- name: domestic_service_fractional_dollar_rounding_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(i)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: one-half dollar or more
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.50'
+- name: domestic_service_fractional_dollar_rounding_increment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(i)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: it shall be increased to $1
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1'
+- name: religious_order_member_monthly_remuneration_floor
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 26 USC 3121(i)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: shall not be less than $100 a month
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '100'
+- name: domestic_service_cash_remuneration_deemed_amount
+  kind: derived
+  entity: Payment
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(i)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/i#domestic_service_fractional_dollar_rounding_threshold
+          output: domestic_service_fractional_dollar_rounding_threshold
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/i#domestic_service_fractional_dollar_rounding_increment
+          output: domestic_service_fractional_dollar_rounding_increment
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if cash_remuneration_for_domestic_service_described_in_subsection_a_7_B
+      and regulations_prescribe_nearest_dollar_computation_under_chapter: floor(payment_amount)
+      + (if payment_amount - floor(payment_amount) >= domestic_service_fractional_dollar_rounding_threshold:
+      domestic_service_fractional_dollar_rounding_increment else: 0) else: payment_amount'
+- name: uniformed_service_remuneration_included_before_subsection_a_1_limit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(i)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/n#member_of_uniformed_service
+          output: member_of_uniformed_service
+          hash: sha256:bc7c567f659adac073f8f981aeee4b05b923be056d34e2bda291f6a9751334c8
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "if individual_performs_service_as_member_of_uniformed_service and member_of_uniformed_service\
+      \ and provisions_of_subsection_m_1_are_applicable_to_service:\n  if service_to_which_subsection_m_1_A_applies:\n\
+      \    basic_pay_described_in_chapter_3_and_section_1009_of_title_37\n  else:\n\
+      \    if service_to_which_subsection_m_1_B_applies:\n      compensation_for_service_determined_under_section_206_a_of_title_37\n\
+      \    else:\n      0\nelse:\n  0"
+- name: religious_order_member_service_remuneration_before_subsection_a_1_limit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 26 USC 3121(i)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#member
+          output: member
+          hash: sha256:8a989feccfbad2103ad98e111ea654768d3c919bfd11f6fa42086ba5996bdc75
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/r#election_of_coverage_in_effect
+          output: election_of_coverage_in_effect
+          hash: sha256:8a989feccfbad2103ad98e111ea654768d3c919bfd11f6fa42086ba5996bdc75
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/i#religious_order_member_monthly_remuneration_floor
+          output: religious_order_member_monthly_remuneration_floor
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if member and individual_performs_service_in_exercise_of_duties_required_by_religious_order
+      and election_of_coverage_in_effect: max(fair_market_value_of_board_lodging_clothing_and_other_perquisites_furnished_to_member_for_month,
+      religious_order_member_monthly_remuneration_floor) else: 0'
+- name: retired_justice_or_judge_section_371_b_payment_excluded_from_wages
+  kind: derived
+  entity: Payment
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(i)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3121
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if individual_performs_service_under_section_294_of_title_28 and payment_under_section_371_b_of_title_28_received_during_period_of_such_service:
+      payment_amount else: 0'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(i), including domestic-service rounding, uniformed-service remuneration, religious-order member remuneration, and retired judge payment exclusion outputs
- add generated tests covering rounding, uniformed-service pay, religious-order monthly floor, retired judge exclusion, and auto-zero branches
- include signed axiom-encode apply manifest

## Generation
- axiom-encode 0.2.202
- commit d0a4fbe857404bd5f032943667aba0aceb5cdd75
- model gpt-5.5
- run ab644e9d

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-i-v2-20260525/statutes/26/3121/i.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-i-v2-20260525/statutes/26/3121/i.test.yaml --root /private/tmp/rulespec-us-3121-i-v2-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-i-v2-20260525/statutes/26/3121/i.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-i-v2-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121-i-v2-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable