### PR TITLE
Add generated 3306(b)(4) FUTA sickness exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/4.yaml",
+      "sha256": "e227ba9ad7c66375a2ca1a351189986cbc0b100756c2d9c3763f2e0af2415c76"
+    },
+    {
+      "path": "statutes/26/3306/b/4.test.yaml",
+      "sha256": "dadb9972c396855e938f849fc6e1496c7605914808a9db9cf0bb89e47c0ea78b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "49fb5263825a9f4cc5ab83f724d803ff8e2be301",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.224",
+    "version_commit": "49fb5263825a9f4cc5ab83f724d803ff8e2be301"
+  },
+  "axiom_encode_version": "0.2.224",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(4)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "782d80c1ed48c520049fac484661358d9da2846ff1949b2326683cdd41beaaba",
+  "generated_at": "2026-05-25T13:35:05.282996+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/codex-gpt-5.5/statutes/26/3306/b/4.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-4-20260525-v224",
+  "generated_output_sha256": "e227ba9ad7c66375a2ca1a351189986cbc0b100756c2d9c3763f2e0af2415c76",
+  "generation_prompt_sha256": "c1ee959b6dc52fb5f21deadb7491a9b9eb7869ee637bdb5862253da0bf475841",
+  "model": "gpt-5.5",
+  "run_id": "cf542cbe",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6ecd6b643e7f6c1bb2c1b4dc76c5c40fc60841898c46fb9d0082f989bd66bac6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/traces/codex-gpt-5.5/26-USC-3306-b-4.json",
+  "trace_sha256": "65a166b3076b1a8b86c45b2ad39afd8be5105169c6fe19c5d44b725647929023"
+}

--- a/statutes/26/3306/b/4.test.yaml
+++ b/statutes/26/3306/b/4.test.yaml
@@ -1,0 +1,68 @@
+- name: qualifying_sickness_payment_to_employee_after_waiting_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: true
+      ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 6
+  output:
+    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - holds
+- name: nonqualifying_payment_category_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: false
+      ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 6
+  output:
+    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - not_holds
+- name: employer_employee_payment_connection_missing
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: true
+      ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 6
+  output:
+    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - not_holds
+- name: payment_before_waiting_period_expired
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: true
+      ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: true
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
+      us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 5
+  output:
+    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - not_holds

--- a/statutes/26/3306/b/4.yaml
+++ b/statutes/26/3306/b/4.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    any payment on account of sickness or accident disability, or medical or hospitalization expenses ... after the expiration of 6 calendar months following the last calendar month in which the employee worked
+rules:
+  - name: sickness_accident_disability_payment_waiting_period_calendar_months
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: after the expiration of 6 calendar months
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          6
+
+  - name: post_work_sickness_accident_or_medical_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: payment on account of sickness or accident disability, or medical or hospitalization expenses in connection with sickness or accident disability
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: made by an employer to, or on behalf of, an employee
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: after the expiration of 6 calendar months following the last calendar month in which the employee worked
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/4#sickness_accident_disability_payment_waiting_period_calendar_months
+              output: sickness_accident_disability_payment_waiting_period_calendar_months
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (payment_on_account_of_sickness_or_accident_disability
+          or payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability)
+          and (payment_made_by_employer_to_employee
+          or payment_made_by_employer_on_behalf_of_employee)
+          and full_calendar_months_following_last_work_month_expired_before_payment >= sickness_accident_disability_payment_waiting_period_calendar_months


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3306(b)(4), covering the post-work sickness, accident-disability, medical, and hospitalization FUTA wage exclusion after the six-calendar-month waiting period.
- Add generated companion tests for qualifying sickness payments and failed category, employer-connection, and waiting-period gates.
- Add signed `axiom-encode encode --apply` manifest for run `cf542cbe`.

## Provenance
- Tool: `axiom-encode encode --apply`
- Encoder: `0.2.224` (`49fb5263825a9f4cc5ab83f724d803ff8e2be301`)
- Model: `gpt-5.5`
- Run ID: `cf542cbe`
- Encoder oracle mapping dependency: TheAxiomFoundation/axiom-encode#236

## Validation
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-4-20260525-v224 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-4-20260525/statutes/26/3306/b/4.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-b-4-20260525/statutes/26/3306/b/4.test.yaml --root /private/tmp/rulespec-us-3306-b-4-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-4-20260525/statutes/26/3306/b/4.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-4-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-4-v224-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

PE oracle coverage result: tax outputs `comparable=226`, `known_not_comparable=779`, untested comparable outputs `0`.
