### PR TITLE
Add generated 3306(c)(13) FUTA health training rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/13.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/13.yaml",
+      "sha256": "803bb30103b84d63975fdafa081e8a4ba0cbeba403ee192832e0b8704b45ab3c"
+    },
+    {
+      "path": "statutes/26/3306/c/13.test.yaml",
+      "sha256": "e593077af1e72f2c0549d9b1905f90387ec30ed7cc749c0f2cd7c2d5f8e5330a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0efd213656d94fe064a52413ed2f3b8699fcb99c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.252",
+    "version_commit": "0efd213656d94fe064a52413ed2f3b8699fcb99c"
+  },
+  "axiom_encode_version": "0.2.252",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(13)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "8110b0bc42ab9fe78744149bfdb3db3ad8422afba3fec0df687ebbc4551d854f",
+  "generated_at": "2026-05-26T01:39:34.337457+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/13.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525",
+  "generated_output_sha256": "803bb30103b84d63975fdafa081e8a4ba0cbeba403ee192832e0b8704b45ab3c",
+  "generation_prompt_sha256": "11cb6309fb0175ea1cbca49a8423f53539aa3e3716f4b291108df47012afa2ee",
+  "model": "gpt-5.5",
+  "run_id": "2e67116a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8a27d16f16f2ac83c421bfead5e9e9b5d53f6bee845892a5ddc020d7ab9474c6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-13.json",
+  "trace_sha256": "ce6e2dac048fd42315e6cfcca68c245b129c112360bf1a4e32ecdd36912a71aa"
+}

--- a/statutes/26/3306/c/13.test.yaml
+++ b/statutes/26/3306/c/13.test.yaml
@@ -1,0 +1,171 @@
+- name: student_nurse_in_hospital_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: false
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: holds
+- name: student_nurse_in_training_school_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: false
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: false
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: holds
+- name: hospital_intern_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: false
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: true
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: holds
+- name: no_qualifying_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: false
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: true
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds
+- name: student_nurse_not_enrolled
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: false
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds
+- name: student_nurse_not_regularly_attending
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: false
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds
+- name: nurses_training_school_not_approved
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: false
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: false
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds
+- name: intern_did_not_complete_four_year_course
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: false
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: true
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: false
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds
+- name: medical_school_not_approved
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/13#input.service_performed_as_student_nurse: false
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_hospital: true
+    us:statutes/26/3306/c/13#input.service_performed_in_employ_of_nurses_training_school: false
+    us:statutes/26/3306/c/13#input.individual_enrolled_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.individual_regularly_attending_classes_in_nurses_training_school: true
+    us:statutes/26/3306/c/13#input.nurses_training_school_chartered_or_approved_pursuant_to_state_law: true
+    us:statutes/26/3306/c/13#input.service_performed_as_intern: true
+    us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
+    us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: false
+  output:
+    us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/13.yaml
+++ b/statutes/26/3306/c/13.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed as a student nurse in the employ of a hospital or a nurses' training school ...; and service performed as an intern in the employ of a hospital ...
+rules:
+  - name: student_nurse_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(13), student nurse clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed as a student nurse in the employ of a hospital or a nurses' training school
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_as_student_nurse
+          and (
+            service_performed_in_employ_of_hospital
+            or service_performed_in_employ_of_nurses_training_school
+          )
+          and individual_enrolled_in_nurses_training_school
+          and individual_regularly_attending_classes_in_nurses_training_school
+          and nurses_training_school_chartered_or_approved_pursuant_to_state_law
+  - name: hospital_intern_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(13), intern clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: service performed as an intern in the employ of a hospital by an individual who has completed a 4 years' course
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_as_intern
+          and service_performed_in_employ_of_hospital
+          and individual_completed_four_year_course_in_medical_school
+          and medical_school_chartered_or_approved_pursuant_to_state_law
+  - name: student_nurse_or_hospital_intern_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment
+              output: student_nurse_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment
+              output: hospital_intern_service_excepted_from_employment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          student_nurse_service_excepted_from_employment
+          or hospital_intern_service_excepted_from_employment


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3306(c)(13) student nurse and hospital intern FUTA employment exceptions
- add generated companion tests and apply manifest
- generated with axiom-encode 0.2.252 at commit 0efd213656d94fe064a52413ed2f3b8699fcb99c using gpt-5.5, run id 2e67116a

## Validation
- axiom-encode validate statutes/26/3306/c/13.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/13.test.yaml --root /private/tmp/rulespec-us-3306-c-13-20260525 --json
- axiom-encode proof-validate statutes/26/3306/c/13.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-13-20260525 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-13-rerun-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable