### PR TITLE
Add generated 3302(c)(2)(C) FUTA advance reduction rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/c/2/C.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/c/2/C.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/c/2/C.yaml",
+      "sha256": "b71853a74e3e7db7c1549bffd00cc73ab02c20e82a379114bb4ace62425ece09"
+    },
+    {
+      "path": "statutes/26/3302/c/2/C.test.yaml",
+      "sha256": "d0eb97d3d9e7fbb7709f3e8c848a722d58c136adf6bc8585ee69c4a063410618"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "23c9a6d28f2f354dbd86034955e592c7587ab1b0",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.217",
+    "version_commit": "23c9a6d28f2f354dbd86034955e592c7587ab1b0"
+  },
+  "axiom_encode_version": "0.2.217",
+  "backend": "codex",
+  "citation": "26 USC 3302(c)(2)(C)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-c-2-c-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3302-c-2-C/workspace/context-manifest.json",
+  "context_manifest_sha256": "97f8db950142f2bfc16c0785db609ef8db0c7328f47ad863a6259826fc9c8642",
+  "generated_at": "2026-05-25T11:23:55.520309+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-c-2-c-20260525/codex-gpt-5.5/statutes/26/3302/c/2/C.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-c-2-c-20260525",
+  "generated_output_sha256": "b71853a74e3e7db7c1549bffd00cc73ab02c20e82a379114bb4ace62425ece09",
+  "generation_prompt_sha256": "9308039db38e8dcbe19563442244cdaff481158bedd074cd8bd9b7803e10c6fd",
+  "model": "gpt-5.5",
+  "run_id": "5d8000f3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c07c76f6e7fe1da9b88c521d6e612988934e0499f651e242737d5ef952514a91"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-c-2-c-20260525/traces/codex-gpt-5.5/26-USC-3302-c-2-C.json",
+  "trace_sha256": "c5402ea51b3112bb96ddfb91193bf8fa024d4ae4c87996d5520e71f8c063eb8a"
+}

--- a/statutes/26/3302/c/2/C.test.yaml
+++ b/statutes/26/3302/c/2/C.test.yaml
@@ -1,0 +1,77 @@
+- name: fifth_or_succeeding_balance_applies_using_benchmark_floor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/C#input.taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances: true
+    ? us:statutes/26/3302/c/2/C#input.timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+    : false
+    us:statutes/26/3302/c/2/C#input.five_year_benefit_cost_rate_applicable_to_state_for_taxable_year: 0.02
+    us:statutes/26/3302/c/2/C#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.007
+    us:statutes/26/3302/c/2/C#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+  output:
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_floor_rate: 0.027
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies: holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead: not_holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor: 0.027
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage: 0.02
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate: 0.02
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount: 200
+- name: fifth_or_succeeding_balance_uses_higher_five_year_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/C#input.taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances: true
+    ? us:statutes/26/3302/c/2/C#input.timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+    : false
+    us:statutes/26/3302/c/2/C#input.five_year_benefit_cost_rate_applicable_to_state_for_taxable_year: 0.04
+    us:statutes/26/3302/c/2/C#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.01
+    us:statutes/26/3302/c/2/C#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+  output:
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies: holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead: not_holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor: 0.04
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage: 0.03
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate: 0.03
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount: 300
+- name: no_fifth_or_succeeding_balance_no_subparagraph_c_reduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/C#input.taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances: false
+    ? us:statutes/26/3302/c/2/C#input.timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+    : false
+    us:statutes/26/3302/c/2/C#input.five_year_benefit_cost_rate_applicable_to_state_for_taxable_year: 0.02
+    us:statutes/26/3302/c/2/C#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.03
+    us:statutes/26/3302/c/2/C#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+  output:
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies: not_holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead: not_holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor: 0.027
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage: 0
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate: 0
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount: 0
+- name: timely_secretary_determination_displaces_subparagraph_c
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/2/C#input.taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances: true
+    ? us:statutes/26/3302/c/2/C#input.timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+    : true
+    us:statutes/26/3302/c/2/C#input.five_year_benefit_cost_rate_applicable_to_state_for_taxable_year: 0.04
+    us:statutes/26/3302/c/2/C#input.average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year: 0.01
+    us:statutes/26/3302/c/2/C#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+  output:
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies: not_holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead: holds
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor: 0.04
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage: 0.03
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate: 0
+    us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount: 0

--- a/statutes/26/3302/c/2/C.yaml
+++ b/statutes/26/3302/c/2/C.yaml
@@ -1,0 +1,190 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    In a taxable year beginning with the fifth or succeeding consecutive January 1 with a balance of advances, the amount is wages attributable to the State multiplied by the percentage, if any, by which the 5-year benefit cost rate, or if higher 2.7 percent, exceeds the State average employer contribution rate. Subparagraph (C) shall not apply, and subparagraph (B) shall apply, if the Secretary of Labor timely determines that the State meets subsection (f)(2)(B).
+rules:
+  - name: fifth_or_succeeding_benefit_cost_floor_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(c)(2)(C)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "or (if higher) 2.7 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.027
+
+  - name: fifth_or_succeeding_advances_balance_reduction_applies
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3302(c)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "taxable year beginning with the fifth or any succeeding consecutive January 1 as of the beginning of which there is a balance of such advances"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "Subparagraph (C) shall not apply ... if the Secretary of Labor determines (on or before November 10 of such taxable year)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances
+          and not timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+
+  - name: fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3302(c)(2)(C), second sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "taxable year to which it would otherwise apply"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "but subparagraph (B) shall apply to such taxable year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          taxable_year_begins_with_fifth_or_succeeding_consecutive_january1_with_balance_of_advances
+          and timely_secretary_of_labor_determination_state_meets_subsection_f_2_B_requirements_for_taxable_year
+
+  - name: fifth_or_succeeding_benefit_cost_rate_after_floor
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(c)(2)(C)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "the 5-year benefit cost rate applicable to such State for such taxable year or (if higher) 2.7 percent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_floor_rate
+              output: fifth_or_succeeding_benefit_cost_floor_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              five_year_benefit_cost_rate_applicable_to_state_for_taxable_year,
+              fifth_or_succeeding_benefit_cost_floor_rate
+          )
+
+  - name: fifth_or_succeeding_advances_balance_excess_percentage
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(c)(2)(C)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "percentage (if any) by which ... exceeds ... the average employer contribution rate"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor
+              output: fifth_or_succeeding_benefit_cost_rate_after_floor
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              fifth_or_succeeding_benefit_cost_rate_after_floor
+              - average_employer_contribution_rate_for_state_for_calendar_year_preceding_taxable_year
+          )
+
+  - name: fifth_or_succeeding_advances_balance_reduction_rate
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(c)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "by the amount determined by multiplying the wages ... by the percentage"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies
+              output: fifth_or_succeeding_advances_balance_reduction_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage
+              output: fifth_or_succeeding_advances_balance_excess_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if fifth_or_succeeding_advances_balance_reduction_applies: fifth_or_succeeding_advances_balance_excess_percentage else: 0
+
+  - name: fifth_or_succeeding_advances_balance_credit_reduction_amount
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "multiplying the wages paid by such taxpayer during such taxable year which are attributable to such State by the percentage"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate
+              output: fifth_or_succeeding_advances_balance_reduction_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          wages_paid_by_taxpayer_during_taxable_year_attributable_to_state
+          * fifth_or_succeeding_advances_balance_reduction_rate


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(c)(2)(C) FUTA fifth-or-succeeding consecutive January 1 advance-balance rules
- cover the 2.7 percent benefit-cost floor, fifth-year excess percentage, credit-reduction amount, and the Secretary of Labor subparagraph (B) substitution exception
- include the signed axiom encoding manifest for run 5d8000f3

## Validation
- TMPDIR=/private/tmp/axiom-validate-tmp-3302-c-2-c-20260525-v218 uv run axiom-encode validate /private/tmp/rulespec-us-3302-c-2-c-20260525/statutes/26/3302/c/2/C.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3302-c-2-c-20260525/statutes/26/3302/c/2/C.test.yaml --root /private/tmp/rulespec-us-3302-c-2-c-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-c-2-c-20260525/statutes/26/3302/c/2/C.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-c-2-c-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-c-current --program tax --fail-on-unmapped --fail-on-untested-comparable

Note: PE oracle coverage depends on axiom-encode 0.2.218 from encoder PR #229.