### PR TITLE
Add generated 26 USC 3212 compensation rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3212.json
+++ b/.axiom/encoding-manifests/statutes/26/3212.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3212.yaml",
+      "sha256": "256e7158daa31128aaf27b3887d3c8c49a4e0f5c0854ff76f180c696a7d88ca3"
+    },
+    {
+      "path": "statutes/26/3212.test.yaml",
+      "sha256": "0c2e430661c490b1a7d2572744c9b72a372f7e6dc5562ae4280688d5b9cf251c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "538eaa3f87fd7c004107ac4f90f7b267e6271217",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.274",
+    "version_commit": "538eaa3f87fd7c004107ac4f90f7b267e6271217"
+  },
+  "axiom_encode_version": "0.2.274",
+  "backend": "openai",
+  "citation": "26 USC 3212",
+  "context_manifest_file": "/private/tmp/axiom-encode-3212-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3212/workspace/context-manifest.json",
+  "context_manifest_sha256": "f05c8eb1c33caefc00149bd24264d8b754f8c5dc1d45076b0517eb6a41744703",
+  "generated_at": "2026-05-26T12:01:27.518933+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3212-20260526/openai-gpt-5.5/statutes/26/3212.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3212-20260526",
+  "generated_output_sha256": "256e7158daa31128aaf27b3887d3c8c49a4e0f5c0854ff76f180c696a7d88ca3",
+  "generation_prompt_sha256": "c1c2b3197e65271966462ccf9a7306966aa3bd7201740e677a14b2baa670b5fd",
+  "model": "gpt-5.5",
+  "run_id": "a5f1baaf",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7fd0939875d2ce3df0ad4d1b88d1f5d01ed8f1280437074ad75f7c10972e489b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3212-20260526/traces/openai-gpt-5.5/26-USC-3212.json",
+  "trace_sha256": "d218609cf360dfcc4c05962c9418e2b6a1d11f2126ed0bde69ba8a0e1de3d099"
+}

--- a/statutes/26/3212.test.yaml
+++ b/statutes/26/3212.test.yaml
@@ -1,0 +1,33 @@
+- name: employee_representative_compensation_counted_when_employed_by_employee_organization
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3212#input.person_is_employee_representative: true
+    us:statutes/26/3212#input.employee_representative_is_employed_by_employee_organization: true
+    us:statutes/26/3212#input.compensation_paid_by_employee_organization_to_employee_representative: 50000
+  output:
+    us:statutes/26/3212#employee_representative_compensation_for_tax_ascertainment: 50000
+- name: non_employee_representative_compensation_not_counted_under_section_3212
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3212#input.person_is_employee_representative: false
+    us:statutes/26/3212#input.employee_representative_is_employed_by_employee_organization: true
+    us:statutes/26/3212#input.compensation_paid_by_employee_organization_to_employee_representative: 50000
+  output:
+    us:statutes/26/3212#employee_representative_compensation_for_tax_ascertainment: 0
+- name: employee_representative_not_employed_by_employee_organization_not_counted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3212#input.person_is_employee_representative: true
+    us:statutes/26/3212#input.employee_representative_is_employed_by_employee_organization: false
+    us:statutes/26/3212#input.compensation_paid_by_employee_organization_to_employee_representative: 50000
+  output:
+    us:statutes/26/3212#employee_representative_compensation_for_tax_ascertainment: 0

--- a/statutes/26/3212.yaml
+++ b/statutes/26/3212.yaml
@@ -1,0 +1,34 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3212
+  summary: The compensation of an employee representative for ascertaining the tax
+    shall be determined as if the employee organization employing the representative
+    were an employer as defined in section 3231(a).
+rules:
+- name: employee_representative_compensation_for_tax_ascertainment
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3212
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3212
+          excerpt: The compensation of an employee representative for the purpose
+            of ascertaining the tax thereon shall be determined in the same manner
+            and with the same effect as if the employee organization by which such
+            employee representative is employed were an employer as defined in section
+            3231(a).
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if person_is_employee_representative and employee_representative_is_employed_by_employee_organization:
+      max(0, compensation_paid_by_employee_organization_to_employee_representative)
+      else: 0'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3212 employee-representative compensation for RRTA tax ascertainment
- add generated companion tests covering counted compensation and two zero branches
- add the signed axiom-encode apply manifest

## Provenance
- generated with `axiom-encode encode --apply`
- run ID: `a5f1baaf`
- model/backend: `gpt-5.5` / `openai`
- generator: axiom-encode `0.2.274` at `538eaa3f87fd7c004107ac4f90f7b267e6271217`
- manifest: `.axiom/encoding-manifests/statutes/26/3212.json`

## Local checks
- `uv run axiom-encode validate statutes/26/3212.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate statutes/26/3212.yaml`
- `uv run axiom-encode test --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3212.test.yaml` (`3 case(s)`)
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3212-20260526/rulespec-us --base-ref origin/main --head-ref HEAD --json`

## Oracle coverage
Rerun from merged axiom-encode main after TheAxiomFoundation/axiom-encode#290:
- total outputs: 1128
- comparable: 226
- known not comparable: 902
- unmapped: 0
- untested comparable: 0
