### PR TITLE
Add generated 3306(b)(14) FUTA meals and lodging exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/14.yaml",
+      "sha256": "708c712a63f0ed9a38fd0240b09daa9da62eae0cbfc3a96ca5dbe739358aff5a"
+    },
+    {
+      "path": "statutes/26/3306/b/14.test.yaml",
+      "sha256": "448a90df26d07fdab4fdc368f5c33838e17901af412110accaec74ae982b310b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d77a349253e4d14277acac666c3e64c0344ea2f7",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.232",
+    "version_commit": "d77a349253e4d14277acac666c3e64c0344ea2f7"
+  },
+  "axiom_encode_version": "0.2.232",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(14)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "f99f99550111f65c1bfbcd731f1e6e8037971f9368a2067bbca59f4e94469b8d",
+  "generated_at": "2026-05-25T16:42:23.679934+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/14.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-14-regen-20260525",
+  "generated_output_sha256": "708c712a63f0ed9a38fd0240b09daa9da62eae0cbfc3a96ca5dbe739358aff5a",
+  "generation_prompt_sha256": "e69d75023784e8f427bb4dc022f8cf8fb960865be312866f538bc907ec302c7f",
+  "model": "gpt-5.5",
+  "run_id": "93a717ed",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "281d2070aaa3991bc6b770e67c1741ac94cbe80a5e920904b1e58a4971ff8996"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-14.json",
+  "trace_sha256": "cd60324e2b1100e6173eb11575352fea13db0d46555fd0568faf311e0bd83547"
+}

--- a/statutes/26/3306/b/14.test.yaml
+++ b/statutes/26/3306/b/14.test.yaml
@@ -1,0 +1,40 @@
+- name: employer furnished meals or lodging reasonably expected excludable under section
+    119
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/14#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer_to_employee: true
+    ? us:statutes/26/3306/b/14#input.reasonable_at_time_of_furnishing_to_believe_employee_can_exclude_meals_or_lodging_from_income_under_section_119
+    : true
+    us:statutes/26/3306/b/14#input.value_of_meals_or_lodging_furnished_to_employee: 500
+  output:
+    us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing: holds
+    us:statutes/26/3306/b/14#meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion: 500
+- name: meals or lodging not furnished by or on behalf of employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/14#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer_to_employee: false
+    ? us:statutes/26/3306/b/14#input.reasonable_at_time_of_furnishing_to_believe_employee_can_exclude_meals_or_lodging_from_income_under_section_119
+    : true
+    us:statutes/26/3306/b/14#input.value_of_meals_or_lodging_furnished_to_employee: 500
+  output:
+    us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing: not_holds
+    us:statutes/26/3306/b/14#meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion: 0
+- name: no reasonable belief of section 119 exclusion at furnishing
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/14#input.meals_or_lodging_furnished_by_or_on_behalf_of_employer_to_employee: true
+    ? us:statutes/26/3306/b/14#input.reasonable_at_time_of_furnishing_to_believe_employee_can_exclude_meals_or_lodging_from_income_under_section_119
+    : false
+    us:statutes/26/3306/b/14#input.value_of_meals_or_lodging_furnished_to_employee: 500
+  output:
+    us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing: not_holds
+    us:statutes/26/3306/b/14#meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion: 0

--- a/statutes/26/3306/b/14.yaml
+++ b/statutes/26/3306/b/14.yaml
@@ -1,0 +1,59 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "the value of any meals or lodging furnished by or on behalf of the employer" if, when furnished, it is "reasonable to believe" the employee can exclude the items from income under section 119.
+rules:
+  - name: meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: meals or lodging furnished by or on behalf of the employer
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: at the time of such furnishing it is reasonable to believe that the employee will be able to exclude such items from income under section 119
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          meals_or_lodging_furnished_by_or_on_behalf_of_employer_to_employee
+          and reasonable_at_time_of_furnishing_to_believe_employee_can_exclude_meals_or_lodging_from_income_under_section_119
+
+  - name: meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: the value of any meals or lodging furnished by or on behalf of the employer
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing
+              output: meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing: value_of_meals_or_lodging_furnished_to_employee else: 0


### PR DESCRIPTION
Generated-only RuleSpec PR for 26 USC 3306(b)(14).

Generated with:
- axiom-encode 0.2.232 at d77a349253e4d14277acac666c3e64c0344ea2f7
- model gpt-5.5
- run_id 93a717ed

Local checks:
- axiom-encode validate statutes/26/3306/b/14.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/b/14.test.yaml --root /private/tmp/rulespec-us-3306-b-14-20260525 --json
- axiom-encode proof-validate statutes/26/3306/b/14.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-14-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-14-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage after encoder mapping #244: 1016 executable tax outputs, comparable=226, known_not_comparable=790, untested comparable outputs=0.