### PR TITLE
Add generated 3306(b)(17) FUTA section 106(b) payment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/17.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/17.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/17.yaml",
+      "sha256": "8ca0b9b286151e74aec8bfede9e1f1e83c68630d311515ea0bc537972a7face2"
+    },
+    {
+      "path": "statutes/26/3306/b/17.test.yaml",
+      "sha256": "1372168045ee7ca55f034f37bc0af22b226680145fa147367a6ffcc31107c87e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f41679ff2e53d0d9bd650b1e4ca27b244706c5ab",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.235",
+    "version_commit": "f41679ff2e53d0d9bd650b1e4ca27b244706c5ab"
+  },
+  "axiom_encode_version": "0.2.235",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(17)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-17/workspace/context-manifest.json",
+  "context_manifest_sha256": "6d410441ceb5e3a4cfa9b414e8ab2543b1aa8834772743b49c94ad00b81cc24f",
+  "generated_at": "2026-05-25T19:20:19.056615+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/17.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-17-regen-20260525",
+  "generated_output_sha256": "8ca0b9b286151e74aec8bfede9e1f1e83c68630d311515ea0bc537972a7face2",
+  "generation_prompt_sha256": "9556a3b064e69916a32296e4d2803e6c563b531d24850e8f9b0c5a57b0b90f0e",
+  "model": "gpt-5.5",
+  "run_id": "ef3fcead",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "acb7f849280ef52c0c963feb8ce0bbe2232c5d3ebe86267594c29841c2594b56"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-17.json",
+  "trace_sha256": "9115c30d3b68ddac56c938dafc5598f0a116e80b8f19b7dbe04df9a4e1ed537c"
+}

--- a/statutes/26/3306/b/17.test.yaml
+++ b/statutes/26/3306/b/17.test.yaml
@@ -1,0 +1,51 @@
+- name: excludes payment reasonably expected excludable under section 106 b
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/17#input.payment_amount: 1200
+      us:statutes/26/3306/b/17#input.payment_made_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3306/b/17#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_b
+      : true
+  output:
+    us:statutes/26/3306/b/17#payment_made_to_employee_with_expected_section_106_b_income_exclusion:
+    - holds
+    us:statutes/26/3306/b/17#payment_excluded_from_wages_due_to_expected_section_106_b_income_exclusion:
+    - 1200
+- name: does not exclude payment not made to or for benefit of employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/17#input.payment_amount: 1200
+      us:statutes/26/3306/b/17#input.payment_made_to_or_for_benefit_of_employee: false
+      ? us:statutes/26/3306/b/17#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_b
+      : true
+  output:
+    us:statutes/26/3306/b/17#payment_made_to_employee_with_expected_section_106_b_income_exclusion:
+    - not_holds
+    us:statutes/26/3306/b/17#payment_excluded_from_wages_due_to_expected_section_106_b_income_exclusion:
+    - 0
+- name: does not exclude payment without reasonable section 106 b belief
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/17#input.payment_amount: 1200
+      us:statutes/26/3306/b/17#input.payment_made_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3306/b/17#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_b
+      : false
+  output:
+    us:statutes/26/3306/b/17#payment_made_to_employee_with_expected_section_106_b_income_exclusion:
+    - not_holds
+    us:statutes/26/3306/b/17#payment_excluded_from_wages_due_to_expected_section_106_b_income_exclusion:
+    - 0

--- a/statutes/26/3306/b/17.yaml
+++ b/statutes/26/3306/b/17.yaml
@@ -1,0 +1,59 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (17) any payment made to or for the benefit of an employee if at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(b);
+rules:
+  - name: payment_made_to_employee_with_expected_section_106_b_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(17)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: any payment made to or for the benefit of an employee
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(b)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_for_benefit_of_employee
+          and reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_b
+
+  - name: payment_excluded_from_wages_due_to_expected_section_106_b_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3306(b)(17)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: any payment made to or for the benefit of an employee
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/17#payment_made_to_employee_with_expected_section_106_b_income_exclusion
+              output: payment_made_to_employee_with_expected_section_106_b_income_exclusion
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_made_to_employee_with_expected_section_106_b_income_exclusion: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(17), excluding payments reasonably believed excludable under section 106(b) from FUTA wages
- add generated executable tests and apply manifest/provenance

## Provenance
- generated by axiom-encode 0.2.235 at f41679ff2e53d0d9bd650b1e4ca27b244706c5ab
- model: gpt-5.5
- run_id: ef3fcead
- applied with axiom-encode encode --apply; no manual RuleSpec edits

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-17-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-17-20260525/statutes/26/3306/b/17.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-17-20260525/statutes/26/3306/b/17.test.yaml --root /private/tmp/rulespec-us-3306-b-17-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-17-20260525/statutes/26/3306/b/17.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-17-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-17-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable=1021, comparable=226, known_not_comparable=795, unmapped=0, untested_comparable=0