### PR TITLE
Add generated 3306(c)(5) FUTA family employment rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/5.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/5.yaml",
+      "sha256": "77f80fe420be476f7825dd67ea40440533970e5eaee72a0fe3738bfc3533bad1"
+    },
+    {
+      "path": "statutes/26/3306/c/5.test.yaml",
+      "sha256": "cbd5c4a286086b5e5666ce4f7f55fac16423ac5345dbb2b3acaa2860da75b216"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3ef9acd31e42e4f15630f76c9b4bd46207fb0f47",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.244",
+    "version_commit": "3ef9acd31e42e4f15630f76c9b4bd46207fb0f47"
+  },
+  "axiom_encode_version": "0.2.244",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(5)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "3d7cb364ea893b162cb621a1d49a3f7461dc771bf315269ef01768b1fb6b3c1d",
+  "generated_at": "2026-05-25T22:44:53.100718+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/5.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525",
+  "generated_output_sha256": "77f80fe420be476f7825dd67ea40440533970e5eaee72a0fe3738bfc3533bad1",
+  "generation_prompt_sha256": "94f8269d0a54cc11d6ec914f0a1041c46dd31af67c1bfd6ca4420eeb099c8c07",
+  "model": "gpt-5.5",
+  "run_id": "4c10bf81",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "37d0d4880cfd1bc864cd14bcf6f452b1c8d6f4d44df8fcad2f7a855a5014d680"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-5.json",
+  "trace_sha256": "f2e76a9c7ece0f5314f8ac1ef466bb78754ffcd8bf15afcd66918f700192e8eb"
+}

--- a/statutes/26/3306/c/5.test.yaml
+++ b/statutes/26/3306/c/5.test.yaml
@@ -1,0 +1,87 @@
+- name: specified_family_employment_relationships_are_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Person:
+    - us:statutes/26/3306/c/5#input.service_performer_age: 40
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: true
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+    - us:statutes/26/3306/c/5#input.service_performer_age: 40
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: true
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+    - us:statutes/26/3306/c/5#input.service_performer_age: 40
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: true
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+    - us:statutes/26/3306/c/5#input.service_performer_age: 20
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: true
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+    - us:statutes/26/3306/c/5#input.service_performer_age: 20
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: true
+  output:
+    us:statutes/26/3306/c/5#family_employment_child_age_limit: 21
+    us:statutes/26/3306/c/5#service_performer_under_family_employment_child_age_limit:
+    - not_holds
+    - not_holds
+    - not_holds
+    - holds
+    - holds
+    us:statutes/26/3306/c/5#family_employment_service_excepted_from_employment:
+    - holds
+    - holds
+    - holds
+    - holds
+    - holds
+- name: parent_employment_requires_child_under_age_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Person:
+    - us:statutes/26/3306/c/5#input.service_performer_age: 21
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: true
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+    - us:statutes/26/3306/c/5#input.service_performer_age: 21
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: true
+    - us:statutes/26/3306/c/5#input.service_performer_age: 20
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_son: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_daughter: false
+      us:statutes/26/3306/c/5#input.service_performed_by_individual_in_employ_of_individuals_spouse: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_father: false
+      us:statutes/26/3306/c/5#input.service_performed_by_child_in_employ_of_childs_mother: false
+  output:
+    us:statutes/26/3306/c/5#service_performer_under_family_employment_child_age_limit:
+    - not_holds
+    - not_holds
+    - holds
+    us:statutes/26/3306/c/5#family_employment_service_excepted_from_employment:
+    - not_holds
+    - not_holds
+    - not_holds

--- a/statutes/26/3306/c/5.yaml
+++ b/statutes/26/3306/c/5.yaml
@@ -1,0 +1,93 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (5) service performed by an individual in the employ of his son, daughter, or spouse, and service performed by a child under the age of 21 in the employ of his father or mother;
+rules:
+  - name: family_employment_child_age_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "child under the age of 21"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          21
+
+  - name: service_performer_under_family_employment_child_age_limit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "child under the age of 21"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/5#family_employment_child_age_limit
+              output: family_employment_child_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performer_age < family_employment_child_age_limit
+
+  - name: family_employment_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "employ of his son, daughter, or spouse"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "child under the age of 21 in the employ of his father or mother"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/5#service_performer_under_family_employment_child_age_limit
+              output: service_performer_under_family_employment_child_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_individual_in_employ_of_individuals_son
+          or service_performed_by_individual_in_employ_of_individuals_daughter
+          or service_performed_by_individual_in_employ_of_individuals_spouse
+          or (
+            service_performer_under_family_employment_child_age_limit
+            and (
+              service_performed_by_child_in_employ_of_childs_father
+              or service_performed_by_child_in_employ_of_childs_mother
+            )
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(5) family-employment exceptions to FUTA employment
- include generated companion tests for son/daughter/spouse and under-21 child parent-employment cases
- include signed encoder manifest from axiom-encode 0.2.244 (`3ef9acd31e42e4f15630f76c9b4bd46207fb0f47`), run `4c10bf81`, model `gpt-5.5`

## Tests
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-5-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-5-20260525/statutes/26/3306/c/5.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-c-5-20260525/statutes/26/3306/c/5.test.yaml --root /private/tmp/rulespec-us-3306-c-5-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-5-20260525/statutes/26/3306/c/5.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-5-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-5-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`