### PR TITLE
Add generated 3306(c)(3) FUTA nonbusiness service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/3.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/3.yaml",
+      "sha256": "d67d7847d76e6b5f8f3b65a6f48c54da77faa1736d50e38260c12da195a798a8"
+    },
+    {
+      "path": "statutes/26/3306/c/3.test.yaml",
+      "sha256": "aa0a0b1bc8666f96db76c21f1e52a3f07b0cb87a7e46cf57306fed829d7ce3bb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f703db88832d3793ead829eab582441180fb5218",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.242",
+    "version_commit": "f703db88832d3793ead829eab582441180fb5218"
+  },
+  "axiom_encode_version": "0.2.242",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(3)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "dd4e04b01d2944db0d6b3aef76bd540f9d0afeb88422cd3675306e1bfddb9e09",
+  "generated_at": "2026-05-25T22:00:38.546109+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/3.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525",
+  "generated_output_sha256": "d67d7847d76e6b5f8f3b65a6f48c54da77faa1736d50e38260c12da195a798a8",
+  "generation_prompt_sha256": "059948936c2800f8f72e874558fb7bcd0d267ec4918b812b8474119cba1898ea",
+  "model": "gpt-5.5",
+  "run_id": "75b8aeb5",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "710beb9ce89b4c23294e451ff3c803f59800a6c1379b6121bfa1afd1f3f12054"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-3.json",
+  "trace_sha256": "d30edf8dadd07e4c21d5692f8be124b19bac6eb98b1855e8bee0783da8211754"
+}

--- a/statutes/26/3306/c/3.test.yaml
+++ b/statutes/26/3306/c/3.test.yaml
@@ -1,0 +1,87 @@
+- name: cash_below_threshold_keeps_nonbusiness_service_excepted
+  period:
+    period_kind: tax_year
+    start: '1990-01-01'
+    end: '1990-12-31'
+  input:
+    us:statutes/26/3306/c/3#input.cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter: 49
+    us:statutes/26/3306/c/3#input.counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer: 24
+    ? us:statutes/26/3306/c/3#input.person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+    : true
+    ? us:statutes/26/3306/c/3#input.person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+    : false
+  output:
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_quarter_threshold: 50
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_days_threshold: 24
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_excepted_from_employment: holds
+- name: cash_and_current_quarter_regular_employment_remove_exception
+  period:
+    period_kind: tax_year
+    start: '1990-01-01'
+    end: '1990-12-31'
+  input:
+    us:statutes/26/3306/c/3#input.cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter: 50
+    us:statutes/26/3306/c/3#input.counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer: 24
+    ? us:statutes/26/3306/c/3#input.person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+    : true
+    ? us:statutes/26/3306/c/3#input.person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+    : false
+  output:
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_excepted_from_employment: not_holds
+- name: preceding_quarter_regular_employment_satisfies_unless_clause
+  period:
+    period_kind: tax_year
+    start: '1990-01-01'
+    end: '1990-12-31'
+  input:
+    us:statutes/26/3306/c/3#input.cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter: 50
+    us:statutes/26/3306/c/3#input.counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer: 23
+    ? us:statutes/26/3306/c/3#input.person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+    : true
+    ? us:statutes/26/3306/c/3#input.person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+    : true
+  output:
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_excepted_from_employment: not_holds
+- name: cash_at_threshold_but_not_regularly_employed_is_excepted
+  period:
+    period_kind: tax_year
+    start: '1990-01-01'
+    end: '1990-12-31'
+  input:
+    us:statutes/26/3306/c/3#input.cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter: 50
+    us:statutes/26/3306/c/3#input.counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer: 23
+    ? us:statutes/26/3306/c/3#input.person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+    : true
+    ? us:statutes/26/3306/c/3#input.person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+    : false
+  output:
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied: holds
+    us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_excepted_from_employment: holds
+- name: service_outside_nonbusiness_category_is_not_excepted_by_this_paragraph
+  period:
+    period_kind: tax_year
+    start: '1990-01-01'
+    end: '1990-12-31'
+  input:
+    us:statutes/26/3306/c/3#input.cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter: 0
+    us:statutes/26/3306/c/3#input.counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer: 0
+    ? us:statutes/26/3306/c/3#input.person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+    : false
+    ? us:statutes/26/3306/c/3#input.person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+    : false
+  output:
+    us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied: not_holds
+    us:statutes/26/3306/c/3#nonbusiness_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/3.yaml
+++ b/statutes/26/3306/c/3.yaml
@@ -1,0 +1,134 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (3) service not in the course of the employer’s trade or business performed in any calendar quarter by an employee, unless the cash remuneration paid for such service is $50 or more and such service is performed by an individual who is regularly employed by such employer to perform such service. For purposes of this paragraph, an individual shall be deemed to be regularly employed by an employer during a calendar quarter only if— (A) on each of some 24 days during such quarter such individual performs for such employer for some portion of the day service not in the course of the employer’s trade or business, or (B) such individual was regularly employed (as determined under subparagraph (A)) by such employer in the performance of such service during the preceding calendar quarter;
+rules:
+  - name: nonbusiness_service_cash_remuneration_quarter_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "cash remuneration paid for such service is $50 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          50
+
+  - name: nonbusiness_service_regular_employment_days_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on each of some 24 days during such quarter"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          24
+
+  - name: nonbusiness_service_cash_remuneration_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "cash remuneration paid for such service is $50 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter >= nonbusiness_service_cash_remuneration_quarter_threshold
+
+  - name: nonbusiness_service_current_quarter_regular_employment_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on each of some 24 days during such quarter such individual performs"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer >= nonbusiness_service_regular_employment_days_threshold
+
+  - name: nonbusiness_service_regular_employment_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(3)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "only if— (A) on each of some 24 days"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "during the preceding calendar quarter"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          nonbusiness_service_current_quarter_regular_employment_test_satisfied
+          or person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+
+  - name: nonbusiness_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service not in the course of the employer’s trade or business performed in any calendar quarter by an employee, unless"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "unless the cash remuneration paid for such service is $50 or more and such service is performed by an individual who is regularly employed"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+          and not (
+            nonbusiness_service_cash_remuneration_test_satisfied
+            and nonbusiness_service_regular_employment_test_satisfied
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(3) nonbusiness-service FUTA employment exception
- cover the  cash-remuneration threshold, 24-day regular-employment test, preceding-quarter rule, and exception predicate
- include signed axiom-encode apply manifest

## Provenance
- tool: axiom-encode encode --apply
- encoder: 0.2.242 at f703db88832d3793ead829eab582441180fb5218
- model: gpt-5.5
- run_id: 75b8aeb5
- generated output: /private/tmp/axiom-encode-3306-c-3-rerun-20260525

## Checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-3-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-3-20260525/statutes/26/3306/c/3.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-c-3-20260525/statutes/26/3306/c/3.test.yaml --root /private/tmp/rulespec-us-3306-c-3-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-3-20260525/statutes/26/3306/c/3.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-3-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-3-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable