### PR TITLE
Add generated 3302(c)(3) FUTA Trade Act rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/c/3.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/c/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/c/3.yaml",
+      "sha256": "ba5cabb56b58b4240a8a278f579a636295243354a5c007e697821d9ba19b2898"
+    },
+    {
+      "path": "statutes/26/3302/c/3.test.yaml",
+      "sha256": "6d86ca5c963f9b8e3ab88d859423b34e009683befb303705980ce840e328abd8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1db557d0183b550671fc357544e0ef0b982b4d29",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.219",
+    "version_commit": "1db557d0183b550671fc357544e0ef0b982b4d29"
+  },
+  "axiom_encode_version": "0.2.219",
+  "backend": "codex",
+  "citation": "26 USC 3302(c)(3)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-c-3-v219-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3302-c-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "17b46d33fea55566524d57a785a88b8b60837190c3dccfe371cfcf5e3e015992",
+  "generated_at": "2026-05-25T11:59:43.640815+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-c-3-v219-20260525/codex-gpt-5.5/statutes/26/3302/c/3.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-c-3-v219-20260525",
+  "generated_output_sha256": "ba5cabb56b58b4240a8a278f579a636295243354a5c007e697821d9ba19b2898",
+  "generation_prompt_sha256": "b79d308e909f26d81d25e4c1153005149d4691dd43f21acce990598c474b0286",
+  "model": "gpt-5.5",
+  "run_id": "96639ca7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ee1bb9caf1fb1bec1d9a157ced5650745ccffcddd346d905085a0d2558bedc8b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-c-3-v219-20260525/traces/codex-gpt-5.5/26-USC-3302-c-3.json",
+  "trace_sha256": "42442f28c1727fd31ff85e153c979666e7fc4d0bbca83d672a8f083183dc798b"
+}

--- a/statutes/26/3302/c/3.test.yaml
+++ b/statutes/26/3302/c/3.test.yaml
@@ -1,0 +1,77 @@
+- name: reduction applies when Secretary determines State did not enter agreement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/3#input.taxpayer_subject_to_unemployment_compensation_law_of_state: true
+    ? us:statutes/26/3302/c/3#input.taxable_year_is_during_state_or_agency_does_not_enter_or_fulfill_trade_act_section_239_agreement
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_enter_trade_act_section_239_agreement_before_deadline
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_fulfill_trade_act_section_239_agreement_commitments
+    : false
+    us:statutes/26/3302/c/3#input.tax_imposed_with_respect_to_state_attributable_wages: 4000
+    us:statutes/26/3302/c/3#input.total_credits_otherwise_allowable_under_section_after_subsections_a_b_and_paragraphs_1_and_2: 1000
+  output:
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_rate: 0.075
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies: holds
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction: 300
+    us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction: 700
+- name: no reduction when taxpayer is not subject to State unemployment law
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/3#input.taxpayer_subject_to_unemployment_compensation_law_of_state: false
+    ? us:statutes/26/3302/c/3#input.taxable_year_is_during_state_or_agency_does_not_enter_or_fulfill_trade_act_section_239_agreement
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_enter_trade_act_section_239_agreement_before_deadline
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_fulfill_trade_act_section_239_agreement_commitments
+    : false
+    us:statutes/26/3302/c/3#input.tax_imposed_with_respect_to_state_attributable_wages: 4000
+    us:statutes/26/3302/c/3#input.total_credits_otherwise_allowable_under_section_after_subsections_a_b_and_paragraphs_1_and_2: 1000
+  output:
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies: not_holds
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction: 0
+    us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction: 1000
+- name: no reduction outside a nonentry or nonfulfillment year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/3#input.taxpayer_subject_to_unemployment_compensation_law_of_state: true
+    ? us:statutes/26/3302/c/3#input.taxable_year_is_during_state_or_agency_does_not_enter_or_fulfill_trade_act_section_239_agreement
+    : false
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_enter_trade_act_section_239_agreement_before_deadline
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_fulfill_trade_act_section_239_agreement_commitments
+    : false
+    us:statutes/26/3302/c/3#input.tax_imposed_with_respect_to_state_attributable_wages: 4000
+    us:statutes/26/3302/c/3#input.total_credits_otherwise_allowable_under_section_after_subsections_a_b_and_paragraphs_1_and_2: 1000
+  output:
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies: not_holds
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction: 0
+    us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction: 1000
+- name: no reduction without either Secretary determination
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/c/3#input.taxpayer_subject_to_unemployment_compensation_law_of_state: true
+    ? us:statutes/26/3302/c/3#input.taxable_year_is_during_state_or_agency_does_not_enter_or_fulfill_trade_act_section_239_agreement
+    : true
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_enter_trade_act_section_239_agreement_before_deadline
+    : false
+    ? us:statutes/26/3302/c/3#input.secretary_of_labor_determined_state_or_agency_did_not_fulfill_trade_act_section_239_agreement_commitments
+    : false
+    us:statutes/26/3302/c/3#input.tax_imposed_with_respect_to_state_attributable_wages: 4000
+    us:statutes/26/3302/c/3#input.total_credits_otherwise_allowable_under_section_after_subsections_a_b_and_paragraphs_1_and_2: 1000
+  output:
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies: not_holds
+    us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction: 0
+    us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction: 1000

--- a/statutes/26/3302/c/3.yaml
+++ b/statutes/26/3302/c/3.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    "If the Secretary of Labor determines that a State, or State agency, has not" entered the Trade Act section 239 agreement before July 15, 1975, or fulfilled its commitments, "the total credits ... shall be reduced by 7½ percent" of the attributable tax.
+rules:
+  - name: trade_act_agreement_credit_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "reduced by 7½ percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.075
+
+  - name: trade_act_agreement_credit_reduction_applies
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3302(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "If the Secretary of Labor determines that a State, or State agency, has not"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          taxpayer_subject_to_unemployment_compensation_law_of_state
+          and taxable_year_is_during_state_or_agency_does_not_enter_or_fulfill_trade_act_section_239_agreement
+          and (
+            secretary_of_labor_determined_state_or_agency_did_not_enter_trade_act_section_239_agreement_before_deadline
+            or secretary_of_labor_determined_state_or_agency_did_not_fulfill_trade_act_section_239_agreement_commitments
+          )
+
+  - name: trade_act_agreement_credit_reduction
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "shall be reduced by 7½ percent of the tax imposed"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if trade_act_agreement_credit_reduction_applies: trade_act_agreement_credit_reduction_rate * tax_imposed_with_respect_to_state_attributable_wages else: 0
+
+  - name: total_credits_allowed_under_section_after_trade_act_agreement_reduction
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "the total credits ... otherwise allowable under this section ... shall be reduced"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, total_credits_otherwise_allowable_under_section_after_subsections_a_b_and_paragraphs_1_and_2 - trade_act_agreement_credit_reduction)


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(c)(3) RuleSpec for the Trade Act agreement credit reduction
- cover the 7.5 percent reduction rate, application predicate, reduction amount, and total credits after the reduction
- include signed encoding manifest for run 96639ca7

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3302-c-3-20260525/statutes/26/3302/c/3.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3302-c-3-20260525/statutes/26/3302/c/3.test.yaml --root /private/tmp/rulespec-us-3302-c-3-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-c-3-20260525/statutes/26/3302/c/3.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-c-3-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-3-v219-20260525b --program tax --fail-on-unmapped --fail-on-untested-comparable`

Depends on TheAxiomFoundation/axiom-encode#232, now merged.
