### PR TITLE
Add generated 3306(c)(7) FUTA state and tribal service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/7.yaml",
+      "sha256": "e937fc3dd0cc3ec7ba690a1090f496f9ece46a2f8ca26c10e630e560d4d52c8c"
+    },
+    {
+      "path": "statutes/26/3306/c/7.test.yaml",
+      "sha256": "04008a8722dd0ddff7b98d51cedb71890196d9c1c9078c559964b74339ad2911"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "458000687cea18506b755be7d30aaa9010d68f5c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.246",
+    "version_commit": "458000687cea18506b755be7d30aaa9010d68f5c"
+  },
+  "axiom_encode_version": "0.2.246",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(7)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-7-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "18206ee4176142efdb17c6cc50704c6a10be129a5d8dd295ff8394deb7a4cc49",
+  "generated_at": "2026-05-25T23:23:47.727773+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-7-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/7.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-7-rerun-20260525",
+  "generated_output_sha256": "e937fc3dd0cc3ec7ba690a1090f496f9ece46a2f8ca26c10e630e560d4d52c8c",
+  "generation_prompt_sha256": "0bcbba75d0b78fec4b45fb61af8bc4f3704544cf72a7dbc527e52dacfc4a2cc0",
+  "model": "gpt-5.5",
+  "run_id": "8aa1b416",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "235ca98bc8221916a1c7eea380b9eec166a55267c5601883976022ef28c5c1c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-7-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-7.json",
+  "trace_sha256": "c64d321f519d387b45fd83cc058c170603a3957d4119b7343d9a71c73cbe1c27"
+}

--- a/statutes/26/3306/c/7.test.yaml
+++ b/statutes/26/3306/c/7.test.yaml
@@ -1,0 +1,88 @@
+- name: state_service_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: true
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+    : false
+    us:statutes/26/3306/c/7#input.instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes: true
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+    : false
+    ? us:statutes/26/3306/c/7#input.instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+    : false
+  output:
+    us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe: holds
+    us:statutes/26/3306/c/7#service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality: not_holds
+    ? us:statutes/26/3306/c/7#state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    : holds
+- name: wholly_owned_instrumentality_service_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+    : true
+    us:statutes/26/3306/c/7#input.instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes: true
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+    : false
+    ? us:statutes/26/3306/c/7#input.instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+    : true
+  output:
+    us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality: holds
+    us:statutes/26/3306/c/7#service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality: not_holds
+    ? us:statutes/26/3306/c/7#state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    : holds
+- name: constitutionally_immune_instrumentality_service_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+    : true
+    us:statutes/26/3306/c/7#input.instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+    : true
+    ? us:statutes/26/3306/c/7#input.instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+    : true
+  output:
+    us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality: holds
+    ? us:statutes/26/3306/c/7#state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    : holds
+- name: nonqualifying_service_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+    : false
+    us:statutes/26/3306/c/7#input.instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes: false
+    ? us:statutes/26/3306/c/7#input.service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+    : true
+    ? us:statutes/26/3306/c/7#input.instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+    : false
+  output:
+    us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality: not_holds
+    us:statutes/26/3306/c/7#service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality: not_holds
+    ? us:statutes/26/3306/c/7#state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    : not_holds

--- a/statutes/26/3306/c/7.yaml
+++ b/statutes/26/3306/c/7.yaml
@@ -1,0 +1,108 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    "service performed in the employ of a State, or any political subdivision thereof, or in the employ of an Indian tribe"; wholly owned instrumentalities of the foregoing; and state or political subdivision instrumentalities immune from the section 3301 tax.
+rules:
+  - name: service_in_employ_of_state_political_subdivision_or_indian_tribe
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed in the employ of a State, or any political subdivision thereof, or in the employ of an Indian tribe"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state
+          or service_performed_in_employ_of_political_subdivision_of_state
+          or service_performed_in_employ_of_indian_tribe
+
+  - name: service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "instrumentality of any one or more of the foregoing which is wholly owned"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+          and instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes
+
+  - name: service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "employ of any instrumentality of one or more States or political subdivisions"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "immune under the Constitution of the United States from the tax imposed by section 3301"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+          and instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+
+  - name: state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe
+              output: service_in_employ_of_state_political_subdivision_or_indian_tribe
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/7#service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+              output: service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/7#service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality
+              output: service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_state_political_subdivision_or_indian_tribe
+          or service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+          or service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(7) State, political-subdivision, Indian-tribe, and immune-instrumentality service exceptions to FUTA employment
- include generated companion tests for direct government/tribal service, wholly owned instrumentalities, constitutionally immune instrumentalities, and nonqualifying instrumentalities
- include signed encoder manifest from axiom-encode 0.2.246 (`458000687cea18506b755be7d30aaa9010d68f5c`), run `8aa1b416`, model `gpt-5.5`

## Tests
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-7-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-7-20260525/statutes/26/3306/c/7.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-c-7-20260525/statutes/26/3306/c/7.test.yaml --root /private/tmp/rulespec-us-3306-c-7-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-7-20260525/statutes/26/3306/c/7.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-7-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-7-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`