### PR TITLE
Add generated 3306(c)(2) FUTA domestic service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/2.yaml",
+      "sha256": "b71de3bd3232a6562d8f4678ae21223db455612aafa5e3a9a62803a8190bd63e"
+    },
+    {
+      "path": "statutes/26/3306/c/2.test.yaml",
+      "sha256": "52493f648df811e7304dbf277acb76df26a951e8e86dce8c5dec7d316012feb6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "55ace8ec2d2043b6cf66e9ceb70b25f657927e99",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.241",
+    "version_commit": "55ace8ec2d2043b6cf66e9ceb70b25f657927e99"
+  },
+  "axiom_encode_version": "0.2.241",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(2)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "3ef102351cbecb7d19e9c85c1b4aa2a7fbb390969d972cc4a6a91a119a660699",
+  "generated_at": "2026-05-25T21:35:53.053754+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/codex-gpt-5.5/statutes/26/3306/c/2.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-2-regen-20260525",
+  "generated_output_sha256": "b71de3bd3232a6562d8f4678ae21223db455612aafa5e3a9a62803a8190bd63e",
+  "generation_prompt_sha256": "58535bde1a29ee20dc2984f6acac5a624ffdee8d93803f1edb3e7505214e1247",
+  "model": "gpt-5.5",
+  "run_id": "76954e8f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f0695636050130cc1f38b18d1909e9406dc82d9901695b9511d65f1b1c44edf4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-c-2.json",
+  "trace_sha256": "ee40fe303642914ab38ea5aea991db45934b886c179fa1298f64f99610be11e1"
+}

--- a/statutes/26/3306/c/2.test.yaml
+++ b/statutes/26/3306/c/2.test.yaml
@@ -1,0 +1,42 @@
+- name: domestic service below threshold is excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/2#input.service_is_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority
+    : true
+    ? us:statutes/26/3306/c/2#input.maximum_cash_remuneration_paid_to_individuals_employed_in_such_domestic_service_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 999
+  output:
+    us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/2#domestic_service_excepted_from_employment: holds
+- name: domestic service at threshold is not excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/2#input.service_is_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority
+    : true
+    ? us:statutes/26/3306/c/2#input.maximum_cash_remuneration_paid_to_individuals_employed_in_such_domestic_service_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 1000
+  output:
+    us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/2#domestic_service_excepted_from_employment: not_holds
+- name: non domestic service is not covered by this exception
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/2#input.service_is_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority
+    : false
+    ? us:statutes/26/3306/c/2#input.maximum_cash_remuneration_paid_to_individuals_employed_in_such_domestic_service_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
+    : 0
+  output:
+    us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/2#domestic_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/2.yaml
+++ b/statutes/26/3306/c/2.yaml
@@ -1,0 +1,77 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    Domestic service in a private home, local college club, or local chapter of a college fraternity or sorority is excepted unless performed for a person who paid cash remuneration of $1,000 or more in any calendar quarter in the calendar year or preceding calendar year.
+rules:
+  - name: domestic_service_cash_remuneration_quarter_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "$1,000 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1000
+
+  - name: domestic_service_cash_remuneration_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid cash remuneration of $1,000 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/2#domestic_service_cash_remuneration_quarter_threshold
+              output: domestic_service_cash_remuneration_quarter_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_cash_remuneration_paid_to_individuals_employed_in_such_domestic_service_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year >= domestic_service_cash_remuneration_quarter_threshold
+
+  - name: domestic_service_excepted_from_employment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "domestic service in a private home, local college club, or local chapter of a college fraternity or sorority unless"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied
+              output: domestic_service_cash_remuneration_test_satisfied
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_is_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority
+          and not domestic_service_cash_remuneration_test_satisfied


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(2)
- include generated executable tests for domestic-service FUTA employment threshold and exception treatment
- include signed axiom-encode apply manifest

## Provenance
- generated by axiom-encode 0.2.241 at 55ace8ec2d2043b6cf66e9ceb70b25f657927e99
- model: gpt-5.5
- run id: 76954e8f
- generated with signed axiom-encode encode --apply

## Local checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-2-regen-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-2-20260525/statutes/26/3306/c/2.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-c-2-20260525/statutes/26/3306/c/2.test.yaml --root /private/tmp/rulespec-us-3306-c-2-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-2-20260525/statutes/26/3306/c/2.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-2-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-2-regen-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable