### PR TITLE
Refresh generated 26 USC 3241(b) payroll table

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20"
+      "sha256": "12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
@@ -10,44 +10,44 @@
     },
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "c36a57c70aecdeb20efcf49c1e010585607a5011790b34467e22ff1a7a8fc500"
+      "sha256": "3172cbc30360e50af16165a1e7882996ca5de69751edb5ca2ba3639737f3eff6"
     },
     {
       "path": "statutes/26/3211.yaml",
-      "sha256": "e3dbd4938b1c0a8797d0459c476624804d0716c579d6730635ccf3a9a943ca89"
+      "sha256": "a863bcb8dbc1ff22f30c0526d5bfc03c693d38695dac6cdb2927f6b69b959edd"
     },
     {
       "path": "statutes/26/3221.yaml",
-      "sha256": "40cf7f7ae4e094f278416573b412671c47b6c389e3489c63fb7f9989df2f3848"
+      "sha256": "099f43b59c0f599b2eb767b7f22a08105dda6d4e4b200673027b96d4969ebc5c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "e006935ecc6750ab697660f0bafc08a8888b33be",
+    "commit": "606cd9c431649b854e8030aab7d658acf7cde0a8",
     "dirty_tracked": false,
     "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.155",
-    "version_commit": "e006935ecc6750ab697660f0bafc08a8888b33be"
+    "version": "0.2.273",
+    "version_commit": "606cd9c431649b854e8030aab7d658acf7cde0a8"
   },
-  "axiom_encode_version": "0.2.155",
+  "axiom_encode_version": "0.2.273",
   "backend": "openai",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3241b-apply-20260524/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "858aeb8456f9c38204e8a246207e98eabb7b75c39dcc1e715e02049024cb4700",
-  "generated_at": "2026-05-24T19:20:55.471236+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3241b-apply-20260524/openai-gpt-5.5/statutes/26/3241/b.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3241b-apply-20260524",
-  "generated_output_sha256": "83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20",
-  "generation_prompt_sha256": "f615a100bd6d1ed336cbef74a778d28da0732ecf2628ddd3610c5165983d542c",
+  "context_manifest_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "e26b371818e9addcbf72284a8d2cb5771f8bb96d6e4082b8af07bd9ea66c8e45",
+  "generated_at": "2026-05-26T11:41:29.727105+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/openai-gpt-5.5/statutes/26/3241/b.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526",
+  "generated_output_sha256": "12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a",
+  "generation_prompt_sha256": "1f29e104cb5c1385a1beb08c26d07a422baf7aab5bd6d4e51e540c16e0795d10",
   "model": "gpt-5.5",
-  "run_id": "2213422f",
+  "run_id": "ef67b7f9",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "054de4f3216deb6586319d4a06c02e7b9417dcff0df7dd4e13914e151326ca3a"
+    "value": "940caeae4c4b959682e33af3459bc2e52357b8aaadaa39bce9771ce1aec4d336"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3241b-apply-20260524/traces/openai-gpt-5.5/26-USC-3241-b.json",
-  "trace_sha256": "ffb6bcdb7adb5f85af0f232ca94380eea5a6fbc62f30bcfd1dfdf84ddcae2141"
+  "trace_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/traces/openai-gpt-5.5/26-USC-3241-b.json",
+  "trace_sha256": "a861e7776d94d49e893dada9ddac16d4b2b1edab6f4e1db89f8aa2a42013410f"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -36,7 +36,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
               output: applicable_percentage_for_section_3201_b
-              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
+              hash: sha256:12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3211.yaml
+++ b/statutes/26/3211.yaml
@@ -37,7 +37,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
+              hash: sha256:12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3221.yaml
+++ b/statutes/26/3221.yaml
@@ -21,7 +21,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:83a23d029b4b64e6b0c11164cea35b673957ab3e865457fe921412182e959d20
+              hash: sha256:12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3241
   summary: |-
-    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 | 3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1 | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5 | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0 | .............. | 8.2 | 0 |
+    26 USC 3241(b) tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
 rules:
   - name: average_account_benefits_ratio_band
     kind: derived
@@ -17,9 +17,14 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
+            kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
+              excerpt: "Average account benefits ratio: At least / But less than"
+              table:
+                header: Tax rate schedule
+                row_key: Average account benefits ratio
+                column_key: Average account benefits ratio band
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -37,6 +42,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
+              excerpt: "Applicable percentage for sections 3211(b) and 3221(b): 22.1, 18.1, 15.1, 14.1, 13.1, 12.6, 12.1, 11.6, 11.1, 10.1, 9.1, 8.2"
               table:
                 header: Tax rate schedule
                 row_key: Average account benefits ratio
@@ -69,6 +75,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
+              excerpt: "Applicable percentage for section 3201(b): 4.9, 4.4, 3.9, 3.4, 2.9, 1.9, 0.9, 0"
               table:
                 header: Tax rate schedule
                 row_key: Average account benefits ratio
@@ -99,9 +106,17 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3241
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#average_account_benefits_ratio_band
+              output: average_account_benefits_ratio_band
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+              output: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -117,9 +132,17 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3241
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#average_account_benefits_ratio_band
+              output: average_account_benefits_ratio_band
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b_by_ratio_band
+              output: applicable_percentage_for_section_3201_b_by_ratio_band
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- refresh signed generated RuleSpec for 26 USC 3241(b) with current axiom-encode
- update generated dependent import hashes in 26 USC 3201, 3211, and 3221
- keep the companion tests unchanged and passing

## Provenance
- generated by `axiom-encode encode '26 USC 3241(b)' --apply`
- run id: `ef67b7f9`
- axiom-encode: `0.2.273` at `606cd9c431649b854e8030aab7d658acf7cde0a8`
- model/backend: `gpt-5.5` via `openai`
- generated files are signed in `.axiom/encoding-manifests/statutes/26/3241/b.json`

## Local checks
- `uv run axiom-encode validate statutes/26/3241/b.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate statutes/26/3241/b.yaml`
- `uv run axiom-encode test --root rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3241/b.test.yaml`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3241b-current-verify-20260526 --oracle policyengine --program tax --json`

## PolicyEngine oracle coverage
- total outputs: 1122
- comparable: 226
- known not comparable: 896
- unmapped: 0
- untested comparable: 0
