### PR TITLE
Add generated 3302(c)(1) FUTA credit cap rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/c/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/c/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/c/1.yaml",
+      "sha256": "951325c82fef48fa333bbcafd6eaa28dfbaac014284e68a2a6f79dadc47f1036"
+    },
+    {
+      "path": "statutes/26/3302/c/1.test.yaml",
+      "sha256": "bc3434f004eae9f783d49b62a4c501d9540acdbeb011170bbfe75e468624454f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7b11257cf2c55a7a1fd55c52f52c5b7e586983ab",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.210",
+    "version_commit": "7b11257cf2c55a7a1fd55c52f52c5b7e586983ab"
+  },
+  "axiom_encode_version": "0.2.210",
+  "backend": "openai",
+  "citation": "26 USC 3302(c)(1)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-c-1-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-c-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "c827a27f7f1a79d6c0ae89b08d75acecabd3ab28b780c38dd8c342c55d215527",
+  "generated_at": "2026-05-25T09:49:11.476254+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-c-1-20260525/openai-gpt-5.5/statutes/26/3302/c/1.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-c-1-20260525",
+  "generated_output_sha256": "951325c82fef48fa333bbcafd6eaa28dfbaac014284e68a2a6f79dadc47f1036",
+  "generation_prompt_sha256": "42f01efa82fff109290d2df3428f72e567c062699867c3343d915e92ac088b3e",
+  "model": "gpt-5.5",
+  "run_id": "dd348f82",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aecb53987e801b7f2272e21b4c0add77e41d08d301371d2cf9d1084417a79937"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-c-1-20260525/traces/openai-gpt-5.5/26-USC-3302-c-1.json",
+  "trace_sha256": "9b8226d18d1aa9b312141184a6fa83bc88a32cc0a588c1dea2eb67795a2324a4"
+}

--- a/statutes/26/3302/c/1.test.yaml
+++ b/statutes/26/3302/c/1.test.yaml
@@ -1,0 +1,24 @@
+- name: credits_below_ninety_percent_tax_are_allowed_in_full
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/1#input.tax_against_which_credits_are_allowable: 1000
+    us:statutes/26/3302/c/1#input.total_credits_allowed_under_section_before_subsection_c_limit: 800
+  output:
+    us:statutes/26/3302/c/1#total_credits_allowed_percentage_limit: 0.9
+    us:statutes/26/3302/c/1#total_credits_allowed_under_section_limit: 900
+    us:statutes/26/3302/c/1#total_credits_allowed_under_section_after_limit: 800
+- name: credits_above_ninety_percent_tax_are_capped
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/1#input.tax_against_which_credits_are_allowable: 1000
+    us:statutes/26/3302/c/1#input.total_credits_allowed_under_section_before_subsection_c_limit: 950
+  output:
+    us:statutes/26/3302/c/1#total_credits_allowed_percentage_limit: 0.9
+    us:statutes/26/3302/c/1#total_credits_allowed_under_section_limit: 900
+    us:statutes/26/3302/c/1#total_credits_allowed_under_section_after_limit: 900

--- a/statutes/26/3302/c/1.yaml
+++ b/statutes/26/3302/c/1.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    "The total credits allowed to a taxpayer under this section shall not exceed 90 percent of the tax against which such credits are allowable."
+rules:
+  - name: total_credits_allowed_percentage_limit
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "90 percent of the tax"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.90
+
+  - name: total_credits_allowed_under_section_limit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "shall not exceed 90 percent of the tax against which such credits are allowable"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/1#total_credits_allowed_percentage_limit
+              output: total_credits_allowed_percentage_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          total_credits_allowed_percentage_limit * max(0, tax_against_which_credits_are_allowable)
+
+  - name: total_credits_allowed_under_section_after_limit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "The total credits allowed to a taxpayer under this section shall not exceed 90 percent of the tax"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/1#total_credits_allowed_under_section_limit
+              output: total_credits_allowed_under_section_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+              max(0, total_credits_allowed_under_section_before_subsection_c_limit),
+              total_credits_allowed_under_section_limit
+          )


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(c)(1) total FUTA credit cap rules
- include 90 percent cap and before/after limit examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-1-current --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run axiom-encode validate /private/tmp/rulespec-us-3302-c-1-20260525/statutes/26/3302/c/1.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-c-1-20260525/statutes/26/3302/c/1.test.yaml --root /private/tmp/rulespec-us-3302-c-1-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-c-1-20260525/statutes/26/3302/c/1.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-c-1-20260525 --base-ref origin/main --json