### PR TITLE
Add generated 3306(b)(11) FUTA agricultural exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/11.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/11.yaml",
+      "sha256": "0d66bbbc3049119d26aa8c6b3293b171e3f641657a7518f122292c90d94239e5"
+    },
+    {
+      "path": "statutes/26/3306/b/11.test.yaml",
+      "sha256": "4a6eba59dd483964b2218daca0b4f3a00fc50a5618b8ac9617c7e6e410fa4fdd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "884ecffb54d204ead21abf540c4258a6123cc97b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.230",
+    "version_commit": "884ecffb54d204ead21abf540c4258a6123cc97b"
+  },
+  "axiom_encode_version": "0.2.230",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(11)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "3b7281b5ebccddc13ab66fbf732cdad25bfaaa33c5f1512344085e27ba913b26",
+  "generated_at": "2026-05-25T15:52:02.142389+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/11.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-11-regen-20260525",
+  "generated_output_sha256": "0d66bbbc3049119d26aa8c6b3293b171e3f641657a7518f122292c90d94239e5",
+  "generation_prompt_sha256": "45726465a1f59792225be57a13196442ecd691e2c3c6ee714728716611faddd8",
+  "model": "gpt-5.5",
+  "run_id": "061457d9",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bbef23732eaa80a89a0b41a7654eb02706c0b4424fbf7cee6a577b315fec8d21"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-11.json",
+  "trace_sha256": "65483264fa7114a700943fc3bf5722552a8001291d816e97ac545831c1904d83"
+}

--- a/statutes/26/3306/b/11.test.yaml
+++ b/statutes/26/3306/b/11.test.yaml
@@ -1,0 +1,42 @@
+- name: noncash agricultural labor remuneration is excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/11#input.remuneration_amount: 250
+      us:statutes/26/3306/b/11#input.remuneration_for_agricultural_labor: true
+      us:statutes/26/3306/b/11#input.remuneration_paid_in_medium_other_than_cash: true
+  output:
+    us:statutes/26/3306/b/11#noncash_agricultural_labor_remuneration_excluded_from_wages:
+    - 250
+- name: cash agricultural labor remuneration is not excluded by this paragraph
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/11#input.remuneration_amount: 250
+      us:statutes/26/3306/b/11#input.remuneration_for_agricultural_labor: true
+      us:statutes/26/3306/b/11#input.remuneration_paid_in_medium_other_than_cash: false
+  output:
+    us:statutes/26/3306/b/11#noncash_agricultural_labor_remuneration_excluded_from_wages:
+    - 0
+- name: noncash nonagricultural remuneration is not excluded by this paragraph
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/11#input.remuneration_amount: 250
+      us:statutes/26/3306/b/11#input.remuneration_for_agricultural_labor: false
+      us:statutes/26/3306/b/11#input.remuneration_paid_in_medium_other_than_cash: true
+  output:
+    us:statutes/26/3306/b/11#noncash_agricultural_labor_remuneration_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/11.yaml
+++ b/statutes/26/3306/b/11.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    remuneration for agricultural labor paid in any medium other than cash
+rules:
+  - name: noncash_agricultural_labor_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "remuneration for agricultural labor paid in any medium other than cash"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if remuneration_for_agricultural_labor and remuneration_paid_in_medium_other_than_cash: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated 26 USC 3306(b)(11) FUTA exclusion rules for noncash agricultural labor remuneration
- add generated tests for qualifying noncash agricultural remuneration and the cash/nonagricultural gates
- add generated encoding manifest from axiom-encode 0.2.230, run 061457d9, model gpt-5.5

## Generated-only note
These files were produced by `axiom-encode encode --apply`; no RuleSpec YAML was hand-edited.

## Checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-11-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-11-20260525/statutes/26/3306/b/11.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-11-20260525/statutes/26/3306/b/11.test.yaml --root /private/tmp/rulespec-us-3306-b-11-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-11-20260525/statutes/26/3306/b/11.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-11-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-11-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable outputs 1012; comparable 226; known_not_comparable 786; untested comparable 0.