### PR TITLE
Add generated 3302(d)(2) FUTA state attribution rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/d/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/d/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/d/2.yaml",
+      "sha256": "07b955981b3ba67510315429e7f895d3db99580ad49a87bba26325aae6b625d9"
+    },
+    {
+      "path": "statutes/26/3302/d/2.test.yaml",
+      "sha256": "ea3560a3e267b70108d8cbd33db19a5f06e808a3438050a781fce14dc8a19515"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "cf3a1aafba636980415c5096cfa8dc687b3fec2d",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.213",
+    "version_commit": "cf3a1aafba636980415c5096cfa8dc687b3fec2d"
+  },
+  "axiom_encode_version": "0.2.213",
+  "backend": "openai",
+  "citation": "26 USC 3302(d)(2)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-d-2-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-d-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "b84401855525eb4b77eed9265a43dcb8709b451596e98db7737d4d7ae4a2e12f",
+  "generated_at": "2026-05-25T10:24:29.146183+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-d-2-20260525/openai-gpt-5.5/statutes/26/3302/d/2.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-d-2-20260525",
+  "generated_output_sha256": "07b955981b3ba67510315429e7f895d3db99580ad49a87bba26325aae6b625d9",
+  "generation_prompt_sha256": "870611882a878ea7ca73b53e9a381c17cc13763640ad972e74c4ebdf23c35356",
+  "model": "gpt-5.5",
+  "run_id": "927acd4b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "59efa0e4bd74519fff9042f596564c127229cdd39a7983854114ab6f19c77388"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-d-2-20260525/traces/openai-gpt-5.5/26-USC-3302-d-2.json",
+  "trace_sha256": "af7198d10b2dd8820c88509c3a6620ee2337d21db46184ada97e140aa845f062"
+}

--- a/statutes/26/3302/d/2.test.yaml
+++ b/statutes/26/3302/d/2.test.yaml
@@ -1,0 +1,52 @@
+- name: wages_attributable_when_subject_to_particular_state_law
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3302/d/2#input.wages_subject_to_unemployment_compensation_law_of_particular_state: true
+      us:statutes/26/3302/d/2#input.wages_not_subject_to_unemployment_compensation_law_of_any_state: false
+      us:statutes/26/3302/d/2#input.wages_determined_under_secretary_rules_attributable_to_particular_state: false
+  output:
+    us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c:
+    - holds
+- name: wages_attributable_when_not_subject_to_any_state_law_and_secretary_rules_determine_state
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3302/d/2#input.wages_subject_to_unemployment_compensation_law_of_particular_state: false
+      us:statutes/26/3302/d/2#input.wages_not_subject_to_unemployment_compensation_law_of_any_state: true
+      us:statutes/26/3302/d/2#input.wages_determined_under_secretary_rules_attributable_to_particular_state: true
+  output:
+    us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c:
+    - holds
+- name: wages_not_attributable_when_not_subject_to_any_state_law_but_no_secretary_determination
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3302/d/2#input.wages_subject_to_unemployment_compensation_law_of_particular_state: false
+      us:statutes/26/3302/d/2#input.wages_not_subject_to_unemployment_compensation_law_of_any_state: true
+      us:statutes/26/3302/d/2#input.wages_determined_under_secretary_rules_attributable_to_particular_state: false
+  output:
+    us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c:
+    - not_holds
+- name: wages_not_attributable_when_subject_to_some_state_law_but_not_particular_state_law
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3302/d/2#input.wages_subject_to_unemployment_compensation_law_of_particular_state: false
+      us:statutes/26/3302/d/2#input.wages_not_subject_to_unemployment_compensation_law_of_any_state: false
+      us:statutes/26/3302/d/2#input.wages_determined_under_secretary_rules_attributable_to_particular_state: true
+  output:
+    us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c:
+    - not_holds

--- a/statutes/26/3302/d/2.yaml
+++ b/statutes/26/3302/d/2.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    Wages are attributable to a particular State if subject to that State's unemployment compensation law, or, if not subject to any State's law, determined under Secretary rules to be attributable to that State.
+rules:
+  - name: wages_attributable_to_particular_state_for_subsection_c
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3302(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3302
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "subject to the unemployment compensation law of the State"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "if not subject to the unemployment compensation law of any State"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "determined (under rules or regulations prescribed by the Secretary) to be attributable to such State"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          wages_subject_to_unemployment_compensation_law_of_particular_state
+          or (
+              wages_not_subject_to_unemployment_compensation_law_of_any_state
+              and wages_determined_under_secretary_rules_attributable_to_particular_state
+          )


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(d)(2) FUTA state-attribution rule for subsection (c)
- include positive and negative attribution examples
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3302-d-2-20260525/statutes/26/3302/d/2.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-d-2-20260525/statutes/26/3302/d/2.test.yaml --root /private/tmp/rulespec-us-3302-d-2-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-d-2-20260525/statutes/26/3302/d/2.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-d-2-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-2-current --program tax --fail-on-unmapped --fail-on-untested-comparable