### PR TITLE
Add generated 3306(b)(10) FUTA death and disability payment rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/10.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/10.yaml",
+      "sha256": "87186c901bcd0bf93c9246417fdcd8c0c9b84e395c832d57b8a0e1976ccb69f6"
+    },
+    {
+      "path": "statutes/26/3306/b/10.test.yaml",
+      "sha256": "d44f0417de81b563760dbc01311012009feaab8d0e10a48de300e6c58fcc6e87"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "bf4406137ab1d5d783f4a7723685d4439ca4a5c1",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.229",
+    "version_commit": "bf4406137ab1d5d783f4a7723685d4439ca4a5c1"
+  },
+  "axiom_encode_version": "0.2.229",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(10)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "4ed8476f072850ab63b22999be7994ee30fd2d6dd5c662c9efd843053a71c9a1",
+  "generated_at": "2026-05-25T15:30:57.705754+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/10.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-10-regen-20260525",
+  "generated_output_sha256": "87186c901bcd0bf93c9246417fdcd8c0c9b84e395c832d57b8a0e1976ccb69f6",
+  "generation_prompt_sha256": "5a76db6a2eb025a9b11e283423da5bbd3ea17344f8418a0d2199647e87b63a97",
+  "model": "gpt-5.5",
+  "run_id": "f6f0446b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5204b3c1bf26693820bbbba0a22956a816ccf20103d712d4bb15e0373077fef1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-10.json",
+  "trace_sha256": "dde6d395365f244f1f301bf4e8bdf46105d0244667b33e69e356d63fcfe859c8"
+}

--- a/statutes/26/3306/b/10.test.yaml
+++ b/statutes/26/3306/b/10.test.yaml
@@ -1,0 +1,76 @@
+- name: qualifying death and disability retirement payments with termination exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 1000
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 800
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: false
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: true
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 1000
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: true
+  output:
+    us:statutes/26/3306/b/10#death_or_disability_retirement_termination_plan_payment_excluded_from_wages:
+    - 1000
+    - 800
+    - 0
+- name: required termination plan payment gates missing
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 600
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: false
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 600
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: false
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 600
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: false
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: true
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+    - us:statutes/26/3306/b/10#input.payment_or_series_amount: 600
+      us:statutes/26/3306/b/10#input.payment_or_series_paid_by_employer_to_employee_or_dependent: true
+      us:statutes/26/3306/b/10#input.payment_paid_upon_or_after_termination_of_employment_relationship: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_death: true
+      us:statutes/26/3306/b/10#input.employment_relationship_terminated_because_of_retirement_for_disability: false
+      us:statutes/26/3306/b/10#input.employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents: false
+      us:statutes/26/3306/b/10#input.payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated: false
+  output:
+    us:statutes/26/3306/b/10#death_or_disability_retirement_termination_plan_payment_excluded_from_wages:
+    - 0
+    - 0
+    - 0
+    - 0

--- a/statutes/26/3306/b/10.yaml
+++ b/statutes/26/3306/b/10.yaml
@@ -1,0 +1,57 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "any payment or series of payments by an employer to an employee or any of his dependents"; "because of (i) death, or (ii) retirement for disability"; "under a plan established by the employer"; "other than any such payment or series of payments which would have been paid"
+rules:
+  - name: death_or_disability_retirement_termination_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any payment or series of payments by an employer to an employee or any of his dependents"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "upon or after the termination"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "because of (i) death, or (ii) retirement for disability"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "under a plan established by the employer which makes provision for his employees generally or a class or classes of his employees"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "other than any such payment or series of payments which would have been paid"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            payment_or_series_paid_by_employer_to_employee_or_dependent
+            and payment_paid_upon_or_after_termination_of_employment_relationship
+            and (
+              employment_relationship_terminated_because_of_death
+              or employment_relationship_terminated_because_of_retirement_for_disability
+            )
+            and employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents
+            and not payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated
+          ): payment_or_series_amount else: 0


### PR DESCRIPTION
## Summary
- add generated 26 USC 3306(b)(10) FUTA exclusion rules for employer-plan death and disability retirement termination payments
- add generated tests for qualifying payments, statutory gate failures, and the exception for payments that would have been paid absent termination
- add generated encoding manifest from axiom-encode 0.2.229, run f6f0446b, model gpt-5.5

## Generated-only note
These files were produced by `axiom-encode encode --apply`; no RuleSpec YAML was hand-edited.

## Checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-10-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-10-20260525/statutes/26/3306/b/10.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-10-20260525/statutes/26/3306/b/10.test.yaml --root /private/tmp/rulespec-us-3306-b-10-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-10-20260525/statutes/26/3306/b/10.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-10-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-10-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable outputs 1011; comparable 226; known_not_comparable 785; untested comparable 0.