### PR TITLE
Add generated 3306(b)(13) FUTA income exclusion benefit rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/13.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/13.yaml",
+      "sha256": "a82271e2ca7c10303cc4c8193e241aa95a038bb5a2d8ba618df1dbdd0e612580"
+    },
+    {
+      "path": "statutes/26/3306/b/13.test.yaml",
+      "sha256": "b7e39371e504436e5073df7de230b5cb8ed63cf4427466ce5b8521be7b174130"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b24bef4d4ffe43eb0f8e469ff5de838c38f27270",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.231",
+    "version_commit": "b24bef4d4ffe43eb0f8e469ff5de838c38f27270"
+  },
+  "axiom_encode_version": "0.2.231",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(13)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "d0de64e203e8981336d7123dd8aaeaabbbad393ac1c1126d181df4c270805784",
+  "generated_at": "2026-05-25T16:22:38.665302+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/13.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-13-regen-20260525",
+  "generated_output_sha256": "a82271e2ca7c10303cc4c8193e241aa95a038bb5a2d8ba618df1dbdd0e612580",
+  "generation_prompt_sha256": "50bcf26cca6d27df8d9b347a8654e6a1efc7cfbf346d4a6082f8657706cfc3be",
+  "model": "gpt-5.5",
+  "run_id": "d16e5559",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9ec5d9e86c5de84c1a199b01f3adb085ec108a4e5b4db4b9f154b6902629d33e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-13.json",
+  "trace_sha256": "91d47a2f3624122c301cfb9793aee3f11ec033a4f7df97a90f22064ced40f26e"
+}

--- a/statutes/26/3306/b/13.test.yaml
+++ b/statutes/26/3306/b/13.test.yaml
@@ -1,0 +1,93 @@
+- name: excludes payments for each cited income exclusion belief
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 1200
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : false
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 700
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: false
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: true
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : false
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 800
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: false
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : true
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : false
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 600
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: false
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : true
+  output:
+    us:statutes/26/3306/b/13#cited_income_exclusion_reasonably_expected:
+    - holds
+    - holds
+    - holds
+    - holds
+    us:statutes/26/3306/b/13#payment_or_benefit_excluded_from_wages_due_to_expected_income_exclusion:
+    - 1200
+    - 700
+    - 800
+    - 600
+- name: does not exclude payment without cited reasonable belief
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 1200
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: false
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : false
+  output:
+    us:statutes/26/3306/b/13#cited_income_exclusion_reasonably_expected:
+    - not_holds
+    us:statutes/26/3306/b/13#payment_or_benefit_excluded_from_wages_due_to_expected_income_exclusion:
+    - 0
+- name: does not exclude item not made or furnished to or for employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/13#input.payment_or_benefit_amount: 1200
+      us:statutes/26/3306/b/13#input.payment_made_or_benefit_furnished_to_or_for_benefit_of_employee: false
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127: true
+      us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129: false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+      : false
+      ? us:statutes/26/3306/b/13#input.reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+      : false
+  output:
+    us:statutes/26/3306/b/13#cited_income_exclusion_reasonably_expected:
+    - holds
+    us:statutes/26/3306/b/13#payment_or_benefit_excluded_from_wages_due_to_expected_income_exclusion:
+    - 0

--- a/statutes/26/3306/b/13.yaml
+++ b/statutes/26/3306/b/13.yaml
@@ -1,0 +1,56 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (13) any payment made, or benefit furnished, to or for the benefit of an employee if at the time of such payment or such furnishing it is reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5);
+rules:
+  - name: cited_income_exclusion_reasonably_expected
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_127
+          or reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_129
+          or reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_4
+          or reasonable_to_believe_employee_can_exclude_payment_or_benefit_from_income_under_section_134_b_5
+
+  - name: payment_or_benefit_excluded_from_wages_due_to_expected_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3306(b)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any payment made, or benefit furnished, to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/13#cited_income_exclusion_reasonably_expected
+              output: cited_income_exclusion_reasonably_expected
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_made_or_benefit_furnished_to_or_for_benefit_of_employee and cited_income_exclusion_reasonably_expected: payment_or_benefit_amount else: 0


### PR DESCRIPTION
## Summary
- add generated 26 USC 3306(b)(13) FUTA exclusion rules for payments or benefits reasonably believed excludable from income under sections 127, 129, 134(b)(4), or 134(b)(5)
- add generated tests for each cited reasonable-belief route and the missing-gate cases
- add generated encoding manifest from axiom-encode 0.2.231, run d16e5559, model gpt-5.5

## Generated-only note
These files were produced by `axiom-encode encode --apply`; no RuleSpec YAML was hand-edited.

## Checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-13-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-13-20260525/statutes/26/3306/b/13.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-13-20260525/statutes/26/3306/b/13.test.yaml --root /private/tmp/rulespec-us-3306-b-13-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-13-20260525/statutes/26/3306/b/13.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-13-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-13-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable outputs 1014; comparable 226; known_not_comparable 788; untested comparable 0.