### PR TITLE
Add generated 3302(d)(1) FUTA subsection c rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/d/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/d/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/d/1.yaml",
+      "sha256": "19102446f684ee51f6f687edea721bda4a1b8ef49e7cc7004f0ee767404d4e48"
+    },
+    {
+      "path": "statutes/26/3302/d/1.test.yaml",
+      "sha256": "da8b2cbd641c35e5b1119252b469f0c7c716bca43687b8301a3f4d796cc537cc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6a4b80b91e1edd7575a05fe67ba543a2859d42ae",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.212",
+    "version_commit": "6a4b80b91e1edd7575a05fe67ba543a2859d42ae"
+  },
+  "axiom_encode_version": "0.2.212",
+  "backend": "openai",
+  "citation": "26 USC 3302(d)(1)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-d-1-20260525-v212/_eval_workspaces/openai-gpt-5.5/26-USC-3302-d-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "0c27bc65abd74dad825195ed328549e03cfd082a5e723d48faa8bd19ee87195e",
+  "generated_at": "2026-05-25T10:13:02.910164+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-d-1-20260525-v212/openai-gpt-5.5/statutes/26/3302/d/1.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-d-1-20260525-v212",
+  "generated_output_sha256": "19102446f684ee51f6f687edea721bda4a1b8ef49e7cc7004f0ee767404d4e48",
+  "generation_prompt_sha256": "229879a91c4f48c9832ca8e6d498207b852cd9ec249cf286083a9cb9a648716e",
+  "model": "gpt-5.5",
+  "run_id": "7fabd73e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fc038337698030e5b4cc74afebb5bb49265a02d0c5e2712edc8ed04ced0e3790"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-d-1-20260525-v212/traces/openai-gpt-5.5/26-USC-3302-d-1.json",
+  "trace_sha256": "f5258198a711683ceb3e38466020661eb75c7bb7516b455d514bb761ddfac3af"
+}

--- a/statutes/26/3302/d/1.test.yaml
+++ b/statutes/26/3302/d/1.test.yaml
@@ -1,0 +1,21 @@
+- name: subsection_c_tax_computation_uses_six_percent_section_3301_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3302/d/1#subsection_c_tax_computation_rate: 0.06
+    us:statutes/26/3302/d/1#tax_imposed_by_section_3301_for_applying_subsection_c: 600
+- name: subsection_c_tax_computation_zero_when_section_3301_wages_are_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 0
+  output:
+    us:statutes/26/3302/d/1#tax_imposed_by_section_3301_for_applying_subsection_c: 0

--- a/statutes/26/3302/d/1.yaml
+++ b/statutes/26/3302/d/1.yaml
@@ -1,0 +1,53 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    For 26 USC 3302(d)(1), in applying subsection (c), the tax imposed by section 3301 shall be computed at the rate of 6 percent in lieu of the rate provided by such section.
+imports:
+  - us:statutes/26/3301#federal_unemployment_excise_tax
+rules:
+  - name: subsection_c_tax_computation_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "computed at the rate of 6 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.06
+
+  - name: tax_imposed_by_section_3301_for_applying_subsection_c
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "In applying subsection (c), the tax imposed by section 3301 shall be computed at the rate of 6 percent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3301#federal_unemployment_excise_tax
+              output: federal_unemployment_excise_tax
+              hash: sha256:c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          federal_unemployment_excise_tax


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(d)(1) subsection (c) FUTA tax-computation rules
- include 6 percent subsection (c) computation rate and section 3301 tax examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3302-d-1-20260525/statutes/26/3302/d/1.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-d-1-20260525/statutes/26/3302/d/1.test.yaml --root /private/tmp/rulespec-us-3302-d-1-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-d-1-20260525/statutes/26/3302/d/1.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-d-1-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-1-current --program tax --fail-on-unmapped --fail-on-untested-comparable