### PR TITLE
Add generated 3306(c)(1) FUTA agricultural labor rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/1.yaml",
+      "sha256": "038e33ba094e5168862ef95fb93d91abfbf30f4ea2b66b1e3ab9009687a652aa"
+    },
+    {
+      "path": "statutes/26/3306/c/1.test.yaml",
+      "sha256": "751dc9b61d9646798fdcecf2e0e40d443bc5049917023b3c462ad284c4c52817"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e0b7b2b6789aa0dcea6700379605ded7607cb85b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.240",
+    "version_commit": "e0b7b2b6789aa0dcea6700379605ded7607cb85b"
+  },
+  "axiom_encode_version": "0.2.240",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(1)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "670729fbe738ef04e5576e44eeeb3f45787daa83a3863a64160c1f3fda7f67c9",
+  "generated_at": "2026-05-25T21:19:17.480578+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/codex-gpt-5.5/statutes/26/3306/c/1.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-1-regen-20260525",
+  "generated_output_sha256": "038e33ba094e5168862ef95fb93d91abfbf30f4ea2b66b1e3ab9009687a652aa",
+  "generation_prompt_sha256": "83def7e5101a2b2779d7eee01c11218eba36d3c54fc66c4576cb4af4f48177a4",
+  "model": "gpt-5.5",
+  "run_id": "a497e548",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1d91af26b27341941a08d950fcdb14465bae6e317ef92df351311b5d86e2d57b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-c-1.json",
+  "trace_sha256": "4deec1797bedafda70ca8a7c2b56c7c001f423271259942db8d6029f93c05604"
+}

--- a/statutes/26/3306/c/1.test.yaml
+++ b/statutes/26/3306/c/1.test.yaml
@@ -1,0 +1,79 @@
+- name: cash threshold met and non-alien agricultural labor is not excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/1#input.maximum_cash_remuneration_paid_to_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 20000
+    us:statutes/26/3306/c/1#input.counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week: 20
+    ? us:statutes/26/3306/c/1#input.minimum_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_employed_for_some_portion_of_each_counted_day
+    : 9
+    us:statutes/26/3306/c/1#input.labor_is_agricultural_labor: true
+    us:statutes/26/3306/c/1#input.labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien: false
+  output:
+    us:statutes/26/3306/c/1#agricultural_labor_cash_remuneration_quarter_threshold: 20000
+    us:statutes/26/3306/c/1#agricultural_labor_days_different_weeks_threshold: 20
+    us:statutes/26/3306/c/1#agricultural_labor_individuals_per_day_threshold: 10
+    us:statutes/26/3306/c/1#agricultural_labor_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_day_count_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_employer_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: not_holds
+- name: same employer facts but admitted alien agricultural labor remains excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/1#input.maximum_cash_remuneration_paid_to_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 20000
+    us:statutes/26/3306/c/1#input.counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week: 20
+    ? us:statutes/26/3306/c/1#input.minimum_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_employed_for_some_portion_of_each_counted_day
+    : 9
+    us:statutes/26/3306/c/1#input.labor_is_agricultural_labor: true
+    us:statutes/26/3306/c/1#input.labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien: true
+  output:
+    us:statutes/26/3306/c/1#agricultural_labor_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_day_count_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_employer_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: holds
+- name: neither cash nor day threshold met so agricultural labor is excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/1#input.maximum_cash_remuneration_paid_to_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 19999
+    us:statutes/26/3306/c/1#input.counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week: 19
+    ? us:statutes/26/3306/c/1#input.minimum_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_employed_for_some_portion_of_each_counted_day
+    : 10
+    us:statutes/26/3306/c/1#input.labor_is_agricultural_labor: true
+    us:statutes/26/3306/c/1#input.labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien: false
+  output:
+    us:statutes/26/3306/c/1#agricultural_labor_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_day_count_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_employer_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: holds
+- name: day count threshold met but non-agricultural labor is outside the exception
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/1#input.maximum_cash_remuneration_paid_to_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 0
+    us:statutes/26/3306/c/1#input.counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week: 20
+    ? us:statutes/26/3306/c/1#input.minimum_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_employed_for_some_portion_of_each_counted_day
+    : 10
+    us:statutes/26/3306/c/1#input.labor_is_agricultural_labor: false
+    us:statutes/26/3306/c/1#input.labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien: false
+  output:
+    us:statutes/26/3306/c/1#agricultural_labor_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/1#agricultural_labor_day_count_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_employer_test_satisfied: holds
+    us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/1.yaml
+++ b/statutes/26/3306/c/1.yaml
@@ -1,0 +1,138 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    Agricultural labor is excepted unless the employer meets the cash-remuneration or day-count test and the labor is not performed by the specified admitted alien worker.
+rules:
+  - name: agricultural_labor_cash_remuneration_quarter_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(c)(1)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: cash of $20,000 or more
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20000
+
+  - name: agricultural_labor_days_different_weeks_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(1)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: some 20 days
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: agricultural_labor_individuals_per_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(1)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: 10 or more individuals
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: agricultural_labor_cash_remuneration_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(1)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_cash_remuneration_paid_to_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year >= agricultural_labor_cash_remuneration_quarter_threshold
+
+  - name: agricultural_labor_day_count_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(1)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week >= agricultural_labor_days_different_weeks_threshold
+          and minimum_agricultural_labor_individuals_including_immigration_and_nationality_act_agricultural_worker_aliens_employed_for_some_portion_of_each_counted_day >= agricultural_labor_individuals_per_day_threshold
+
+  - name: agricultural_labor_employer_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          agricultural_labor_cash_remuneration_test_satisfied
+          or agricultural_labor_day_count_test_satisfied
+
+  - name: agricultural_labor_excepted_from_employment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          labor_is_agricultural_labor
+          and (
+            not agricultural_labor_employer_test_satisfied
+            or labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(1)
- include generated executable tests for agricultural-labor FUTA employment thresholds and exceptions
- include signed axiom-encode apply manifest

## Provenance
- generated by axiom-encode 0.2.240 at e0b7b2b6789aa0dcea6700379605ded7607cb85b
- model: gpt-5.5
- run id: a497e548
- generated with signed axiom-encode encode --apply

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-1-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-1-20260525/statutes/26/3306/c/1.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-c-1-20260525/statutes/26/3306/c/1.test.yaml --root /private/tmp/rulespec-us-3306-c-1-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-1-20260525/statutes/26/3306/c/1.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-1-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-1-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable