### PR TITLE
Add generated 3301 FUTA excise tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3301.json
+++ b/.axiom/encoding-manifests/statutes/26/3301.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3301.yaml",
+      "sha256": "c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27"
+    },
+    {
+      "path": "statutes/26/3301.test.yaml",
+      "sha256": "f6bcab6526d283b311ebc800fb89e6174b063c6b2cf0d2eecfa0b3e18c9d739d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "43b531d43149352028f0687d8f6d489266b6c766",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.206",
+    "version_commit": "43b531d43149352028f0687d8f6d489266b6c766"
+  },
+  "axiom_encode_version": "0.2.206",
+  "backend": "openai",
+  "citation": "26 USC 3301",
+  "context_manifest_file": "/private/tmp/axiom-encode-3301-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3301/workspace/context-manifest.json",
+  "context_manifest_sha256": "ff23076730b0b687d8ebcd0c6447d14e2841c5e1ac1e83e4ff3a6e1d91a79f24",
+  "generated_at": "2026-05-25T09:08:21.623964+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3301-20260525/openai-gpt-5.5/statutes/26/3301.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3301-20260525",
+  "generated_output_sha256": "c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27",
+  "generation_prompt_sha256": "b4cfae538b1d0d28ea72fcd1b0180a2435cf16fd7e6661a5b7cde2416d77d841",
+  "model": "gpt-5.5",
+  "run_id": "2f8191e7",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6ab2056ff13da7450490adc82528ee19f10599b90e98bacce7fa4ac164cf2041"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3301-20260525/traces/openai-gpt-5.5/26-USC-3301.json",
+  "trace_sha256": "b228c047561670e6bb023e77614f70c395fd002885612d7de529d8a29b3c07e6"
+}

--- a/statutes/26/3301.test.yaml
+++ b/statutes/26/3301.test.yaml
@@ -1,0 +1,23 @@
+- name: employer_tax_equals_six_percent_of_wages
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3301#federal_unemployment_excise_tax_rate: 0.06
+    us:statutes/26/3301#federal_unemployment_excise_tax: 600
+- name: employer_tax_zero_when_wages_are_zero
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 0
+  output:
+    us:statutes/26/3301#federal_unemployment_excise_tax: 0

--- a/statutes/26/3301.yaml
+++ b/statutes/26/3301.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3301
+  summary: |-
+    There is hereby imposed on every employer, for each calendar year, an excise tax equal to 6 percent of the total wages paid by such employer during the calendar year with respect to employment.
+rules:
+  - name: federal_unemployment_excise_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3301
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3301
+              excerpt: "equal to 6 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.06
+
+  - name: federal_unemployment_excise_tax
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3301
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3301
+              excerpt: "equal to 6 percent of the total wages ... paid by such employer during the calendar year with respect to employment"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3301#federal_unemployment_excise_tax_rate
+              output: federal_unemployment_excise_tax_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          federal_unemployment_excise_tax_rate
+          * max(
+              0,
+              total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+          )


### PR DESCRIPTION
## Summary
- add generated 26 USC 3301 FUTA gross excise tax rate and tax rules
- include companion examples for positive and zero wages
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate statutes/26/3301.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3301.test.yaml --root /private/tmp/rulespec-us-3301-20260525 --json
- uv run axiom-encode proof-validate statutes/26/3301.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3301-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3301-current --program tax --fail-on-untested-comparable