### PR TITLE
Add generated 3306(c)(4) FUTA vessel and aircraft rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/4.yaml",
+      "sha256": "b3db6d2a97ef7351697caf23ab0dc534bf4886c7ec9b4de18191685bd4f2f09c"
+    },
+    {
+      "path": "statutes/26/3306/c/4.test.yaml",
+      "sha256": "f31b4e5ab3650aa4579eb06624322c90c6cf610f3246878f893011bc04de00bb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6a09be5a0d4b4468e57e4a9ad01fd672d05bff79",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.243",
+    "version_commit": "6a09be5a0d4b4468e57e4a9ad01fd672d05bff79"
+  },
+  "axiom_encode_version": "0.2.243",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(4)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "5eb58404b5f4519b7cab71c21986909ae3d84b086fda630607b8efeb19dc4cd0",
+  "generated_at": "2026-05-25T22:21:37.732362+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/4.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525",
+  "generated_output_sha256": "b3db6d2a97ef7351697caf23ab0dc534bf4886c7ec9b4de18191685bd4f2f09c",
+  "generation_prompt_sha256": "19e51d2aa458d8c9bd54bda47d00830c97ac80c05980cf2bf2a849d26af31a1b",
+  "model": "gpt-5.5",
+  "run_id": "1bfd69de",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9419479f16d09a3b46e882b1bdb26185b2469e4a13b6862893895b042898b541"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-4.json",
+  "trace_sha256": "8a3b0bc711f5ae700e0248ae46d907ca3b5ee4fceca60a30d8c55b111fe50497"
+}

--- a/statutes/26/3306/c/4.test.yaml
+++ b/statutes/26/3306/c/4.test.yaml
@@ -1,0 +1,100 @@
+- name: non_american_vessel_and_aircraft_service_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
+      us:statutes/26/3121/f#input.asset_is_vessel: true
+      us:statutes/26/3121/f#input.asset_is_aircraft: false
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: true
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
+      us:statutes/26/3121/f#input.asset_is_vessel: false
+      us:statutes/26/3121/f#input.asset_is_aircraft: true
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
+    - holds
+    - holds
+- name: service_not_on_or_in_connection_with_vessel_or_aircraft
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: false
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
+      us:statutes/26/3121/f#input.asset_is_vessel: true
+      us:statutes/26/3121/f#input.asset_is_aircraft: false
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: true
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
+    - not_holds
+- name: employee_not_employed_on_asset_outside_united_states
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: false
+      us:statutes/26/3121/f#input.asset_is_vessel: true
+      us:statutes/26/3121/f#input.asset_is_aircraft: false
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: true
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
+    - not_holds
+- name: american_vessel_or_aircraft_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
+      us:statutes/26/3121/f#input.asset_is_vessel: true
+      us:statutes/26/3121/f#input.asset_is_aircraft: false
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: true
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+    - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
+      us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
+      us:statutes/26/3121/f#input.asset_is_vessel: false
+      us:statutes/26/3121/f#input.asset_is_aircraft: true
+      us:statutes/26/3121/f#input.vessel_documented_or_numbered_under_laws_of_united_states: false
+      us:statutes/26/3121/f#input.vessel_documented_under_laws_of_any_foreign_country: false
+      ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
+      : false
+      us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: true
+  output:
+    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
+    - not_holds
+    - not_holds

--- a/statutes/26/3306/c/4.yaml
+++ b/statutes/26/3306/c/4.yaml
@@ -1,0 +1,47 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3121/f#american_vessel
+  - us:statutes/26/3121/f#american_aircraft
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (4) service performed on or in connection with a vessel or aircraft not an American vessel or American aircraft, if the employee is employed on and in connection with such vessel or aircraft when outside the United States;
+rules:
+  - name: non_american_vessel_or_aircraft_service_excepted_from_employment
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/f#american_vessel
+              output: american_vessel
+              hash: sha256:339d2567923e0428f0cdbb4efa34900172ab3424eb5c58c374843bd3130d3361
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/f#american_aircraft
+              output: american_aircraft
+              hash: sha256:339d2567923e0428f0cdbb4efa34900172ab3424eb5c58c374843bd3130d3361
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_on_or_in_connection_with_vessel_or_aircraft
+          and employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states
+          and (
+            not american_vessel
+            and
+            not american_aircraft
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(4) vessel and aircraft FUTA employment exception
- import section 3121(f) American vessel and American aircraft definitions
- include signed axiom-encode apply manifest

## Provenance
- tool: axiom-encode encode --apply
- encoder: 0.2.243 at 6a09be5a0d4b4468e57e4a9ad01fd672d05bff79
- model: gpt-5.5
- run_id: 1bfd69de
- generated output: /private/tmp/axiom-encode-3306-c-4-rerun-20260525

## Checks
- env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-4-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-4-20260525/statutes/26/3306/c/4.yaml --skip-reviewers --json
- uv run axiom-encode test /private/tmp/rulespec-us-3306-c-4-20260525/statutes/26/3306/c/4.test.yaml --root /private/tmp/rulespec-us-3306-c-4-20260525 --json
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-4-20260525/statutes/26/3306/c/4.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-4-20260525 --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-4-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable