### PR TITLE
Add generated 3306(b)(15) FUTA survivor payment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/15.yaml",
+      "sha256": "85e1229992584b64a7bd943019130f112250a5f6050b258960d8fa1628a1e80b"
+    },
+    {
+      "path": "statutes/26/3306/b/15.test.yaml",
+      "sha256": "c76e3bfcca3cbfc1ff1e013bcdc66733ae63567fb829e0ad047b64c988f5136e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "24e74430eef0bd49626ae3e2f5591b3560efa5a4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.233",
+    "version_commit": "24e74430eef0bd49626ae3e2f5591b3560efa5a4"
+  },
+  "axiom_encode_version": "0.2.233",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(15)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "06d44d5eb9405e918c4300cdb6a04eb5d39795d12dc5cc5ae4a5384928578bf7",
+  "generated_at": "2026-05-25T17:00:23.234543+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/15.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-15-regen-20260525",
+  "generated_output_sha256": "85e1229992584b64a7bd943019130f112250a5f6050b258960d8fa1628a1e80b",
+  "generation_prompt_sha256": "c1e4e36d5e667024f8b9178026a331d8b2b8028ec039cf53f26f5cf551288e53",
+  "model": "gpt-5.5",
+  "run_id": "5b364246",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fa5ede9e56f46bacedea63673189f3bf6cebae6071ae7432c651f09cef746d8f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-15.json",
+  "trace_sha256": "eb7f4d0f55acf1d500a8a7c7fc64dadf1c0cb261e6b162608d4086a88656d81b"
+}

--- a/statutes/26/3306/b/15.test.yaml
+++ b/statutes/26/3306/b/15.test.yaml
@@ -1,0 +1,52 @@
+- name: survivor_payment_after_death_year_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/15#input.payment_amount: 1200
+    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  output:
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 1200
+- name: estate_payment_after_death_year_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/15#input.payment_amount: 800
+    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: true
+  output:
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 800
+- name: survivor_payment_not_after_death_year_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/15#input.payment_amount: 1200
+    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: false
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  output:
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 0
+- name: payment_after_death_year_to_neither_survivor_nor_estate_not_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/15#input.payment_amount: 1200
+    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
+    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  output:
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 0

--- a/statutes/26/3306/b/15.yaml
+++ b/statutes/26/3306/b/15.yaml
@@ -1,0 +1,27 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    Any payment made by an employer to a survivor or the estate of a former employee after the calendar year in which such employee died.
+rules:
+  - name: survivor_or_estate_payment_after_employee_death_year_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_made_after_calendar_year_in_which_former_employee_died and (payment_made_by_employer_to_survivor_of_former_employee or payment_made_by_employer_to_estate_of_former_employee): payment_amount else: 0


### PR DESCRIPTION
Generated-only RuleSpec PR for 26 USC 3306(b)(15).

Generated with:
- axiom-encode 0.2.233 at 24e74430eef0bd49626ae3e2f5591b3560efa5a4
- model gpt-5.5
- run_id 5b364246

Local checks:
- axiom-encode validate statutes/26/3306/b/15.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/b/15.test.yaml --root /private/tmp/rulespec-us-3306-b-15-20260525 --json
- axiom-encode proof-validate statutes/26/3306/b/15.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-15-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-15-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage after encoder mapping #245: 1017 executable tax outputs, comparable=226, known_not_comparable=791, untested comparable outputs=0.