### PR TITLE
Add generated 26 USC 3302(f) credit reduction limitation rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3302/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3302/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3302/f.yaml",
+      "sha256": "5b615bfe6d6e378cb79d06275df5fb8459dce9a12926ac89c756d29b3eefd008"
+    },
+    {
+      "path": "statutes/26/3302/f.test.yaml",
+      "sha256": "4dc2021692d0f6501bb588426ec1da2c17c2738624b28720641d1e90f4dce074"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9478d98b3f42d2ded6898b5dfddd5ddb5771c572",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.272",
+    "version_commit": "9478d98b3f42d2ded6898b5dfddd5ddb5771c572"
+  },
+  "axiom_encode_version": "0.2.272",
+  "backend": "openai",
+  "citation": "26 USC 3302(f)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3302-f-openai-post286-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3302-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "ddfb6a8fe8a3ce7f015b5fc2ab5763dbe363d116de6c23c3c75406b56d03ecd9",
+  "generated_at": "2026-05-26T11:05:13.234256+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3302-f-openai-post286-20260526/openai-gpt-5.5/statutes/26/3302/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3302-f-openai-post286-20260526",
+  "generated_output_sha256": "5b615bfe6d6e378cb79d06275df5fb8459dce9a12926ac89c756d29b3eefd008",
+  "generation_prompt_sha256": "fdc8e41f631c607685cef73424784a2777253f9bf591c6ce2fa2912deb0f771d",
+  "model": "gpt-5.5",
+  "run_id": "23b8f9a7",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ff942cca153eeab848dc80b23ec1c1d8a788d71dc83df7e3e2e03f14bc919ab5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3302-f-openai-post286-20260526/traces/openai-gpt-5.5/26-USC-3302-f.json",
+  "trace_sha256": "329dfc97487bdf5f5c52026b64ca8f06504b9a042b66072d758cd883fa015228"
+}

--- a/statutes/26/3302/f.test.yaml
+++ b/statutes/26/3302/f.test.yaml
@@ -1,0 +1,129 @@
+- name: state_meets_requirements_and_credit_reduction_is_capped_by_greater_of_prior_reduction_or_wage_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/f#input.total_contributions_paid_into_state_unemployment_fund_with_respect_to_taxable_year: 500
+    ? us:statutes/26/3302/f#input.total_remuneration_subject_to_contributions_under_state_law_with_respect_to_taxable_year_without_wage_limit
+    : 10000
+    us:statutes/26/3302/f#input.total_compensation_paid_under_state_unemployment_compensation_law_during_calendar_year: 525
+    us:statutes/26/3302/f#input.compensation_for_which_state_is_entitled_to_reimbursement_under_federal_law: 20
+    us:statutes/26/3302/f#input.compensation_attributable_to_services_performed_for_reimbursing_employer: 10
+    us:statutes/26/3302/f#input.interest_paid_during_calendar_year_on_title_xii_advances_to_state: 5
+    ? us:statutes/26/3302/f#input.total_remuneration_subject_to_contributions_under_state_law_with_respect_to_calendar_year_without_remuneration_limit
+    : 10000
+    ? us:statutes/26/3302/f#input.secretary_of_labor_determined_on_or_before_november_10_that_state_meets_requirements_for_taxable_year
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_reducing_unemployment_tax_effort_during_12_month_period_ending_september_30
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_net_decreasing_state_unemployment_compensation_system_solvency_during_12_month_period_ending_september_30
+    : true
+    us:statutes/26/3302/f#input.average_benefit_cost_ratio_for_5_calendar_year_period_ending_before_taxable_year: 0.04
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_taxable_year: 100
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_third_preceding_taxable_year: 120
+    us:statutes/26/3302/f#input.reduction_in_effect_under_subsection_c_2_for_state_for_preceding_taxable_year: 50
+    us:statutes/26/3302/f#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/f#input.credit_reduction_under_subsection_c_2_before_subsection_f: 200
+  output:
+    us:statutes/26/3302/f#credit_reduction_limitation_wage_rate: 0.006
+    us:statutes/26/3302/f#benefit_cost_ratio_rounding_multiple: 0.001
+    us:statutes/26/3302/f#state_unemployment_tax_rate: 0.05
+    us:statutes/26/3302/f#benefit_cost_ratio_before_rounding: 0.05
+    us:statutes/26/3302/f#benefit_cost_ratio: 0.05
+    us:statutes/26/3302/f#state_meets_credit_reduction_limitation_requirements: holds
+    us:statutes/26/3302/f#credit_reduction_limitation_amount: 60
+    us:statutes/26/3302/f#credit_reduction_after_limitation: 60
+- name: state_fails_tax_rate_requirement_so_subsection_c2_reduction_is_not_capped
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/f#input.total_contributions_paid_into_state_unemployment_fund_with_respect_to_taxable_year: 300
+    ? us:statutes/26/3302/f#input.total_remuneration_subject_to_contributions_under_state_law_with_respect_to_taxable_year_without_wage_limit
+    : 10000
+    ? us:statutes/26/3302/f#input.secretary_of_labor_determined_on_or_before_november_10_that_state_meets_requirements_for_taxable_year
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_reducing_unemployment_tax_effort_during_12_month_period_ending_september_30
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_net_decreasing_state_unemployment_compensation_system_solvency_during_12_month_period_ending_september_30
+    : true
+    us:statutes/26/3302/f#input.average_benefit_cost_ratio_for_5_calendar_year_period_ending_before_taxable_year: 0.04
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_taxable_year: 100
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_third_preceding_taxable_year: 120
+    us:statutes/26/3302/f#input.reduction_in_effect_under_subsection_c_2_for_state_for_preceding_taxable_year: 50
+    us:statutes/26/3302/f#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/f#input.credit_reduction_under_subsection_c_2_before_subsection_f: 200
+  output:
+    us:statutes/26/3302/f#state_unemployment_tax_rate: 0.03
+    us:statutes/26/3302/f#state_meets_credit_reduction_limitation_requirements: not_holds
+    us:statutes/26/3302/f#credit_reduction_limitation_amount: 60
+    us:statutes/26/3302/f#credit_reduction_after_limitation: 200
+- name: partial_limitation_subparagraph_a_reduces_credit_reduction_but_not_below_paragraph_1_limitation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/f#input.taxable_year_is_before_partial_limitation_cutoff: true
+    us:statutes/26/3302/f#input.state_would_meet_subsection_f_requirements_but_for_failure_of_paragraph_2_c_or_d: true
+    us:statutes/26/3302/f#input.credit_reduction_is_in_effect_for_taxpayers_in_state_for_taxable_year: true
+    us:statutes/26/3302/f#input.total_contributions_paid_into_state_unemployment_fund_with_respect_to_taxable_year: 300
+    ? us:statutes/26/3302/f#input.total_remuneration_subject_to_contributions_under_state_law_with_respect_to_taxable_year_without_wage_limit
+    : 10000
+    ? us:statutes/26/3302/f#input.secretary_of_labor_determined_on_or_before_november_10_that_state_meets_requirements_for_taxable_year
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_reducing_unemployment_tax_effort_during_12_month_period_ending_september_30
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_net_decreasing_state_unemployment_compensation_system_solvency_during_12_month_period_ending_september_30
+    : true
+    us:statutes/26/3302/f#input.average_benefit_cost_ratio_for_5_calendar_year_period_ending_before_taxable_year: 0.04
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_taxable_year: 100
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_third_preceding_taxable_year: 120
+    us:statutes/26/3302/f#input.state_meets_paragraph_2_a_requirement: false
+    us:statutes/26/3302/f#input.state_meets_paragraph_2_b_requirement: false
+    us:statutes/26/3302/f#input.state_meets_social_security_act_section_1202_b_8_b_requirements_with_respect_to_taxable_year: false
+    us:statutes/26/3302/f#input.reduction_in_effect_under_subsection_c_2_for_state_for_preceding_taxable_year: 50
+    us:statutes/26/3302/f#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/f#input.credit_reduction_under_subsection_c_2_before_subsection_f: 65
+  output:
+    us:statutes/26/3302/f#partial_limitation_reduction_rate_for_subparagraph_a: 0.001
+    us:statutes/26/3302/f#additional_partial_limitation_reduction_rate_for_subparagraph_b: 0.001
+    us:statutes/26/3302/f#partial_limitation_subparagraph_a_applies: holds
+    us:statutes/26/3302/f#partial_limitation_subparagraph_b_applies: not_holds
+    us:statutes/26/3302/f#credit_reduction_limitation_amount: 60
+    us:statutes/26/3302/f#credit_reduction_after_partial_limitation: 60
+- name: partial_limitation_subparagraph_b_additional_reduction_applies_when_paragraph_2_a_b_and_social_security_act_requirement_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3302/f#input.taxable_year_is_before_partial_limitation_cutoff: false
+    us:statutes/26/3302/f#input.state_would_meet_subsection_f_requirements_but_for_failure_of_paragraph_2_c_or_d: false
+    us:statutes/26/3302/f#input.credit_reduction_is_in_effect_for_taxpayers_in_state_for_taxable_year: true
+    us:statutes/26/3302/f#input.total_contributions_paid_into_state_unemployment_fund_with_respect_to_taxable_year: 300
+    ? us:statutes/26/3302/f#input.total_remuneration_subject_to_contributions_under_state_law_with_respect_to_taxable_year_without_wage_limit
+    : 10000
+    ? us:statutes/26/3302/f#input.secretary_of_labor_determined_on_or_before_november_10_that_state_meets_requirements_for_taxable_year
+    : false
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_reducing_unemployment_tax_effort_during_12_month_period_ending_september_30
+    : true
+    ? us:statutes/26/3302/f#input.no_nonpreenactment_state_action_net_decreasing_state_unemployment_compensation_system_solvency_during_12_month_period_ending_september_30
+    : true
+    us:statutes/26/3302/f#input.average_benefit_cost_ratio_for_5_calendar_year_period_ending_before_taxable_year: 0.04
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_taxable_year: 100
+    us:statutes/26/3302/f#input.outstanding_title_xii_advances_balance_on_september_30_of_third_preceding_taxable_year: 120
+    us:statutes/26/3302/f#input.state_meets_paragraph_2_a_requirement: true
+    us:statutes/26/3302/f#input.state_meets_paragraph_2_b_requirement: true
+    us:statutes/26/3302/f#input.state_meets_social_security_act_section_1202_b_8_b_requirements_with_respect_to_taxable_year: true
+    us:statutes/26/3302/f#input.reduction_in_effect_under_subsection_c_2_for_state_for_preceding_taxable_year: 50
+    us:statutes/26/3302/f#input.wages_paid_by_taxpayer_during_taxable_year_attributable_to_state: 10000
+    us:statutes/26/3302/f#input.credit_reduction_under_subsection_c_2_before_subsection_f: 100
+  output:
+    us:statutes/26/3302/f#state_meets_credit_reduction_limitation_requirements: not_holds
+    us:statutes/26/3302/f#partial_limitation_subparagraph_a_applies: not_holds
+    us:statutes/26/3302/f#partial_limitation_subparagraph_b_applies: holds
+    us:statutes/26/3302/f#credit_reduction_limitation_amount: 60
+    us:statutes/26/3302/f#credit_reduction_after_partial_limitation: 90

--- a/statutes/26/3302/f.yaml
+++ b/statutes/26/3302/f.yaml
@@ -1,0 +1,379 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+  summary: In the case of a State meeting paragraph (2), the subsection (c)(2) credit
+    reduction "shall not exceed the greater of" the prior-year reduction or "0.6 percent
+    of the wages" attributable to the State. Paragraph (2) states the Secretary of
+    Labor determination requirements. Paragraph (8) provides partial "0.1 percentage
+    point" reductions, but not below the paragraph (1) limitation.
+rules:
+- name: credit_reduction_limitation_wage_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(f)(1)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: 0.6 percent of the wages
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.006'
+- name: partial_limitation_reduction_rate_for_subparagraph_a
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(f)(8)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: shall be reduced by 0.1 percentage point
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.001'
+- name: additional_partial_limitation_reduction_rate_for_subparagraph_b
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(f)(8)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: further reduced by an additional 0.1 percentage point
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.001'
+- name: benefit_cost_ratio_rounding_multiple
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3302(f)(5)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: nearest multiple of .1 percent
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.001'
+- name: state_unemployment_tax_rate
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: obtained by dividing ... contributions paid ... by ... remuneration
+            subject to contributions
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'total_contributions_paid_into_state_unemployment_fund_with_respect_to_taxable_year
+
+      / total_remuneration_subject_to_contributions_under_state_law_with_respect_to_taxable_year_without_wage_limit'
+- name: benefit_cost_ratio_before_rounding
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(f)(5)(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: determined by dividing ... compensation paid ... and any interest
+            paid ... by ... remuneration subject to contributions
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: compensation shall not be taken into account to the extent
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "(\n    total_compensation_paid_under_state_unemployment_compensation_law_during_calendar_year\n\
+      \    - compensation_for_which_state_is_entitled_to_reimbursement_under_federal_law\n\
+      \    - compensation_attributable_to_services_performed_for_reimbursing_employer\n\
+      \    + interest_paid_during_calendar_year_on_title_xii_advances_to_state\n)\n\
+      / total_remuneration_subject_to_contributions_under_state_law_with_respect_to_calendar_year_without_remuneration_limit"
+- name: benefit_cost_ratio
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3302(f)(5)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: shall be reduced to the nearest multiple of .1 percent
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#benefit_cost_ratio_rounding_multiple
+          output: benefit_cost_ratio_rounding_multiple
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#benefit_cost_ratio_before_rounding
+          output: benefit_cost_ratio_before_rounding
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'floor(benefit_cost_ratio_before_rounding / benefit_cost_ratio_rounding_multiple)
+
+      * benefit_cost_ratio_rounding_multiple'
+- name: state_meets_credit_reduction_limitation_requirements
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3302(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: Secretary of Labor determines (on or before November 10
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: no State action was taken during the 12-month period ending on
+            September 30
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: the State unemployment tax rate ... equals or exceeds the average
+            benefit cost ratio
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: outstanding balance ... was not greater than ... on September 30
+            of the third preceding taxable year
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#state_unemployment_tax_rate
+          output: state_unemployment_tax_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'secretary_of_labor_determined_on_or_before_november_10_that_state_meets_requirements_for_taxable_year
+
+      and no_nonpreenactment_state_action_reducing_unemployment_tax_effort_during_12_month_period_ending_september_30
+
+      and no_nonpreenactment_state_action_net_decreasing_state_unemployment_compensation_system_solvency_during_12_month_period_ending_september_30
+
+      and state_unemployment_tax_rate >= average_benefit_cost_ratio_for_5_calendar_year_period_ending_before_taxable_year
+
+      and outstanding_title_xii_advances_balance_on_september_30_of_taxable_year <=
+      outstanding_title_xii_advances_balance_on_september_30_of_third_preceding_taxable_year'
+- name: credit_reduction_limitation_amount
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3302(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: shall not exceed the greater of
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#credit_reduction_limitation_wage_rate
+          output: credit_reduction_limitation_wage_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n    reduction_in_effect_under_subsection_c_2_for_state_for_preceding_taxable_year,\n\
+      \    credit_reduction_limitation_wage_rate\n    * max(0, wages_paid_by_taxpayer_during_taxable_year_attributable_to_state)\n\
+      )"
+- name: credit_reduction_after_limitation
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3302(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: the reduction under subsection (c)(2) ... shall not exceed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#state_meets_credit_reduction_limitation_requirements
+          output: state_meets_credit_reduction_limitation_requirements
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#credit_reduction_limitation_amount
+          output: credit_reduction_limitation_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if state_meets_credit_reduction_limitation_requirements: min( max(0,
+      credit_reduction_under_subsection_c_2_before_subsection_f), credit_reduction_limitation_amount
+      ) else: max(0, credit_reduction_under_subsection_c_2_before_subsection_f)'
+- name: partial_limitation_subparagraph_a_applies
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3302(f)(8)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: would meet the requirements of this subsection for a taxable year
+            prior to 1986 but for its failure to meet one of the requirements contained
+            in subparagraph (C) or (D)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'taxable_year_is_before_partial_limitation_cutoff
+
+      and state_would_meet_subsection_f_requirements_but_for_failure_of_paragraph_2_c_or_d
+
+      and credit_reduction_is_in_effect_for_taxpayers_in_state_for_taxable_year'
+- name: partial_limitation_subparagraph_b_applies
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3302(f)(8)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: does not meet the requirements of paragraph (2) but meets the requirements
+            of subparagraphs (A) and (B)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: also meets the requirements of section 1202(b)(8)(B) of the Social
+            Security Act
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'not state_meets_credit_reduction_limitation_requirements
+
+      and state_meets_paragraph_2_a_requirement
+
+      and state_meets_paragraph_2_b_requirement
+
+      and state_meets_social_security_act_section_1202_b_8_b_requirements_with_respect_to_taxable_year
+
+      and credit_reduction_is_in_effect_for_taxpayers_in_state_for_taxable_year'
+- name: credit_reduction_after_partial_limitation
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3302(f)(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: shall be reduced by 0.1 percentage point
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: shall be further reduced by an additional 0.1 percentage point
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: In no case shall the application of subparagraphs (A) and (B) reduce
+            ... below the limitation under paragraph (1)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#partial_limitation_reduction_rate_for_subparagraph_a
+          output: partial_limitation_reduction_rate_for_subparagraph_a
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#additional_partial_limitation_reduction_rate_for_subparagraph_b
+          output: additional_partial_limitation_reduction_rate_for_subparagraph_b
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#partial_limitation_subparagraph_a_applies
+          output: partial_limitation_subparagraph_a_applies
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#partial_limitation_subparagraph_b_applies
+          output: partial_limitation_subparagraph_b_applies
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3302/f#credit_reduction_limitation_amount
+          output: credit_reduction_limitation_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n    credit_reduction_limitation_amount,\n    max(0, credit_reduction_under_subsection_c_2_before_subsection_f)\n\
+      \    - (\n        (if partial_limitation_subparagraph_a_applies:\n         \
+      \   partial_limitation_reduction_rate_for_subparagraph_a\n            * max(0,\
+      \ wages_paid_by_taxpayer_during_taxable_year_attributable_to_state)\n      \
+      \  else: 0)\n        + (if partial_limitation_subparagraph_b_applies:\n    \
+      \        additional_partial_limitation_reduction_rate_for_subparagraph_b\n \
+      \           * max(0, wages_paid_by_taxpayer_during_taxable_year_attributable_to_state)\n\
+      \        else: 0)\n    )\n)"


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3302(f) FUTA credit-reduction limitation rules
- add generated companion tests and apply manifest

## Provenance
- generated by `axiom-encode encode '26 USC 3302(f)' --apply`
- run id: `23b8f9a7`
- axiom-encode: `0.2.272` at `9478d98b3f42d2ded6898b5dfddd5ddb5771c572`
- model/backend: `gpt-5.5` via `openai`
- generated files are signed in `.axiom/encoding-manifests/statutes/26/3302/f.json`

## Local checks
From merged axiom-encode `main` after TheAxiomFoundation/axiom-encode#288:
- `uv run axiom-encode validate statutes/26/3302/f.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate statutes/26/3302/f.yaml`
- `uv run axiom-encode test --root rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3302/f.test.yaml`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3302-f-20260526 --oracle policyengine --program tax --json`

## PolicyEngine oracle coverage
- total outputs: 1122
- comparable: 226
- known not comparable: 896
- unmapped: 0
- untested comparable: 0
