### PR TITLE
Add generated section 3306(g) contributions rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/g.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/g.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/g.yaml",
+      "sha256": "ee99ed4856c0d0504252d3650ad2c8a1453bf822038415d438089c76120dbb65"
+    },
+    {
+      "path": "statutes/26/3306/g.test.yaml",
+      "sha256": "a2b952569fb6c4fadc154be6d00bb37e61647239e235fcf0e7621a477391f2a5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "84e98c811c25af73fdfbfc5e691f3e2ea61d33bb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.268",
+    "version_commit": "84e98c811c25af73fdfbfc5e691f3e2ea61d33bb"
+  },
+  "axiom_encode_version": "0.2.268",
+  "backend": "codex",
+  "citation": "26 USC 3306(g)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3306-g-final-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "deb47a696771225388209bc5275ff54a0630e5bf3b79955b01f5c14f4727afc6",
+  "generated_at": "2026-05-26T08:25:55.736051+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3306-g-final-20260526/codex-gpt-5.5/statutes/26/3306/g.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3306-g-final-20260526",
+  "generated_output_sha256": "ee99ed4856c0d0504252d3650ad2c8a1453bf822038415d438089c76120dbb65",
+  "generation_prompt_sha256": "d8eefaea3dac4e570bd590adca84ac1a4ef39e994f51f467359b2dbcccf980f8",
+  "model": "gpt-5.5",
+  "run_id": "c6cc95d8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc62cd4ceb097bcd7fff46474cfec8b6b5a6e622bcb6e3cd1b9215c64200b277"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3306-g-final-20260526/traces/codex-gpt-5.5/26-USC-3306-g.json",
+  "trace_sha256": "eabf7b6ef68f88baf9308ea610000c18a6dca25391674a9085898f89ea91debc"
+}

--- a/statutes/26/3306/g.test.yaml
+++ b/statutes/26/3306/g.test.yaml
@@ -1,0 +1,64 @@
+- name: state_required_employment_payment_to_unemployment_fund_counts_to_extent_not_deducted
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/g#input.payment_required_by_state_law_to_be_made_into_destination_fund: true
+    us:statutes/26/3306/g#input.payment_made_by_person_on_account_of_having_individuals_in_employ: true
+    us:statutes/26/3306/g#input.payment_amount_made_by_person: 500
+    us:statutes/26/3306/g#input.payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ: 125
+    us:statutes/26/3306/g#relation.payment_destination_fund:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/g#contributions: 375
+- name: payment_to_non_unemployment_fund_is_not_contributions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/g#input.payment_required_by_state_law_to_be_made_into_destination_fund: true
+    us:statutes/26/3306/g#input.payment_made_by_person_on_account_of_having_individuals_in_employ: true
+    us:statutes/26/3306/g#input.payment_amount_made_by_person: 500
+    us:statutes/26/3306/g#input.payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ: 125
+    us:statutes/26/3306/g#relation.payment_destination_fund:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: false
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/g#contributions: 0
+- name: payment_not_required_by_state_law_is_not_contributions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/g#input.payment_required_by_state_law_to_be_made_into_destination_fund: false
+    us:statutes/26/3306/g#input.payment_made_by_person_on_account_of_having_individuals_in_employ: true
+    us:statutes/26/3306/g#input.payment_amount_made_by_person: 500
+    us:statutes/26/3306/g#input.payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ: 125
+    us:statutes/26/3306/g#relation.payment_destination_fund:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/g#contributions: 0
+- name: payment_not_on_account_of_having_individuals_in_employ_is_not_contributions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/g#input.payment_required_by_state_law_to_be_made_into_destination_fund: true
+    us:statutes/26/3306/g#input.payment_made_by_person_on_account_of_having_individuals_in_employ: false
+    us:statutes/26/3306/g#input.payment_amount_made_by_person: 500
+    us:statutes/26/3306/g#input.payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ: 125
+    us:statutes/26/3306/g#relation.payment_destination_fund:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+  output:
+    us:statutes/26/3306/g#contributions: 0

--- a/statutes/26/3306/g.yaml
+++ b/statutes/26/3306/g.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    (g) Contributions For purposes of this chapter, the term "contributions" means payments required by a State law to be made into an unemployment fund by any person on account of having individuals in his employ, to the extent that such payments are made by him without being deducted or deductible from the remuneration of individuals in his employ.
+imports:
+  - us:statutes/26/3306/f#unemployment_fund
+rules:
+  - name: payment_destination_fund
+    kind: data_relation
+    source: 26 USC 3306(g), "made into an unemployment fund"
+    data_relation:
+      predicate: payment_destination_fund
+      arity: 2
+      arguments: [Payment, Asset]
+
+  - name: contributions
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3306(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/f#unemployment_fund
+              output: unemployment_fund
+              hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if count_where(payment_destination_fund, unemployment_fund) >= 1 and payment_required_by_state_law_to_be_made_into_destination_fund and payment_made_by_person_on_account_of_having_individuals_in_employ: max(0, payment_amount_made_by_person - payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ) else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3306(g) contributions
- add four generated companion tests covering unemployment-fund, state-law, and employment-account gates
- include signed axiom-encode apply manifest from run c6cc95d8

## Provenance
- Generated by axiom-encode 0.2.268 at commit 84e98c811c25af73fdfbfc5e691f3e2ea61d33bb
- Model: gpt-5.5 via codex backend
- RuleSpec files were installed by axiom-encode encode --apply

## Validation
- uv run axiom-encode validate statutes/26/3306/g.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3306/g.yaml
- uv run axiom-encode test --root /private/tmp/axiom-rulespec-3306-g-canonical/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3306/g.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3306-g-canonical/rulespec-us --base-ref origin/main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-3306-g-merged-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20