### PR TITLE
Add generated 3302(c)(2)(A) FUTA advance reduction rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/c/2/A.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/c/2/A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/c/2/A.yaml",
+      "sha256": "0a493e4e56fa52e15097cd6136d1be13bde81f539b311e90f6b0014b9a566c2c"
+    },
+    {
+      "path": "statutes/26/3302/c/2/A.test.yaml",
+      "sha256": "eeca2781f2fe6035477f2492f273676c51a3a056aa51c948fa577d018162ebdf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "dbc0d3a62ccca500052928f146dcc81557ca8419",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.215",
+    "version_commit": "dbc0d3a62ccca500052928f146dcc81557ca8419"
+  },
+  "axiom_encode_version": "0.2.215",
+  "backend": "openai",
+  "citation": "26 USC 3302(c)(2)(A)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-c-2-a-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3302-c-2-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "91199940672e1cd74ec460cf61c5c53ba7698fe2a8bbc0e7036f3bfa3dd8b22e",
+  "generated_at": "2026-05-25T10:48:36.365633+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-c-2-a-20260525/openai-gpt-5.5/statutes/26/3302/c/2/A.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-c-2-a-20260525",
+  "generated_output_sha256": "0a493e4e56fa52e15097cd6136d1be13bde81f539b311e90f6b0014b9a566c2c",
+  "generation_prompt_sha256": "5b8622672e9924ea0c0f6bb50175177204326f0a7a5aedabbaba8eabbf0d8957",
+  "model": "gpt-5.5",
+  "run_id": "86d759b0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "48940cc76752afb86ec334becb3da0c0d07bdcaad774df79698558a124c23670"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-c-2-a-20260525/traces/openai-gpt-5.5/26-USC-3302-c-2-A.json",
+  "trace_sha256": "e16a3a88f5995f667f9ebd208d5dd1637151bb3a718c66781ebb511966819280"
+}

--- a/statutes/26/3302/c/2/A.test.yaml
+++ b/statutes/26/3302/c/2/A.test.yaml
@@ -1,0 +1,58 @@
+- name: second_consecutive_january1_balance_reduces_by_five_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_second_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_succeeding_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/A#input.number_of_succeeding_taxable_years_beginning_with_consecutive_january1_balance: 0
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3302/c/2/A#second_consecutive_january1_advances_balance_reduction_rate: 0.05
+    us:statutes/26/3302/c/2/A#succeeding_consecutive_january1_advances_balance_additional_reduction_rate: 0.05
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_rate: 0.05
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_amount: 30
+- name: first_succeeding_consecutive_january1_balance_reduces_by_additional_five_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_second_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_succeeding_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/A#input.number_of_succeeding_taxable_years_beginning_with_consecutive_january1_balance: 1
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_rate: 0.1
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_amount: 60
+- name: later_succeeding_consecutive_january1_balance_adds_five_percent_for_each_succeeding_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_second_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_succeeding_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/A#input.number_of_succeeding_taxable_years_beginning_with_consecutive_january1_balance: 2
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_rate: 0.15
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_amount: 90
+- name: no_second_or_succeeding_consecutive_january1_balance_has_no_reduction_under_this_subparagraph
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_second_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/A#input.taxable_year_begins_with_succeeding_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/A#input.number_of_succeeding_taxable_years_beginning_with_consecutive_january1_balance: 0
+    ? us:statutes/26/3301#input.total_wages_as_defined_in_section_3306_b_paid_by_employer_during_calendar_year_with_respect_to_employment
+    : 10000
+  output:
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_rate: 0
+    us:statutes/26/3302/c/2/A#advances_credit_reduction_amount: 0

--- a/statutes/26/3302/c/2/A.yaml
+++ b/statutes/26/3302/c/2/A.yaml
@@ -1,0 +1,123 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    In the case of the taxable year beginning with the second consecutive January 1 with a balance of advances, the reduction is by 5 percent of the section 3301 tax with respect to wages attributable to the State; in succeeding taxable years beginning with consecutive January 1 balances, the reduction is by an additional 5 percent for each such succeeding taxable year.
+imports:
+  - us:statutes/26/3301#federal_unemployment_excise_tax
+rules:
+  - name: second_consecutive_january1_advances_balance_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(c)(2)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "by 5 percent of the tax imposed by section 3301"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.05
+
+  - name: succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(c)(2)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "by an additional 5 percent, for each such succeeding taxable year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.05
+
+  - name: advances_credit_reduction_rate
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(c)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "taxable year beginning with the second consecutive January 1"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "any succeeding taxable year beginning with a consecutive January 1"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/A#second_consecutive_january1_advances_balance_reduction_rate
+              output: second_consecutive_january1_advances_balance_reduction_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/A#succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+              output: succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if taxable_year_begins_with_second_consecutive_january1_with_balance_of_advances:
+              second_consecutive_january1_advances_balance_reduction_rate
+          else:
+              if taxable_year_begins_with_succeeding_consecutive_january1_with_balance_of_advances:
+                  second_consecutive_january1_advances_balance_reduction_rate
+                  + (
+                      succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+                      * max(0, number_of_succeeding_taxable_years_beginning_with_consecutive_january1_balance)
+                  )
+              else:
+                  0
+
+  - name: advances_credit_reduction_amount
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "of the tax imposed by section 3301 with respect to the wages paid by such taxpayer during such taxable year which are attributable to such State"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3301#federal_unemployment_excise_tax
+              output: federal_unemployment_excise_tax
+              hash: sha256:c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/A#advances_credit_reduction_rate
+              output: advances_credit_reduction_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          advances_credit_reduction_rate
+          * max(0, federal_unemployment_excise_tax)


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(c)(2)(A) FUTA advance-balance credit-reduction rules
- cover the 5 percent second-consecutive-January-1 reduction and additional 5 percent succeeding-year reductions
- include the signed axiom encoding manifest for run 86d759b0

## Validation
- TMPDIR=/private/tmp/axiom-validate-tmp-3302-c-2-a-20260525-v216 uv run axiom-encode validate /private/tmp/rulespec-us-3302-c-2-a-20260525/statutes/26/3302/c/2/A.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-c-2-a-20260525/statutes/26/3302/c/2/A.test.yaml --root /private/tmp/rulespec-us-3302-c-2-a-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-c-2-a-20260525/statutes/26/3302/c/2/A.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-c-2-a-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-a-current --program tax --fail-on-unmapped --fail-on-untested-comparable

Note: generation used axiom-encode 0.2.215; PE oracle coverage was rerun after encoder PR #227 landed in 0.2.216.