### PR TITLE
Add generated 3306(c)(14) FUTA insurance rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/14.yaml",
+      "sha256": "c5b47668cc92e26437c334862d4d59b8907ab374e6e6397bcd420bc9a7c6890e"
+    },
+    {
+      "path": "statutes/26/3306/c/14.test.yaml",
+      "sha256": "cfdfc1ba2a50c2db65b29e0300fac33d30d60405ef8b7371a5a28ec447db3d99"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a565d6a911285c4bfc37bdf1ffba922435bf6cda",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.253",
+    "version_commit": "a565d6a911285c4bfc37bdf1ffba922435bf6cda"
+  },
+  "axiom_encode_version": "0.2.253",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(14)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "5cfcc9d3afd878d3d39e5aa4bd833db767400a80e39db48c5e9510ecbc232d91",
+  "generated_at": "2026-05-26T01:56:06.254322+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/14.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526",
+  "generated_output_sha256": "c5b47668cc92e26437c334862d4d59b8907ab374e6e6397bcd420bc9a7c6890e",
+  "generation_prompt_sha256": "0fa6b7e3d264b81c84ad43f093b2af01758e35074fc760d2b6d6787cb181b38b",
+  "model": "gpt-5.5",
+  "run_id": "420fc69b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "57fa434fc4b8b05a4276a607964035414896642465337cb6b5005c764c5a3d2d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-14.json",
+  "trace_sha256": "1ac44ca8be887b6ce57754620ad6324fdf81c6b8ab5a0243b430a46a740c571c"
+}

--- a/statutes/26/3306/c/14.test.yaml
+++ b/statutes/26/3306/c/14.test.yaml
@@ -1,0 +1,33 @@
+- name: insurance_agent_or_solicitor_commission_service_is_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/14#input.service_performed_for_person_as_insurance_agent_or_insurance_solicitor: true
+    us:statutes/26/3306/c/14#input.all_service_performed_for_that_person_remunerated_solely_by_commission: true
+  output:
+    us:statutes/26/3306/c/14#insurance_agent_or_solicitor_commission_service_excepted_from_employment: holds
+- name: non_insurance_agent_or_solicitor_service_is_not_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/14#input.service_performed_for_person_as_insurance_agent_or_insurance_solicitor: false
+    us:statutes/26/3306/c/14#input.all_service_performed_for_that_person_remunerated_solely_by_commission: true
+  output:
+    us:statutes/26/3306/c/14#insurance_agent_or_solicitor_commission_service_excepted_from_employment: not_holds
+- name: non_commission_service_is_not_excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/14#input.service_performed_for_person_as_insurance_agent_or_insurance_solicitor: true
+    us:statutes/26/3306/c/14#input.all_service_performed_for_that_person_remunerated_solely_by_commission: false
+  output:
+    us:statutes/26/3306/c/14#insurance_agent_or_solicitor_commission_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/14.yaml
+++ b/statutes/26/3306/c/14.yaml
@@ -1,0 +1,31 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed by an individual for a person as an insurance agent or insurance solicitor, if all such service for that person is remunerated solely by commission
+rules:
+  - name: insurance_agent_or_solicitor_commission_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_for_person_as_insurance_agent_or_insurance_solicitor
+          and all_service_performed_for_that_person_remunerated_solely_by_commission


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3306(c)(14) insurance agent/solicitor commission service FUTA employment exception
- add generated companion tests and apply manifest
- generated with axiom-encode 0.2.253 at commit a565d6a911285c4bfc37bdf1ffba922435bf6cda using gpt-5.5, run id 420fc69b

## Validation
- axiom-encode validate statutes/26/3306/c/14.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/14.test.yaml --root /private/tmp/rulespec-us-3306-c-14-20260526 --json
- axiom-encode proof-validate statutes/26/3306/c/14.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-14-20260526 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-14-rerun-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable