### PR TITLE
Add generated 3302(c)(2)(B) FUTA advance reduction rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/c/2/B.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/c/2/B.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/c/2/B.yaml",
+      "sha256": "cf87e351a236f8b63ce1bc78b01cf1ee4c3a30e93a3dbbf17702bc2241ba03c0"
+    },
+    {
+      "path": "statutes/26/3302/c/2/B.test.yaml",
+      "sha256": "c4de977ba5e4636e035a1bb1ff64d2aac37fa22868b639b009516c5a453d7473"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e74f4336806eac47c75b59e194a2a2380d05f196",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.216",
+    "version_commit": "e74f4336806eac47c75b59e194a2a2380d05f196"
+  },
+  "axiom_encode_version": "0.2.216",
+  "backend": "codex",
+  "citation": "26 USC 3302(c)(2)(B)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-c-2-b-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3302-c-2-B/workspace/context-manifest.json",
+  "context_manifest_sha256": "3da558bcf83d84851d80da4aa9c55a506a31bff4c79c0d23cfe06a0c9469c497",
+  "generated_at": "2026-05-25T11:06:43.062397+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-c-2-b-20260525/codex-gpt-5.5/statutes/26/3302/c/2/B.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-c-2-b-20260525",
+  "generated_output_sha256": "cf87e351a236f8b63ce1bc78b01cf1ee4c3a30e93a3dbbf17702bc2241ba03c0",
+  "generation_prompt_sha256": "a1f52b5d0b89cea2900cd4c159338fea7fb71f1652c679284e2efe5ca464bb02",
+  "model": "gpt-5.5",
+  "run_id": "1587fc25",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a516f0bf724ba2e6a11f40f55c7768d2ac29bec628452bd5d839628940167ecd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-c-2-b-20260525/traces/codex-gpt-5.5/26-USC-3302-c-2-B.json",
+  "trace_sha256": "8534cea33246551d1725c3606565ce9bbf26b5d52fb37e16d8faff569fab5d0f"
+}

--- a/statutes/26/3302/c/2/B.test.yaml
+++ b/statutes/26/3302/c/2/B.test.yaml
@@ -1,0 +1,75 @@
+- name: third_consecutive_january1_balance_applies_positive_excess_percentage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_third_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_fourth_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/B#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/c/2/B#input.wage_base_under_this_chapter: 1000
+    ? us:statutes/26/3302/c/2/B#input.estimated_united_states_average_annual_wage_in_covered_employment_for_calendar_year_of_determination
+    : 10000
+    us:statutes/26/3302/c/2/B#input.state_average_annual_wage_in_covered_employment_for_calendar_year_of_determination: 50000
+    us:statutes/26/3302/c/2/B#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.0007
+  output:
+    us:statutes/26/3302/c/2/B#federal_unemployment_credit_reduction_benchmark_rate: 0.027
+    us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances: holds
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_excess_percentage: 0.002
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate: 0.1
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount: 1000
+- name: fourth_consecutive_january1_balance_also_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_third_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_fourth_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/B#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/c/2/B#input.wage_base_under_this_chapter: 1000
+    ? us:statutes/26/3302/c/2/B#input.estimated_united_states_average_annual_wage_in_covered_employment_for_calendar_year_of_determination
+    : 10000
+    us:statutes/26/3302/c/2/B#input.state_average_annual_wage_in_covered_employment_for_calendar_year_of_determination: 50000
+    us:statutes/26/3302/c/2/B#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.0007
+  output:
+    us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances: holds
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate: 0.1
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount: 1000
+- name: neither_third_nor_fourth_consecutive_january1_balance_has_no_reduction_under_this_subparagraph
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_third_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_fourth_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/B#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/c/2/B#input.wage_base_under_this_chapter: 1000
+    ? us:statutes/26/3302/c/2/B#input.estimated_united_states_average_annual_wage_in_covered_employment_for_calendar_year_of_determination
+    : 10000
+    us:statutes/26/3302/c/2/B#input.state_average_annual_wage_in_covered_employment_for_calendar_year_of_determination: 50000
+    us:statutes/26/3302/c/2/B#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.0007
+  output:
+    us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances: not_holds
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate: 0
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount: 0
+- name: no_excess_over_average_employer_contribution_rate_produces_zero_percentage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_third_consecutive_january1_with_balance_of_advances: true
+    us:statutes/26/3302/c/2/B#input.taxable_year_begins_with_fourth_consecutive_january1_with_balance_of_advances: false
+    us:statutes/26/3302/c/2/B#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/c/2/B#input.wage_base_under_this_chapter: 1000
+    ? us:statutes/26/3302/c/2/B#input.estimated_united_states_average_annual_wage_in_covered_employment_for_calendar_year_of_determination
+    : 10000
+    us:statutes/26/3302/c/2/B#input.state_average_annual_wage_in_covered_employment_for_calendar_year_of_determination: 50000
+    us:statutes/26/3302/c/2/B#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.003
+  output:
+    us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances: holds
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_excess_percentage: 0
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate: 0
+    us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount: 0

--- a/statutes/26/3302/c/2/B.yaml
+++ b/statutes/26/3302/c/2/B.yaml
@@ -1,0 +1,132 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: (B) "third or fourth consecutive January 1" with "a balance of such advances";
+    amount determined by "multiplying the wages paid ... attributable to such State"
+    by an excess percentage based on "2.7 percent" and the State average annual wage
+    fraction.
+rules:
+- name: federal_unemployment_credit_reduction_benchmark_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(c)(2)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: 2.7 percent
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.027'
+- name: taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3302(c)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: third or fourth consecutive January 1 as of the beginning of which
+            there is a balance of such advances
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'taxable_year_begins_with_third_consecutive_january1_with_balance_of_advances
+
+      or taxable_year_begins_with_fourth_consecutive_january1_with_balance_of_advances'
+- name: third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(c)(2)(B)(i)-(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: "by which\u2014 (i) 2.7 percent ... exceeds (ii) the average employer\
+            \ contribution rate"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/c/2/B#federal_unemployment_credit_reduction_benchmark_rate
+          output: federal_unemployment_credit_reduction_benchmark_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n    0,\n    (\n        federal_unemployment_credit_reduction_benchmark_rate\n\
+      \        * wage_base_under_this_chapter\n        / estimated_united_states_average_annual_wage_in_covered_employment_for_calendar_year_of_determination\n\
+      \    )\n    - average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year\n\
+      )"
+- name: third_or_fourth_consecutive_january1_advances_balance_reduction_rate
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(c)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: multiplied by a fraction, the numerator of which is the State's
+            average annual wage ... and the denominator ... wage base
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances
+          output: taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+          output: third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances:
+      third_or_fourth_consecutive_january1_advances_balance_excess_percentage * state_average_annual_wage_in_covered_employment_for_calendar_year_of_determination
+      / wage_base_under_this_chapter else: 0'
+- name: third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3302(c)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: amount determined by multiplying the wages paid ... attributable
+            to such State by the percentage
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate
+          output: third_or_fourth_consecutive_january1_advances_balance_reduction_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'wages_paid_by_taxpayer_during_taxable_year_attributable_to_state
+
+      * third_or_fourth_consecutive_january1_advances_balance_reduction_rate'


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(c)(2)(B) FUTA third/fourth consecutive January 1 advance-balance rules
- cover the 2.7 percent benchmark, excess percentage, wage-fraction reduction rate, and credit-reduction amount
- include the signed axiom encoding manifest for run 1587fc25

## Validation
- TMPDIR=/private/tmp/axiom-validate-tmp-3302-c-2-b-20260525-v217 uv run axiom-encode validate /private/tmp/rulespec-us-3302-c-2-b-20260525/statutes/26/3302/c/2/B.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-c-2-b-20260525/statutes/26/3302/c/2/B.test.yaml --root /private/tmp/rulespec-us-3302-c-2-b-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-c-2-b-20260525/statutes/26/3302/c/2/B.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-c-2-b-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-b-current --program tax --fail-on-unmapped --fail-on-untested-comparable

Note: PE oracle coverage depends on axiom-encode 0.2.217 from encoder PR #228.