### PR TITLE
Add generated 3306(b)(16) FUTA benefit exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/16.yaml",
+      "sha256": "de7e3ab5f7db97f7f89f66e78b4ebe524209584af75b5e1c301a50d0b0b76b84"
+    },
+    {
+      "path": "statutes/26/3306/b/16.test.yaml",
+      "sha256": "0fa74a72296ad4765b63aeb4b10241474817d8199c94dcd91deda2e414fe0a5b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "91c5f2ba443a70c0460950e287adb9e84e65aeaf",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.234",
+    "version_commit": "91c5f2ba443a70c0460950e287adb9e84e65aeaf"
+  },
+  "axiom_encode_version": "0.2.234",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(16)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "3dbd66c9e4e33805b9726ab89fe25837ee0050e9ad5ce5ae9874fa7594b42ef6",
+  "generated_at": "2026-05-25T18:48:29.378785+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/16.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-16-regen-20260525",
+  "generated_output_sha256": "de7e3ab5f7db97f7f89f66e78b4ebe524209584af75b5e1c301a50d0b0b76b84",
+  "generation_prompt_sha256": "14bd52ee9a036097ea21e178a4342820267574ec4d22720887ddea4812cade66",
+  "model": "gpt-5.5",
+  "run_id": "2fe01b0f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "19ca03eb66b3b0fc683baa560200215502bce1c9274679916a2ed26438030ae2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-16.json",
+  "trace_sha256": "e00021fff180fd3f879c999ce25496adfd96ba034cc8e606fe0941ea2796444e"
+}

--- a/statutes/26/3306/b/16.test.yaml
+++ b/statutes/26/3306/b/16.test.yaml
@@ -1,0 +1,61 @@
+- name: benefit excluded when provided to employee and section 74 c exclusion reasonably
+    expected
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/16#input.benefit_amount: 1200
+    us:statutes/26/3306/b/16#input.benefit_provided_to_or_on_behalf_of_employee: true
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+    : true
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+    : false
+  output:
+    us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: holds
+    us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 1200
+- name: benefit not excluded when benefit is not provided to or on behalf of employee
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/16#input.benefit_amount: 1200
+    us:statutes/26/3306/b/16#input.benefit_provided_to_or_on_behalf_of_employee: false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+    : true
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+    : false
+  output:
+    us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: holds
+    us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 0
+- name: benefit not excluded when no cited income exclusion is reasonably expected
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/16#input.benefit_amount: 1200
+    us:statutes/26/3306/b/16#input.benefit_provided_to_or_on_behalf_of_employee: true
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+    : false
+  output:
+    us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: not_holds
+    us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 0

--- a/statutes/26/3306/b/16.yaml
+++ b/statutes/26/3306/b/16.yaml
@@ -1,0 +1,60 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    any benefit provided to or on behalf of an employee if, when provided, it is reasonable to believe the employee can exclude it from income under section 74(c), 108(f)(4), 117, or 132.
+rules:
+  - name: benefit_income_exclusion_reasonably_expected_under_cited_sections
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "reasonable to believe that the employee will be able to exclude such benefit from income under section 74(c), 108(f)(4), 117, or 132"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+  - name: benefit_excluded_from_wages_due_to_expected_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any benefit provided to or on behalf of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "if at the time such benefit is provided it is reasonable to believe"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections
+              output: benefit_income_exclusion_reasonably_expected_under_cited_sections
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if benefit_provided_to_or_on_behalf_of_employee and benefit_income_exclusion_reasonably_expected_under_cited_sections: benefit_amount else: 0


### PR DESCRIPTION
Generated-only RuleSpec PR for 26 USC 3306(b)(16).

Generated with:
- axiom-encode 0.2.234 at 91c5f2ba443a70c0460950e287adb9e84e65aeaf
- model gpt-5.5
- run_id 2fe01b0f

Local checks:
- axiom-encode validate statutes/26/3306/b/16.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/b/16.test.yaml --root /private/tmp/rulespec-us-3306-b-16-20260525 --json
- axiom-encode proof-validate statutes/26/3306/b/16.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-16-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-16-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage after encoder mapping #246: 1019 executable tax outputs, comparable=226, known_not_comparable=793, untested comparable outputs=0.