### PR TITLE
Add generated 3306(b)(6) FUTA state unemployment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/6.yaml",
+      "sha256": "bb0056fbb5ffa0389ea9027d5c0ac9e574f0552fad41f185b26125791fe03460"
+    },
+    {
+      "path": "statutes/26/3306/b/6.test.yaml",
+      "sha256": "5b0170f289b00f23d03c80b325223af1fbbb3a54f77ec6220712197af4dfe99e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "55237f16b4454668c3ea5edfc5de20b2d248eaa3",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.226",
+    "version_commit": "55237f16b4454668c3ea5edfc5de20b2d248eaa3"
+  },
+  "axiom_encode_version": "0.2.226",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(6)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "22c8639dc68f775bc8a8c05d8e4f67cbeb565b2b810a950b2a7edf4eb672e7c0",
+  "generated_at": "2026-05-25T14:28:30.843471+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/codex-gpt-5.5/statutes/26/3306/b/6.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-6-20260525-v226",
+  "generated_output_sha256": "bb0056fbb5ffa0389ea9027d5c0ac9e574f0552fad41f185b26125791fe03460",
+  "generation_prompt_sha256": "fb9fae71018d86d0a945a76e0b4345df15bc70747911b324396d6ede34e33ce5",
+  "model": "gpt-5.5",
+  "run_id": "9ef29654",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8aaaeeeafe276744c3bca8f85bb4c0c720c1dbbe5c38c31f0391a1da233ac549"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/traces/codex-gpt-5.5/26-USC-3306-b-6.json",
+  "trace_sha256": "acde6ff78e45941bb40569d289a2d068ec34b858f4044d69fd7978132cccae26"
+}

--- a/statutes/26/3306/b/6.test.yaml
+++ b/statutes/26/3306/b/6.test.yaml
@@ -1,0 +1,95 @@
+- name: state unemployment payment for domestic service is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 120
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/6#input.payment_amount: 120
+      us:statutes/26/3306/b/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+- name: state unemployment payment for agricultural labor is excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 80
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/6#input.payment_amount: 80
+      us:statutes/26/3306/b/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: true
+- name: deduction from employee remuneration blocks exclusion
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 0
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/6#input.payment_amount: 120
+      us:statutes/26/3306/b/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: false
+      us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+- name: payment not required under state unemployment law is not excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 0
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/6#input.payment_amount: 120
+      us:statutes/26/3306/b/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: false
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+- name: non-domestic non-agricultural remuneration is not excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 0
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/6#input.payment_amount: 120
+      us:statutes/26/3306/b/6#input.payment_made_by_employer_without_deduction_from_employee_remuneration: true
+      us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: false
+      us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false

--- a/statutes/26/3306/b/6.yaml
+++ b/statutes/26/3306/b/6.yaml
@@ -1,0 +1,54 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "payment by an employer (without deduction from the remuneration of the employee)" of "any payment required from an employee under a State unemployment compensation law" with respect to domestic service or agricultural labor remuneration.
+  deferred_outputs:
+    - output: us:statutes/26/3306/b/6#employee_tax_payment_excluded_from_wages
+      reason: The paragraph (6)(A) branch depends on the tax imposed upon an employee under section 3101, but the copied section 3101 context is entity_not_supported and exports no executable employee-tax output; encoding it would require a prohibited local cross-reference fact.
+rules:
+  - name: state_unemployment_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "payment required from an employee under a State unemployment compensation law"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer_without_deduction_from_employee_remuneration
+          and payment_required_from_employee_under_state_unemployment_compensation_law
+          and (
+            remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer
+            or remuneration_paid_to_employee_for_agricultural_labor
+          )
+  - name: employer_state_unemployment_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(6)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "the payment by an employer ... of any payment required from an employee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if state_unemployment_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(6) state unemployment payment FUTA wage exclusion
- add generated five-case regression suite for domestic service/agricultural labor and statutory gate failures
- add generated encoding manifest from axiom-encode 0.2.226, run 9ef29654, model gpt-5.5

## Encoder/Oracle context
- generated through `axiom-encode encode --apply`; no hand-edited rulespec artifacts
- depends on encoder mapping work in TheAxiomFoundation/axiom-encode#237 and #238 for PE oracle coverage

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-6-20260525/statutes/26/3306/b/6.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-b-6-20260525/statutes/26/3306/b/6.test.yaml --root /private/tmp/rulespec-us-3306-b-6-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-6-20260525/statutes/26/3306/b/6.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-6-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-6-v226-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable` -> comparable=226, known_not_comparable=781, untested comparable=0