### PR TITLE
Add generated 3302(d)(4) FUTA contribution-rate rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/d/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/d/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/d/4.yaml",
+      "sha256": "d3411fcc79fccb91cc7c1574f640c60eb77857f1e169eba0a7808f5d3de647d4"
+    },
+    {
+      "path": "statutes/26/3302/d/4.test.yaml",
+      "sha256": "95a6e387c2c4a31b942d7848552d36d8aeead6313f898240740d6dc8e3ee771c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "51b19541736f2b604c2beb7dcef033148a7bca15",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.214",
+    "version_commit": "51b19541736f2b604c2beb7dcef033148a7bca15"
+  },
+  "axiom_encode_version": "0.2.214",
+  "backend": "openai",
+  "citation": "26 USC 3302(d)(4)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-d-4-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-d-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "0af7f9808488757eba2ebbe7e4b3fb8d7cf65be2ce2981de75f59a009314b0d1",
+  "generated_at": "2026-05-25T10:37:59.806397+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-d-4-20260525/openai-gpt-5.5/statutes/26/3302/d/4.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-d-4-20260525",
+  "generated_output_sha256": "d3411fcc79fccb91cc7c1574f640c60eb77857f1e169eba0a7808f5d3de647d4",
+  "generation_prompt_sha256": "7db3387c66c4071f7ac79eab7515f7a5697b3a6a41f6bc688a15558642c8afe2",
+  "model": "gpt-5.5",
+  "run_id": "39bb91b8",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "14c0fca3e71d3c8001893b8a084572ec5b3773ec787962519e67441c7bc7f9b3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-d-4-20260525/traces/openai-gpt-5.5/26-USC-3302-d-4.json",
+  "trace_sha256": "f02026b899833206dc19bc813a2caa930d600bff209e96a586ad0a862c166467"
+}

--- a/statutes/26/3302/d/4.test.yaml
+++ b/statutes/26/3302/d/4.test.yaml
@@ -1,0 +1,9 @@
+- name: employee_payment_adjustment_threshold_is_two_point_seven_percent
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3302/d/4#average_employer_contribution_rate_employee_payment_adjustment_threshold: 0.027

--- a/statutes/26/3302/d/4.yaml
+++ b/statutes/26/3302/d/4.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  status: entity_not_supported
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    For purposes of subsection (c)(2)(B) and (C), the average employer contribution rate for any State for any calendar year is contributions paid into the State unemployment fund divided by the applicable wage or remuneration base; for subsection (c)(2)(C), if the rate equals or exceeds 2.7 percent, employee payments used solely for unemployment compensation are added to the numerator.
+  deferred_outputs:
+    - output: us:statutes/26/3302/d/4#average_employer_contribution_rate_for_subsection_c_2_B
+      reason: The operative subject is a State for a calendar year, but the supported RuleSpec entity set does not include a State entity, so the State-scoped rate definition cannot be faithfully represented.
+    - output: us:statutes/26/3302/d/4#average_employer_contribution_rate_for_subsection_c_2_C
+      reason: The operative subject is a State for a calendar year, but the supported RuleSpec entity set does not include a State entity, so the State-scoped rate definition and its employee-payment numerator adjustment cannot be faithfully represented.
+      source_values:
+        - us:statutes/26/3302/d/4#average_employer_contribution_rate_employee_payment_adjustment_threshold
+rules:
+  - name: average_employer_contribution_rate_employee_payment_adjustment_threshold
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(d)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "equals or exceeds 2.7 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.027


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(d)(4) state contribution-rate threshold artifact
- defer state-scoped average contribution rate outputs because RuleSpec has no State entity for this federal condition
- add signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3302-d-4-20260525/statutes/26/3302/d/4.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-d-4-20260525/statutes/26/3302/d/4.test.yaml --root /private/tmp/rulespec-us-3302-d-4-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-d-4-20260525/statutes/26/3302/d/4.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-d-4-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-4-current --program tax --fail-on-unmapped --fail-on-untested-comparable