### PR TITLE
Add generated 26 USC 3231(b) employee rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/b.yaml",
+      "sha256": "c7e0e40d664459a017b924d9e906e8a4dec67854705ff5a037387091825a7294"
+    },
+    {
+      "path": "statutes/26/3231/b.test.yaml",
+      "sha256": "9a3cbef184acc8f014e9b77a65be54e6fa15c2515410adecaf0b850da0b1a8c9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f28a6e9e21f30005e228283a07b71f6d1f54a579",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.277",
+    "version_commit": "f28a6e9e21f30005e228283a07b71f6d1f54a579"
+  },
+  "axiom_encode_version": "0.2.277",
+  "backend": "openai",
+  "citation": "26 USC 3231(b)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231b-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "0d163438df561201791f2ddfa1d94674f9ad2f663864b91b68b3ac9635308e43",
+  "generated_at": "2026-05-26T12:40:05.860477+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231b-20260526/openai-gpt-5.5/statutes/26/3231/b.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231b-20260526",
+  "generated_output_sha256": "c7e0e40d664459a017b924d9e906e8a4dec67854705ff5a037387091825a7294",
+  "generation_prompt_sha256": "0841f63326c78c178e39fe25a029f85be3d0d774754f17c4b45b6d580abca639",
+  "model": "gpt-5.5",
+  "run_id": "c0657382",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d35279aad4149a82a28ae26f1c49cbc8cc68dbc9b1900e1325f889b8aa0b68ee"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231b-20260526/traces/openai-gpt-5.5/26-USC-3231-b.json",
+  "trace_sha256": "4cf37789bafff949b7d4d7916abecf866de7b4b16e9918ce2597402400cbc606"
+}

--- a/statutes/26/3231/b.test.yaml
+++ b/statutes/26/3231/b.test.yaml
@@ -1,0 +1,64 @@
+- name: individual_in_service_for_compensation_is_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/b#input.individual_in_service_of_one_or_more_employers_for_compensation: true
+    us:statutes/26/3231/b#input.officer_of_employer: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_mining_of_coal: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_preparation_of_coal: false
+    ? us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_handling_coal_not_beyond_mine_tipple_other_than_movement_by_rail_with_standard_railroad_locomotives
+    : false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_loading_coal_at_tipple: false
+  output:
+    us:statutes/26/3231/b#coal_physical_operations_exclusion_applies: not_holds
+    us:statutes/26/3231/b#employee: holds
+- name: officer_of_employer_is_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/b#input.individual_in_service_of_one_or_more_employers_for_compensation: false
+    us:statutes/26/3231/b#input.officer_of_employer: true
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_mining_of_coal: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_preparation_of_coal: false
+    ? us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_handling_coal_not_beyond_mine_tipple_other_than_movement_by_rail_with_standard_railroad_locomotives
+    : false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_loading_coal_at_tipple: false
+  output:
+    us:statutes/26/3231/b#coal_physical_operations_exclusion_applies: not_holds
+    us:statutes/26/3231/b#employee: holds
+- name: coal_mining_physical_operations_excluded_from_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/b#input.individual_in_service_of_one_or_more_employers_for_compensation: true
+    us:statutes/26/3231/b#input.officer_of_employer: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_mining_of_coal: true
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_preparation_of_coal: false
+    ? us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_handling_coal_not_beyond_mine_tipple_other_than_movement_by_rail_with_standard_railroad_locomotives
+    : false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_loading_coal_at_tipple: false
+  output:
+    us:statutes/26/3231/b#coal_physical_operations_exclusion_applies: holds
+    us:statutes/26/3231/b#employee: not_holds
+- name: handling_by_standard_railroad_locomotives_not_coal_handling_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/b#input.individual_in_service_of_one_or_more_employers_for_compensation: true
+    us:statutes/26/3231/b#input.officer_of_employer: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_mining_of_coal: false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_preparation_of_coal: false
+    ? us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_handling_coal_not_beyond_mine_tipple_other_than_movement_by_rail_with_standard_railroad_locomotives
+    : false
+    us:statutes/26/3231/b#input.engaged_in_physical_operations_consisting_of_loading_coal_at_tipple: false
+  output:
+    us:statutes/26/3231/b#coal_physical_operations_exclusion_applies: not_holds
+    us:statutes/26/3231/b#employee: holds

--- a/statutes/26/3231/b.yaml
+++ b/statutes/26/3231/b.yaml
@@ -1,0 +1,79 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: |-
+    For purposes of this chapter, “employee” means any individual in the service of one or more employers for compensation, includes an officer of an employer, and excludes an individual while engaged in specified coal mining, preparation, handling, or tipple-loading physical operations.
+rules:
+  - name: coal_physical_operations_exclusion_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(b), third sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "shall not include any individual while such individual is engaged in the physical operations consisting of the mining of coal"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the preparation of coal"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the handling (other than movement by rail with standard railroad locomotives) of coal not beyond the mine tipple"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the loading of coal at the tipple"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          engaged_in_physical_operations_consisting_of_mining_of_coal
+          or engaged_in_physical_operations_consisting_of_preparation_of_coal
+          or engaged_in_physical_operations_consisting_of_handling_coal_not_beyond_mine_tipple_other_than_movement_by_rail_with_standard_railroad_locomotives
+          or engaged_in_physical_operations_consisting_of_loading_coal_at_tipple
+
+  - name: employee
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the term “employee” means any individual in the service of one or more employers for compensation"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "The term “employee” includes an officer of an employer."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/b#coal_physical_operations_exclusion_applies
+              output: coal_physical_operations_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+              individual_in_service_of_one_or_more_employers_for_compensation
+              or officer_of_employer
+          )
+          and not coal_physical_operations_exclusion_applies


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3231(b) RRTA employee definition and coal-operations exclusion
- add generated companion tests for included employee/officer cases and excluded coal physical operations cases
- include the signed encoding manifest for provenance

## Generation
- command: `axiom-encode encode '26 USC 3231(b)' --apply`
- run ID: `c0657382`
- model/backend: `gpt-5.5` / `openai`
- generator: `axiom-encode 0.2.277` at `f28a6e9e21f30005e228283a07b71f6d1f54a579`

## Local checks
Run from merged encoder main after merging the 3231(b) PE oracle classification:
- `uv run axiom-encode validate statutes/26/3231/b.yaml --skip-reviewers` passed
- `uv run axiom-encode proof-validate statutes/26/3231/b.yaml` passed (`7` atoms)
- `uv run axiom-encode test --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3231/b.test.yaml` passed (`4` cases)
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3231b-20260526/rulespec-us --base-ref origin/main --head-ref HEAD --json` passed

## PolicyEngine oracle coverage
Using merged encoder main with the generated 26 USC 3231(b) artifacts:
- total outputs: 1152
- comparable: 226
- known not comparable: 926
- unmapped: 0
- untested comparable: 0
