### PR TITLE
Add generated 3306(b)(18) FUTA section 106(d) payment exclusion rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/18.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/18.yaml",
+      "sha256": "8a1438a0d3cf1d17402a74684b70ff7819ba074b5caaaf95f2806136aee6623a"
+    },
+    {
+      "path": "statutes/26/3306/b/18.test.yaml",
+      "sha256": "a275724a879d033f01f8204a7618ec5f7050da4b3d091e77a1bc82102dc94573"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f9f0d717aa0175171f55155aff6dc4ec941df6a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.236",
+    "version_commit": "3f9f0d717aa0175171f55155aff6dc4ec941df6a"
+  },
+  "axiom_encode_version": "0.2.236",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(18)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "f4e331ac611e580a7cce01ec2a5fcef155ec07096df4e239b0e2e0ad25241e35",
+  "generated_at": "2026-05-25T19:44:19.388505+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/18.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-18-regen-20260525",
+  "generated_output_sha256": "8a1438a0d3cf1d17402a74684b70ff7819ba074b5caaaf95f2806136aee6623a",
+  "generation_prompt_sha256": "eef72fc01b6bc765f4f4850da201627ef7c4206d374ac5a6455fbd4af25627dc",
+  "model": "gpt-5.5",
+  "run_id": "a3b492fb",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "27e204c6c3672c935f3fdd5ba9e0061d29165286482bf9ee7e3fa182323d8c07"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-18.json",
+  "trace_sha256": "9b63af88e3bd0355747d0517773ce0251badcf85f71cced4aad65aed833e778b"
+}

--- a/statutes/26/3306/b/18.test.yaml
+++ b/statutes/26/3306/b/18.test.yaml
@@ -1,0 +1,51 @@
+- name: excludes payment when section 106 d income exclusion is reasonably expected
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/18#input.payment_amount: 1200
+      us:statutes/26/3306/b/18#input.payment_made_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3306/b/18#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_d
+      : true
+  output:
+    us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment:
+    - holds
+    us:statutes/26/3306/b/18#payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion:
+    - 1200
+- name: does not exclude payment without reasonable section 106 d belief
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/18#input.payment_amount: 1200
+      us:statutes/26/3306/b/18#input.payment_made_to_or_for_benefit_of_employee: true
+      ? us:statutes/26/3306/b/18#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_d
+      : false
+  output:
+    us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment:
+    - not_holds
+    us:statutes/26/3306/b/18#payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion:
+    - 0
+- name: does not exclude payment not made to or for employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/18#input.payment_amount: 1200
+      us:statutes/26/3306/b/18#input.payment_made_to_or_for_benefit_of_employee: false
+      ? us:statutes/26/3306/b/18#input.reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_d
+      : true
+  output:
+    us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment:
+    - not_holds
+    us:statutes/26/3306/b/18#payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion:
+    - 0

--- a/statutes/26/3306/b/18.yaml
+++ b/statutes/26/3306/b/18.yaml
@@ -1,0 +1,59 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    any payment made to or for the benefit of an employee if at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(d);
+rules:
+  - name: section_106_d_income_exclusion_reasonably_expected_at_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any payment made to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(d)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_for_benefit_of_employee
+          and reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_d
+
+  - name: payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3306(b)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any payment made to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment
+              output: section_106_d_income_exclusion_reasonably_expected_at_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if section_106_d_income_exclusion_reasonably_expected_at_payment: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(18), excluding payments reasonably believed excludable under section 106(d) from FUTA wages
- add generated executable tests and apply manifest/provenance

## Provenance
- generated by axiom-encode 0.2.236 at 3f9f0d717aa0175171f55155aff6dc4ec941df6a
- model: gpt-5.5
- run_id: a3b492fb
- applied with axiom-encode encode --apply; no manual RuleSpec edits

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-18-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-18-20260525/statutes/26/3306/b/18.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-18-20260525/statutes/26/3306/b/18.test.yaml --root /private/tmp/rulespec-us-3306-b-18-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-18-20260525/statutes/26/3306/b/18.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-18-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-18-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable=1023, comparable=226, known_not_comparable=797, unmapped=0, untested_comparable=0