### PR TITLE
Add generated 3306(c)(6) FUTA federal service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/6.yaml",
+      "sha256": "8a520faf9be8210b4f79e9a7020007830f94686dd474a31acfbafdb1a76f5a9a"
+    },
+    {
+      "path": "statutes/26/3306/c/6.test.yaml",
+      "sha256": "3656c20061f5bebba8237d70c2ee99842b15ee7e5fb7b21dda9934698e48c9f6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "11c5c68c857f342ad4639e328d9d110538b8b2bf",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.245",
+    "version_commit": "11c5c68c857f342ad4639e328d9d110538b8b2bf"
+  },
+  "axiom_encode_version": "0.2.245",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(6)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "f74d052c6e3d9ce3df8b559fcc8fbc0c65d4615dbe8c1ed957deb63f81c5756a",
+  "generated_at": "2026-05-25T23:05:04.486495+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/6.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525",
+  "generated_output_sha256": "8a520faf9be8210b4f79e9a7020007830f94686dd474a31acfbafdb1a76f5a9a",
+  "generation_prompt_sha256": "4ef4cd329b19f04a479ac5dca2d0fc79c390cf094853df69aafe452373f56276",
+  "model": "gpt-5.5",
+  "run_id": "2136dd7e",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8d0e50a44ac9deed54fccdd38bb1ffe9fcd09016b6e1f80884600cfc79705144"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-6.json",
+  "trace_sha256": "a912a2bef621d148c0a16f87223979071719a3f8a249764bf8d22c3602188db0"
+}

--- a/statutes/26/3306/c/6.test.yaml
+++ b/statutes/26/3306/c/6.test.yaml
@@ -1,0 +1,60 @@
+- name: service_in_employ_of_united_states_government_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_united_states_government: true
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_instrumentality_of_united_states: false
+    us:statutes/26/3306/c/6#input.instrumentality_wholly_or_partially_owned_by_united_states: false
+    ? us:statutes/26/3306/c/6#input.instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+    : false
+  output:
+    us:statutes/26/3306/c/6#service_in_employ_of_qualifying_united_states_instrumentality: not_holds
+    us:statutes/26/3306/c/6#federal_government_or_qualifying_instrumentality_service_excepted_from_employment: holds
+- name: service_in_employ_of_owned_united_states_instrumentality_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_united_states_government: false
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_instrumentality_of_united_states: true
+    us:statutes/26/3306/c/6#input.instrumentality_wholly_or_partially_owned_by_united_states: true
+    ? us:statutes/26/3306/c/6#input.instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+    : false
+  output:
+    us:statutes/26/3306/c/6#service_in_employ_of_qualifying_united_states_instrumentality: holds
+    us:statutes/26/3306/c/6#federal_government_or_qualifying_instrumentality_service_excepted_from_employment: holds
+- name: service_in_employ_of_section_3301_exempt_united_states_instrumentality_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_united_states_government: false
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_instrumentality_of_united_states: true
+    us:statutes/26/3306/c/6#input.instrumentality_wholly_or_partially_owned_by_united_states: false
+    ? us:statutes/26/3306/c/6#input.instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+    : true
+  output:
+    us:statutes/26/3306/c/6#service_in_employ_of_qualifying_united_states_instrumentality: holds
+    us:statutes/26/3306/c/6#federal_government_or_qualifying_instrumentality_service_excepted_from_employment: holds
+- name: service_in_employ_of_nonqualifying_united_states_instrumentality_is_not_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_united_states_government: false
+    us:statutes/26/3306/c/6#input.service_performed_in_employ_of_instrumentality_of_united_states: true
+    us:statutes/26/3306/c/6#input.instrumentality_wholly_or_partially_owned_by_united_states: false
+    ? us:statutes/26/3306/c/6#input.instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+    : false
+  output:
+    us:statutes/26/3306/c/6#service_in_employ_of_qualifying_united_states_instrumentality: not_holds
+    us:statutes/26/3306/c/6#federal_government_or_qualifying_instrumentality_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/6.yaml
+++ b/statutes/26/3306/c/6.yaml
@@ -1,0 +1,72 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (6) service performed in the employ of the United States Government or of an instrumentality of the United States which is— (A) wholly or partially owned by the United States, or (B) exempt from the tax imposed by section 3301 by virtue of any provision of law which specifically refers to such section (or the corresponding section of prior law) in granting such exemption;
+rules:
+  - name: service_in_employ_of_qualifying_united_states_instrumentality
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed in the employ ... of an instrumentality of the United States
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: wholly or partially owned by the United States
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: exempt from the tax imposed by section 3301 by virtue of any provision of law which specifically refers to such section
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_united_states
+          and (
+            instrumentality_wholly_or_partially_owned_by_united_states
+            or instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+          )
+
+  - name: federal_government_or_qualifying_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed in the employ of the United States Government
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: or of an instrumentality of the United States which is—
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/6#service_in_employ_of_qualifying_united_states_instrumentality
+              output: service_in_employ_of_qualifying_united_states_instrumentality
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_united_states_government
+          or service_in_employ_of_qualifying_united_states_instrumentality


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(6) United States Government and qualifying federal-instrumentality service exceptions to FUTA employment
- include generated companion tests for direct federal-government service, owned federal instrumentalities, specifically exempt instrumentalities, and nonqualifying instrumentalities
- include signed encoder manifest from axiom-encode 0.2.245 (`11c5c68c857f342ad4639e328d9d110538b8b2bf`), run `2136dd7e`, model `gpt-5.5`

## Tests
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-6-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-6-20260525/statutes/26/3306/c/6.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-c-6-20260525/statutes/26/3306/c/6.test.yaml --root /private/tmp/rulespec-us-3306-c-6-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-6-20260525/statutes/26/3306/c/6.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-6-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-6-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`