### PR TITLE
Add generated 3306(c)(19) FUTA nonimmigrant rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/19.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/19.yaml",
+      "sha256": "6d978da623271917cef50e57fe4a0a5189e8b4a743b228cdec24e946415b4d3f"
+    },
+    {
+      "path": "statutes/26/3306/c/19.test.yaml",
+      "sha256": "3d4fbb6a62044b031937916c6bb525d6777dcf5e9361dd32ced186ce5fb7f72a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60227c07df77433d3c94e8833cb10c8955efde72",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.258",
+    "version_commit": "60227c07df77433d3c94e8833cb10c8955efde72"
+  },
+  "axiom_encode_version": "0.2.258",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(19)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "ced18e9e01b7720fa4f583b312de76fa985dab1e48afea8fee90f02a79daeb6a",
+  "generated_at": "2026-05-26T03:54:37.138999+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/19.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526",
+  "generated_output_sha256": "6d978da623271917cef50e57fe4a0a5189e8b4a743b228cdec24e946415b4d3f",
+  "generation_prompt_sha256": "042ca7c264087a21e05a82ea528d7f91e8881bbafb8c7e42f21cb5a822fe441f",
+  "model": "gpt-5.5",
+  "run_id": "4da09cb8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "541063dfa8446028c8be72bec3d6bd1baaf07467648cc460005963a2952a6cd8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-19.json",
+  "trace_sha256": "be4314e4bd0387c8623990d20a67908081725a489198b538fbff59b97639a38d"
+}

--- a/statutes/26/3306/c/19.test.yaml
+++ b/statutes/26/3306/c/19.test.yaml
@@ -1,0 +1,57 @@
+- name: qualifying nonresident alien nonimmigrant purpose service is excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/19#input.individual_is_nonresident_alien: true
+    ? us:statutes/26/3306/c/19#input.individual_temporarily_present_in_united_states_as_nonimmigrant_under_immigration_and_nationality_act_section_101_a_15_f_j_m_or_q
+    : true
+    ? us:statutes/26/3306/c/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_immigration_and_nationality_act_subparagraph_f_j_m_or_q
+    : true
+  output:
+    us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: holds
+- name: resident alien service is not excepted under paragraph 19
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/19#input.individual_is_nonresident_alien: false
+    ? us:statutes/26/3306/c/19#input.individual_temporarily_present_in_united_states_as_nonimmigrant_under_immigration_and_nationality_act_section_101_a_15_f_j_m_or_q
+    : true
+    ? us:statutes/26/3306/c/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_immigration_and_nationality_act_subparagraph_f_j_m_or_q
+    : true
+  output:
+    us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: not_holds
+- name: other immigration status service is not excepted under paragraph 19
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/19#input.individual_is_nonresident_alien: true
+    ? us:statutes/26/3306/c/19#input.individual_temporarily_present_in_united_states_as_nonimmigrant_under_immigration_and_nationality_act_section_101_a_15_f_j_m_or_q
+    : false
+    ? us:statutes/26/3306/c/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_immigration_and_nationality_act_subparagraph_f_j_m_or_q
+    : true
+  output:
+    us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: not_holds
+- name: service outside specified nonimmigrant purpose is not excepted under paragraph
+    19
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/19#input.individual_is_nonresident_alien: true
+    ? us:statutes/26/3306/c/19#input.individual_temporarily_present_in_united_states_as_nonimmigrant_under_immigration_and_nationality_act_section_101_a_15_f_j_m_or_q
+    : true
+    ? us:statutes/26/3306/c/19#input.service_performed_to_carry_out_purpose_specified_in_applicable_immigration_and_nationality_act_subparagraph_f_j_m_or_q
+    : false
+  output:
+    us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/19.yaml
+++ b/statutes/26/3306/c/19.yaml
@@ -1,0 +1,32 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    service performed by a nonresident alien individual while temporarily present in the United States as an F, J, M, or Q nonimmigrant, and performed to carry out the purpose specified in that subparagraph
+rules:
+  - name: nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(19)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_is_nonresident_alien
+          and individual_temporarily_present_in_united_states_as_nonimmigrant_under_immigration_and_nationality_act_section_101_a_15_f_j_m_or_q
+          and service_performed_to_carry_out_purpose_specified_in_applicable_immigration_and_nationality_act_subparagraph_f_j_m_or_q


### PR DESCRIPTION
Generated 26 USC 3306(c)(19) FUTA nonresident-alien F/J/M/Q nonimmigrant purpose-service employment exception artifacts with axiom-encode 0.2.258 (commit 60227c07df77433d3c94e8833cb10c8955efde72), model gpt-5.5, run_id 4da09cb8.\n\nLocal validation:\n- axiom-encode validate: passed\n- axiom-encode test: passed (4 cases)\n- axiom-encode guard-generated: passed\n- axiom-encode proof-validate: passed (2 atoms)\n- axiom-encode oracle-coverage: passed (outputs=1081, comparable=226, known_not_comparable=855, untested comparable=0)\n\nGenerated only: statutes/26/3306/c/19.yaml, statutes/26/3306/c/19.test.yaml, and signed manifest.