### PR TITLE
Add generated 3306(c)(17) FUTA aquatic life rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/17.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/17.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/17.yaml",
+      "sha256": "b2bcf2f9d9be9f83aa1a9826d8552bba093bad3b453c699a2272e3ce1ff56081"
+    },
+    {
+      "path": "statutes/26/3306/c/17.test.yaml",
+      "sha256": "dd4f09a1923e7fdffda907989e51e2417459a2b507eebc8948ded0691aae740d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7a00edcf0a8bb0b6293cee94480a1c53e157b43",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.256",
+    "version_commit": "d7a00edcf0a8bb0b6293cee94480a1c53e157b43"
+  },
+  "axiom_encode_version": "0.2.256",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(17)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-17/workspace/context-manifest.json",
+  "context_manifest_sha256": "437fd063c222656c7fc986455d9526836f15491548d6e207eb115074836df875",
+  "generated_at": "2026-05-26T02:59:35.985697+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/17.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526",
+  "generated_output_sha256": "b2bcf2f9d9be9f83aa1a9826d8552bba093bad3b453c699a2272e3ce1ff56081",
+  "generation_prompt_sha256": "bf225278ed7c3a28717387610ee3c9e5ba7d0aeae5c7ce19dcea13fc260b1b48",
+  "model": "gpt-5.5",
+  "run_id": "3f28737d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "310560cee5945287f0987e4698e25303dfa027b6635ebc041bbd54518e57a2cd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-17.json",
+  "trace_sha256": "0b32c545039dab60af0c5a6a5bc3c4590dd561432010f7efb222ac04052c613b"
+}

--- a/statutes/26/3306/c/17.test.yaml
+++ b/statutes/26/3306/c/17.test.yaml
@@ -1,0 +1,70 @@
+- name: qualifying_aquatic_life_service_at_tonnage_threshold_is_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/17#input.service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+    : true
+    us:statutes/26/3306/c/17#input.service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking: false
+    us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: true
+    us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 10
+  output:
+    us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: not_holds
+    us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: holds
+- name: commercial_salmon_or_halibut_service_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/17#input.service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+    : true
+    us:statutes/26/3306/c/17#input.service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking: true
+    us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: true
+    us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 10
+  output:
+    us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: not_holds
+    us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: not_holds
+- name: service_on_large_vessel_is_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/17#input.service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+    : true
+    us:statutes/26/3306/c/17#input.service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking: false
+    us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: true
+    us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 11
+  output:
+    us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: holds
+    us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: not_holds
+- name: high_tonnage_without_vessel_connection_does_not_trigger_vessel_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/17#input.service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+    : true
+    us:statutes/26/3306/c/17#input.service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking: false
+    us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: false
+    us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 11
+  output:
+    us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: not_holds
+    us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: holds
+- name: non_aquatic_life_service_is_not_excepted_under_this_paragraph
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/17#input.service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+    : false
+    us:statutes/26/3306/c/17#input.service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking: false
+    us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: true
+    us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 10
+  output:
+    us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: not_holds
+    us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/17.yaml
+++ b/statutes/26/3306/c/17.yaml
@@ -1,0 +1,76 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed by an individual in ... the catching, taking, harvesting, cultivating, or farming of any kind of fish, shellfish, crustacea, sponges, seaweeds, or other aquatic forms of animal and vegetable life ... except— (A) service performed in connection with the catching or taking of salmon or halibut, for commercial purposes, and (B) service performed on or in connection with a vessel of more than 10 net tons ...
+rules:
+  - name: fishing_service_vessel_net_tonnage_exception_threshold
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3306(c)(17)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "vessel of more than 10 net tons"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: large_vessel_aquatic_life_service_exception_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(17)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed on or in connection with a vessel of more than 10 net tons"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_on_or_in_connection_with_vessel
+          and vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws > fishing_service_vessel_net_tonnage_exception_threshold
+
+  - name: aquatic_life_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(17)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed by an individual in ... the catching, taking, harvesting, cultivating, or farming"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed in connection with the catching or taking of salmon or halibut, for commercial purposes"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed on or in connection with a vessel of more than 10 net tons"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_aquatic_life_catching_taking_harvesting_cultivating_or_farming_or_as_vessel_officer_or_crew_or_ordinary_incident
+          and not service_performed_in_connection_with_commercial_salmon_or_halibut_catching_or_taking
+          and not large_vessel_aquatic_life_service_exception_applies


### PR DESCRIPTION
Generated 26 USC 3306(c)(17) aquatic-life FUTA employment exception artifacts with axiom-encode 0.2.256 (commit d7a00edcf0a8bb0b6293cee94480a1c53e157b43), model gpt-5.5, run_id 3f28737d.\n\nLocal validation:\n- axiom-encode validate: passed\n- axiom-encode test: passed (5 cases)\n- axiom-encode guard-generated: passed\n- axiom-encode proof-validate: passed (5 atoms)\n- axiom-encode oracle-coverage: passed (outputs=1079, comparable=226, known_not_comparable=853, untested comparable=0)\n\nGenerated only: statutes/26/3306/c/17.yaml, statutes/26/3306/c/17.test.yaml, and signed manifest.