### PR TITLE
Add generated 3302(b) FUTA additional credit rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/b.yaml",
+      "sha256": "e2e139efe12688cc2237d0529ffcb1c1afcaa2b101c9cf9da0d8fe17d7ab0b29"
+    },
+    {
+      "path": "statutes/26/3302/b.test.yaml",
+      "sha256": "55d59c8b9d5f949046ecbcf92863caff65023a8ffd00b6ea726ecf69071cc787"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "669a3ece922f3a2f3be924bdbfcb120835f0386d",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.209",
+    "version_commit": "669a3ece922f3a2f3be924bdbfcb120835f0386d"
+  },
+  "axiom_encode_version": "0.2.209",
+  "backend": "openai",
+  "citation": "26 USC 3302(b)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-b-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "c33daeb2e6610155fd7788ce4730e4f93057bb126a9a4a4426c961c8c743bde6",
+  "generated_at": "2026-05-25T09:38:19.332174+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-b-20260525/openai-gpt-5.5/statutes/26/3302/b.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-b-20260525",
+  "generated_output_sha256": "e2e139efe12688cc2237d0529ffcb1c1afcaa2b101c9cf9da0d8fe17d7ab0b29",
+  "generation_prompt_sha256": "a441486bc893aeee7f5430aebc1ed2ca108739f23c18f55998f0879aa71584cf",
+  "model": "gpt-5.5",
+  "run_id": "87f72c5e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ce921b964b55096bdefc2ac533b766f8595f5c7e9c62684cc66ca795e6eb3b6f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-b-20260525/traces/openai-gpt-5.5/26-USC-3302-b.json",
+  "trace_sha256": "f6e0fe3cc1c4b0c0475898ae52245dc063a2e3d98af627b6c5592f7d8cbb5915"
+}

--- a/statutes/26/3302/b.test.yaml
+++ b/statutes/26/3302/b.test.yaml
@@ -1,0 +1,43 @@
+- name: comparison_rate_uses_state_highest_rate_when_below_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/b#input.highest_rate_applied_under_state_unemployment_compensation_law_in_12_month_period_ending_october_31
+    : 0.03
+    ? us:statutes/26/3302/b#input.contributions_taxpayer_would_have_been_required_to_pay_if_subject_to_applicable_additional_credit_comparison_rate
+    : 300
+    us:statutes/26/3302/b#input.contributions_required_to_be_paid_with_respect_to_taxable_year: 200
+  output:
+    us:statutes/26/3302/b#additional_credit_comparison_rate_cap: 0.054
+    us:statutes/26/3302/b#applicable_additional_credit_comparison_rate: 0.03
+    us:statutes/26/3302/b#additional_credit_rate_differential_amount: 100
+- name: comparison_rate_uses_five_point_four_percent_cap_when_state_highest_rate_above_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/b#input.highest_rate_applied_under_state_unemployment_compensation_law_in_12_month_period_ending_october_31
+    : 0.08
+    ? us:statutes/26/3302/b#input.contributions_taxpayer_would_have_been_required_to_pay_if_subject_to_applicable_additional_credit_comparison_rate
+    : 540
+    us:statutes/26/3302/b#input.contributions_required_to_be_paid_with_respect_to_taxable_year: 400
+  output:
+    us:statutes/26/3302/b#applicable_additional_credit_comparison_rate: 0.054
+    us:statutes/26/3302/b#additional_credit_rate_differential_amount: 140
+- name: rate_differential_amount_floored_at_zero_when_required_contributions_not_less
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/b#input.highest_rate_applied_under_state_unemployment_compensation_law_in_12_month_period_ending_october_31
+    : 0.08
+    ? us:statutes/26/3302/b#input.contributions_taxpayer_would_have_been_required_to_pay_if_subject_to_applicable_additional_credit_comparison_rate
+    : 540
+    us:statutes/26/3302/b#input.contributions_required_to_be_paid_with_respect_to_taxable_year: 600
+  output:
+    us:statutes/26/3302/b#applicable_additional_credit_comparison_rate: 0.054
+    us:statutes/26/3302/b#additional_credit_rate_differential_amount: 0

--- a/statutes/26/3302/b.yaml
+++ b/statutes/26/3302/b.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  deferred_outputs:
+    - output: us:statutes/26/3302/b#additional_credit_against_section_3301_tax
+      reason: The final additional credit is allowed only with respect to a State unemployment compensation law, or provisions thereof, certified as provided in section 3303 for the 12-month period ending October 31 of the taxable year. No copied RuleSpec context provides the section 3303 certification mechanics, so the final credit against the section 3301 tax is deferred. This file retains the source-stated comparison-rate cap and rate-differential amount mechanics that can be computed independently.
+      source_values:
+        - us:statutes/26/3302/b#additional_credit_comparison_rate_cap
+        - us:statutes/26/3302/b#applicable_additional_credit_comparison_rate
+        - us:statutes/26/3302/b#additional_credit_rate_differential_amount
+  summary: |-
+    Additional credit equals the excess, if any, of contributions the taxpayer would have been required to pay under the State law at the lower of the highest rate applied during the 12-month period ending October 31 or 5.4 percent, over contributions required to be paid for the taxable year; the credit is with respect to State law or provisions certified as provided in section 3303.
+rules:
+  - name: additional_credit_comparison_rate_cap
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "or to a rate of 5.4 percent, whichever rate is lower"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.054
+
+  - name: applicable_additional_credit_comparison_rate
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "highest rate applied thereunder in such 12-month period ... or to a rate of 5.4 percent, whichever rate is lower"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/b#additional_credit_comparison_rate_cap
+              output: additional_credit_comparison_rate_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+              highest_rate_applied_under_state_unemployment_compensation_law_in_12_month_period_ending_october_31,
+              additional_credit_comparison_rate_cap
+          )
+
+  - name: additional_credit_rate_differential_amount
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "equal to the amount, if any, by which the contributions required to be paid by him ... were less than the contributions such taxpayer would have been required to pay"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              contributions_taxpayer_would_have_been_required_to_pay_if_subject_to_applicable_additional_credit_comparison_rate
+              - contributions_required_to_be_paid_with_respect_to_taxable_year
+          )


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(b) additional FUTA credit comparison-rate rules
- include the 5.4 percent cap and rate-differential examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate statutes/26/3302/b.yaml --skip-reviewers --json
- uv run axiom-encode test statutes/26/3302/b.test.yaml --root /private/tmp/rulespec-us-3302-b-20260525 --json
- uv run axiom-encode proof-validate statutes/26/3302/b.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-b-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-b-current --program tax --fail-on-unmapped --fail-on-untested-comparable