### PR TITLE
Add generated remaining 3121 payroll definition rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/s.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/s.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/s.yaml",
+      "sha256": "0fc65aa0e56d1f517f48b565eef9b055b3aadbc770a7b12c29add0bd3723e5f8"
+    },
+    {
+      "path": "statutes/26/3121/s.test.yaml",
+      "sha256": "f13e894677f64c1562cd250b510a1f58837204c82b67695061ea817c62108c70"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.205",
+    "version_commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460"
+  },
+  "axiom_encode_version": "0.2.205",
+  "backend": "openai",
+  "citation": "26 USC 3121(s)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-s-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-s/workspace/context-manifest.json",
+  "context_manifest_sha256": "fda08047f9cad80d187e09ef7a5be18cc3b58b625cb3e25912bb9d05158c0b58",
+  "generated_at": "2026-05-25T08:29:42.135248+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-s-20260525/openai-gpt-5.5/statutes/26/3121/s.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-s-20260525",
+  "generated_output_sha256": "0fc65aa0e56d1f517f48b565eef9b055b3aadbc770a7b12c29add0bd3723e5f8",
+  "generation_prompt_sha256": "870d3ba90b2bea12f0cb264382e73bea5275e06010682d3028c81033ff4d9546",
+  "model": "gpt-5.5",
+  "run_id": "5bde9a67",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "20cb425b4514297f0b1ed01f954e6d66b67e3d250085f5d7aefddf348b8c5213"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-s-20260525/traces/openai-gpt-5.5/26-USC-3121-s.json",
+  "trace_sha256": "76fa38717209a8cfb5b740e83b2e3da7a915741f5bfddaf0f5a00b937222a968"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/u.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/u.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/u.yaml",
+      "sha256": "3c69c7b0d3aaefcdae2a240c724cd735a18f84a244c0b211d9be371f6a98e710"
+    },
+    {
+      "path": "statutes/26/3121/u.test.yaml",
+      "sha256": "213f66240bbea16808f4a8c457c462f3600078cc5cb09df389e3f2f0e332181e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.205",
+    "version_commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460"
+  },
+  "axiom_encode_version": "0.2.205",
+  "backend": "openai",
+  "citation": "26 USC 3121(u)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-u-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-u/workspace/context-manifest.json",
+  "context_manifest_sha256": "5478308e78a8f384ac35c5c2cd040dbce756cafe6ce4e803aeacc0489b3ab0e5",
+  "generated_at": "2026-05-25T08:31:58.373270+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-u-20260525/openai-gpt-5.5/statutes/26/3121/u.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-u-20260525",
+  "generated_output_sha256": "3c69c7b0d3aaefcdae2a240c724cd735a18f84a244c0b211d9be371f6a98e710",
+  "generation_prompt_sha256": "e6eb24036ac41924a516a65f7284d92277b8cdfda8cc283fb95e518fb64ace6e",
+  "model": "gpt-5.5",
+  "run_id": "1401b2c9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d81a1ebdfe4b4c0780e5195321603dd4e7e6e7934bf3c509a8c4e9fc2727f263"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-u-20260525/traces/openai-gpt-5.5/26-USC-3121-u.json",
+  "trace_sha256": "29ace842924b57e9a3b7e33ccce405d86152a50236c427d135b2923e42793cfe"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/v.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/v.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/v.yaml",
+      "sha256": "6ec35b93bf860b6a33ca7ce8c5547ddface37026e0ec358a7f80c0df0e1cb956"
+    },
+    {
+      "path": "statutes/26/3121/v.test.yaml",
+      "sha256": "7ca79b4173bc56eb4ed0ce4426a711f332630223a6774587aa2f60f54804dfa7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.205",
+    "version_commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460"
+  },
+  "axiom_encode_version": "0.2.205",
+  "backend": "openai",
+  "citation": "26 USC 3121(v)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-v-retry-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-v/workspace/context-manifest.json",
+  "context_manifest_sha256": "509307a6b68338cb1df0e8d799e833fd10472a7ab6d06abc16737f4a35c45302",
+  "generated_at": "2026-05-25T08:37:05.009517+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-v-retry-20260525/openai-gpt-5.5/statutes/26/3121/v.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-v-retry-20260525",
+  "generated_output_sha256": "6ec35b93bf860b6a33ca7ce8c5547ddface37026e0ec358a7f80c0df0e1cb956",
+  "generation_prompt_sha256": "902d9540ca3649ddabcc13cdffdfa476a6dc15afc84b77f0994eff17abb4182b",
+  "model": "gpt-5.5",
+  "run_id": "2b1f259b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "14a1cd752a53fb60f9f981cd9729d1353e05f7f591d7cc1c82595261ee824057"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-v-retry-20260525/traces/openai-gpt-5.5/26-USC-3121-v.json",
+  "trace_sha256": "cb2d8ed32cc25ca7064246dcca817f4a688b34225a2bfb7bc8c2dd5aa63b6716"
+}

--- a/.axiom/encoding-manifests/statutes/26/3121/z.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/z.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/z.yaml",
+      "sha256": "fbd901ed2b3bbf99c47adb2635fcb05257f1bd559df95168938fd95b35a7d12a"
+    },
+    {
+      "path": "statutes/26/3121/z.test.yaml",
+      "sha256": "e3b5bea7f10085cc32d19a9fd97bbfb85ebb35f0cdb43628b04cf6cb22b61d92"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.205",
+    "version_commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460"
+  },
+  "axiom_encode_version": "0.2.205",
+  "backend": "openai",
+  "citation": "26 USC 3121(z)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3121-z-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3121-z/workspace/context-manifest.json",
+  "context_manifest_sha256": "6646ba78ebcd244426b20969836d7c9bf81ceef80b5cf41fc6b2f78dac2b7ddc",
+  "generated_at": "2026-05-25T08:38:26.975496+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3121-z-20260525/openai-gpt-5.5/statutes/26/3121/z.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3121-z-20260525",
+  "generated_output_sha256": "fbd901ed2b3bbf99c47adb2635fcb05257f1bd559df95168938fd95b35a7d12a",
+  "generation_prompt_sha256": "cb32d0ac7fe355c79295e5aee1a1970cf6d51e86e7d8fa3adec0b0dbd2314493",
+  "model": "gpt-5.5",
+  "run_id": "6b56f592",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "277e1e74931586b9cc839c7cc95efc7e0f4f99e49e79d21b2973ca4144e0bfdc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3121-z-20260525/traces/openai-gpt-5.5/26-USC-3121-z.json",
+  "trace_sha256": "7bfc7175ad791a7840fd2ac6a989a604b02d5e425508fef3b34907e72e12cf8e"
+}

--- a/statutes/26/3121/s.test.yaml
+++ b/statutes/26/3121/s.test.yaml
@@ -1,0 +1,80 @@
+- name: common_paymaster_rule_limits_remuneration_to_amounts_actually_disbursed_by_corporation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/s#input.two_or_more_related_corporations: true
+    us:statutes/26/3121/s#input.related_corporations_concurrently_employ_same_individual: true
+    us:statutes/26/3121/s#input.related_corporations_compensate_individual_through_common_paymaster: true
+    us:statutes/26/3121/s#input.common_paymaster_is_one_of_such_corporations: true
+    us:statutes/26/3121/s#input.amount_actually_disbursed_by_corporation_to_individual: 1000
+    us:statutes/26/3121/s#input.amount_actually_disbursed_to_individual_by_another_related_corporation: 2500
+  output:
+    us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies: holds
+    us:statutes/26/3121/s#remuneration_considered_paid_by_corporation_under_common_paymaster_rule: 1000
+    us:statutes/26/3121/s#remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule: 2500
+- name: rule_does_not_apply_without_two_or_more_related_corporations
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/s#input.two_or_more_related_corporations: false
+    us:statutes/26/3121/s#input.related_corporations_concurrently_employ_same_individual: true
+    us:statutes/26/3121/s#input.related_corporations_compensate_individual_through_common_paymaster: true
+    us:statutes/26/3121/s#input.common_paymaster_is_one_of_such_corporations: true
+    us:statutes/26/3121/s#input.amount_actually_disbursed_by_corporation_to_individual: 1000
+    us:statutes/26/3121/s#input.amount_actually_disbursed_to_individual_by_another_related_corporation: 2500
+  output:
+    us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies: not_holds
+    us:statutes/26/3121/s#remuneration_considered_paid_by_corporation_under_common_paymaster_rule: 0
+    us:statutes/26/3121/s#remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule: 0
+- name: rule_does_not_apply_without_concurrent_employment_of_same_individual
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/s#input.two_or_more_related_corporations: true
+    us:statutes/26/3121/s#input.related_corporations_concurrently_employ_same_individual: false
+    us:statutes/26/3121/s#input.related_corporations_compensate_individual_through_common_paymaster: true
+    us:statutes/26/3121/s#input.common_paymaster_is_one_of_such_corporations: true
+    us:statutes/26/3121/s#input.amount_actually_disbursed_by_corporation_to_individual: 1000
+    us:statutes/26/3121/s#input.amount_actually_disbursed_to_individual_by_another_related_corporation: 2500
+  output:
+    us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies: not_holds
+    us:statutes/26/3121/s#remuneration_considered_paid_by_corporation_under_common_paymaster_rule: 0
+    us:statutes/26/3121/s#remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule: 0
+- name: rule_does_not_apply_without_compensation_through_common_paymaster
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/s#input.two_or_more_related_corporations: true
+    us:statutes/26/3121/s#input.related_corporations_concurrently_employ_same_individual: true
+    us:statutes/26/3121/s#input.related_corporations_compensate_individual_through_common_paymaster: false
+    us:statutes/26/3121/s#input.common_paymaster_is_one_of_such_corporations: true
+    us:statutes/26/3121/s#input.amount_actually_disbursed_by_corporation_to_individual: 1000
+    us:statutes/26/3121/s#input.amount_actually_disbursed_to_individual_by_another_related_corporation: 2500
+  output:
+    us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies: not_holds
+    us:statutes/26/3121/s#remuneration_considered_paid_by_corporation_under_common_paymaster_rule: 0
+    us:statutes/26/3121/s#remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule: 0
+- name: rule_does_not_apply_when_common_paymaster_is_not_one_of_such_corporations
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/s#input.two_or_more_related_corporations: true
+    us:statutes/26/3121/s#input.related_corporations_concurrently_employ_same_individual: true
+    us:statutes/26/3121/s#input.related_corporations_compensate_individual_through_common_paymaster: true
+    us:statutes/26/3121/s#input.common_paymaster_is_one_of_such_corporations: false
+    us:statutes/26/3121/s#input.amount_actually_disbursed_by_corporation_to_individual: 1000
+    us:statutes/26/3121/s#input.amount_actually_disbursed_to_individual_by_another_related_corporation: 2500
+  output:
+    us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies: not_holds
+    us:statutes/26/3121/s#remuneration_considered_paid_by_corporation_under_common_paymaster_rule: 0
+    us:statutes/26/3121/s#remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule: 0

--- a/statutes/26/3121/s.yaml
+++ b/statutes/26/3121/s.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    For purposes of sections 3102, 3111, and 3121(a)(1), if two or more related corporations concurrently employ the same individual and compensate such individual through a common paymaster which is one of such corporations, each such corporation shall be considered to have paid as remuneration only the amounts actually disbursed by it and not amounts actually disbursed by another such corporation.
+rules:
+  - name: common_paymaster_concurrent_employment_rule_applies
+    kind: derived
+    entity: Corporation
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(s)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if two or more related corporations concurrently employ the same individual and compensate such individual through a common paymaster which is one of such corporations
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          two_or_more_related_corporations
+          and related_corporations_concurrently_employ_same_individual
+          and related_corporations_compensate_individual_through_common_paymaster
+          and common_paymaster_is_one_of_such_corporations
+
+  - name: remuneration_considered_paid_by_corporation_under_common_paymaster_rule
+    kind: derived
+    entity: Corporation
+    dtype: Money
+    period: Year
+    source: 26 USC 3121(s)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: each such corporation shall be considered to have paid as remuneration to such individual only the amounts actually disbursed by it to such individual
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies
+              output: common_paymaster_concurrent_employment_rule_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if common_paymaster_concurrent_employment_rule_applies: amount_actually_disbursed_by_corporation_to_individual else: 0
+
+  - name: remuneration_not_considered_paid_by_corporation_under_common_paymaster_rule
+    kind: derived
+    entity: Corporation
+    dtype: Money
+    period: Year
+    source: 26 USC 3121(s)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall not be considered to have paid as remuneration to such individual amounts actually disbursed to such individual by another of such corporations
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/s#common_paymaster_concurrent_employment_rule_applies
+              output: common_paymaster_concurrent_employment_rule_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if common_paymaster_concurrent_employment_rule_applies: amount_actually_disbursed_to_individual_by_another_related_corporation else: 0

--- a/statutes/26/3121/u.test.yaml
+++ b/statutes/26/3121/u.test.yaml
@@ -1,0 +1,174 @@
+- name: federal_service_is_hospital_insurance_employment_and_medicare_qualified_when_not_otherwise_employment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_5: true
+      us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_7: false
+      us:statutes/26/3121/u#input.service_performed_by_election_official_or_election_worker: false
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_within_specified_pre_adjustment_window: false
+      us:statutes/26/3121/u#input.calendar_year_remuneration_for_election_service: 0
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_subject_to_social_security_act_adjusted_amount: false
+      us:statutes/26/3121/u#input.adjusted_amount_determined_under_section_218_c_8_B_of_social_security_act_for_calendar_year: 2500
+      us:statutes/26/3121/u#input.service_included_under_agreement_under_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_employed_by_state_or_political_subdivision_to_relieve_unemployment
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_in_hospital_home_or_other_institution_by_patient_or_inmate_as_employee_of_state_political_subdivision_or_district_of_columbia
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_state_political_subdivision_or_district_of_columbia_employee_serving_temporarily_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_included_under_section_5351_2_of_title_5_other_than_medical_or_dental_intern_or_resident
+      : false
+      us:statutes/26/3121/u#input.service_performed_by_individual_in_position_described_in_section_1402_c_2_E: false
+      us:statutes/26/3121/u#input.service_would_be_excluded_from_employment_for_chapter_if_subparagraph_A_did_not_apply: false
+      ? us:statutes/26/3121/u#input.individual_was_performing_substantial_and_regular_service_for_remuneration_for_that_employer_before_applicable_continuity_date
+      : false
+      us:statutes/26/3121/u#input.individual_was_bona_fide_employee_of_that_employer_on_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.employment_relationship_entered_into_for_purposes_of_meeting_continuing_current_employment_exception
+      : false
+      us:statutes/26/3121/u#input.employment_relationship_with_that_employer_terminated_after_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.service_would_be_employment_as_defined_in_subsection_b_without_application_of_paragraphs_1_and_2
+      : false
+  output:
+    us:statutes/26/3121/u#federal_service_employment_for_hospital_insurance_tax:
+    - holds
+    us:statutes/26/3121/u#state_local_service_employment_for_hospital_insurance_tax:
+    - not_holds
+    us:statutes/26/3121/u#medicare_qualified_government_employment:
+    - holds
+- name: state_local_service_is_hospital_insurance_employment_when_no_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_5: false
+      us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_7: true
+      us:statutes/26/3121/u#input.service_performed_by_election_official_or_election_worker: false
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_within_specified_pre_adjustment_window: false
+      us:statutes/26/3121/u#input.calendar_year_remuneration_for_election_service: 0
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_subject_to_social_security_act_adjusted_amount: false
+      us:statutes/26/3121/u#input.adjusted_amount_determined_under_section_218_c_8_B_of_social_security_act_for_calendar_year: 2500
+      us:statutes/26/3121/u#input.service_included_under_agreement_under_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_employed_by_state_or_political_subdivision_to_relieve_unemployment
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_in_hospital_home_or_other_institution_by_patient_or_inmate_as_employee_of_state_political_subdivision_or_district_of_columbia
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_state_political_subdivision_or_district_of_columbia_employee_serving_temporarily_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_included_under_section_5351_2_of_title_5_other_than_medical_or_dental_intern_or_resident
+      : false
+      us:statutes/26/3121/u#input.service_performed_by_individual_in_position_described_in_section_1402_c_2_E: false
+      us:statutes/26/3121/u#input.service_would_be_excluded_from_employment_for_chapter_if_subparagraph_A_did_not_apply: false
+      ? us:statutes/26/3121/u#input.individual_was_performing_substantial_and_regular_service_for_remuneration_for_that_employer_before_applicable_continuity_date
+      : false
+      us:statutes/26/3121/u#input.individual_was_bona_fide_employee_of_that_employer_on_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.employment_relationship_entered_into_for_purposes_of_meeting_continuing_current_employment_exception
+      : false
+      us:statutes/26/3121/u#input.employment_relationship_with_that_employer_terminated_after_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.service_would_be_employment_as_defined_in_subsection_b_without_application_of_paragraphs_1_and_2
+      : false
+  output:
+    us:statutes/26/3121/u#state_local_hospital_insurance_employment_certain_services_exception:
+    - not_holds
+    us:statutes/26/3121/u#state_local_hospital_insurance_employment_continuing_current_employment_exception:
+    - not_holds
+    us:statutes/26/3121/u#state_local_service_employment_for_hospital_insurance_tax:
+    - holds
+    us:statutes/26/3121/u#medicare_qualified_government_employment:
+    - holds
+- name: section_218_agreement_exception_blocks_state_local_hospital_insurance_employment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_5: false
+      us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_7: true
+      us:statutes/26/3121/u#input.service_performed_by_election_official_or_election_worker: false
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_within_specified_pre_adjustment_window: false
+      us:statutes/26/3121/u#input.calendar_year_remuneration_for_election_service: 0
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_subject_to_social_security_act_adjusted_amount: false
+      us:statutes/26/3121/u#input.adjusted_amount_determined_under_section_218_c_8_B_of_social_security_act_for_calendar_year: 2500
+      us:statutes/26/3121/u#input.service_included_under_agreement_under_section_218_of_social_security_act: true
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_employed_by_state_or_political_subdivision_to_relieve_unemployment
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_in_hospital_home_or_other_institution_by_patient_or_inmate_as_employee_of_state_political_subdivision_or_district_of_columbia
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_state_political_subdivision_or_district_of_columbia_employee_serving_temporarily_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_included_under_section_5351_2_of_title_5_other_than_medical_or_dental_intern_or_resident
+      : false
+      us:statutes/26/3121/u#input.service_performed_by_individual_in_position_described_in_section_1402_c_2_E: false
+      us:statutes/26/3121/u#input.service_would_be_excluded_from_employment_for_chapter_if_subparagraph_A_did_not_apply: false
+      ? us:statutes/26/3121/u#input.individual_was_performing_substantial_and_regular_service_for_remuneration_for_that_employer_before_applicable_continuity_date
+      : false
+      us:statutes/26/3121/u#input.individual_was_bona_fide_employee_of_that_employer_on_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.employment_relationship_entered_into_for_purposes_of_meeting_continuing_current_employment_exception
+      : false
+      us:statutes/26/3121/u#input.employment_relationship_with_that_employer_terminated_after_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.service_would_be_employment_as_defined_in_subsection_b_without_application_of_paragraphs_1_and_2
+      : false
+  output:
+    us:statutes/26/3121/u#state_local_hospital_insurance_employment_certain_services_exception:
+    - holds
+    us:statutes/26/3121/u#state_local_service_employment_for_hospital_insurance_tax:
+    - not_holds
+    us:statutes/26/3121/u#medicare_qualified_government_employment:
+    - not_holds
+- name: election_worker_below_statutory_threshold_is_certain_services_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_5: false
+      us:statutes/26/3121/u#input.service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_7: true
+      us:statutes/26/3121/u#input.service_performed_by_election_official_or_election_worker: true
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_within_specified_pre_adjustment_window: true
+      us:statutes/26/3121/u#input.calendar_year_remuneration_for_election_service: 999
+      us:statutes/26/3121/u#input.service_performed_in_calendar_year_subject_to_social_security_act_adjusted_amount: false
+      us:statutes/26/3121/u#input.adjusted_amount_determined_under_section_218_c_8_B_of_social_security_act_for_calendar_year: 2500
+      us:statutes/26/3121/u#input.service_included_under_agreement_under_section_218_of_social_security_act: false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_employed_by_state_or_political_subdivision_to_relieve_unemployment
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_in_hospital_home_or_other_institution_by_patient_or_inmate_as_employee_of_state_political_subdivision_or_district_of_columbia
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_state_political_subdivision_or_district_of_columbia_employee_serving_temporarily_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+      : false
+      ? us:statutes/26/3121/u#input.service_performed_by_individual_included_under_section_5351_2_of_title_5_other_than_medical_or_dental_intern_or_resident
+      : false
+      us:statutes/26/3121/u#input.service_performed_by_individual_in_position_described_in_section_1402_c_2_E: false
+      us:statutes/26/3121/u#input.service_would_be_excluded_from_employment_for_chapter_if_subparagraph_A_did_not_apply: false
+      ? us:statutes/26/3121/u#input.individual_was_performing_substantial_and_regular_service_for_remuneration_for_that_employer_before_applicable_continuity_date
+      : false
+      us:statutes/26/3121/u#input.individual_was_bona_fide_employee_of_that_employer_on_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.employment_relationship_entered_into_for_purposes_of_meeting_continuing_current_employment_exception
+      : false
+      us:statutes/26/3121/u#input.employment_relationship_with_that_employer_terminated_after_applicable_continuity_date: false
+      ? us:statutes/26/3121/u#input.service_would_be_employment_as_defined_in_subsection_b_without_application_of_paragraphs_1_and_2
+      : false
+  output:
+    us:statutes/26/3121/u#election_worker_remuneration_below_applicable_threshold:
+    - holds
+    us:statutes/26/3121/u#state_local_hospital_insurance_employment_certain_services_exception:
+    - holds
+    us:statutes/26/3121/u#state_local_service_employment_for_hospital_insurance_tax:
+    - not_holds
+- name: election_worker_below_statutory_threshold_is_certain_services_exception_scalar_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3121/u#election_worker_remuneration_threshold_for_specified_calendar_years: 1000

--- a/statutes/26/3121/u.yaml
+++ b/statutes/26/3121/u.yaml
@@ -1,0 +1,212 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(u) applies the hospital insurance taxes imposed by sections 3101(b) and 3111(b) to Federal, State, and local employment by applying subsection (b) without regard to paragraph (5) for Federal employment and, subject to stated exceptions, without regard to paragraph (7) for State and local employment. It also defines “medicare qualified government employment” as service that is employment with paragraphs (1) and (2) applied but would not be employment without those paragraphs.
+rules:
+  - name: election_worker_remuneration_threshold_for_specified_calendar_years
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3121(u)(2)(B)(ii)(V)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: remuneration paid in a calendar year for such service is less than $1,000 with respect to service performed during any calendar year commencing on or after January 1, 1995, ending on or before December 31, 1999
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1000
+
+  - name: election_worker_remuneration_below_applicable_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(2)(B)(ii)(V)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: remuneration paid in a calendar year for such service is less than $1,000
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: adjusted amount determined under section 218(c)(8)(B) of the Social Security Act for any calendar year commencing on or after January 1, 2000
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#election_worker_remuneration_threshold_for_specified_calendar_years
+              output: election_worker_remuneration_threshold_for_specified_calendar_years
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_election_official_or_election_worker
+          and (
+            (
+              service_performed_in_calendar_year_within_specified_pre_adjustment_window
+              and calendar_year_remuneration_for_election_service < election_worker_remuneration_threshold_for_specified_calendar_years
+            )
+            or (
+              service_performed_in_calendar_year_subject_to_social_security_act_adjusted_amount
+              and calendar_year_remuneration_for_election_service < adjusted_amount_determined_under_section_218_c_8_B_of_social_security_act_for_calendar_year
+            )
+          )
+
+  - name: state_local_hospital_insurance_employment_certain_services_exception
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#election_worker_remuneration_below_applicable_threshold
+              output: election_worker_remuneration_below_applicable_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_included_under_agreement_under_section_218_of_social_security_act
+          or service_performed_by_individual_employed_by_state_or_political_subdivision_to_relieve_unemployment
+          or service_performed_in_hospital_home_or_other_institution_by_patient_or_inmate_as_employee_of_state_political_subdivision_or_district_of_columbia
+          or service_performed_by_state_political_subdivision_or_district_of_columbia_employee_serving_temporarily_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+          or service_performed_by_individual_included_under_section_5351_2_of_title_5_other_than_medical_or_dental_intern_or_resident
+          or election_worker_remuneration_below_applicable_threshold
+          or service_performed_by_individual_in_position_described_in_section_1402_c_2_E
+
+  - name: state_local_hospital_insurance_employment_continuing_current_employment_exception
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Service performed for an employer shall not be treated as employment by reason of subparagraph (A) if
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_would_be_excluded_from_employment_for_chapter_if_subparagraph_A_did_not_apply
+          and individual_was_performing_substantial_and_regular_service_for_remuneration_for_that_employer_before_applicable_continuity_date
+          and individual_was_bona_fide_employee_of_that_employer_on_applicable_continuity_date
+          and not employment_relationship_entered_into_for_purposes_of_meeting_continuing_current_employment_exception
+          and not employment_relationship_with_that_employer_terminated_after_applicable_continuity_date
+
+  - name: state_local_service_employment_for_hospital_insurance_tax
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(2)(A)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: subsection (b) shall be applied without regard to paragraph (7) thereof
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Except as provided in subparagraphs (B) and (C)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#state_local_hospital_insurance_employment_certain_services_exception
+              output: state_local_hospital_insurance_employment_certain_services_exception
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#state_local_hospital_insurance_employment_continuing_current_employment_exception
+              output: state_local_hospital_insurance_employment_continuing_current_employment_exception
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_7
+          and not state_local_hospital_insurance_employment_certain_services_exception
+          and not state_local_hospital_insurance_employment_continuing_current_employment_exception
+
+  - name: federal_service_employment_for_hospital_insurance_tax
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: subsection (b) shall be applied without regard to paragraph (5) thereof
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_is_employment_as_defined_in_subsection_b_disregarding_paragraph_5
+
+  - name: medicare_qualified_government_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(u)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: is employment (as defined in subsection (b)) with the application of paragraphs (1) and (2), but would not be employment (as so defined) without the application of such paragraphs
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#federal_service_employment_for_hospital_insurance_tax
+              output: federal_service_employment_for_hospital_insurance_tax
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/u#state_local_service_employment_for_hospital_insurance_tax
+              output: state_local_service_employment_for_hospital_insurance_tax
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            federal_service_employment_for_hospital_insurance_tax
+            or state_local_service_employment_for_hospital_insurance_tax
+          )
+          and not service_would_be_employment_as_defined_in_subsection_b_without_application_of_paragraphs_1_and_2

--- a/statutes/26/3121/v.test.yaml
+++ b/statutes/26/3121/v.test.yaml
@@ -1,0 +1,248 @@
+- name: qualified_cash_or_deferred_arrangement_contribution_included_in_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/v#input.employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k: true
+      us:statutes/26/3121/v#input.contribution_not_included_in_gross_income_by_reason_of_section_402_e_3: true
+      us:statutes/26/3121/v#input.contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c: false
+      us:statutes/26/3121/v#input.amount_treated_as_employer_contribution_under_section_414_h_2: false
+      us:statutes/26/3121/v#input.pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement: false
+      us:statutes/26/3121/v#input.employer_contribution_or_treated_employer_contribution_amount: 5000
+      us:statutes/26/3121/v#input.plan_or_other_arrangement_for_deferral_of_compensation: false
+      us:statutes/26/3121/v#input.plan_described_in_subsection_a_5: false
+      us:statutes/26/3121/v#input.amount_deferred_under_plan: false
+      us:statutes/26/3121/v#input.services_have_been_performed: false
+      us:statutes/26/3121/v#input.no_substantial_risk_of_forfeiture_of_rights_to_amount: false
+      us:statutes/26/3121/v#input.excess_parachute_payment_as_defined_in_section_280G_b: false
+      ? us:statutes/26/3121/v#input.specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+      : false
+      us:statutes/26/3121/v#input.deferred_compensation_amount: 0
+      us:statutes/26/3121/v#input.amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.previously_taken_into_account_amount_and_income_attributable_thereto: 0
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: false
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : false
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/v#employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - holds
+    us:statutes/26/3121/v#employer_contribution_amount_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - 5000
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_plan:
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_for_chapter:
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_as_wages:
+    - 0
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages:
+    - not_holds
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_excluded_from_later_wages:
+    - 0
+    us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan:
+    - not_holds
+- name: section_414_pickup_under_salary_reduction_agreement_included_in_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/v#input.employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k: false
+      us:statutes/26/3121/v#input.contribution_not_included_in_gross_income_by_reason_of_section_402_e_3: false
+      us:statutes/26/3121/v#input.contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c: false
+      us:statutes/26/3121/v#input.amount_treated_as_employer_contribution_under_section_414_h_2: true
+      us:statutes/26/3121/v#input.pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement: true
+      us:statutes/26/3121/v#input.employer_contribution_or_treated_employer_contribution_amount: 3000
+      us:statutes/26/3121/v#input.plan_or_other_arrangement_for_deferral_of_compensation: false
+      us:statutes/26/3121/v#input.plan_described_in_subsection_a_5: false
+      us:statutes/26/3121/v#input.amount_deferred_under_plan: false
+      us:statutes/26/3121/v#input.services_have_been_performed: false
+      us:statutes/26/3121/v#input.no_substantial_risk_of_forfeiture_of_rights_to_amount: false
+      us:statutes/26/3121/v#input.excess_parachute_payment_as_defined_in_section_280G_b: false
+      ? us:statutes/26/3121/v#input.specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+      : false
+      us:statutes/26/3121/v#input.deferred_compensation_amount: 0
+      us:statutes/26/3121/v#input.amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.previously_taken_into_account_amount_and_income_attributable_thereto: 0
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: false
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : false
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/v#employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - holds
+    us:statutes/26/3121/v#employer_contribution_amount_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - 3000
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_plan:
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_for_chapter:
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_as_wages:
+    - 0
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages:
+    - not_holds
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_excluded_from_later_wages:
+    - 0
+    us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan:
+    - not_holds
+- name: nonqualified_deferred_compensation_taken_into_account_and_not_later_treated_as_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/v#input.employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k: false
+      us:statutes/26/3121/v#input.contribution_not_included_in_gross_income_by_reason_of_section_402_e_3: false
+      us:statutes/26/3121/v#input.contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c: false
+      us:statutes/26/3121/v#input.amount_treated_as_employer_contribution_under_section_414_h_2: false
+      us:statutes/26/3121/v#input.pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement: false
+      us:statutes/26/3121/v#input.employer_contribution_or_treated_employer_contribution_amount: 0
+      us:statutes/26/3121/v#input.plan_or_other_arrangement_for_deferral_of_compensation: true
+      us:statutes/26/3121/v#input.plan_described_in_subsection_a_5: false
+      us:statutes/26/3121/v#input.amount_deferred_under_plan: true
+      us:statutes/26/3121/v#input.services_have_been_performed: true
+      us:statutes/26/3121/v#input.no_substantial_risk_of_forfeiture_of_rights_to_amount: true
+      us:statutes/26/3121/v#input.excess_parachute_payment_as_defined_in_section_280G_b: false
+      ? us:statutes/26/3121/v#input.specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+      : false
+      us:statutes/26/3121/v#input.deferred_compensation_amount: 10000
+      us:statutes/26/3121/v#input.amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: true
+      us:statutes/26/3121/v#input.income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.previously_taken_into_account_amount_and_income_attributable_thereto: 11000
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: false
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : false
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/v#employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - not_holds
+    us:statutes/26/3121/v#employer_contribution_amount_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - 0
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_plan:
+    - holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_for_chapter:
+    - holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_as_wages:
+    - 10000
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages:
+    - holds
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_excluded_from_later_wages:
+    - 11000
+    us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan:
+    - not_holds
+- name: governmental_deferred_compensation_plan_qualifies_unless_enumerated_exclusion_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/v#input.employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k: false
+      us:statutes/26/3121/v#input.contribution_not_included_in_gross_income_by_reason_of_section_402_e_3: false
+      us:statutes/26/3121/v#input.contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c: false
+      us:statutes/26/3121/v#input.amount_treated_as_employer_contribution_under_section_414_h_2: false
+      us:statutes/26/3121/v#input.pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement: false
+      us:statutes/26/3121/v#input.employer_contribution_or_treated_employer_contribution_amount: 0
+      us:statutes/26/3121/v#input.plan_or_other_arrangement_for_deferral_of_compensation: false
+      us:statutes/26/3121/v#input.plan_described_in_subsection_a_5: false
+      us:statutes/26/3121/v#input.amount_deferred_under_plan: false
+      us:statutes/26/3121/v#input.services_have_been_performed: false
+      us:statutes/26/3121/v#input.no_substantial_risk_of_forfeiture_of_rights_to_amount: false
+      us:statutes/26/3121/v#input.excess_parachute_payment_as_defined_in_section_280G_b: false
+      ? us:statutes/26/3121/v#input.specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+      : false
+      us:statutes/26/3121/v#input.deferred_compensation_amount: 0
+      us:statutes/26/3121/v#input.amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.previously_taken_into_account_amount_and_income_attributable_thereto: 0
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+    - us:statutes/26/3121/v#input.employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k: false
+      us:statutes/26/3121/v#input.contribution_not_included_in_gross_income_by_reason_of_section_402_e_3: false
+      us:statutes/26/3121/v#input.contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c: false
+      us:statutes/26/3121/v#input.amount_treated_as_employer_contribution_under_section_414_h_2: false
+      us:statutes/26/3121/v#input.pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement: false
+      us:statutes/26/3121/v#input.employer_contribution_or_treated_employer_contribution_amount: 0
+      us:statutes/26/3121/v#input.plan_or_other_arrangement_for_deferral_of_compensation: false
+      us:statutes/26/3121/v#input.plan_described_in_subsection_a_5: false
+      us:statutes/26/3121/v#input.amount_deferred_under_plan: false
+      us:statutes/26/3121/v#input.services_have_been_performed: false
+      us:statutes/26/3121/v#input.no_substantial_risk_of_forfeiture_of_rights_to_amount: false
+      us:statutes/26/3121/v#input.excess_parachute_payment_as_defined_in_section_280G_b: false
+      ? us:statutes/26/3121/v#input.specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+      : false
+      us:statutes/26/3121/v#input.deferred_compensation_amount: 0
+      us:statutes/26/3121/v#input.amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A: false
+      us:statutes/26/3121/v#input.previously_taken_into_account_amount_and_income_attributable_thereto: 0
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: true
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/v#employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/v#employer_contribution_amount_included_in_wages_notwithstanding_subsection_a_exclusions:
+    - 0
+    - 0
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_plan:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_for_chapter:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_as_wages:
+    - 0
+    - 0
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_excluded_from_later_wages:
+    - 0
+    - 0
+    us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan:
+    - holds
+    - not_holds

--- a/statutes/26/3121/v.yaml
+++ b/statutes/26/3121/v.yaml
@@ -1,0 +1,242 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(v) provides special wage treatment for certain employer contributions, nonqualified deferred compensation plans, and exempt governmental deferred compensation plans. Certain employer contributions are not excluded from “wages”; nonqualified deferred compensation is taken into account at the later of service performance or absence of substantial forfeiture risk, with stated exceptions and no later wage treatment; and “exempt governmental deferred compensation plan” is defined with enumerated exclusions.
+rules:
+  - name: employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(v)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Nothing in any paragraph of subsection (a) (other than paragraph (1)) shall exclude from the term “wages”
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any employer contribution under a qualified cash or deferred arrangement
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any amount treated as an employer contribution under section 414(h)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            employer_contribution_under_qualified_cash_or_deferred_arrangement_as_defined_in_section_401_k
+            and (
+              contribution_not_included_in_gross_income_by_reason_of_section_402_e_3
+              or contribution_consists_of_designated_roth_contributions_as_defined_in_section_402A_c
+            )
+          )
+          or (
+            amount_treated_as_employer_contribution_under_section_414_h_2
+            and pickup_referred_to_in_section_414_h_2_is_pursuant_to_salary_reduction_agreement
+          )
+
+  - name: employer_contribution_amount_included_in_wages_notwithstanding_subsection_a_exclusions
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(v)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall exclude from the term “wages”— (A) any employer contribution ... or (B) any amount treated as an employer contribution
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/v#employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions
+              output: employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if employer_contribution_included_in_wages_notwithstanding_subsection_a_exclusions: employer_contribution_or_treated_employer_contribution_amount else: 0
+
+  - name: nonqualified_deferred_compensation_plan
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(v)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any plan or other arrangement for deferral of compensation other than a plan described in subsection (a)(5)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          plan_or_other_arrangement_for_deferral_of_compensation
+          and not plan_described_in_subsection_a_5
+
+  - name: nonqualified_deferred_compensation_amount_taken_into_account_for_chapter
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(v)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Any amount deferred under a nonqualified deferred compensation plan
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as of the later of— (i) when the services are performed, or (ii) when there is no substantial risk of forfeiture
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall not apply to any excess parachute payment ... or to any specified stock compensation
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/v#nonqualified_deferred_compensation_plan
+              output: nonqualified_deferred_compensation_plan
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_deferred_under_plan
+          and nonqualified_deferred_compensation_plan
+          and services_have_been_performed
+          and no_substantial_risk_of_forfeiture_of_rights_to_amount
+          and not excess_parachute_payment_as_defined_in_section_280G_b
+          and not specified_stock_compensation_as_defined_in_section_4985_on_which_tax_is_imposed_by_section_4985
+
+  - name: nonqualified_deferred_compensation_amount_taken_into_account_as_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(v)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Any amount deferred under a nonqualified deferred compensation plan shall be taken into account for purposes of this chapter
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/v#nonqualified_deferred_compensation_amount_taken_into_account_for_chapter
+              output: nonqualified_deferred_compensation_amount_taken_into_account_for_chapter
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if nonqualified_deferred_compensation_amount_taken_into_account_for_chapter: deferred_compensation_amount else: 0
+
+  - name: previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(v)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Any amount taken into account as wages by reason of subparagraph (A) (and the income attributable thereto) shall not thereafter be treated as wages
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_taken_into_account_as_wages_by_reason_of_subparagraph_A
+          or income_attributable_to_amount_taken_into_account_as_wages_by_reason_of_subparagraph_A
+
+  - name: previously_taken_into_account_deferred_compensation_excluded_from_later_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(v)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: shall not thereafter be treated as wages for purposes of this chapter
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/v#previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages
+              output: previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if previously_taken_into_account_deferred_compensation_not_thereafter_treated_as_wages: previously_taken_into_account_amount_and_income_attributable_thereto else: 0
+
+  - name: exempt_governmental_deferred_compensation_plan
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(v)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any plan providing for deferral of compensation established and maintained for its employees by the United States, by a State or political subdivision thereof, or by an agency or instrumentality
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Such term shall not include— (A) any plan to which section 83, 402(b), 403(c), 457(a), or 457(f)(1) applies
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any annuity contract described in section 403(b), and (C) the Thrift Savings Fund
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          plan_provides_for_deferral_of_compensation
+          and plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+          and not plan_to_which_section_83_applies
+          and not plan_to_which_section_402_b_applies
+          and not plan_to_which_section_403_c_applies
+          and not plan_to_which_section_457_a_applies
+          and not plan_to_which_section_457_f_1_applies
+          and not annuity_contract_described_in_section_403_b
+          and not thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5

--- a/statutes/26/3121/z.test.yaml
+++ b/statutes/26/3121/z.test.yaml
@@ -1,0 +1,36 @@
+- name: controlled_group_threshold_is_more_than_fifty_percent_substitution
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3121/z#controlled_group_ownership_percentage_threshold: 0.5
+- name: subsection_l_agreement_services_make_paragraph_1_inapplicable
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/z#input.services_are_covered_by_agreement_under_subsection_l: true
+  output:
+    us:statutes/26/3121/z#paragraph_1_inapplicable_for_subsection_l_agreement_services: holds
+- name: services_not_covered_by_subsection_l_agreement_do_not_trigger_that_inapplicability
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/z#input.services_are_covered_by_agreement_under_subsection_l: false
+  output:
+    us:statutes/26/3121/z#paragraph_1_inapplicable_for_subsection_l_agreement_services: not_holds
+- name: equivalent_foreign_taxation_established_to_secretary_makes_paragraph_1_inapplicable
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/z#input.employer_establishes_to_satisfaction_of_secretary: true
+    us:statutes/26/3121/z#input.remuneration_for_services_subject_to_substantially_equivalent_foreign_country_tax: true
+  output:
+    us:statutes/26/3121/z#paragraph_1_inapplicable_for_equivalent_foreign_taxation: holds

--- a/statutes/26/3121/z.yaml
+++ b/statutes/26/3121/z.yaml
@@ -1,0 +1,83 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(z) treats certain foreign persons as American employers for services connected with a United States Government contract and a domestically controlled group; defines that group by reference to sections 1563(a)(1) and 954(d)(3); makes the common parent jointly and severally liable; provides exceptions for services covered by subsection (l) agreements or substantially equivalent foreign taxation; and cross-references sections 3101(c) and 3111(c).
+  deferred_outputs:
+    - output: us:statutes/26/3121/z#domestically_controlled_group_of_entities
+      reason: The definition depends on the controlled group rules of section 1563(a)(1), disregarding parts of section 1563, and on control within the meaning of section 954(d)(3); those cited RuleSpec sources are not available in the provided context.
+      source_values:
+        - us:statutes/26/3121/z#controlled_group_ownership_percentage_threshold
+    - output: us:statutes/26/3121/z#foreign_person_treated_as_american_employer_for_contract_services
+      reason: The operative treatment requires determining membership in a domestically controlled group of entities, whose definition depends on unavailable sections 1563(a)(1) and 954(d)(3).
+      source_values:
+        - us:statutes/26/3121/z#controlled_group_ownership_percentage_threshold
+    - output: us:statutes/26/3121/z#common_parent_joint_and_several_liability_for_foreign_person_tax
+      reason: The common-parent liability rule applies to a foreign person that is a member of a domestically controlled group of entities, whose definition depends on unavailable sections 1563(a)(1) and 954(d)(3).
+      source_values:
+        - us:statutes/26/3121/z#controlled_group_ownership_percentage_threshold
+rules:
+  - name: controlled_group_ownership_percentage_threshold
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 26 USC 3121(z)(2)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: “more than 50 percent” shall be substituted for “at least 80 percent”
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.50
+
+  - name: paragraph_1_inapplicable_for_subsection_l_agreement_services
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(z)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: Paragraph (1) shall not apply to any services which are covered by an agreement under subsection (l).
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          services_are_covered_by_agreement_under_subsection_l
+
+  - name: paragraph_1_inapplicable_for_equivalent_foreign_taxation
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(z)(4)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: remuneration paid by such employer for such services is subject to a tax imposed by a foreign country which is substantially equivalent
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: if the employer establishes to the satisfaction of the Secretary
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_establishes_to_satisfaction_of_secretary
+          and remuneration_for_services_subject_to_substantially_equivalent_foreign_country_tax


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(s), 3121(u), 3121(v), and 3121(z)
- cover common-paymaster rules, Medicare qualified government employment, deferred-compensation wage timing, and foreign-person American-employer treatment rules
- add generated tests and signed manifests for each subsection

## Generation
- axiom-encode 0.2.205
- commit e63d21ae3eebc14c1579e449c28f67a8783e3460
- model gpt-5.5
- runs: 3121(s) 5bde9a67; 3121(u) 1401b2c9; 3121(v) 2b1f259b; 3121(z) 6b56f592

## Validation
- uv run axiom-encode validate .../statutes/26/3121/{s,u,v,z}.yaml --skip-reviewers --json
- uv run axiom-encode test .../statutes/26/3121/{s,u,v,z}.test.yaml --root /private/tmp/rulespec-us-3121-remaining-20260525 --json
- uv run axiom-encode proof-validate .../statutes/26/3121/{s,u,v,z}.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3121-remaining-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121-remaining-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable