### PR TITLE
Add generated 26 USC 3202 withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3202.json
+++ b/.axiom/encoding-manifests/statutes/26/3202.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3202.yaml",
+      "sha256": "6385ca9f0fa15a3a1dc01150f1fa88b4ed828c59826eacefe973bf33dfeb15a1"
+    },
+    {
+      "path": "statutes/26/3202.test.yaml",
+      "sha256": "b1bb198b0150bf34441714c20224f10ee7c9fdb982ad5211c3eba73969f3dad0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "606cd9c431649b854e8030aab7d658acf7cde0a8",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.273",
+    "version_commit": "606cd9c431649b854e8030aab7d658acf7cde0a8"
+  },
+  "axiom_encode_version": "0.2.273",
+  "backend": "openai",
+  "citation": "26 USC 3202",
+  "context_manifest_file": "/private/tmp/axiom-encode-3202-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3202/workspace/context-manifest.json",
+  "context_manifest_sha256": "7dd8dbcc3b2350d90d1c60f4658497cb1141976ffb2453f85b47dca0ca210e98",
+  "generated_at": "2026-05-26T11:49:59.839856+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3202-20260526/openai-gpt-5.5/statutes/26/3202.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3202-20260526",
+  "generated_output_sha256": "6385ca9f0fa15a3a1dc01150f1fa88b4ed828c59826eacefe973bf33dfeb15a1",
+  "generation_prompt_sha256": "4684848801671e65eba7096d5fa3cb1b8541cced0cfdbd40565549fe0e495d75",
+  "model": "gpt-5.5",
+  "run_id": "3004a277",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a57fc4a92d1b54eb456da3df6a38ec5eabbf1f0094b8dc9fe0fd90b530a8f98b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3202-20260526/traces/openai-gpt-5.5/26-USC-3202.json",
+  "trace_sha256": "36734f4729d34a7f24f01ff891a5046e28509d64f1c1e1b7946d2a240eb04016"
+}

--- a/statutes/26/3202.test.yaml
+++ b/statutes/26/3202.test.yaml
@@ -1,0 +1,48 @@
+- name: tier_2_tax_collected_by_deduction_limited_to_compensation_under_control
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3201#input.compensation_received_for_services_rendered_by_employee_for_calendar_year: 100000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+    us:statutes/26/3202#input.compensation_of_employee_available_for_employer_deduction: 3000
+  output:
+    us:statutes/26/3202#monthly_tip_collection_deadline_day: 10
+    us:statutes/26/3202#quarterly_tip_collection_deadline_day: 30
+    us:statutes/26/3202#tier_2_employee_tax_collectible_by_employer_deduction: 3000
+- name: tier_2_tax_collected_by_deduction_when_compensation_covers_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3201#input.compensation_received_for_services_rendered_by_employee_for_calendar_year: 100000
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.0
+    us:statutes/26/3202#input.compensation_of_employee_available_for_employer_deduction: 6000
+  output:
+    us:statutes/26/3202#tier_2_employee_tax_collectible_by_employer_deduction: 4900
+- name: employer_required_to_deduct_is_liable_and_indemnified_for_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: true
+    us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 1200
+    us:statutes/26/3202#input.amount_of_section_3201_tax_payment_made_by_employer: 1000
+  output:
+    us:statutes/26/3202#employer_section_3201_tax_payment_liability: 1200
+    us:statutes/26/3202#employer_indemnified_section_3201_tax_payment_amount: 1000
+- name: employer_not_required_to_deduct_has_no_section_3202_b_payment_liability_or_indemnified_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: false
+    us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 1200
+    us:statutes/26/3202#input.amount_of_section_3201_tax_payment_made_by_employer: 1000
+  output:
+    us:statutes/26/3202#employer_section_3201_tax_payment_liability: 0
+    us:statutes/26/3202#employer_indemnified_section_3201_tax_payment_amount: 0

--- a/statutes/26/3202.yaml
+++ b/statutes/26/3202.yaml
@@ -1,0 +1,130 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3201#tier_2_employee_tax
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3202
+  deferred_outputs:
+  - output: us:statutes/26/3202#tips_section_3201_tax_collectible_by_employer
+    reason: Tips collection under 26 USC 3202(c) depends on written statements furnished
+      pursuant to section 6053(a) and on the section 3231(e) compensation/tips rules,
+      but no executable RuleSpec context is available for those cited provisions.
+    source_values:
+    - us:statutes/26/3202#monthly_tip_collection_deadline_day
+    - us:statutes/26/3202#quarterly_tip_collection_deadline_day
+  - output: us:statutes/26/3202#group_term_life_insurance_section_3201_tax_paid_by_employee
+    reason: The special rule for group-term life insurance requires determining the
+      section 3201 tax imposed on payments that constitute compensation and coverage
+      periods during which an employment relationship no longer exists. The available
+      section 3201 context exports only an annual tier 2 employee tax and does not
+      provide a payment-scoped section 3201 tax for this subsection.
+  summary: 26 USC 3202(a) requires taxes imposed by section 3201 to be collected by
+    the employer by deducting the amount from employee compensation as paid. Subsection
+    (b) makes an employer required to deduct the tax liable for payment and not liable
+    to any person for such payment. Subsection (c) limits tips collection to written
+    statements under section 6053(a), collectible from compensation under employer
+    control before the 10th day following the month or, under regulations, the 30th
+    day following the quarter; excess uncollected tax is paid by the employee. Subsection
+    (d) provides that subsection (a) does not apply to certain post-employment group-term
+    life insurance compensation, requires separate section 6051 reporting, and makes
+    the employee pay the section 3201 tax on those payments.
+rules:
+- name: monthly_tip_collection_deadline_day
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3202(c)(1), 3202(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3202
+          excerpt: before the close of the 10th day following the calendar month
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '10'
+- name: quarterly_tip_collection_deadline_day
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3202(c)(1), 3202(c)(2), 3202(c)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3202
+          excerpt: the 30th day following the quarter
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '30'
+- name: tier_2_employee_tax_collectible_by_employer_deduction
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3202(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3202
+          excerpt: The taxes imposed by section 3201 shall be collected by the employer
+            of the taxpayer by deducting the amount of the taxes from the compensation
+            of the employee as and when paid.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3201#tier_2_employee_tax
+          output: tier_2_employee_tax
+          hash: sha256:3172cbc30360e50af16165a1e7882996ca5de69751edb5ca2ba3639737f3eff6
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "min(\n    max(0, compensation_of_employee_available_for_employer_deduction),\n\
+      \    max(0, tier_2_employee_tax)\n)"
+- name: employer_section_3201_tax_payment_liability
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3202(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3202
+          excerpt: Every employer required under subsection (a) to deduct the tax
+            shall be liable for the payment of such tax
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if employer_required_under_subsection_a_to_deduct_tax: max(0, tax_required_to_deduct_from_employee_compensation)
+      else: 0'
+- name: employer_indemnified_section_3201_tax_payment_amount
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3202(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3202
+          excerpt: and shall not be liable to any person for the amount of any such
+            payment
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if employer_required_under_subsection_a_to_deduct_tax: max(0, amount_of_section_3201_tax_payment_made_by_employer)
+      else: 0'


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3202 RRTA employee-tax withholding, employer payment liability, indemnification, and tip-collection deadline parameters
- add generated companion tests and apply manifest

## Provenance
- generated by `axiom-encode encode '26 USC 3202' --apply`
- run id: `3004a277`
- axiom-encode: `0.2.273` at `606cd9c431649b854e8030aab7d658acf7cde0a8`
- model/backend: `gpt-5.5` via `openai`
- generated files are signed in `.axiom/encoding-manifests/statutes/26/3202.json`

## Local checks
From merged axiom-encode `main` after TheAxiomFoundation/axiom-encode#289:
- `uv run axiom-encode validate statutes/26/3202.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate statutes/26/3202.yaml`
- `uv run axiom-encode test --root rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3202.test.yaml`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes --json`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3202-20260526 --oracle policyengine --program tax --json`

## PolicyEngine oracle coverage
- total outputs: 1127
- comparable: 226
- known not comparable: 901
- unmapped: 0
- untested comparable: 0
