### PR TITLE
Add generated 3306(c)(12) FUTA foreign instrumentality rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/12.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/12.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/12.yaml",
+      "sha256": "1ecf23c5f9510dac494b97967fe2ebc4a5bdf68dd7f6803dc05791598f023afb"
+    },
+    {
+      "path": "statutes/26/3306/c/12.test.yaml",
+      "sha256": "c99a3164cd110eb0b3fad12424bd92129112b21c5719715c1c7167610b7aad9c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d3b7f89ffe7d5c81b9f6b5f6f03001795e63948a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.251",
+    "version_commit": "d3b7f89ffe7d5c81b9f6b5f6f03001795e63948a"
+  },
+  "axiom_encode_version": "0.2.251",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(12)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "437b37dbe9e3825dcf8337fb19ce9ae5aef66816873f426adffb7e843405061e",
+  "generated_at": "2026-05-26T01:17:15.881727+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/12.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525",
+  "generated_output_sha256": "1ecf23c5f9510dac494b97967fe2ebc4a5bdf68dd7f6803dc05791598f023afb",
+  "generation_prompt_sha256": "3aedde505913df0479daeb69303d6f5b0299af89be26bf5b04002b97b32eb003",
+  "model": "gpt-5.5",
+  "run_id": "1172788f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7734954800edafa60b2b46903f1f4927f91cc00347ebf1c8a6e93f60f76175b6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-12.json",
+  "trace_sha256": "13d1ed9d0cfb63f97a5edef63be90d3c3d6561091e25b4bc4c695e7f4aa4e011"
+}

--- a/statutes/26/3306/c/12.test.yaml
+++ b/statutes/26/3306/c/12.test.yaml
@@ -1,0 +1,52 @@
+- name: all_conditions_met_service_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+    ? us:statutes/26/3306/c/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+    : true
+    ? us:statutes/26/3306/c/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+    : true
+  output:
+    us:statutes/26/3306/c/12#foreign_government_wholly_owned_instrumentality_service_excepted_from_employment: holds
+- name: not_wholly_owned_instrumentality_service_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: false
+    ? us:statutes/26/3306/c/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+    : true
+    ? us:statutes/26/3306/c/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+    : true
+  output:
+    us:statutes/26/3306/c/12#foreign_government_wholly_owned_instrumentality_service_excepted_from_employment: not_holds
+- name: dissimilar_service_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+    ? us:statutes/26/3306/c/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+    : false
+    ? us:statutes/26/3306/c/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+    : true
+  output:
+    us:statutes/26/3306/c/12#foreign_government_wholly_owned_instrumentality_service_excepted_from_employment: not_holds
+- name: no_secretary_of_state_certification_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/12#input.service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government: true
+    ? us:statutes/26/3306/c/12#input.service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+    : true
+    ? us:statutes/26/3306/c/12#input.secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+    : false
+  output:
+    us:statutes/26/3306/c/12#foreign_government_wholly_owned_instrumentality_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/12.yaml
+++ b/statutes/26/3306/c/12.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed in the employ of an instrumentality wholly owned by a foreign government, if the service is similar to foreign-country service by United States Government or instrumentality employees and the Secretary of State certifies reciprocal exemption.
+rules:
+  - name: foreign_government_wholly_owned_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 U.S.C. 3306(c)(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed in the employ of an instrumentality wholly owned by a foreign government
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service is of a character similar to that performed in foreign countries
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: Secretary of State shall certify to the Secretary of the Treasury
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government
+          and service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+          and secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec artifacts for 26 USC 3306(c)(12)
- model foreign-government wholly owned instrumentality service with service-character and State Department reciprocity certification conditions
- include generated positive and negative tests for each required condition

## Provenance
- generated with axiom-encode 0.2.251
- encoder commit d3b7f89ffe7d5c81b9f6b5f6f03001795e63948a
- model gpt-5.5
- run id 1172788f
- applied with signed axiom-encode --apply

## Validation
- axiom-encode validate statutes/26/3306/c/12.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/12.test.yaml --root /private/tmp/rulespec-us-3306-c-12-20260525 --json
- axiom-encode proof-validate statutes/26/3306/c/12.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-12-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-12-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable