### PR TITLE
Add generated 3302(d)(6) FUTA rounding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/d/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/d/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/d/6.yaml",
+      "sha256": "24fd4b0668459b9facd0770464f46451ddb56172232b8353ce03d8cda5e65ded"
+    },
+    {
+      "path": "statutes/26/3302/d/6.test.yaml",
+      "sha256": "1bc305de08f944d06e587add42d5107fc70a472a07addbf9d83552802a70b087"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "eee8fc32b134570f7e5a4765298d33c0423bdbb9",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.221",
+    "version_commit": "eee8fc32b134570f7e5a4765298d33c0423bdbb9"
+  },
+  "axiom_encode_version": "0.2.221",
+  "backend": "codex",
+  "citation": "26 USC 3302(d)(6)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-d-6-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3302-d-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "f254e5b5e2b8caf94efde0fa1e7326381299931f25de9e835e91621637d10422",
+  "generated_at": "2026-05-25T12:31:34.519764+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-d-6-20260525/codex-gpt-5.5/statutes/26/3302/d/6.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-d-6-20260525",
+  "generated_output_sha256": "24fd4b0668459b9facd0770464f46451ddb56172232b8353ce03d8cda5e65ded",
+  "generation_prompt_sha256": "899984e1096017df7368c157e2e2b333754f82fbfd1da34c4bccee421c4e4aaa",
+  "model": "gpt-5.5",
+  "run_id": "9c5e6a5f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "730dcddbd25ece3fea5c2778dd627efb48d9b3bfc17cf17b7d6f856920475379"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-d-6-20260525/traces/codex-gpt-5.5/26-USC-3302-d-6.json",
+  "trace_sha256": "29976630e19cb9f654c8bd8d8ea43fc8fce68be6e745d9a0f0e5963c32763c99"
+}

--- a/statutes/26/3302/d/6.test.yaml
+++ b/statutes/26/3302/d/6.test.yaml
@@ -1,0 +1,28 @@
+- name: exact_multiple_is_unchanged
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/d/6#input.subparagraph_b_or_c_percentage: 0.012
+  output:
+    us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_rounding_multiple: 0.001
+    us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_after_rounding: 0.012
+- name: nonmultiple_rounds_down_to_nearest_tenth_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/d/6#input.subparagraph_b_or_c_percentage: 0.01234
+  output:
+    us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_after_rounding: 0.012
+- name: nonmultiple_rounds_up_to_nearest_tenth_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/d/6#input.subparagraph_b_or_c_percentage: 0.01256
+  output:
+    us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_after_rounding: 0.013

--- a/statutes/26/3302/d/6.yaml
+++ b/statutes/26/3302/d/6.yaml
@@ -1,0 +1,44 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: |-
+    If any percentage referred to in either subparagraph (B) or (C) of subsection (c)(2) is not a multiple of .1 percent, it shall be rounded to the nearest multiple of .1 percent.
+rules:
+  - name: subparagraph_b_or_c_percentage_rounding_multiple
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3302(d)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "nearest multiple of .1 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.001
+
+  - name: subparagraph_b_or_c_percentage_after_rounding
+    kind: derived
+    entity: Employer
+    dtype: Rate
+    period: Year
+    source: 26 USC 3302(d)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: "not a multiple of .1 percent, it shall be rounded to the nearest multiple of .1 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          floor((subparagraph_b_or_c_percentage / subparagraph_b_or_c_percentage_rounding_multiple) + (1 / 2)) * subparagraph_b_or_c_percentage_rounding_multiple


### PR DESCRIPTION
## Summary
- add generated 26 USC 3302(d)(6) RuleSpec for rounding percentages used by section 3302(c)(2)(B) and (C)
- encode the 0.1 percent rounding multiple and nearest-multiple rounded percentage formula
- include generated tests for exact multiples, down-rounding, and up-rounding
- include signed encoding manifest for run 9c5e6a5f

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3302-d-6-20260525/statutes/26/3302/d/6.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3302-d-6-20260525/statutes/26/3302/d/6.test.yaml --root /private/tmp/rulespec-us-3302-d-6-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3302-d-6-20260525/statutes/26/3302/d/6.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3302-d-6-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-6-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

Depends on TheAxiomFoundation/axiom-encode#234, now merged.
