### PR TITLE
Add generated 26 USC 3306(f) unemployment fund rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/f.yaml",
+      "sha256": "e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b"
+    },
+    {
+      "path": "statutes/26/3306/f.test.yaml",
+      "sha256": "8bec4787ab5b6f4f62aff1bfbb9bc527ed76b27276e3956131ff355445aab36b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.266",
+    "version_commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce"
+  },
+  "axiom_encode_version": "0.2.266",
+  "backend": "codex",
+  "citation": "26 USC 3306(f)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-f-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "1f00d45dad6300d5c05986d28d7a8442243c29a34f8f1cf08c78e5f89c866dda",
+  "generated_at": "2026-05-26T07:29:12.746591+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-f-20260526/codex-gpt-5.5/statutes/26/3306/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-f-20260526",
+  "generated_output_sha256": "e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b",
+  "generation_prompt_sha256": "bb6300aceb11e94ead2f84d858a9170700d846cd88475bcbdadc712a97fe27c2",
+  "model": "gpt-5.5",
+  "run_id": "19911e53",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0d8eb495830ad9c1a78b0213169e9c572ac30aa4171a2e3eb9ea38b5eaa46ade"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-f-20260526/traces/codex-gpt-5.5/26-USC-3306-f.json",
+  "trace_sha256": "8e0e7c16e3259ae65e88f9825b3ffe339a7b092864277554bb3e1eb9048c29c0"
+}

--- a/statutes/26/3306/f.test.yaml
+++ b/statutes/26/3306/f.test.yaml
@@ -1,0 +1,56 @@
+- name: special_state_agency_compensation_fund_is_unemployment_fund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/f#unemployment_fund:
+    - holds
+- name: fund_not_special_under_state_law_is_not_unemployment_fund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: false
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/f#unemployment_fund:
+    - not_holds
+- name: fund_not_administered_by_state_agency_is_not_unemployment_fund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: false
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/f#unemployment_fund:
+    - not_holds
+- name: fund_not_for_payment_of_compensation_is_not_unemployment_fund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: false
+  output:
+    us:statutes/26/3306/f#unemployment_fund:
+    - not_holds

--- a/statutes/26/3306/f.yaml
+++ b/statutes/26/3306/f.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (f) Unemployment fund For purposes of this chapter, the term "unemployment fund" means a special fund, established under a State law and administered by a State agency, for the payment of compensation. ... An unemployment fund shall be deemed to be maintained during a taxable year only if ... no part of the moneys of such fund was expended for any purpose other than [specified permitted purposes and enumerated exceptions].
+  deferred_outputs:
+    - output: us:statutes/26/3306/f#unemployment_fund_maintained
+      source: 26 USC 3306(f), maintained-during-taxable-year sentence and exceptions (1)-(6)
+      reason: Computation of whether an unemployment fund is deemed maintained requires classifying permitted expenditures and exceptions by reference to section 3305(b), Social Security Act sections 903(c)(2), 903(d)(4), and 303(g), and definitions in 26 USC 3306(t) and 26 USC 3306(v), which are not available as copied RuleSpec dependencies for this artifact.
+rules:
+  - name: unemployment_fund
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(f), first sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "the term unemployment fund means a special fund, established under a State law and administered by a State agency, for the payment of compensation"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          fund_is_special_fund_established_under_state_law
+          and fund_administered_by_state_agency
+          and fund_for_payment_of_compensation


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(f), defining `unemployment_fund`
- defer the maintained-fund/expenditure exception chain until the referenced fund-maintenance surfaces are available
- include generated companion tests and signed apply manifest

## Provenance
- axiom-encode 0.2.266
- encoder commit 4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce
- model/backend: gpt-5.5 / codex
- run_id: 19911e53

## Validation
- `uv run axiom-encode validate /private/tmp/rulespec-us-3306-f-20260526/statutes/26/3306/f.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/rulespec-us-3306-f-20260526/statutes/26/3306/f.yaml`
- `uv run axiom-encode test --root /private/tmp/rulespec-us-3306-f-20260526 --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 /private/tmp/rulespec-us-3306-f-20260526/statutes/26/3306/f.test.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/rulespec-us-3306-f-20260526 --base-ref origin/main --head-ref HEAD`
- after encoder #281: `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-3306-f-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`