### PR TITLE
Add generated 3302(d)(5) FUTA benefit-cost rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/d/5.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/d/5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/d/5.yaml",
+      "sha256": "7ca40a54c7e84b75a5a90d8d4102541accb51612f1ae242805665d2b63fe7936"
+    },
+    {
+      "path": "statutes/26/3302/d/5.test.yaml",
+      "sha256": "9aa964da3832505aac91357bb0e3c6a461f4e8d0efeae7103ec0b58fa4d1544b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e6dc7c99e2c71a7789c25f7c4f2f6d16b58f97ec",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.220",
+    "version_commit": "e6dc7c99e2c71a7789c25f7c4f2f6d16b58f97ec"
+  },
+  "axiom_encode_version": "0.2.220",
+  "backend": "codex",
+  "citation": "26 USC 3302(d)(5)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-d-5-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3302-d-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "f63803a1761eb340cfffa724db7dacc35bd111998bebf1d4223a63786f016e1b",
+  "generated_at": "2026-05-25T12:17:23.405479+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-d-5-20260525/codex-gpt-5.5/statutes/26/3302/d/5.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-d-5-20260525",
+  "generated_output_sha256": "7ca40a54c7e84b75a5a90d8d4102541accb51612f1ae242805665d2b63fe7936",
+  "generation_prompt_sha256": "b9c38d8eb41a4fcfc5208be4ace729fec21a3185b9e39404189c2d9a7dcbe2c4",
+  "model": "gpt-5.5",
+  "run_id": "e08a9452",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "462d9e6d37693a9bf170b9b54de0dfbda85d237a09d8161cff916e2e0cfae9b4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-d-5-20260525/traces/codex-gpt-5.5/26-USC-3302-d-5.json",
+  "trace_sha256": "4432882e653c3ee731282572490ca350e284106cf3d55d31c23a36535c3ee898"
+}

--- a/statutes/26/3302/d/5.test.yaml
+++ b/statutes/26/3302/d/5.test.yaml
@@ -1,0 +1,9 @@
+- name: benefit_cost_rate_source_scalars
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3302/d/5#benefit_cost_rate_compensation_lookback_years: 5
+    us:statutes/26/3302/d/5#benefit_cost_rate_compensation_averaging_fraction: 0.2

--- a/statutes/26/3302/d/5.yaml
+++ b/statutes/26/3302/d/5.yaml
@@ -1,0 +1,49 @@
+format: rulespec/v1
+module:
+  status: entity_not_supported
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    The "5-year benefit cost rate applicable to any State for any taxable year" is obtained by dividing "one-fifth of the total of the compensation paid" during the stated 5-year period by "the total of the remuneration subject to contributions" for the stated preceding calendar year.
+  deferred_outputs:
+    - output: us:statutes/26/3302/d/5#five_year_benefit_cost_rate_applicable_to_state_for_taxable_year
+      reason: The operative subject is a State for a taxable year, but the supported RuleSpec entity set does not include a State entity, so the State-scoped benefit cost rate definition cannot be faithfully represented.
+      source_values:
+        - us:statutes/26/3302/d/5#benefit_cost_rate_compensation_lookback_years
+        - us:statutes/26/3302/d/5#benefit_cost_rate_compensation_averaging_fraction
+rules:
+  - name: benefit_cost_rate_compensation_lookback_years
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3302(d)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "during the 5-year period"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          5
+
+  - name: benefit_cost_rate_compensation_averaging_fraction
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(d)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "one-fifth of the total of the compensation paid"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1 / 5


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(d)(5) RuleSpec for the benefit-cost-rate source scalars
- capture the 5-year compensation lookback and one-fifth averaging fraction
- defer the State-scoped benefit-cost-rate output because RuleSpec does not yet support a State entity
- include signed encoding manifest for run e08a9452

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3302-d-5-20260525/statutes/26/3302/d/5.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3302-d-5-20260525/statutes/26/3302/d/5.test.yaml --root /private/tmp/rulespec-us-3302-d-5-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-d-5-20260525/statutes/26/3302/d/5.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-d-5-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-5-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

Depends on TheAxiomFoundation/axiom-encode#233, now merged.
