### PR TITLE
Add generated 3306(b)(20) FUTA third-party employer treatment rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/20.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/b/20.yaml",
+      "sha256": "e091a58d4018e9f208b9a8687772d23eb3f6529dd76b52c204a4816cde0d9a12"
+    },
+    {
+      "path": "statutes/26/3306/b/20.test.yaml",
+      "sha256": "59ff3a13e0b8f86f1a14859d938781cbfe638f4cc5cfaa96ed842ea59f17427a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "cb644c60240544125495a0576c30a28d48c259ee",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.238",
+    "version_commit": "cb644c60240544125495a0576c30a28d48c259ee"
+  },
+  "axiom_encode_version": "0.2.238",
+  "backend": "codex",
+  "citation": "26 USC 3306(b)(20)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "3cbe6d4fa97de3ba85281fc4ec724e0a307d8e0fa5cfa1e446331a7c701d74ae",
+  "generated_at": "2026-05-25T20:27:48.386166+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/20.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-b-20-regen-20260525",
+  "generated_output_sha256": "e091a58d4018e9f208b9a8687772d23eb3f6529dd76b52c204a4816cde0d9a12",
+  "generation_prompt_sha256": "d60876648d590fde61a1d156b1170d2e6b76fd25720ef066ae05987659e245b0",
+  "model": "gpt-5.5",
+  "run_id": "d9ec6919",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "509746f57e63a011acaf3f7d2c142b363ef18fa5a94f0a0f0169cd7b1930605b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-20.json",
+  "trace_sha256": "98091bd87f6819fef64a4172a50524f2b2bd602256790725c2645a0cfccf5043"
+}

--- a/statutes/26/3306/b/20.test.yaml
+++ b/statutes/26/3306/b/20.test.yaml
@@ -1,0 +1,48 @@
+- name: third_party_treated_as_employer_when_all_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/20#input.third_party_makes_payment: true
+    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+    : true
+    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: false
+  output:
+    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: holds
+- name: no_treatment_when_third_party_does_not_make_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/20#input.third_party_makes_payment: false
+    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+    : true
+    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: false
+  output:
+    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds
+- name: no_treatment_when_payment_not_included_solely_by_parenthetical
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/20#input.third_party_makes_payment: true
+    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+    : false
+    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: false
+  output:
+    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds
+- name: no_treatment_when_secretary_regulations_provide_otherwise
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/20#input.third_party_makes_payment: true
+    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+    : true
+    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: true
+  output:
+    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds

--- a/statutes/26/3306/b/20.yaml
+++ b/statutes/26/3306/b/20.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "any benefit or payment which is excludable from the gross income of the employee under section 139B(b)" and, except as Secretarial regulations otherwise provide, third-party payments described by paragraph (2)(A)'s parenthetical are treated as employer wages for this chapter and chapter 22.
+  deferred_outputs:
+    - output: us:statutes/26/3306/b/20#benefit_or_payment_excluded_from_wages_due_to_employee_gross_income_exclusion
+      reason: Requires determining whether the benefit or payment is excludable from employee gross income under 26 U.S.C. 139B(b), but no copied RuleSpec target for that subsection is available.
+rules:
+  - name: third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 U.S.C. 3306(b)(20), second sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          third_party_makes_payment
+          and payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+          and not regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(b)(20)
- include generated executable tests for the third-party employer treatment rule
- include signed axiom-encode apply manifest

## Provenance
- generated by axiom-encode 0.2.238 at cb644c60240544125495a0576c30a28d48c259ee
- model: gpt-5.5
- run id: d9ec6919
- generated with signed axiom-encode encode --apply

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-b-20-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-b-20-20260525/statutes/26/3306/b/20.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-b-20-20260525/statutes/26/3306/b/20.test.yaml --root /private/tmp/rulespec-us-3306-b-20-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-b-20-20260525/statutes/26/3306/b/20.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-b-20-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-20-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable