### PR TITLE
Add generated 3306(a) FUTA employer rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/a.yaml",
+      "sha256": "e468d76c46a42e3ca18a424aa92b89bad8062aba265dbd55f7669e0ad34c31fe"
+    },
+    {
+      "path": "statutes/26/3306/a.test.yaml",
+      "sha256": "ef83f3786dd5700d4fa6eff9e88107aede9408548e1d14f48562f61c33f0f581"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c477dfdcf8d7d2c0568e4f2205c9f14f4068f86e",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.264",
+    "version_commit": "c477dfdcf8d7d2c0568e4f2205c9f14f4068f86e"
+  },
+  "axiom_encode_version": "0.2.264",
+  "backend": "codex",
+  "citation": "26 USC 3306(a)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-a-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "a8ea4e5a982601d7e0180da5501943eebbb58e59f1eebc50a1fdbfe773d14395",
+  "generated_at": "2026-05-26T06:48:57.891879+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-a-20260526/codex-gpt-5.5/statutes/26/3306/a.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-a-20260526",
+  "generated_output_sha256": "e468d76c46a42e3ca18a424aa92b89bad8062aba265dbd55f7669e0ad34c31fe",
+  "generation_prompt_sha256": "d291ea5d25a25d0503c09dafff87d6a5b2571048506e4d3d2efa7cce880fed58",
+  "model": "gpt-5.5",
+  "run_id": "7a73eff7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ecb5816dedb8c4ea14ebe6c4cc09be1d24b510ef399e20cac443d0f4cf463d2b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-a-20260526/traces/codex-gpt-5.5/26-USC-3306-a.json",
+  "trace_sha256": "0c3b960d212e49a23411477fe2b03ca9a3a0ff150f32b8a24ea5f0470d74a517"
+}

--- a/statutes/26/3306/a.test.yaml
+++ b/statutes/26/3306/a.test.yaml
@@ -1,0 +1,84 @@
+- name: general_and_agricultural_wage_thresholds
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/a#input.maximum_wages_paid_in_a_calendar_quarter_current_or_preceding_year_excluding_domestic_service: 1500
+    us:statutes/26/3306/a#input.general_employment_days_in_current_or_preceding_year_different_calendar_weeks: 0
+    ? us:statutes/26/3306/a#input.minimum_individuals_employed_in_employment_on_each_general_counted_day_excluding_domestic_service
+    : 0
+    us:statutes/26/3306/a#input.maximum_agricultural_labor_wages_paid_in_a_calendar_quarter_current_or_preceding_year: 20000
+    us:statutes/26/3306/a#input.agricultural_labor_employment_days_in_current_or_preceding_year_different_calendar_weeks: 0
+    us:statutes/26/3306/a#input.minimum_individuals_employed_in_agricultural_labor_on_each_counted_day: 0
+    ? us:statutes/26/3306/a#input.maximum_cash_wages_paid_for_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority_in_a_calendar_quarter_current_or_preceding_year
+    : 0
+  output:
+    us:statutes/26/3306/a#employer_under_general_rule: holds
+    us:statutes/26/3306/a#employer_for_agricultural_labor: holds
+    us:statutes/26/3306/a#employer_for_domestic_service: not_holds
+    us:statutes/26/3306/a#employer_with_respect_to_service_other_than_domestic_service: holds
+    us:statutes/26/3306/a#employer: holds
+- name: general_employment_day_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/a#input.maximum_wages_paid_in_a_calendar_quarter_current_or_preceding_year_excluding_domestic_service: 1499
+    us:statutes/26/3306/a#input.general_employment_days_in_current_or_preceding_year_different_calendar_weeks: 20
+    ? us:statutes/26/3306/a#input.minimum_individuals_employed_in_employment_on_each_general_counted_day_excluding_domestic_service
+    : 1
+    us:statutes/26/3306/a#input.maximum_agricultural_labor_wages_paid_in_a_calendar_quarter_current_or_preceding_year: 19999
+    us:statutes/26/3306/a#input.agricultural_labor_employment_days_in_current_or_preceding_year_different_calendar_weeks: 0
+    us:statutes/26/3306/a#input.minimum_individuals_employed_in_agricultural_labor_on_each_counted_day: 0
+    ? us:statutes/26/3306/a#input.maximum_cash_wages_paid_for_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority_in_a_calendar_quarter_current_or_preceding_year
+    : 999
+  output:
+    us:statutes/26/3306/a#employer_under_general_rule: holds
+    us:statutes/26/3306/a#employer_for_agricultural_labor: not_holds
+    us:statutes/26/3306/a#employer_for_domestic_service: not_holds
+    us:statutes/26/3306/a#employer_with_respect_to_service_other_than_domestic_service: holds
+    us:statutes/26/3306/a#employer: holds
+- name: agricultural_labor_employment_day_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/a#input.maximum_wages_paid_in_a_calendar_quarter_current_or_preceding_year_excluding_domestic_service: 1499
+    us:statutes/26/3306/a#input.general_employment_days_in_current_or_preceding_year_different_calendar_weeks: 0
+    ? us:statutes/26/3306/a#input.minimum_individuals_employed_in_employment_on_each_general_counted_day_excluding_domestic_service
+    : 0
+    us:statutes/26/3306/a#input.maximum_agricultural_labor_wages_paid_in_a_calendar_quarter_current_or_preceding_year: 19999
+    us:statutes/26/3306/a#input.agricultural_labor_employment_days_in_current_or_preceding_year_different_calendar_weeks: 20
+    us:statutes/26/3306/a#input.minimum_individuals_employed_in_agricultural_labor_on_each_counted_day: 10
+    ? us:statutes/26/3306/a#input.maximum_cash_wages_paid_for_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority_in_a_calendar_quarter_current_or_preceding_year
+    : 999
+  output:
+    us:statutes/26/3306/a#employer_under_general_rule: not_holds
+    us:statutes/26/3306/a#employer_for_agricultural_labor: holds
+    us:statutes/26/3306/a#employer_for_domestic_service: not_holds
+    us:statutes/26/3306/a#employer_with_respect_to_service_other_than_domestic_service: holds
+    us:statutes/26/3306/a#employer: holds
+- name: domestic_service_only_does_not_create_non_domestic_employer_status
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/a#input.maximum_wages_paid_in_a_calendar_quarter_current_or_preceding_year_excluding_domestic_service: 1499
+    us:statutes/26/3306/a#input.general_employment_days_in_current_or_preceding_year_different_calendar_weeks: 19
+    ? us:statutes/26/3306/a#input.minimum_individuals_employed_in_employment_on_each_general_counted_day_excluding_domestic_service
+    : 1
+    us:statutes/26/3306/a#input.maximum_agricultural_labor_wages_paid_in_a_calendar_quarter_current_or_preceding_year: 19999
+    us:statutes/26/3306/a#input.agricultural_labor_employment_days_in_current_or_preceding_year_different_calendar_weeks: 19
+    us:statutes/26/3306/a#input.minimum_individuals_employed_in_agricultural_labor_on_each_counted_day: 10
+    ? us:statutes/26/3306/a#input.maximum_cash_wages_paid_for_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority_in_a_calendar_quarter_current_or_preceding_year
+    : 1000
+  output:
+    us:statutes/26/3306/a#employer_under_general_rule: not_holds
+    us:statutes/26/3306/a#employer_for_agricultural_labor: not_holds
+    us:statutes/26/3306/a#employer_for_domestic_service: holds
+    us:statutes/26/3306/a#employer_with_respect_to_service_other_than_domestic_service: not_holds
+    us:statutes/26/3306/a#employer: holds

--- a/statutes/26/3306/a.yaml
+++ b/statutes/26/3306/a.yaml
@@ -1,0 +1,232 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (a) Employer ... (1) ... paid wages of $1,500 or more, or ... 20 days ... employed at least one individual ... domestic services ... not be taken into account. (2) Agricultural labor ... paid wages of $20,000 or more ... 20 days ... at least 10 individuals. (3) Domestic service ... paid wages in cash of $1,000 or more. (4) Special rule ... paragraph (3) shall not be treated as an employer with respect to wages paid for any service other than domestic service ... unless ... paragraph (1) or (2).
+rules:
+  - name: general_calendar_quarter_wage_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(a)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid wages of $1,500 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1500
+
+  - name: general_employment_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(a)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on each of some 20 days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: general_individuals_per_employment_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(a)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "employed at least one individual"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1
+
+  - name: agricultural_calendar_quarter_wage_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(a)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid wages of $20,000 or more for agricultural labor"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20000
+
+  - name: agricultural_employment_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(a)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on each of some 20 days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: agricultural_individuals_per_employment_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(a)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "employed at least 10 individuals"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: domestic_service_cash_wage_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3306(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid wages in cash of $1,000 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1000
+
+  - name: employer_under_general_rule
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_wages_paid_in_a_calendar_quarter_current_or_preceding_year_excluding_domestic_service >= general_calendar_quarter_wage_threshold
+          or (
+            general_employment_days_in_current_or_preceding_year_different_calendar_weeks >= general_employment_day_threshold
+            and minimum_individuals_employed_in_employment_on_each_general_counted_day_excluding_domestic_service >= general_individuals_per_employment_day_threshold
+          )
+
+  - name: employer_for_agricultural_labor
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_agricultural_labor_wages_paid_in_a_calendar_quarter_current_or_preceding_year >= agricultural_calendar_quarter_wage_threshold
+          or (
+            agricultural_labor_employment_days_in_current_or_preceding_year_different_calendar_weeks >= agricultural_employment_day_threshold
+            and minimum_individuals_employed_in_agricultural_labor_on_each_counted_day >= agricultural_individuals_per_employment_day_threshold
+          )
+
+  - name: employer_for_domestic_service
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_cash_wages_paid_for_domestic_service_in_private_home_local_college_club_or_local_chapter_of_college_fraternity_or_sorority_in_a_calendar_quarter_current_or_preceding_year >= domestic_service_cash_wage_threshold
+
+  - name: employer_with_respect_to_service_other_than_domestic_service
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_under_general_rule or employer_for_agricultural_labor
+
+  - name: employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_under_general_rule or employer_for_agricultural_labor or employer_for_domestic_service


### PR DESCRIPTION
## Summary\n- add generated 26 USC 3306(a) FUTA employer-status rules\n- add companion tests for general, agricultural, domestic-service, and special-rule branches\n- add signed axiom-encode apply manifest\n\n## Provenance\n- Generated with axiom-encode 0.2.264 from merged encoder commit c477dfdcf8d7d2c0568e4f2205c9f14f4068f86e\n- Run ID: 7a73eff7\n- Model/backend: gpt-5.5 / codex\n- Encoder follow-up #279 classifies 3306(a) PolicyEngine coverage as known-not-comparable; no RuleSpec artifact changes\n\n## Validation\n- uv run axiom-encode validate /private/tmp/rulespec-us-3306-a-20260526/statutes/26/3306/a.yaml --skip-reviewers\n- uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-a-20260526/statutes/26/3306/a.yaml\n- uv run axiom-encode test --root /private/tmp/rulespec-us-3306-a-20260526 --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 /private/tmp/rulespec-us-3306-a-20260526/statutes/26/3306/a.test.yaml\n- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-a-20260526 --base-ref origin/main --head-ref HEAD\n- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-coverage-3306-a --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20