### PR TITLE
Add generated 3306(b)(19) FUTA stock remuneration rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/19.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/19.yaml",
+      "sha256": "ded4aa69aaa64ed4da51bb81651a2fd8f62d59b4b4cd39d24607914984d576bd"
+    },
+    {
+      "path": "statutes/26/3306/b/19.test.yaml",
+      "sha256": "59a7eb034e89f0fa7dd310d4f5e8edcd6f49b8db23b09cf3c345d1c0cf28bb51"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5dfedf1829f9cf17bcbf22d719a57f991662ff64",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.237",
+    "version_commit": "5dfedf1829f9cf17bcbf22d719a57f991662ff64"
+  },
+  "axiom_encode_version": "0.2.237",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(19)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "32042d1866e671bf9abcbe70d1a0a31ab70fbb7ca0b1e05a9a203f4fef266fb4",
+  "generated_at": "2026-05-25T20:05:32.361176+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/19.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-19-regen-20260525",
+  "generated_output_sha256": "ded4aa69aaa64ed4da51bb81651a2fd8f62d59b4b4cd39d24607914984d576bd",
+  "generation_prompt_sha256": "de6c6faa36dcd5609cee1136e268011b53f0c69f77840bb56afa21a1352b30f9",
+  "model": "gpt-5.5",
+  "run_id": "820ee886",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "80f43ff62bc752b81905e9e1be0809e51b8149ffbe4c592b5b2b3d57ce280114"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-19.json",
+  "trace_sha256": "f7ed970fc0790b2160fcd3027ed9dc27cc25b8536ede2771370f6e80641ce3ff"
+}

--- a/statutes/26/3306/b/19.test.yaml
+++ b/statutes/26/3306/b/19.test.yaml
@@ -1,0 +1,51 @@
+- name: stock option and employee stock purchase plan remuneration exclusions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/19#input.remuneration_amount: 1000
+      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
+      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: true
+      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+      : false
+    - us:statutes/26/3306/b/19#input.remuneration_amount: 800
+      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
+      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: true
+      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+      : false
+    - us:statutes/26/3306/b/19#input.remuneration_amount: 600
+      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
+      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+      : true
+    - us:statutes/26/3306/b/19#input.remuneration_amount: 400
+      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
+      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
+      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+      : false
+    - us:statutes/26/3306/b/19#input.remuneration_amount: 500
+      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
+      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: true
+      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
+      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+      : false
+  output:
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies:
+    - holds
+    - holds
+    - holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages:
+    - 1000
+    - 800
+    - 600
+    - 0
+    - 0

--- a/statutes/26/3306/b/19.yaml
+++ b/statutes/26/3306/b/19.yaml
@@ -1,0 +1,75 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "remuneration on account of" a cited stock transfer or "any disposition by the individual of such stock"
+rules:
+  - name: stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(b)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "a transfer of a share of stock to any individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "pursuant to an exercise of an incentive stock option (as defined in section 422(b))"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "under an employee stock purchase plan (as defined in section 423(b))"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any disposition by the individual of such stock"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            remuneration_on_account_of_transfer_of_share_of_stock_to_individual
+            and (
+              stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b
+              or stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b
+            )
+          )
+          or remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
+
+  - name: stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(b)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "remuneration on account of"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies
+              output: stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies: remuneration_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(19), excluding qualifying incentive stock option and employee stock purchase plan stock remuneration from FUTA wages
- add generated executable tests and apply manifest/provenance

## Provenance
- generated by axiom-encode 0.2.237 at 5dfedf1829f9cf17bcbf22d719a57f991662ff64
- model: gpt-5.5
- run_id: 820ee886
- applied with axiom-encode encode --apply; no manual RuleSpec edits

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-19-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-19-20260525/statutes/26/3306/b/19.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-19-20260525/statutes/26/3306/b/19.test.yaml --root /private/tmp/rulespec-us-3306-b-19-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-19-20260525/statutes/26/3306/b/19.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-19-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-19-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable

PE coverage: executable=1025, comparable=226, known_not_comparable=799, unmapped=0, untested_comparable=0