### PR TITLE
Add generated 3306(d) FUTA pay-period rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/d.yaml",
+      "sha256": "0037a2f722b5e10bc10900c77ce23ff62a8d5317bf70658d3eba8a6497f789ec"
+    },
+    {
+      "path": "statutes/26/3306/d.test.yaml",
+      "sha256": "1f2e48b4ed5fed22ae4f627ccc9cd7184bbbe1320da1abab21dfc5799eab79e8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "169172970860a3cd8c85d2203d434bacfa0f05f5",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.263",
+    "version_commit": "169172970860a3cd8c85d2203d434bacfa0f05f5"
+  },
+  "axiom_encode_version": "0.2.263",
+  "backend": "codex",
+  "citation": "26 USC 3306(d)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "e34c67e774858a6337b0fbe78610e7325c4f112f1245e55c08975d3313f7388d",
+  "generated_at": "2026-05-26T06:15:43.626726+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/codex-gpt-5.5/statutes/26/3306/d.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-d-merged-20260526",
+  "generated_output_sha256": "e9ec03f67c432cf6dd2c3189ede2846715384807222867efbec2f4247b29cbea",
+  "generation_prompt_sha256": "a56f076720d32c21f18817e7cce96efe4960ba89bb6eae85f5fb86a1069f9621",
+  "model": "gpt-5.5",
+  "run_id": "ff080956",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5468dbd60241bb3e4f5346bb043514c15fbfc45f4ddaffa5ed0812145233114e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/traces/codex-gpt-5.5/26-USC-3306-d.json",
+  "trace_sha256": "b6cc09a7f9d8c1d65b6d49a6beeb89278334f30801b83ca321ecb219f2e5d047"
+}

--- a/statutes/26/3306/d.test.yaml
+++ b/statutes/26/3306/d.test.yaml
@@ -1,0 +1,75 @@
+- name: one_half_or_more_employment_services_makes_all_services_deemed_employment
+  period: 2026-01
+  input:
+    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3306/d#input.pay_period_consecutive_days: 31
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.5
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.5
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
+    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: holds
+    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds
+- name: subsection_c_9_excepted_service_blocks_all_services_deeming
+  period: 2026-01
+  input:
+    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3306/d#input.pay_period_consecutive_days: 31
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.5
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.5
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : true
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
+    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds
+- name: more_than_one_half_nonemployment_services_makes_no_services_deemed_employment
+  period: 2026-02
+  input:
+    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3306/d#input.pay_period_consecutive_days: 15
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.4
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
+    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: holds
+- name: subsection_c_9_excepted_service_blocks_no_services_deeming
+  period: 2026-02
+  input:
+    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3306/d#input.pay_period_consecutive_days: 15
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.4
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : true
+  output:
+    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
+    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds
+- name: period_longer_than_31_consecutive_days_is_not_pay_period
+  period: 2026-03
+  input:
+    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
+    us:statutes/26/3306/d#input.pay_period_consecutive_days: 32
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.6
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.4
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
+    : false
+  output:
+    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: not_holds
+    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
+    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds

--- a/statutes/26/3306/d.yaml
+++ b/statutes/26/3306/d.yaml
@@ -1,0 +1,160 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: "(d) Included and excluded service For purposes of this chapter, if the\
+    \ services performed during one-half or more of any pay period by an employee\
+    \ for the person employing him constitute employment, all the services of such\
+    \ employee for such period shall be deemed to be employment; but if the services\
+    \ performed during more than one-half of any such pay period by an employee for\
+    \ the person employing him do not constitute employment, then none of the services\
+    \ of such employee for such period shall be deemed to be employment. As used in\
+    \ this subsection, the term \u201Cpay period\u201D means a period (of not more\
+    \ than 31 consecutive days) for which a payment of remuneration is ordinarily\
+    \ made to the employee by the person employing him. This subsection shall not\
+    \ be applicable with respect to services performed in a pay period by an employee\
+    \ for the person employing him, where any of such service is excepted by subsection\
+    \ (c)(9)."
+imports:
+- us:statutes/26/3121/c#pay_period_max_consecutive_days
+- us:statutes/26/3121/c#one_half_services_threshold
+- us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment
+rules:
+- name: pay_period_for_included_and_excluded_service
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 26 USC 3306(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: "the term \u201Cpay period\u201D means a period (of not more than\
+            \ 31 consecutive days) for which a payment of remuneration is ordinarily\
+            \ made"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/c#pay_period_max_consecutive_days
+          output: pay_period_max_consecutive_days
+          hash: sha256:52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer
+
+      and pay_period_consecutive_days <= pay_period_max_consecutive_days'
+- name: local_all_services_for_pay_period_deemed_employment
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 26 USC 3306(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: if the services performed during one-half or more of any pay period
+            by an employee for the person employing him constitute employment
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: all the services of such employee for such period shall be deemed
+            to be employment
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: This subsection shall not be applicable with respect to services
+            performed in a pay period by an employee for the person employing him,
+            where any of such service is excepted by subsection (c)(9).
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/d#pay_period_for_included_and_excluded_service
+          output: pay_period_for_included_and_excluded_service
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/c#one_half_services_threshold
+          output: one_half_services_threshold
+          hash: sha256:52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment
+          output: railroad_employee_or_employee_representative_service_excepted_from_employment
+          hash: sha256:25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'pay_period_for_included_and_excluded_service
+
+      and services_performed_for_employer_during_pay_period_that_constitute_employment_fraction
+      >= one_half_services_threshold
+
+      and not railroad_employee_or_employee_representative_service_excepted_from_employment'
+- name: local_no_services_for_pay_period_deemed_employment
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 26 USC 3306(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: if the services performed during more than one-half of any such
+            pay period by an employee for the person employing him do not constitute
+            employment
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: then none of the services of such employee for such period shall
+            be deemed to be employment
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: This subsection shall not be applicable with respect to services
+            performed in a pay period by an employee for the person employing him,
+            where any of such service is excepted by subsection (c)(9).
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/d#pay_period_for_included_and_excluded_service
+          output: pay_period_for_included_and_excluded_service
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/c#one_half_services_threshold
+          output: one_half_services_threshold
+          hash: sha256:52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment
+          output: railroad_employee_or_employee_representative_service_excepted_from_employment
+          hash: sha256:25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'pay_period_for_included_and_excluded_service
+
+      and services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction
+      > one_half_services_threshold
+
+      and not railroad_employee_or_employee_representative_service_excepted_from_employment'


### PR DESCRIPTION
## Summary\n- add generated 26 USC 3306(d) FUTA included/excluded service pay-period deeming rules\n- add companion tests for employment-service, nonemployment-service, subsection (c)(9), and over-31-day pay-period cases\n- add signed axiom-encode apply manifest\n\n## Provenance\n- Generated with axiom-encode 0.2.263 from merged encoder commit 169172970860a3cd8c85d2203d434bacfa0f05f5\n- Run ID: ff080956\n- Model/backend: gpt-5.5 / codex\n- Encoder follow-up #278 classifies 3306(d) PolicyEngine coverage as known-not-comparable; no RuleSpec artifact changes\n\n## Validation\n- uv run axiom-encode validate /private/tmp/rulespec-us-3306-d-20260526/statutes/26/3306/d.yaml --skip-reviewers\n- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-d-20260526/statutes/26/3306/d.yaml\n- uv run axiom-encode test --root /private/tmp/rulespec-us-3306-d-20260526 --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 /private/tmp/rulespec-us-3306-d-20260526/statutes/26/3306/d.test.yaml\n- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-d-20260526 --base-ref origin/main --head-ref HEAD\n- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-coverage-3306-d --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20