### PR TITLE
Add generated 3306(c)(20) FUTA organized camp rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/20.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/c/20.yaml",
+      "sha256": "4086eec327a704021d277cd555a1d705d608f4549afd4f874bb6aa7d70862744"
+    },
+    {
+      "path": "statutes/26/3306/c/20.test.yaml",
+      "sha256": "b2a7a3c4f215e7056471714db50aaec2652bbde430d9aab7761ee2cc1af3a92a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f1fd5ad02e858f854213aad43ea4db5a7baa61b7",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.261",
+    "version_commit": "f1fd5ad02e858f854213aad43ea4db5a7baa61b7"
+  },
+  "axiom_encode_version": "0.2.261",
+  "backend": "codex",
+  "citation": "26 USC 3306(c)(20)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "602de2acd4c64a73b6b9ebb74243a6c42925c146cb74f79fca93407ba9380338",
+  "generated_at": "2026-05-26T05:27:37.295792+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/codex-gpt-5.5/statutes/26/3306/c/20.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-c-20-final-20260526",
+  "generated_output_sha256": "4086eec327a704021d277cd555a1d705d608f4549afd4f874bb6aa7d70862744",
+  "generation_prompt_sha256": "f67b3ee34e7bc033e9e9ea331c9ccb597709b58b26c76c021a7ae5bf40fec28c",
+  "model": "gpt-5.5",
+  "run_id": "3ee1d0c2",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b9d83cc1a2ae96637a0dc4d7884a32f89fd0b8b2fdcbac9f0efd40679df5fef4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/traces/codex-gpt-5.5/26-USC-3306-c-20.json",
+  "trace_sha256": "d2d784c565642437050590bd1153ddff3759726b63f337087168f7751c0bd0dd"
+}

--- a/statutes/26/3306/c/20.test.yaml
+++ b/statutes/26/3306/c/20.test.yaml
@@ -1,0 +1,132 @@
+- name: organized camp student service qualifies under short operating season test
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : true
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 7
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 7
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 900
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 12
+  output:
+    us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
+    us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: holds
+    us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: holds
+- name: organized camp student service qualifies under short operating season test_scalar_outputs
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : true
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 7
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 7
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 900
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 12
+  output:
+    us:statutes/26/3306/c/20#organized_camp_operation_month_limit: 7
+    us:statutes/26/3306/c/20#organized_camp_gross_receipts_average_month_count: 6
+    us:statutes/26/3306/c/20#organized_camp_student_service_calendar_week_limit: 13
+- name: organized camp student service qualifies under gross receipts seasonality
+    test
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : true
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 8
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 8
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 600
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 12
+  output:
+    us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: holds
+    us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
+    us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: holds
+    us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: holds
+- name: organized camp student service does not qualify when neither camp test is
+    met
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : true
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 8
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 8
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 900
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 12
+  output:
+    us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: not_holds
+    us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: holds
+    us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: not_holds
+- name: organized camp student service does not qualify at thirteen calendar weeks
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : true
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 7
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 7
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 900
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 13
+  output:
+    us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
+    us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: not_holds
+    us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: not_holds
+- name: service outside full time student organized camp category is not excepted
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3306/c/20#input.service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+    : false
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 7
+    us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 7
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
+    : 600
+    ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
+    : 2400
+    us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 12
+  output:
+    us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: holds
+    us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
+    us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: holds
+    us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/20.yaml
+++ b/statutes/26/3306/c/20.yaml
@@ -1,0 +1,170 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    Service performed by a full time student in the employ of an organized camp, if the camp satisfies the 7-month operating test or the 33⅓ percent gross receipts test, and the student served for less than 13 calendar weeks.
+rules:
+  - name: organized_camp_operation_month_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(20)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "did not operate for more than 7 months"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          7
+
+  - name: organized_camp_gross_receipts_average_month_count
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(20)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "average gross receipts for any 6 months"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          6
+
+  - name: organized_camp_gross_receipts_percentage_limit
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3306(c)(20)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "not more than 33⅓ percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1 / 3
+
+  - name: organized_camp_student_service_calendar_week_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(20)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "less than 13 calendar weeks"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          13
+
+  - name: employing_organized_camp_short_operating_season_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(20)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employing_organized_camp_operated_months_in_calendar_year <= organized_camp_operation_month_limit
+          and employing_organized_camp_operated_months_in_preceding_calendar_year <= organized_camp_operation_month_limit
+
+  - name: employing_organized_camp_gross_receipts_seasonality_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(20)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year / organized_camp_gross_receipts_average_month_count) <= organized_camp_gross_receipts_percentage_limit * (employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year / organized_camp_gross_receipts_average_month_count)
+
+  - name: employing_organized_camp_qualifies_for_student_service_exception
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(20)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employing_organized_camp_short_operating_season_test_satisfied
+          or employing_organized_camp_gross_receipts_seasonality_test_satisfied
+
+  - name: full_time_student_organized_camp_service_weeks_below_limit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(20)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp < organized_camp_student_service_calendar_week_limit
+
+  - name: organized_camp_full_time_student_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(c)(20)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_full_time_student_as_defined_in_subsection_q_in_employ_of_organized_camp
+          and employing_organized_camp_qualifies_for_student_service_exception
+          and full_time_student_organized_camp_service_weeks_below_limit


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(c)(20), the FUTA organized-camp full-time-student service exception
- add generated companion tests for the operating-season, gross-receipts, week-limit, and category-gate paths
- include signed axiom-encode apply manifest from encoder 0.2.261 / f1fd5ad

## Validation
- uv run axiom-encode validate /private/tmp/rulespec-us-3306-c-20-20260526/statutes/26/3306/c/20.yaml --skip-reviewers
- uv run axiom-encode test --root /private/tmp/rulespec-us-3306-c-20-20260526 --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 /private/tmp/rulespec-us-3306-c-20-20260526/statutes/26/3306/c/20.test.yaml
- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-c-20-20260526/statutes/26/3306/c/20.yaml
- uv run axiom-encode guard-generated --root /private/tmp/rulespec-us-3306-c-20-20260526
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-20-final-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable
- git diff --check