### PR TITLE
Add generated 3306(c)(9) FUTA railroad employment rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/9.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/9.yaml",
+      "sha256": "25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525"
+    },
+    {
+      "path": "statutes/26/3306/c/9.test.yaml",
+      "sha256": "cf36a883fec091ec69094f463b6cd402b6ad549beac2cc8fc5c2479748c2dc4b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "dae05b0017be0420e8c2d7389d5032877b7a6733",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.248",
+    "version_commit": "dae05b0017be0420e8c2d7389d5032877b7a6733"
+  },
+  "axiom_encode_version": "0.2.248",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(9)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "3de2b5c86024857c553acc7b863de8935e6feffa4c48a99d2c2d2a1f61d83a3c",
+  "generated_at": "2026-05-25T23:58:40.410722+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/9.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525",
+  "generated_output_sha256": "25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525",
+  "generation_prompt_sha256": "6d6685bb06fcb8a47d18dbbb84906a18c2aba49de744676649e2669bde05407a",
+  "model": "gpt-5.5",
+  "run_id": "960cbae4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "df6ac8a032bdc7512f59a7c868a0246454527499924524710f38fc9a2289f473"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-9.json",
+  "trace_sha256": "b9c69d54f5c3996db87ff01710c59f156979410dbf325ce046f00b2939e6100e"
+}

--- a/statutes/26/3306/c/9.test.yaml
+++ b/statutes/26/3306/c/9.test.yaml
@@ -1,0 +1,36 @@
+- name: employee_defined_in_railroad_unemployment_insurance_act
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : true
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment: holds
+- name: employee_representative_defined_in_railroad_unemployment_insurance_act
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : true
+  output:
+    us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment: holds
+- name: neither_railroad_employee_nor_employee_representative
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/9.yaml
+++ b/statutes/26/3306/c/9.yaml
@@ -1,0 +1,37 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (9) service performed by an individual as an employee or employee representative as defined in section 1 of the Railroad Unemployment Insurance Act (45 U.S.C. 351)
+rules:
+  - name: railroad_employee_or_employee_representative_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed by an individual as an employee
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: employee representative as defined in section 1 of the Railroad Unemployment Insurance Act
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+          or service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec artifacts for 26 USC 3306(c)(9)
- model railroad employee and employee-representative service as a FUTA employment exception predicate
- include generated tests for employee, employee representative, and neither cases

## Provenance
- generated with axiom-encode 0.2.248
- encoder commit dae05b0017be0420e8c2d7389d5032877b7a6733
- model gpt-5.5
- run id 960cbae4
- applied with signed axiom-encode --apply

## Validation
- axiom-encode validate statutes/26/3306/c/9.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/9.test.yaml --root /private/tmp/rulespec-us-3306-c-9-20260525 --json
- axiom-encode proof-validate statutes/26/3306/c/9.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-9-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-9-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable