### PR TITLE
Add generated 3306(c)(18) FUTA fishing boat rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/18.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/18.yaml",
+      "sha256": "65007ea958f447bcf489b0b261be98ab2c22574c5e4bc7f434a3a36e09c597c1"
+    },
+    {
+      "path": "statutes/26/3306/c/18.test.yaml",
+      "sha256": "8e800eb6f430368a387f3df3c2a8bcde777a2277c65e819aad5b3daf8719c380"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8a26d9f26c93544f8ac2f6a7bc8420e0329f1406",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.257",
+    "version_commit": "8a26d9f26c93544f8ac2f6a7bc8420e0329f1406"
+  },
+  "axiom_encode_version": "0.2.257",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(18)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "5a82bbc2382802e0fd7e29e8bd13d38e8afd175e2c77b43dd0666fcfe55bf2e3",
+  "generated_at": "2026-05-26T03:26:23.061790+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/18.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526",
+  "generated_output_sha256": "65007ea958f447bcf489b0b261be98ab2c22574c5e4bc7f434a3a36e09c597c1",
+  "generation_prompt_sha256": "d5c40e87a4f259bdb62e184422b40acb15209a7cb9d9057adc4a8f86614315c7",
+  "model": "gpt-5.5",
+  "run_id": "ebb60527",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7058b562298d0043e37c8aad9ffaf5573f8080d08d9cca38c3d48cffffa6a71e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-18.json",
+  "trace_sha256": "edffde21f3fe11e9883d25f5a2c205e3081997786a37422e8c375f87083ca83b"
+}

--- a/statutes/26/3306/c/18.test.yaml
+++ b/statutes/26/3306/c/18.test.yaml
@@ -1,0 +1,46 @@
+- name: section_3121_b_20_fishing_boat_service_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: false
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 0
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: false
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: false
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3306/c/18#fishing_boat_service_excepted_from_employment:
+    - holds
+- name: service_not_described_in_section_3121_b_20_not_excepted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/20#input.service_described_in_paragraph_3_A: true
+      ? us:statutes/26/3121/b/20#input.service_performed_by_individual_on_boat_engaged_in_catching_fish_or_other_aquatic_animal_life
+      : true
+      us:statutes/26/3121/b/20#input.service_performed_under_arrangement_with_owner_or_operator_of_boat: true
+      us:statutes/26/3121/b/20#input.individual_receives_no_cash_remuneration_other_than_share_of_catch_or_proceeds: true
+      us:statutes/26/3121/b/20#input.cash_remuneration_per_trip: 0
+      us:statutes/26/3121/b/20#input.cash_remuneration_contingent_on_minimum_catch: false
+      us:statutes/26/3121/b/20#input.cash_remuneration_paid_solely_for_additional_duties: false
+      us:statutes/26/3121/b/20#input.additional_cash_remuneration_for_duties_traditional_in_industry: false
+      us:statutes/26/3121/b/20#input.individual_receives_share_of_boat_catch_or_proceeds_from_sale_of_catch: true
+      us:statutes/26/3121/b/20#input.individual_share_amount_depends_on_amount_of_boat_catch: true
+      us:statutes/26/3121/b/20#input.operating_crew_normally_made_up_of_individual_count: 9
+  output:
+    us:statutes/26/3306/c/18#fishing_boat_service_excepted_from_employment:
+    - not_holds

--- a/statutes/26/3306/c/18.yaml
+++ b/statutes/26/3306/c/18.yaml
@@ -1,0 +1,35 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (18) service described in section 3121(b)(20);
+imports:
+  - us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment
+rules:
+  - name: fishing_boat_service_excepted_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(18)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "service described in section 3121(b)(20)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment
+              output: fishing_boat_service_excluded_from_employment
+              hash: sha256:2dcd60ad243ef88c716126c5cdf99b3659f5f265550c63f0c8e79a6c7075594d
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          fishing_boat_service_excluded_from_employment


### PR DESCRIPTION
Generated 26 USC 3306(c)(18) FUTA fishing-boat employment exception artifacts with axiom-encode 0.2.257 (commit 8a26d9f26c93544f8ac2f6a7bc8420e0329f1406), model gpt-5.5, run_id ebb60527.\n\nLocal validation:\n- axiom-encode validate: passed\n- axiom-encode test: passed (2 cases)\n- axiom-encode guard-generated: passed\n- axiom-encode proof-validate: passed (2 atoms)\n- axiom-encode oracle-coverage: passed (outputs=1080, comparable=226, known_not_comparable=854, untested comparable=0)\n\nGenerated only: statutes/26/3306/c/18.yaml, statutes/26/3306/c/18.test.yaml, and signed manifest.