### PR TITLE
Add generated 3306(b)(7) FUTA noncash exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/7.yaml",
+      "sha256": "301863e37b93eed022c1c9b688eaea1abbcf6e361e71fada3c9a84c75bf366d4"
+    },
+    {
+      "path": "statutes/26/3306/b/7.test.yaml",
+      "sha256": "9ff0302035f03e6399f130e19d1ed3fdc3183b066c7b0427aa459d8835fa5d2d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8e5189d2da399b802956f5745b6d2e356b7daa9a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.227",
+    "version_commit": "8e5189d2da399b802956f5745b6d2e356b7daa9a"
+  },
+  "axiom_encode_version": "0.2.227",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(7)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "e1b878c16b586af5ba405c5644b096f9e02f6fc897936ce186f36e4130781bf8",
+  "generated_at": "2026-05-25T14:47:25.506858+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/codex-gpt-5.5/statutes/26/3306/b/7.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-7-20260525-v227",
+  "generated_output_sha256": "301863e37b93eed022c1c9b688eaea1abbcf6e361e71fada3c9a84c75bf366d4",
+  "generation_prompt_sha256": "39df2bd35482733326c1091c7e9a3a305cdaf5c02253b82986dc59deea769758",
+  "model": "gpt-5.5",
+  "run_id": "d2ff1dec",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9b175512f774006a38a9c383b0018ac0fa435098786b20ec74c69c203863c31d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/traces/codex-gpt-5.5/26-USC-3306-b-7.json",
+  "trace_sha256": "6b68f76f6d413a18006c12b1c6d365e17b7cdea756f0c0c536d70b6435e210db"
+}

--- a/statutes/26/3306/b/7.test.yaml
+++ b/statutes/26/3306/b/7.test.yaml
@@ -1,0 +1,60 @@
+- name: noncash nonbusiness service remuneration is excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/7#input.payment_amount: 500
+      us:statutes/26/3306/b/7#input.remuneration_paid_to_employee: true
+      us:statutes/26/3306/b/7#input.remuneration_paid_in_medium_other_than_cash: true
+      us:statutes/26/3306/b/7#input.remuneration_for_service_not_in_course_of_employers_trade_or_business: true
+  output:
+    us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages:
+    - 500
+- name: cash remuneration is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/7#input.payment_amount: 500
+      us:statutes/26/3306/b/7#input.remuneration_paid_to_employee: true
+      us:statutes/26/3306/b/7#input.remuneration_paid_in_medium_other_than_cash: false
+      us:statutes/26/3306/b/7#input.remuneration_for_service_not_in_course_of_employers_trade_or_business: true
+  output:
+    us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages:
+    - 0
+- name: trade or business service remuneration is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/7#input.payment_amount: 500
+      us:statutes/26/3306/b/7#input.remuneration_paid_to_employee: true
+      us:statutes/26/3306/b/7#input.remuneration_paid_in_medium_other_than_cash: true
+      us:statutes/26/3306/b/7#input.remuneration_for_service_not_in_course_of_employers_trade_or_business: false
+  output:
+    us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages:
+    - 0
+- name: remuneration not paid to employee is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/7#input.payment_amount: 500
+      us:statutes/26/3306/b/7#input.remuneration_paid_to_employee: false
+      us:statutes/26/3306/b/7#input.remuneration_paid_in_medium_other_than_cash: true
+      us:statutes/26/3306/b/7#input.remuneration_for_service_not_in_course_of_employers_trade_or_business: true
+  output:
+    us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/7.yaml
+++ b/statutes/26/3306/b/7.yaml
@@ -1,0 +1,47 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    remuneration paid in any medium other than cash to an employee for service not in the course of the employer’s trade or business
+rules:
+  - name: noncash_nonbusiness_service_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "remuneration paid"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid in any medium other than cash"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "to an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "for service not in the course of the employer’s trade or business"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            remuneration_paid_to_employee
+            and remuneration_paid_in_medium_other_than_cash
+            and remuneration_for_service_not_in_course_of_employers_trade_or_business
+          ): payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(7), excluding noncash remuneration for service outside the employer trade or business from FUTA wages
- add generated four-case regression suite for the statutory inclusion and each gate failure
- add generated encoding manifest from axiom-encode 0.2.227, run d2ff1dec, model gpt-5.5

## Encoder/Oracle context
- generated through `axiom-encode encode --apply`; no hand-edited rulespec artifacts
- depends on encoder PE coverage classification in TheAxiomFoundation/axiom-encode#239

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-7-20260525/statutes/26/3306/b/7.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-b-7-20260525/statutes/26/3306/b/7.test.yaml --root /private/tmp/rulespec-us-3306-b-7-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-7-20260525/statutes/26/3306/b/7.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-7-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-7-v227-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable` -> comparable=226, known_not_comparable=782, untested comparable=0