### PR TITLE
Add generated 3306(b)(9) FUTA section 217 exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/9.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/9.yaml",
+      "sha256": "591889dc10e836eebb1c61e07539da62d94e7a508f00afcbd2e223ff0432330a"
+    },
+    {
+      "path": "statutes/26/3306/b/9.test.yaml",
+      "sha256": "d11739da8be4f269130128ec676e093ee2b0f86ce2d982a4d28d3c20b9583f34"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "43f7d73d9da914aaecb04e3d373562b9e152d504",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.228",
+    "version_commit": "43f7d73d9da914aaecb04e3d373562b9e152d504"
+  },
+  "axiom_encode_version": "0.2.228",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(9)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "064591ff6d46c18adcbd4b512ea848b063740ca1e72eef97566ee46efdd643ca",
+  "generated_at": "2026-05-25T15:09:25.447460+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/codex-gpt-5.5/statutes/26/3306/b/9.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-9-20260525-v228",
+  "generated_output_sha256": "591889dc10e836eebb1c61e07539da62d94e7a508f00afcbd2e223ff0432330a",
+  "generation_prompt_sha256": "99b1c157d05dc2e93d65f61d9f5163a77ed6769284145a143ed8d5e7bde54a33",
+  "model": "gpt-5.5",
+  "run_id": "a30f4ce0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "68f567bc2c85676c32620b5263b5f009f5877b09bfd17f98ef66a7ca0732c3f7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/traces/codex-gpt-5.5/26-USC-3306-b-9.json",
+  "trace_sha256": "a827c1a23f11ab4a4b33989dbb49a62f7649229540532ddb9451974aac0b9ca7"
+}

--- a/statutes/26/3306/b/9.test.yaml
+++ b/statutes/26/3306/b/9.test.yaml
@@ -1,0 +1,84 @@
+- name: remuneration paid to employee is excluded to section 217 extent
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/9#input.payment_amount: 1000
+      ? us:statutes/26/3306/b/9#input.corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 600
+      us:statutes/26/3306/b/9#input.remuneration_paid_to_employee: true
+      us:statutes/26/3306/b/9#input.remuneration_paid_on_behalf_of_employee: false
+      ? us:statutes/26/3306/b/9#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : true
+  output:
+    us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n:
+    - holds
+    us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages:
+    - 600
+- name: remuneration paid on behalf of employee is capped at payment amount
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/9#input.payment_amount: 700
+      ? us:statutes/26/3306/b/9#input.corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 900
+      us:statutes/26/3306/b/9#input.remuneration_paid_to_employee: false
+      us:statutes/26/3306/b/9#input.remuneration_paid_on_behalf_of_employee: true
+      ? us:statutes/26/3306/b/9#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : true
+  output:
+    us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n:
+    - holds
+    us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages:
+    - 700
+- name: no reasonable belief blocks section 217 wage exclusion
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/9#input.payment_amount: 1000
+      ? us:statutes/26/3306/b/9#input.corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 600
+      us:statutes/26/3306/b/9#input.remuneration_paid_to_employee: true
+      us:statutes/26/3306/b/9#input.remuneration_paid_on_behalf_of_employee: false
+      ? us:statutes/26/3306/b/9#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : false
+  output:
+    us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n:
+    - not_holds
+    us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages:
+    - 0
+- name: remuneration not paid to or on behalf of employee is not excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/9#input.payment_amount: 1000
+      ? us:statutes/26/3306/b/9#input.corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : 600
+      us:statutes/26/3306/b/9#input.remuneration_paid_to_employee: false
+      us:statutes/26/3306/b/9#input.remuneration_paid_on_behalf_of_employee: false
+      ? us:statutes/26/3306/b/9#input.reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+      : true
+  output:
+    us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n:
+    - not_holds
+    us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/9.yaml
+++ b/statutes/26/3306/b/9.yaml
@@ -1,0 +1,67 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    remuneration paid to or on behalf of an employee if (and to the extent that) at the time of payment it is reasonable to believe a corresponding deduction is allowable under section 217, determined without regard to section 274(n)
+rules:
+  - name: corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "remuneration paid to or on behalf of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "at the time of the payment of such remuneration it is reasonable to believe"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "corresponding deduction is allowable under section 217 (determined without regard to section 274(n))"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (remuneration_paid_to_employee or remuneration_paid_on_behalf_of_employee) and reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+  - name: section_217_deduction_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "if (and to the extent that)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "corresponding deduction is allowable under section 217 (determined without regard to section 274(n))"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
+              output: corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n: min(max(0, payment_amount), max(0, corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n)) else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(9), excluding remuneration to the extent a corresponding section 217 deduction is reasonably believed allowable
- add generated four-case regression suite covering the paid-to/on-behalf gates, reasonable-belief gate, and payment/deduction cap
- add generated encoding manifest from axiom-encode 0.2.228, run a30f4ce0, model gpt-5.5

## Encoder/Oracle context
- generated through `axiom-encode encode --apply`; no hand-edited rulespec artifacts
- depends on encoder PE coverage classification in TheAxiomFoundation/axiom-encode#240

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-9-20260525/statutes/26/3306/b/9.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-b-9-20260525/statutes/26/3306/b/9.test.yaml --root /private/tmp/rulespec-us-3306-b-9-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-9-20260525/statutes/26/3306/b/9.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-9-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-9-v228-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable` -> comparable=226, known_not_comparable=784, untested comparable=0