### PR TITLE
Add generated 3306(c)(16) FUTA international organization rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/16.yaml",
+      "sha256": "41adb628091d449431cb30e3b7d7f551eb954d06c69d147dad0376811af1620d"
+    },
+    {
+      "path": "statutes/26/3306/c/16.test.yaml",
+      "sha256": "6e2a4426fe225b0dc5a9d7f9171a1f93bbfd8089a1182cea5544c7c523975cb6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6d5e2f3edd7d9a0ee0cdbc379bf2236636001742",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.255",
+    "version_commit": "6d5e2f3edd7d9a0ee0cdbc379bf2236636001742"
+  },
+  "axiom_encode_version": "0.2.255",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(16)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "770a0072b8c3936001472118b207d76bef94147e9067852ee844545fb65ce615",
+  "generated_at": "2026-05-26T02:32:21.139989+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/16.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526",
+  "generated_output_sha256": "41adb628091d449431cb30e3b7d7f551eb954d06c69d147dad0376811af1620d",
+  "generation_prompt_sha256": "cb2cb192dde28add535a3d52fc912730c9b0741bb311273bd92b750077a27c7d",
+  "model": "gpt-5.5",
+  "run_id": "d114cc9f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "79d23579b3ccaa2fb8b6d241aa61c2ba830f447039f28b99c242e1438a0c02e8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-16.json",
+  "trace_sha256": "e4b4384d4fc68c875139b5644c5f642673da6cac3e537cf95c0fd513bcc37c46"
+}

--- a/statutes/26/3306/c/16.test.yaml
+++ b/statutes/26/3306/c/16.test.yaml
@@ -1,0 +1,18 @@
+- name: service_in_employ_of_international_organization_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/16#input.service_performed_in_employ_of_international_organization: true
+  output:
+    us:statutes/26/3306/c/16#international_organization_service_excepted_from_employment: holds
+- name: service_not_in_employ_of_international_organization_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/16#input.service_performed_in_employ_of_international_organization: false
+  output:
+    us:statutes/26/3306/c/16#international_organization_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/16.yaml
+++ b/statutes/26/3306/c/16.yaml
@@ -1,0 +1,26 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed in the employ of an international organization
+rules:
+  - name: international_organization_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(16)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3306(c)(16) international organization service FUTA employment exception
- add generated companion tests and apply manifest
- generated with axiom-encode 0.2.255 at commit 6d5e2f3edd7d9a0ee0cdbc379bf2236636001742 using gpt-5.5, run id d114cc9f

## Validation
- axiom-encode validate statutes/26/3306/c/16.yaml --skip-reviewers --json
- axiom-encode test statutes/26/3306/c/16.test.yaml --root /private/tmp/rulespec-us-3306-c-16-20260526 --json
- axiom-encode proof-validate statutes/26/3306/c/16.yaml
- axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-c-16-20260526 --base-ref origin/main --json
- axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-16-rerun-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable