### PR TITLE
Add generated 26 USC 3231(c) employee representative rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/c.yaml",
+      "sha256": "2b3eb2633ca607d93fd378c954f5368727413ace120fb336481376f949da127d"
+    },
+    {
+      "path": "statutes/26/3231/c.test.yaml",
+      "sha256": "6afd467804bcec96ae7e868910781ceefbf90c97c84994e2ce7c03e1e93660fb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e77be1489e7953220c4b8aa4612effb2ebe01e7c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.278",
+    "version_commit": "e77be1489e7953220c4b8aa4612effb2ebe01e7c"
+  },
+  "axiom_encode_version": "0.2.278",
+  "backend": "openai",
+  "citation": "26 USC 3231(c)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231c-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "9a561810e7ac2abf7f8651b9b738aefa4b18a615e64a21d755fd5da2c12a8247",
+  "generated_at": "2026-05-26T12:50:51.820446+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231c-20260526/openai-gpt-5.5/statutes/26/3231/c.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231c-20260526",
+  "generated_output_sha256": "2b3eb2633ca607d93fd378c954f5368727413ace120fb336481376f949da127d",
+  "generation_prompt_sha256": "69d29ebc71e59f284e137978613476c0f71516eb20deba1775b417fb472e126f",
+  "model": "gpt-5.5",
+  "run_id": "9d22129b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "87dc1e7184034fb528d1477f6ced1988b7da74668a6c5dfd8e049e5f3a540d9f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231c-20260526/traces/openai-gpt-5.5/26-USC-3231-c.json",
+  "trace_sha256": "2a6ff825d6d387a4457a508b0701b09a0dab514a660a0a1b33eaf373e8e5fb43"
+}

--- a/statutes/26/3231/c.test.yaml
+++ b/statutes/26/3231/c.test.yaml
@@ -1,0 +1,114 @@
+- name: railway_labor_officer_representative_is_employee_representative
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: true
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: true
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: true
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : false
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: holds
+    us:statutes/26/3231/c#regularly_assigned_or_employed_individual_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: holds
+- name: labor_organization_included_as_employer_blocks_officer_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: true
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: true
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: true
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: true
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : false
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: not_holds
+- name: non_officer_does_not_satisfy_officer_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: false
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: true
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: true
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : false
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: not_holds
+- name: no_prior_or_later_service_of_employer_blocks_officer_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: true
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: false
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: true
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : false
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: not_holds
+- name: lack_of_railway_labor_act_authorization_blocks_officer_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: true
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: true
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: false
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : false
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: not_holds
+- name: regularly_assigned_individual_is_employee_representative
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: false
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: false
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: false
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : true
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: true
+  output:
+    us:statutes/26/3231/c#railway_labor_officer_representative_qualifies: not_holds
+    us:statutes/26/3231/c#regularly_assigned_or_employed_individual_qualifies: holds
+    us:statutes/26/3231/c#employee_representative: holds
+- name: assigned_individual_not_connected_with_office_duties_does_not_qualify
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/c#input.officer_or_official_representative_of_railway_labor_organization: false
+    us:statutes/26/3231/c#input.railway_labor_organization_included_in_employer_under_subsection_a: false
+    us:statutes/26/3231/c#input.was_in_service_of_employer_under_subsection_a_at_relevant_time: false
+    us:statutes/26/3231/c#input.duly_authorized_and_designated_to_represent_employees_under_railway_labor_act: false
+    ? us:statutes/26/3231/c#input.individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+    : true
+    us:statutes/26/3231/c#input.assignment_or_employment_connected_with_duties_of_officer_or_representative_office: false
+  output:
+    us:statutes/26/3231/c#regularly_assigned_or_employed_individual_qualifies: not_holds
+    us:statutes/26/3231/c#employee_representative: not_holds

--- a/statutes/26/3231/c.yaml
+++ b/statutes/26/3231/c.yaml
@@ -1,0 +1,97 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: |-
+    “employee representative” means an officer or official representative of a railway labor organization, other than a labor organization included in “employer” under subsection (a), who was in the service of such an employer and is duly authorized under the Railway Labor Act, and any individual regularly assigned to or employed by such officer or representative in connection with the duties of his office.
+rules:
+  - name: railway_labor_officer_representative_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(c), officer or official representative clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "any officer or official representative of a railway labor organization"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "other than a labor organization included in the term “employer” as defined in subsection (a)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "was in the service of an employer as defined in subsection (a)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "duly authorized and designated to represent employees in accordance with the Railway Labor Act"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          officer_or_official_representative_of_railway_labor_organization
+          and not railway_labor_organization_included_in_employer_under_subsection_a
+          and was_in_service_of_employer_under_subsection_a_at_relevant_time
+          and duly_authorized_and_designated_to_represent_employees_under_railway_labor_act
+
+  - name: regularly_assigned_or_employed_individual_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(c), assigned or employed individual clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "any individual who is regularly assigned to or regularly employed by such officer or official representative"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "in connection with the duties of his office"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_regularly_assigned_to_or_regularly_employed_by_such_officer_or_official_representative
+          and assignment_or_employment_connected_with_duties_of_officer_or_representative_office
+
+  - name: employee_representative
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/c#railway_labor_officer_representative_qualifies
+              output: railway_labor_officer_representative_qualifies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/c#regularly_assigned_or_employed_individual_qualifies
+              output: regularly_assigned_or_employed_individual_qualifies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          railway_labor_officer_representative_qualifies
+          or regularly_assigned_or_employed_individual_qualifies


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3231(c) RRTA employee-representative definition
- add generated companion tests for regular employee-representative and railway labor officer cases
- include the signed encoding manifest for provenance

## Generation
- command: `axiom-encode encode '26 USC 3231(c)' --apply`
- run ID: `9d22129b`
- model/backend: `gpt-5.5` / `openai`
- generator: `axiom-encode 0.2.278` at `e77be1489e7953220c4b8aa4612effb2ebe01e7c`

## Local checks
Run from merged encoder main after merging the 3231(c) PE oracle classification:
- `uv run axiom-encode validate statutes/26/3231/c.yaml --skip-reviewers` passed
- `uv run axiom-encode proof-validate statutes/26/3231/c.yaml` passed (`8` atoms)
- `uv run axiom-encode test --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3231/c.test.yaml` passed (`7` cases)
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3231c-20260526/rulespec-us --base-ref origin/main --head-ref HEAD --json` passed

## PolicyEngine oracle coverage
Using merged encoder main with the generated 26 USC 3231(c) artifacts:
- total outputs: 1155
- comparable: 226
- known not comparable: 929
- unmapped: 0
- untested comparable: 0
