### PR TITLE
Add generated 3306(c)(8) FUTA exempt organization rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/8.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/8.yaml",
+      "sha256": "31e1212820f29c341a72698d0d6fc325879b7bee20b3cbeee413ab26ee890f43"
+    },
+    {
+      "path": "statutes/26/3306/c/8.test.yaml",
+      "sha256": "a3d85e4669f4139d17c9687a45f360cf13e00bd1ef9f577be75d662f3bc82e9a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9ea986123cf58a6c5dfaf2959ea5c7dbcd14e6ed",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.247",
+    "version_commit": "9ea986123cf58a6c5dfaf2959ea5c7dbcd14e6ed"
+  },
+  "axiom_encode_version": "0.2.247",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(8)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "1613db35c556380088db1c71c834c15914717790364ea40bfb374d21e1304e63",
+  "generated_at": "2026-05-25T23:40:23.714388+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/8.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525",
+  "generated_output_sha256": "31e1212820f29c341a72698d0d6fc325879b7bee20b3cbeee413ab26ee890f43",
+  "generation_prompt_sha256": "e97507c81c57ad54ef80dadefd8731d72bf6d9c0f7a6ec4c4af782c51ab6a792",
+  "model": "gpt-5.5",
+  "run_id": "36d506fb",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8fc773f15e8a6288ad4bb047fe64d5a269b3e216af57d68d2d88ac2a4dbad169"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-8.json",
+  "trace_sha256": "3c94534e3160db55c7d31bdc24daf17cc840e194344029d0a57e15472e3f417c"
+}

--- a/statutes/26/3306/c/8.test.yaml
+++ b/statutes/26/3306/c/8.test.yaml
@@ -1,0 +1,36 @@
+- name: service_for_tax_exempt_501_c_3_organization_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/8#input.service_performed_in_employ_of_religious_charitable_educational_or_other_organization_described_in_section_501_c_3
+    : true
+    us:statutes/26/3306/c/8#input.employing_organization_exempt_from_income_tax_under_section_501_a: true
+  output:
+    us:statutes/26/3306/c/8#tax_exempt_section_501_c_3_organization_service_excepted_from_employment: holds
+- name: service_not_for_501_c_3_organization_is_not_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/8#input.service_performed_in_employ_of_religious_charitable_educational_or_other_organization_described_in_section_501_c_3
+    : false
+    us:statutes/26/3306/c/8#input.employing_organization_exempt_from_income_tax_under_section_501_a: true
+  output:
+    us:statutes/26/3306/c/8#tax_exempt_section_501_c_3_organization_service_excepted_from_employment: not_holds
+- name: service_for_non_exempt_organization_is_not_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/8#input.service_performed_in_employ_of_religious_charitable_educational_or_other_organization_described_in_section_501_c_3
+    : true
+    us:statutes/26/3306/c/8#input.employing_organization_exempt_from_income_tax_under_section_501_a: false
+  output:
+    us:statutes/26/3306/c/8#tax_exempt_section_501_c_3_organization_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/8.yaml
+++ b/statutes/26/3306/c/8.yaml
@@ -1,0 +1,31 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed in the employ of a religious, charitable, educational, or other organization described in section 501(c)(3) which is exempt from income tax under section 501(a)
+rules:
+  - name: tax_exempt_section_501_c_3_organization_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_religious_charitable_educational_or_other_organization_described_in_section_501_c_3
+          and employing_organization_exempt_from_income_tax_under_section_501_a


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(8) service for section 501(c)(3) organizations exempt under section 501(a)
- include generated companion tests for qualifying exempt organizations and each failed predicate case
- include signed encoder manifest from axiom-encode 0.2.247 (`9ea986123cf58a6c5dfaf2959ea5c7dbcd14e6ed`), run `36d506fb`, model `gpt-5.5`

## Tests
- `env TMPDIR=/private/tmp/axiom-validate-tmp-3306-c-8-rerun-20260525 uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-8-20260525/statutes/26/3306/c/8.yaml --skip-reviewers --json`
- `uv run axiom-encode test /private/tmp/rulespec-us-3306-c-8-20260525/statutes/26/3306/c/8.test.yaml --root /private/tmp/rulespec-us-3306-c-8-20260525 --json`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-8-20260525/statutes/26/3306/c/8.yaml`
- `uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-8-20260525 --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-8-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`