### PR TITLE
Add generated 3306(b)(1) FUTA wage base rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/1.yaml",
+      "sha256": "5a95295ab9e6721ae4123e37aace1282aa59a66f9463d73cfde28cc87c0bc0f8"
+    },
+    {
+      "path": "statutes/26/3306/b/1.test.yaml",
+      "sha256": "05b3681ee2e19530302f8ab4544637b1b9c698bf04f0d969c86c479719206afa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.205",
+    "version_commit": "e63d21ae3eebc14c1579e449c28f67a8783e3460"
+  },
+  "axiom_encode_version": "0.2.205",
+  "backend": "openai",
+  "citation": "26 USC 3306(b)(1)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-1-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "c8aa299b7080ec21a9152680d90b25ab19f8f83f8d437f7163b66624f4a83da9",
+  "generated_at": "2026-05-25T08:50:24.281236+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-1-20260525/openai-gpt-5.5/statutes/26/3306/b/1.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-1-20260525",
+  "generated_output_sha256": "5a95295ab9e6721ae4123e37aace1282aa59a66f9463d73cfde28cc87c0bc0f8",
+  "generation_prompt_sha256": "1befd01605a082405c8eaf51b24277c6b563a0f4eafe27cfe00c3e499d5fdcde",
+  "model": "gpt-5.5",
+  "run_id": "c38e3d7b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d3b36ac8e5550d8cf29d0f5758bb178591b243a16f22dd084cc57e829073eb5c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-1-20260525/traces/openai-gpt-5.5/26-USC-3306-b-1.json",
+  "trace_sha256": "65c00f88a29b4ecfb635676e4fd1e126ad2c34ad53ab3a6cdccfd44b345bc183"
+}

--- a/statutes/26/3306/b/1.test.yaml
+++ b/statutes/26/3306/b/1.test.yaml
@@ -1,0 +1,73 @@
+- name: non_successor_remuneration_below_limit_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/1#input.employer_is_successor_employer: false
+    ? us:statutes/26/3306/b/1#input.successor_acquired_substantially_all_property_used_in_predecessor_trade_or_business_or_separate_unit
+    : false
+    us:statutes/26/3306/b/1#input.successor_immediately_after_acquisition_employs_individual_in_trade_or_business: false
+    us:statutes/26/3306/b/1#input.individual_immediately_prior_to_acquisition_was_employed_in_predecessor_trade_or_business: false
+    ? us:statutes/26/3306/b/1#input.predecessor_remuneration_with_respect_to_employment_paid_or_considered_paid_to_individual_during_calendar_year_before_acquisition_excluding_succeeding_paragraphs
+    : 0
+    ? us:statutes/26/3306/b/1#input.remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs
+    : 5000
+  output:
+    us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit: 7000
+    us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid: 0
+    us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit: 0
+- name: non_successor_remuneration_above_limit_excludes_excess
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/1#input.employer_is_successor_employer: false
+    ? us:statutes/26/3306/b/1#input.successor_acquired_substantially_all_property_used_in_predecessor_trade_or_business_or_separate_unit
+    : false
+    us:statutes/26/3306/b/1#input.successor_immediately_after_acquisition_employs_individual_in_trade_or_business: false
+    us:statutes/26/3306/b/1#input.individual_immediately_prior_to_acquisition_was_employed_in_predecessor_trade_or_business: false
+    ? us:statutes/26/3306/b/1#input.predecessor_remuneration_with_respect_to_employment_paid_or_considered_paid_to_individual_during_calendar_year_before_acquisition_excluding_succeeding_paragraphs
+    : 0
+    ? us:statutes/26/3306/b/1#input.remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs
+    : 9000
+  output:
+    us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid: 0
+    us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit: 2000
+- name: successor_counts_predecessor_remuneration_before_acquisition
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/1#input.employer_is_successor_employer: true
+    ? us:statutes/26/3306/b/1#input.successor_acquired_substantially_all_property_used_in_predecessor_trade_or_business_or_separate_unit
+    : true
+    us:statutes/26/3306/b/1#input.successor_immediately_after_acquisition_employs_individual_in_trade_or_business: true
+    us:statutes/26/3306/b/1#input.individual_immediately_prior_to_acquisition_was_employed_in_predecessor_trade_or_business: true
+    ? us:statutes/26/3306/b/1#input.predecessor_remuneration_with_respect_to_employment_paid_or_considered_paid_to_individual_during_calendar_year_before_acquisition_excluding_succeeding_paragraphs
+    : 6000
+    ? us:statutes/26/3306/b/1#input.remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs
+    : 3000
+  output:
+    us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid: 6000
+    us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit: 2000
+- name: successor_rule_not_met_without_immediate_prior_employment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/1#input.employer_is_successor_employer: true
+    ? us:statutes/26/3306/b/1#input.successor_acquired_substantially_all_property_used_in_predecessor_trade_or_business_or_separate_unit
+    : true
+    us:statutes/26/3306/b/1#input.successor_immediately_after_acquisition_employs_individual_in_trade_or_business: true
+    us:statutes/26/3306/b/1#input.individual_immediately_prior_to_acquisition_was_employed_in_predecessor_trade_or_business: false
+    ? us:statutes/26/3306/b/1#input.predecessor_remuneration_with_respect_to_employment_paid_or_considered_paid_to_individual_during_calendar_year_before_acquisition_excluding_succeeding_paragraphs
+    : 6000
+    ? us:statutes/26/3306/b/1#input.remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs
+    : 3000
+  output:
+    us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid: 0
+    us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit: 0

--- a/statutes/26/3306/b/1.yaml
+++ b/statutes/26/3306/b/1.yaml
@@ -1,0 +1,91 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: Paragraph (1) covers that part of remuneration paid after remuneration
+    with respect to employment equal to $7,000 has been paid during the calendar year,
+    and treats certain predecessor remuneration as paid by a successor employer after
+    a substantial acquisition and immediate continued employment.
+rules:
+- name: annual_remuneration_wage_base_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 3306(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: remuneration ... equal to $7,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '7000'
+- name: successor_predecessor_remuneration_considered_paid
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3306(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3306
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3306
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if employer_is_successor_employer and successor_acquired_substantially_all_property_used_in_predecessor_trade_or_business_or_separate_unit
+      and successor_immediately_after_acquisition_employs_individual_in_trade_or_business
+      and individual_immediately_prior_to_acquisition_was_employed_in_predecessor_trade_or_business:
+      max(0, predecessor_remuneration_with_respect_to_employment_paid_or_considered_paid_to_individual_during_calendar_year_before_acquisition_excluding_succeeding_paragraphs)
+      else: 0'
+- name: remuneration_excluded_from_wages_after_annual_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3306(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: after remuneration ... equal to $7,000 ... has been paid
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: other than remuneration referred to in the succeeding paragraphs
+            of this subsection
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
+          output: annual_remuneration_wage_base_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid
+          output: successor_predecessor_remuneration_considered_paid
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "min(\n    max(0, remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs),\n\
+      \    max(\n        0,\n        remuneration_with_respect_to_employment_paid_to_individual_by_employer_during_calendar_year_excluding_succeeding_paragraphs\n\
+      \        + successor_predecessor_remuneration_considered_paid\n        - annual_remuneration_wage_base_limit\n\
+      \    )\n)"


### PR DESCRIPTION
## Summary
- add generated 26 USC 3306(b)(1) FUTA annual wage base limit rules
- include successor/predecessor remuneration treatment and examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate statutes/26/3306/b/1.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3306/b/1.test.yaml --root /private/tmp/rulespec-us-3306-b-20260525 --json
- uv run axiom-encode proof-validate statutes/26/3306/b/1.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-1-copy --program tax --fail-on-untested-comparable