### PR TITLE
Add generated 3306(b)(2) FUTA wage exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/2.yaml",
+      "sha256": "07b436f2076d7f2a7b7354dab1b0671cac2c9f9c6aaa40efe7f5bce512a6fc01"
+    },
+    {
+      "path": "statutes/26/3306/b/2.test.yaml",
+      "sha256": "14b98db90ab73cf90deebaa298e6894d0a62fb64fab73bd72146b24b43aa3f64"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "79e996b90d2708b590a7ca8884fabe6eb2e13bd4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.223",
+    "version_commit": "79e996b90d2708b590a7ca8884fabe6eb2e13bd4"
+  },
+  "axiom_encode_version": "0.2.223",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(2)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "453e32cb1fdd91b2a8424fe8ba5efcc4ae13625ab131e310d658ee96309818d1",
+  "generated_at": "2026-05-25T13:11:36.092342+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/codex-gpt-5.5/statutes/26/3306/b/2.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-2-20260525-v223",
+  "generated_output_sha256": "07b436f2076d7f2a7b7354dab1b0671cac2c9f9c6aaa40efe7f5bce512a6fc01",
+  "generation_prompt_sha256": "067a5e48c91c09446b8a185d0807e550d3ab5ab82dc29017ed6b97c225cdc531",
+  "model": "gpt-5.5",
+  "run_id": "4737e08b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2fb25d95308cbe76be40caa451328f0c84d6ef04790e698c807d5bcf9851fa1f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/traces/codex-gpt-5.5/26-USC-3306-b-2.json",
+  "trace_sha256": "da38616978ef9ea30d4e4cf026d7b6950fd0524b3e491932a82d5748d819a162"
+}

--- a/statutes/26/3306/b/2.test.yaml
+++ b/statutes/26/3306/b/2.test.yaml
@@ -1,0 +1,120 @@
+- name: qualifying employer plan payments are excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/2#input.payment_amount: 1200
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: true
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: false
+    - us:statutes/26/3306/b/2#input.payment_amount: 700
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: false
+    - us:statutes/26/3306/b/2#input.payment_amount: 800
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: false
+    - us:statutes/26/3306/b/2#input.payment_amount: 600
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: true
+  output:
+    us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
+    - 1200
+    - 700
+    - 800
+    - 600
+- name: direct sickness disability payment not excluded without workers compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/2#input.payment_amount: 1200
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: true
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: false
+  output:
+    us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
+    - 0
+- name: plan and employee payment gates are required
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/2#input.payment_amount: 600
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: true
+    - us:statutes/26/3306/b/2#input.payment_amount: 600
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: true
+  output:
+    us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
+    - 0
+    - 0
+- name: non enumerated employer plan payment not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/2#input.payment_amount: 500
+      us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
+      us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
+      us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true
+      us:statutes/26/3306/b/2#input.payment_on_account_of_sickness_or_accident_disability: false
+      us:statutes/26/3306/b/2#input.payment_received_under_workmens_compensation_law: false
+      ? us:statutes/26/3306/b/2#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/2#input.payment_on_account_of_death: false
+  output:
+    us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/2.yaml
+++ b/statutes/26/3306/b/2.yaml
@@ -1,0 +1,52 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    Excludes "the amount of any payment ... made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer" on account of sickness or accident disability, medical or hospitalization expenses in connection with sickness or accident disability, or death; direct sickness or accident disability payments are limited to amounts "received under a workmen's compensation law."
+rules:
+  - name: employer_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on account of-- (A) sickness or accident disability ... (B) medical or hospitalization expenses ... (C) death"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "only payments which are received under a workmen's compensation law"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            (payment_made_to_employee_or_dependent or payment_made_on_behalf_of_employee_or_dependent)
+            and employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents
+            and (
+              payment_on_account_of_death
+              or payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+              or (
+                payment_on_account_of_sickness_or_accident_disability
+                and (
+                  payment_made_on_behalf_of_employee_or_dependent
+                  or payment_received_under_workmens_compensation_law
+                )
+              )
+            )
+          ): payment_amount else: 0


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3306(b)(2), covering employer-plan payments excluded from FUTA wages.
- Add companion generated tests for direct payments, on-behalf payments, plan gate failures, and non-enumerated payments.
- Add signed `axiom-encode encode --apply` manifest for run `4737e08b`.

## Provenance
- Tool: `axiom-encode encode --apply`
- Encoder: `0.2.223` (`79e996b90d2708b590a7ca8884fabe6eb2e13bd4`)
- Model: `gpt-5.5`
- Run ID: `4737e08b`

## Validation
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-2-20260525-v223-rerun uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-2-20260525/statutes/26/3306/b/2.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-b-2-20260525/statutes/26/3306/b/2.test.yaml --root /private/tmp/rulespec-us-3306-b-2-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-2-20260525/statutes/26/3306/b/2.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-2-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-2-v223-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

PE oracle coverage result: tax outputs `comparable=226`, `known_not_comparable=777`, untested comparable outputs `0`.
