### PR TITLE
Add generated 3121(x) domestic service threshold rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/x.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/x.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/x.yaml",
+      "sha256": "428ca248f56bec98b7228e63b8aec1e1572e511508f72a268ce8218e2f5b52cb"
+    },
+    {
+      "path": "statutes/26/3121/x.test.yaml",
+      "sha256": "0cb395d007d23e9004ec6266e6c60560dbd4c10a2fd2b0133bea4a234af7aad7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9070fe5903600f3b7298d747175f2274ba12a7b1",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.203",
+    "version_commit": "9070fe5903600f3b7298d747175f2274ba12a7b1"
+  },
+  "axiom_encode_version": "0.2.203",
+  "backend": "openai",
+  "citation": "26 USC 3121(x)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-x-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-x/workspace/context-manifest.json",
+  "context_manifest_sha256": "96be08f1fbd20ca7d738b44925fbcf778cc64353d7f934e8ea7cbd0691c5afba",
+  "generated_at": "2026-05-25T08:10:01.529951+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-x-20260525/openai-gpt-5.5/statutes/26/3121/x.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-x-20260525",
+  "generated_output_sha256": "428ca248f56bec98b7228e63b8aec1e1572e511508f72a268ce8218e2f5b52cb",
+  "generation_prompt_sha256": "2a4084e2ea7252cf28ad78f13e98d5535a6667703f2b88ca52c370e28d454fd0",
+  "model": "gpt-5.5",
+  "run_id": "adafc5b5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a01a1f9e8037c2bbffb5a3fa3bb27abaa430881fcc1a8adf9b0646f77d7f9f5f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-x-20260525/traces/openai-gpt-5.5/26-USC-3121-x.json",
+  "trace_sha256": "a942b84b1622095f22bf44cb886542f91e20f338690137d36ee4b3ecff56c89e"
+}

--- a/statutes/26/3121/x.test.yaml
+++ b/statutes/26/3121/x.test.yaml
@@ -1,0 +1,44 @@
+- name: base_calendar_year_uses_one_thousand_dollar_threshold
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '1995-01-01'
+    end: '1995-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+  output:
+    us:statutes/26/3121/x#statutory_applicable_dollar_threshold_base_amount: 1000
+    us:statutes/26/3121/x#adjusted_threshold_rounding_multiple: 100
+    us:statutes/26/3121/x#applicable_dollar_threshold:
+    - 1000
+- name: adjusted_amount_that_is_multiple_of_one_hundred_is_unchanged
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: true
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 2600
+  output:
+    us:statutes/26/3121/x#applicable_dollar_threshold:
+    - 2600
+- name: adjusted_amount_not_multiple_of_one_hundred_rounds_down
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: true
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 2699
+  output:
+    us:statutes/26/3121/x#applicable_dollar_threshold:
+    - 2600

--- a/statutes/26/3121/x.yaml
+++ b/statutes/26/3121/x.yaml
@@ -1,0 +1,102 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: "For purposes of subsection (a)(7)(B), \u201Capplicable dollar threshold\u201D\
+    \ means $1,000. For calendar years after 1995, that amount is adjusted at the\
+    \ same time and in the same manner as specified under section 215(a)(1)(B)(ii)\
+    \ of the Social Security Act, with 1993 substituted for the referenced calendar\
+    \ year, and any adjusted amount not a multiple of $100 is rounded to the next\
+    \ lowest multiple of $100."
+rules:
+- name: statutory_applicable_dollar_threshold_base_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(x)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: "the term \u201Capplicable dollar threshold\u201D means $1,000"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1000'
+- name: adjusted_threshold_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(x)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: not a multiple of $100
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '100'
+- name: applicable_dollar_threshold
+  kind: derived
+  entity: Payment
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3121(x)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: "For purposes of subsection (a)(7)(B), the term \u201Capplicable\
+            \ dollar threshold\u201D means $1,000"
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: In the case of calendar years after 1995
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: shall adjust such $1,000 amount at the same time and in the same
+            manner as under section 215(a)(1)(B)(ii) of the Social Security Act
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: 1993 shall be substituted for the calendar year referred to in
+            section 215(a)(1)(B)(ii)(II)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3121
+          excerpt: rounded to the next lowest multiple of $100
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/x#statutory_applicable_dollar_threshold_base_amount
+          output: statutory_applicable_dollar_threshold_base_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/x#adjusted_threshold_rounding_multiple
+          output: adjusted_threshold_rounding_multiple
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if calendar_year_after_base_year_for_adjustment: floor(social_security_act_adjusted_threshold_before_rounding
+      / adjusted_threshold_rounding_multiple) * adjusted_threshold_rounding_multiple
+      else: statutory_applicable_dollar_threshold_base_amount'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(x), defining the domestic-service applicable dollar threshold, adjustment rule, and  rounding multiple
- add generated tests for base-year threshold and adjusted-threshold rounding
- include signed axiom-encode apply manifest

## Generation
- axiom-encode 0.2.203
- commit 9070fe5903600f3b7298d747175f2274ba12a7b1
- model gpt-5.5
- run adafc5b5

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-x-20260525/statutes/26/3121/x.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3121-x-20260525/statutes/26/3121/x.test.yaml --root /private/tmp/rulespec-us-3121-x-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3121-x-20260525/statutes/26/3121/x.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-x-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121-x-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable