### PR TITLE
Add generated 3302(a) FUTA contribution credit rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/a.yaml",
+      "sha256": "7dc9e614ba67ccf9bd9854ab09b531550a5ffc519719e50c8790ca68566ce4a5"
+    },
+    {
+      "path": "statutes/26/3302/a.test.yaml",
+      "sha256": "90157810669dd53dc891184072617d8247f1841dd85f98e71a5c84a0670423b0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5666b275d0ecfd0117b58323d876ed9f40324e87",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.207",
+    "version_commit": "5666b275d0ecfd0117b58323d876ed9f40324e87"
+  },
+  "axiom_encode_version": "0.2.207",
+  "backend": "openai",
+  "citation": "26 USC 3302(a)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-a-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "49daffc3dbeaa12262e995ce485068a5427bd19236f421ed7671cf8ee5c656d3",
+  "generated_at": "2026-05-25T09:25:57.620318+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-a-20260525/openai-gpt-5.5/statutes/26/3302/a.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-a-20260525",
+  "generated_output_sha256": "7dc9e614ba67ccf9bd9854ab09b531550a5ffc519719e50c8790ca68566ce4a5",
+  "generation_prompt_sha256": "56546b68233812cf664e24a6949be74d5f66afe0d610db24786e6bbddb3367ac",
+  "model": "gpt-5.5",
+  "run_id": "dac140f5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ea74d210dec1d983b113334b8bd61995184633444c81809c5d971a80f9d15e7f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-a-20260525/traces/openai-gpt-5.5/26-USC-3302-a.json",
+  "trace_sha256": "73598be907baeb04938a90483d02e86a2d5f10ebccaccd30a49b280e664d10c6"
+}

--- a/statutes/26/3302/a.test.yaml
+++ b/statutes/26/3302/a.test.yaml
@@ -1,0 +1,41 @@
+- name: ordinary_late_paid_contributions_limited_to_ninety_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/a#input.wages_paid_by_trustee_of_estate_under_title_11: false
+    us:statutes/26/3302/a#input.failure_to_pay_contributions_on_time_was_without_fault_by_trustee: false
+    ? us:statutes/26/3302/a#input.amount_which_would_have_been_allowable_as_credit_on_account_of_late_contributions_if_timely_paid
+    : 1000
+  output:
+    us:statutes/26/3302/a#late_paid_contributions_credit_percentage: 0.9
+    us:statutes/26/3302/a#title11_trustee_no_fault_late_paid_contributions_credit_percentage: 1
+    us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage: 0.9
+    us:statutes/26/3302/a#credit_for_late_paid_contributions_limit: 900
+- name: title11_trustee_without_fault_uses_one_hundred_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/a#input.wages_paid_by_trustee_of_estate_under_title_11: true
+    us:statutes/26/3302/a#input.failure_to_pay_contributions_on_time_was_without_fault_by_trustee: true
+    ? us:statutes/26/3302/a#input.amount_which_would_have_been_allowable_as_credit_on_account_of_late_contributions_if_timely_paid
+    : 1000
+  output:
+    us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage: 1
+    us:statutes/26/3302/a#credit_for_late_paid_contributions_limit: 1000
+- name: title11_trustee_with_fault_does_not_receive_substitution
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/a#input.wages_paid_by_trustee_of_estate_under_title_11: true
+    us:statutes/26/3302/a#input.failure_to_pay_contributions_on_time_was_without_fault_by_trustee: false
+    ? us:statutes/26/3302/a#input.amount_which_would_have_been_allowable_as_credit_on_account_of_late_contributions_if_timely_paid
+    : 1000
+  output:
+    us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage: 0.9
+    us:statutes/26/3302/a#credit_for_late_paid_contributions_limit: 900

--- a/statutes/26/3302/a.yaml
+++ b/statutes/26/3302/a.yaml
@@ -1,0 +1,124 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  deferred_outputs:
+  - output: us:statutes/26/3302/a#state_unemployment_contribution_credit_against_section_3301_tax
+    reason: The final credit against the tax imposed by section 3301 is limited by
+      subsection (c), requires determining whether the State unemployment compensation
+      law is certified as provided in section 3304, and requires determining the section
+      6071 return filing deadline. The copied context does not provide section 3304,
+      section 6071, or subsection (c), so the final credit surface is deferred. This
+      file retains the source-stated late-payment percentage limits that can be computed
+      independently.
+    source_values:
+    - us:statutes/26/3302/a#late_paid_contributions_credit_percentage
+    - us:statutes/26/3302/a#title11_trustee_no_fault_late_paid_contributions_credit_percentage
+    - us:statutes/26/3302/a#credit_for_late_paid_contributions_limit
+  summary: "The taxpayer may, to the extent provided in this subsection and subsection\
+    \ (c), credit against the tax imposed by section 3301 contributions paid into\
+    \ a certified State unemployment fund. Credit is allowed only for contributions\
+    \ paid with respect to the taxable year and generally paid by the section 6071\
+    \ return due date; for later payments, the credit shall not exceed 90 percent\
+    \ of the amount otherwise allowable if timely paid. For wages paid by a title\
+    \ 11 estate trustee, if the failure to pay on time was without fault by the trustee,\
+    \ paragraph (3) substitutes \u201C100 percent\u201D for \u201C90 percent\u201D\
+    ."
+rules:
+- name: late_paid_contributions_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(a)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: credit shall not exceed 90 percent
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.90'
+- name: title11_trustee_no_fault_late_paid_contributions_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(a)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: "substituting \u201C100 percent\u201D for \u201C90 percent\u201D"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1.00'
+- name: applicable_late_paid_contributions_credit_percentage
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(a)(3), 26 USC 3302(a)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: In the case of wages paid by the trustee of an estate under title
+            11 of the United States Code, if the failure to pay contributions on time
+            was without fault by the trustee
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/a#late_paid_contributions_credit_percentage
+          output: late_paid_contributions_credit_percentage
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/a#title11_trustee_no_fault_late_paid_contributions_credit_percentage
+          output: title11_trustee_no_fault_late_paid_contributions_credit_percentage
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if wages_paid_by_trustee_of_estate_under_title_11 and failure_to_pay_contributions_on_time_was_without_fault_by_trustee:
+      title11_trustee_no_fault_late_paid_contributions_credit_percentage else: late_paid_contributions_credit_percentage'
+- name: credit_for_late_paid_contributions_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3302(a)(3), 26 USC 3302(a)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: credit shall not exceed 90 percent of the amount which would have
+            been allowable as credit on account of such contributions had they been
+            paid on or before such last day
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: "substituting \u201C100 percent\u201D for \u201C90 percent\u201D"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage
+          output: applicable_late_paid_contributions_credit_percentage
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "applicable_late_paid_contributions_credit_percentage\n* max(\n    0,\n\
+      \    amount_which_would_have_been_allowable_as_credit_on_account_of_late_contributions_if_timely_paid\n\
+      )"


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(a) late-paid state unemployment contribution credit rules
- include the title 11 trustee no-fault percentage substitution and companion examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate statutes/26/3302/a.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3302/a.test.yaml --root /private/tmp/rulespec-us-3302-a-20260525 --json
- uv run axiom-encode proof-validate statutes/26/3302/a.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-a-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-a-current --program tax --fail-on-unmapped --fail-on-untested-comparable