### PR TITLE
Add generated section 3302(e) successor employer credit rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/e.yaml",
+      "sha256": "a3c176e9028d091f4c99231c50c0fc109a39ebc52fa47fb3c52aa9b8ad6ae8f2"
+    },
+    {
+      "path": "statutes/26/3302/e.test.yaml",
+      "sha256": "552875330f579fab719e69c07131991ee4957695359a1de2af40475494dfc044"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a75bada2bf333bcaa54d126f063fe8403f820d53",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.269",
+    "version_commit": "a75bada2bf333bcaa54d126f063fe8403f820d53"
+  },
+  "axiom_encode_version": "0.2.269",
+  "backend": "codex",
+  "citation": "26 USC 3302(e)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-e-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3302-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "978624b831c980b3b6f295ef90778f6f2e474aa03b227b461128d3dc7807d71c",
+  "generated_at": "2026-05-26T09:15:06.684027+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-e-20260526/codex-gpt-5.5/statutes/26/3302/e.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-e-20260526",
+  "generated_output_sha256": "a3c176e9028d091f4c99231c50c0fc109a39ebc52fa47fb3c52aa9b8ad6ae8f2",
+  "generation_prompt_sha256": "845f8030e31b4557fc9dc779cf3bb3858f0d137dbca246bf22e951112a4102a4",
+  "model": "gpt-5.5",
+  "run_id": "b9323532",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8f0be70c5632ed15b03074d768782635c5cf6a93f001e4f787e9a88677ebc439"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-e-20260526/traces/codex-gpt-5.5/26-USC-3302-e.json",
+  "trace_sha256": "34caacae1767a78bf98b1496b952383063ece22677a872adb15a7df1dd71721e"
+}

--- a/statutes/26/3302/e.test.yaml
+++ b/statutes/26/3302/e.test.yaml
@@ -1,0 +1,64 @@
+- name: successor_credit_allowed_when_acquisition_employment_and_nonemployer_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/e#input.employer_acquired_substantially_all_property_used_in_other_person_trade_or_business_or_separate_unit_during_calendar_year
+    : true
+    ? us:statutes/26/3302/e#input.employer_immediately_after_acquisition_employs_one_or_more_individuals_immediately_previously_employed_by_other_person
+    : true
+    us:statutes/26/3302/e#input.other_person_is_not_employer_for_calendar_year_in_which_acquisition_takes_place: true
+    ? us:statutes/26/3302/e#input.other_person_hypothetical_a_b_and_e_credits_without_subsection_c_for_transferred_individual_remuneration
+    : 1200
+  output:
+    us:statutes/26/3302/e#successor_employer_credit_applies: holds
+    us:statutes/26/3302/e#successor_employer_credit_before_subsection_c_limit: 1200
+- name: no_successor_credit_without_substantially_all_property_acquisition
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/e#input.employer_acquired_substantially_all_property_used_in_other_person_trade_or_business_or_separate_unit_during_calendar_year
+    : false
+    ? us:statutes/26/3302/e#input.employer_immediately_after_acquisition_employs_one_or_more_individuals_immediately_previously_employed_by_other_person
+    : true
+    us:statutes/26/3302/e#input.other_person_is_not_employer_for_calendar_year_in_which_acquisition_takes_place: true
+    ? us:statutes/26/3302/e#input.other_person_hypothetical_a_b_and_e_credits_without_subsection_c_for_transferred_individual_remuneration
+    : 1200
+  output:
+    us:statutes/26/3302/e#successor_employer_credit_applies: not_holds
+    us:statutes/26/3302/e#successor_employer_credit_before_subsection_c_limit: 0
+- name: no_successor_credit_without_immediate_employment_of_transferred_individuals
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/e#input.employer_acquired_substantially_all_property_used_in_other_person_trade_or_business_or_separate_unit_during_calendar_year
+    : true
+    ? us:statutes/26/3302/e#input.employer_immediately_after_acquisition_employs_one_or_more_individuals_immediately_previously_employed_by_other_person
+    : false
+    us:statutes/26/3302/e#input.other_person_is_not_employer_for_calendar_year_in_which_acquisition_takes_place: true
+    ? us:statutes/26/3302/e#input.other_person_hypothetical_a_b_and_e_credits_without_subsection_c_for_transferred_individual_remuneration
+    : 1200
+  output:
+    us:statutes/26/3302/e#successor_employer_credit_applies: not_holds
+    us:statutes/26/3302/e#successor_employer_credit_before_subsection_c_limit: 0
+- name: no_successor_credit_when_other_person_is_employer_for_acquisition_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3302/e#input.employer_acquired_substantially_all_property_used_in_other_person_trade_or_business_or_separate_unit_during_calendar_year
+    : true
+    ? us:statutes/26/3302/e#input.employer_immediately_after_acquisition_employs_one_or_more_individuals_immediately_previously_employed_by_other_person
+    : true
+    us:statutes/26/3302/e#input.other_person_is_not_employer_for_calendar_year_in_which_acquisition_takes_place: false
+    ? us:statutes/26/3302/e#input.other_person_hypothetical_a_b_and_e_credits_without_subsection_c_for_transferred_individual_remuneration
+    : 1200
+  output:
+    us:statutes/26/3302/e#successor_employer_credit_applies: not_holds
+    us:statutes/26/3302/e#successor_employer_credit_before_subsection_c_limit: 0

--- a/statutes/26/3302/e.yaml
+++ b/statutes/26/3302/e.yaml
@@ -1,0 +1,86 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  deferred_outputs:
+    - output: us:statutes/26/3302/e#successor_employer_credit_against_section_3301_tax_after_subsection_c_limits
+      reason: The source makes the successor-employer credit subject to the limits provided by subsection (c). The copied context does not provide a single composable output applying all subsection (c) limits to this subsection's additional credit together with credits under subsections (a) and (b), so the final credit against section 3301 tax is deferred. This file retains the source-stated applicability test and the without-subsection-(c) successor credit amount.
+      source_values:
+        - us:statutes/26/3302/e#successor_employer_credit_applies
+        - us:statutes/26/3302/e#successor_employer_credit_before_subsection_c_limit
+  summary: |-
+    If an employer acquires "substantially all the property used in the trade or business of another person" or a separate unit, immediately employs "one or more individuals" previously employed there, and "such other person is not an employer" for the acquisition year, then, subject to subsection (c), the employer may credit an amount equal to credits that, without regard to subsection (c), would have been allowable to that other person under subsections (a), (b), and (e) for remuneration paid to those individuals.
+rules:
+  - name: successor_employer_credit_applies
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3302(e)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: employer acquires during any calendar year substantially all the property used in the trade or business of another person, or used in a separate unit
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: immediately after the acquisition employs in his trade or business one or more individuals who immediately prior to the acquisition were employed
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: such other person is not an employer for the calendar year in which the acquisition takes place
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_acquired_substantially_all_property_used_in_other_person_trade_or_business_or_separate_unit_during_calendar_year
+          and employer_immediately_after_acquisition_employs_one_or_more_individuals_immediately_previously_employed_by_other_person
+          and other_person_is_not_employer_for_calendar_year_in_which_acquisition_takes_place
+
+  - name: successor_employer_credit_before_subsection_c_limit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3302(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: such employer may credit ... an amount equal to the credits which (without regard to subsection (c)) would have been allowable
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: under subsections (a) and (b) and this subsection for such year, if such other person had been an employer
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3302
+              excerpt: with respect to remuneration subject to contributions under the unemployment compensation law of a State paid by such other person to the individual or individuals described in paragraph (1)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3302/e#successor_employer_credit_applies
+              output: successor_employer_credit_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if successor_employer_credit_applies:
+              max(
+                  0,
+                  other_person_hypothetical_a_b_and_e_credits_without_subsection_c_for_transferred_individual_remuneration
+              )
+          else: 0


### PR DESCRIPTION
## Summary
- add signed/generated RuleSpec for 26 USC 3302(e), successor employer credit rules
- add companion cases for each statutory eligibility condition and the pre-subsection-(c) credit amount
- include generated apply manifest from axiom-encode run b9323532

## Provenance
- generated by axiom-encode 0.2.269 at commit a75bada2bf333bcaa54d126f063fe8403f820d53
- model: gpt-5.5 via codex backend
- PE oracle coverage rerun after encoder #284 merged: comparable=226, known_not_comparable=883, unmapped=0, untested comparable=0

## Checks
- uv run axiom-encode validate statutes/26/3302/e.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3302/e.yaml
- uv run axiom-encode test --root /private/tmp/axiom-rulespec-3302-e-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3302/e.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3302-e-20260526/rulespec-us --base-ref origin/main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-3302-e-merged-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20