### PR TITLE
Add generated 3306(c)(15) FUTA newspaper rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/15.yaml",
+      "sha256": "7d7b6cb3237062c4d783a189a71a7ded2d51c486076a59218e4a5ac8ae726c49"
+    },
+    {
+      "path": "statutes/26/3306/c/15.test.yaml",
+      "sha256": "880065cc2c48ff072d65ffd920c4ffabb1a4e3dc43e6f6f3e012fbc5de90d836"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0574321c2bb437c6bc5d1fdbd5fee73910968e6f",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.254",
+    "version_commit": "0574321c2bb437c6bc5d1fdbd5fee73910968e6f"
+  },
+  "axiom_encode_version": "0.2.254",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(15)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "6e1992ffd27ce1fc75844aa75600fa02bd4c8d5db9c15f416b8efee30c709528",
+  "generated_at": "2026-05-26T02:15:39.618675+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/15.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526",
+  "generated_output_sha256": "7d7b6cb3237062c4d783a189a71a7ded2d51c486076a59218e4a5ac8ae726c49",
+  "generation_prompt_sha256": "12594ddcbf9c22ba093a7f03cd31f80d6534bffd87a07cc54c3db937221db120",
+  "model": "gpt-5.5",
+  "run_id": "0251aa07",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "049cd1e6a8254dd19700dccc90cbb1287c40efa28b2f6fb808f56724af9678f7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-15.json",
+  "trace_sha256": "40b8f50c9e93004346d8763a69cd84b71b481cccce8d791d22bf22d0270b11fd"
+}

--- a/statutes/26/3306/c/15.test.yaml
+++ b/statutes/26/3306/c/15.test.yaml
@@ -1,0 +1,85 @@
+- name: underage_newspaper_delivery_service_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/15#input.individual_under_age_18: true
+    us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: true
+    ? us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+    : false
+    us:statutes/26/3306/c/15#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers: false
+    us:statutes/26/3306/c/15#input.newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price: true
+    us:statutes/26/3306/c/15#input.compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual: true
+  output:
+    us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#newspaper_delivery_or_sales_service_excepted_from_employment: holds
+- name: subsequent_distribution_delivery_service_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/15#input.individual_under_age_18: true
+    us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: true
+    ? us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+    : true
+    us:statutes/26/3306/c/15#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers: false
+    us:statutes/26/3306/c/15#input.newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price: true
+    us:statutes/26/3306/c/15#input.compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual: true
+  output:
+    us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#newspaper_delivery_or_sales_service_excepted_from_employment: not_holds
+- name: adult_delivery_and_sale_without_fixed_price_are_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/15#input.individual_under_age_18: false
+    us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: true
+    ? us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+    : false
+    us:statutes/26/3306/c/15#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers: true
+    us:statutes/26/3306/c/15#input.newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price: false
+    us:statutes/26/3306/c/15#input.compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual: true
+  output:
+    us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#newspaper_delivery_or_sales_service_excepted_from_employment: not_holds
+- name: ultimate_consumer_fixed_price_sale_service_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/15#input.individual_under_age_18: false
+    us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: false
+    ? us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+    : false
+    us:statutes/26/3306/c/15#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers: true
+    us:statutes/26/3306/c/15#input.newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price: true
+    us:statutes/26/3306/c/15#input.compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual: true
+  output:
+    us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/15#newspaper_delivery_or_sales_service_excepted_from_employment: holds
+- name: sale_without_excess_retention_compensation_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/15#input.individual_under_age_18: false
+    us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news: false
+    ? us:statutes/26/3306/c/15#input.service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+    : false
+    us:statutes/26/3306/c/15#input.service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers: true
+    us:statutes/26/3306/c/15#input.newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price: true
+    us:statutes/26/3306/c/15#input.compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual: false
+  output:
+    us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/15#newspaper_delivery_or_sales_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/15.yaml
+++ b/statutes/26/3306/c/15.yaml
@@ -1,0 +1,90 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed by an individual under the age of 18 in the delivery or distribution of newspapers or shopping news, not including delivery or distribution to any point for subsequent delivery or distribution; service performed by an individual in, and at the time of, the sale of newspapers or magazines to ultimate consumers
+rules:
+  - name: newspaper_delivery_distribution_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(15)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: under the age of 18 in the delivery or distribution of newspapers or shopping news
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: not including delivery or distribution to any point for subsequent delivery or distribution
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_under_age_18
+          and service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news
+          and not service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+  - name: ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(15)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: in, and at the time of, the sale of newspapers or magazines to ultimate consumers
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: newspapers or magazines are to be sold by him at a fixed price
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: compensation being based on the retention of the excess
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers
+          and newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price
+          and compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+  - name: newspaper_delivery_or_sales_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/15#newspaper_delivery_distribution_service_excepted_from_employment
+              output: newspaper_delivery_distribution_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/15#ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment
+              output: ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          newspaper_delivery_distribution_service_excepted_from_employment
+          or ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3306(c)(15) newspaper delivery/distribution and ultimate-consumer sales FUTA employment exceptions
- add generated companion tests and apply manifest
- generated with axiom-encode 0.2.254 at commit 0574321c2bb437c6bc5d1fdbd5fee73910968e6f using gpt-5.5, run id 0251aa07

## Validation
- axiom-encode validate statutes/26/3306/c/15.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/15.test.yaml --root /private/tmp/rulespec-us-3306-c-15-20260526 --json
- axiom-encode proof-validate statutes/26/3306/c/15.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-15-20260526 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-15-rerun-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable