### PR TITLE
Add generated 3306(c)(11) FUTA foreign government rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/11.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/11.yaml",
+      "sha256": "9da1fbaaed0b620f3739b4548d3ae75c019dc76cd841fbfe108a41a56c3f1ca9"
+    },
+    {
+      "path": "statutes/26/3306/c/11.test.yaml",
+      "sha256": "2c2b73fc498bb288e13b214ca20b63e1fc55120d390f7eaf7f2070bc08509601"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d192631eecd0885f49c87d3ea433bcfea7db6cca",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.250",
+    "version_commit": "d192631eecd0885f49c87d3ea433bcfea7db6cca"
+  },
+  "axiom_encode_version": "0.2.250",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(11)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "87dd8e83bfe704bccf43cee04d01edbdb402787eba8b5698b44c3a5543444e6a",
+  "generated_at": "2026-05-26T00:59:41.025411+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/11.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525",
+  "generated_output_sha256": "9da1fbaaed0b620f3739b4548d3ae75c019dc76cd841fbfe108a41a56c3f1ca9",
+  "generation_prompt_sha256": "67117bac63b644a91f9233d6f276df4bb06f9f12ce82e62ef2aedf1c9e662607",
+  "model": "gpt-5.5",
+  "run_id": "8e15e032",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d02f4bb338b0d8f861b4ae4e5f8c02b6ca821d74191ddd724971c86220763458"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-11.json",
+  "trace_sha256": "bb789f15f8ac6902ff7710a3428d2d29a4c9a491e4c5ebdda687f9cc8e588ab1"
+}

--- a/statutes/26/3306/c/11.test.yaml
+++ b/statutes/26/3306/c/11.test.yaml
@@ -1,0 +1,48 @@
+- name: service_in_employ_of_foreign_government_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/11#input.service_performed_in_employ_of_foreign_government: true
+    us:statutes/26/3306/c/11#input.service_performed_as_consular_or_other_officer_or_employee_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_nondiplomatic_representative_of_foreign_government: false
+  output:
+    us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
+- name: consular_or_other_officer_or_employee_service_is_included
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/11#input.service_performed_in_employ_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_consular_or_other_officer_or_employee_of_foreign_government: true
+    us:statutes/26/3306/c/11#input.service_performed_as_nondiplomatic_representative_of_foreign_government: false
+  output:
+    us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
+- name: nondiplomatic_representative_service_is_included
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/11#input.service_performed_in_employ_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_consular_or_other_officer_or_employee_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_nondiplomatic_representative_of_foreign_government: true
+  output:
+    us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
+- name: non_foreign_government_service_is_not_excepted_by_this_paragraph
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/11#input.service_performed_in_employ_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_consular_or_other_officer_or_employee_of_foreign_government: false
+    us:statutes/26/3306/c/11#input.service_performed_as_nondiplomatic_representative_of_foreign_government: false
+  output:
+    us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/11.yaml
+++ b/statutes/26/3306/c/11.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed in the employ of a foreign government, including consular or other officers or employees and nondiplomatic representatives
+rules:
+  - name: foreign_government_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_foreign_government
+          or service_performed_as_consular_or_other_officer_or_employee_of_foreign_government
+          or service_performed_as_nondiplomatic_representative_of_foreign_government


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec artifacts for 26 USC 3306(c)(11)
- model foreign-government, consular/officer/employee, and nondiplomatic-representative service as FUTA employment exceptions
- include generated positive and negative tests

## Provenance
- generated with axiom-encode 0.2.250
- encoder commit d192631eecd0885f49c87d3ea433bcfea7db6cca
- model gpt-5.5
- run id 8e15e032
- applied with signed axiom-encode --apply

## Validation
- axiom-encode validate statutes/26/3306/c/11.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/11.test.yaml --root /private/tmp/rulespec-us-3306-c-11-20260525 --json
- axiom-encode proof-validate statutes/26/3306/c/11.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-11-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-11-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable