### PR TITLE
Add generated 26 USC 3231(d) service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/d.yaml",
+      "sha256": "30ca7b9c1a10d4058f8479a39f7d841ce516662c2a6b5a4366d13ff8c78d085d"
+    },
+    {
+      "path": "statutes/26/3231/d.test.yaml",
+      "sha256": "ce92b4ecbde14f871047c249f9a6b26e6a4a9b3f18675c484478627feee3f257"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ffd25222de8d85ecb490ea509c3ed537fe4bf6cb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.279",
+    "version_commit": "ffd25222de8d85ecb490ea509c3ed537fe4bf6cb"
+  },
+  "axiom_encode_version": "0.2.279",
+  "backend": "openai",
+  "citation": "26 USC 3231(d)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231d-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "d174c87596fa58ad04dc9758c1fd00950a60cb63daca057968d5a862de2103e3",
+  "generated_at": "2026-05-26T13:07:42.474139+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231d-20260526/openai-gpt-5.5/statutes/26/3231/d.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231d-20260526",
+  "generated_output_sha256": "30ca7b9c1a10d4058f8479a39f7d841ce516662c2a6b5a4366d13ff8c78d085d",
+  "generation_prompt_sha256": "70305ef1221fcdb3a9048a564a5dbdcb59cf5b43e807b02474202ddb0ab40c61",
+  "model": "gpt-5.5",
+  "run_id": "1385bd18",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c1550e8471b5a466b45c9473287b79632116909ad24a4e79bd16c9b81cd7fc95"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231d-20260526/traces/openai-gpt-5.5/26-USC-3231-d.json",
+  "trace_sha256": "8823bf4add38087c7571d7a4613b535703384a062b1f821e615b5ef468c10a34"
+}

--- a/statutes/26/3231/d.test.yaml
+++ b/statutes/26/3231/d.test.yaml
@@ -1,0 +1,156 @@
+- name: ordinary_supervised_compensated_service_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/d#input.subject_to_continuing_authority_of_employer_to_supervise_and_direct_manner_of_service: true
+    us:statutes/26/3231/d#input.rendering_professional_or_technical_services: false
+    us:statutes/26/3231/d#input.integrated_into_staff_of_employer: false
+    us:statutes/26/3231/d#input.rendering_other_personal_services_on_property_used_in_employer_operations: false
+    us:statutes/26/3231/d#input.rendition_integrated_into_employer_operations: false
+    us:statutes/26/3231/d#input.renders_service_for_compensation: true
+    us:statutes/26/3231/d#input.employer_not_conducting_principal_part_of_business_in_united_states: false
+    us:statutes/26/3231/d#input.employer_is_local_lodge_or_division_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.employer_is_general_committee_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.rendering_service_to_employer_in_united_states: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_members_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    us:statutes/26/3231/d#input.headquarters_of_local_lodge_or_division_located_in_united_states: false
+    us:statutes/26/3231/d#input.representing_local_lodge_or_division_described_in_paragraph_3_or_4: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_individuals_represented_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    ? us:statutes/26/3231/d#input.acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+    : false
+    us:statutes/26/3231/d#input.individual_not_citizen_or_resident_of_united_states: false
+    us:statutes/26/3231/d#input.rendering_service_outside_united_states: false
+    ? us:statutes/26/3231/d#input.employer_required_under_laws_applicable_where_service_rendered_to_employ_citizens_or_residents_of_that_place
+    : false
+  output:
+    us:statutes/26/3231/d#basic_service_conditions_satisfied: holds
+    us:statutes/26/3231/d#non_us_principal_non_labor_organization_employer_service_qualifies: not_holds
+    us:statutes/26/3231/d#local_lodge_or_division_service_qualifies: not_holds
+    us:statutes/26/3231/d#general_committee_service_qualifies: not_holds
+    us:statutes/26/3231/d#noncitizen_nonresident_foreign_required_hire_exception_applies: not_holds
+    us:statutes/26/3231/d#service: holds
+- name: non_us_principal_non_labor_employer_requires_united_states_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/d#input.subject_to_continuing_authority_of_employer_to_supervise_and_direct_manner_of_service: true
+    us:statutes/26/3231/d#input.rendering_professional_or_technical_services: false
+    us:statutes/26/3231/d#input.integrated_into_staff_of_employer: false
+    us:statutes/26/3231/d#input.rendering_other_personal_services_on_property_used_in_employer_operations: false
+    us:statutes/26/3231/d#input.rendition_integrated_into_employer_operations: false
+    us:statutes/26/3231/d#input.renders_service_for_compensation: true
+    us:statutes/26/3231/d#input.employer_not_conducting_principal_part_of_business_in_united_states: true
+    us:statutes/26/3231/d#input.employer_is_local_lodge_or_division_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.employer_is_general_committee_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.rendering_service_to_employer_in_united_states: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_members_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    us:statutes/26/3231/d#input.headquarters_of_local_lodge_or_division_located_in_united_states: false
+    us:statutes/26/3231/d#input.representing_local_lodge_or_division_described_in_paragraph_3_or_4: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_individuals_represented_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    ? us:statutes/26/3231/d#input.acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+    : false
+    us:statutes/26/3231/d#input.individual_not_citizen_or_resident_of_united_states: false
+    us:statutes/26/3231/d#input.rendering_service_outside_united_states: false
+    ? us:statutes/26/3231/d#input.employer_required_under_laws_applicable_where_service_rendered_to_employ_citizens_or_residents_of_that_place
+    : false
+  output:
+    us:statutes/26/3231/d#basic_service_conditions_satisfied: holds
+    us:statutes/26/3231/d#non_us_principal_non_labor_organization_employer_service_qualifies: not_holds
+    us:statutes/26/3231/d#service: not_holds
+- name: foreign_required_hire_exception_blocks_otherwise_qualifying_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/d#input.subject_to_continuing_authority_of_employer_to_supervise_and_direct_manner_of_service: true
+    us:statutes/26/3231/d#input.rendering_professional_or_technical_services: false
+    us:statutes/26/3231/d#input.integrated_into_staff_of_employer: false
+    us:statutes/26/3231/d#input.rendering_other_personal_services_on_property_used_in_employer_operations: false
+    us:statutes/26/3231/d#input.rendition_integrated_into_employer_operations: false
+    us:statutes/26/3231/d#input.renders_service_for_compensation: true
+    us:statutes/26/3231/d#input.employer_not_conducting_principal_part_of_business_in_united_states: false
+    us:statutes/26/3231/d#input.employer_is_local_lodge_or_division_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.employer_is_general_committee_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.rendering_service_to_employer_in_united_states: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_members_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    us:statutes/26/3231/d#input.headquarters_of_local_lodge_or_division_located_in_united_states: false
+    us:statutes/26/3231/d#input.representing_local_lodge_or_division_described_in_paragraph_3_or_4: false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_individuals_represented_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    ? us:statutes/26/3231/d#input.acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+    : false
+    us:statutes/26/3231/d#input.individual_not_citizen_or_resident_of_united_states: true
+    us:statutes/26/3231/d#input.rendering_service_outside_united_states: true
+    ? us:statutes/26/3231/d#input.employer_required_under_laws_applicable_where_service_rendered_to_employ_citizens_or_residents_of_that_place
+    : true
+  output:
+    us:statutes/26/3231/d#basic_service_conditions_satisfied: holds
+    us:statutes/26/3231/d#noncitizen_nonresident_foreign_required_hire_exception_applies: holds
+    us:statutes/26/3231/d#service: not_holds
+- name: general_chairman_mileage_proration_above_minimum_is_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3231/d#input.acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+    : true
+    us:statutes/26/3231/d#input.office_or_headquarters_not_located_in_united_states: true
+    ? us:statutes/26/3231/d#input.individuals_represented_by_general_committee_are_employees_of_employer_not_conducting_principal_part_of_business_in_united_states
+    : true
+    us:statutes/26/3231/d#input.mileage_formula_applicable: true
+    us:statutes/26/3231/d#input.remuneration_for_general_chairman_service: 1000
+    us:statutes/26/3231/d#input.mileage_in_united_states_under_general_committee_jurisdiction: 2
+    us:statutes/26/3231/d#input.total_mileage_under_general_committee_jurisdiction: 10
+    us:statutes/26/3231/d#input.compensation_amount_under_railroad_retirement_board_prescribed_other_formula: 0
+  output:
+    us:statutes/26/3231/d#general_chairman_minimum_compensation_percentage: 0.1
+    us:statutes/26/3231/d#general_chairman_service_remuneration_regarded_as_compensation: 200
+- name: auto_zero_general_chairman_service_remuneration_regarded_as_compensation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3231/d#input.acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+    : false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_individuals_represented_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    ? us:statutes/26/3231/d#input.all_or_substantially_all_members_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+    : false
+    us:statutes/26/3231/d#input.compensation_amount_under_railroad_retirement_board_prescribed_other_formula: 0
+    us:statutes/26/3231/d#input.employer_is_general_committee_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.employer_is_local_lodge_or_division_of_railway_labor_organization_employer: false
+    us:statutes/26/3231/d#input.employer_not_conducting_principal_part_of_business_in_united_states: false
+    ? us:statutes/26/3231/d#input.employer_required_under_laws_applicable_where_service_rendered_to_employ_citizens_or_residents_of_that_place
+    : false
+    us:statutes/26/3231/d#input.headquarters_of_local_lodge_or_division_located_in_united_states: false
+    us:statutes/26/3231/d#input.individual_not_citizen_or_resident_of_united_states: false
+    ? us:statutes/26/3231/d#input.individuals_represented_by_general_committee_are_employees_of_employer_not_conducting_principal_part_of_business_in_united_states
+    : false
+    us:statutes/26/3231/d#input.integrated_into_staff_of_employer: false
+    us:statutes/26/3231/d#input.mileage_formula_applicable: false
+    us:statutes/26/3231/d#input.mileage_in_united_states_under_general_committee_jurisdiction: 0
+    us:statutes/26/3231/d#input.office_or_headquarters_not_located_in_united_states: false
+    us:statutes/26/3231/d#input.remuneration_for_general_chairman_service: 0
+    us:statutes/26/3231/d#input.rendering_other_personal_services_on_property_used_in_employer_operations: false
+    us:statutes/26/3231/d#input.rendering_professional_or_technical_services: false
+    us:statutes/26/3231/d#input.rendering_service_outside_united_states: false
+    us:statutes/26/3231/d#input.rendering_service_to_employer_in_united_states: false
+    us:statutes/26/3231/d#input.renders_service_for_compensation: false
+    us:statutes/26/3231/d#input.rendition_integrated_into_employer_operations: false
+    us:statutes/26/3231/d#input.representing_local_lodge_or_division_described_in_paragraph_3_or_4: false
+    us:statutes/26/3231/d#input.subject_to_continuing_authority_of_employer_to_supervise_and_direct_manner_of_service: false
+    us:statutes/26/3231/d#input.total_mileage_under_general_committee_jurisdiction: 0
+  output:
+    us:statutes/26/3231/d#general_chairman_service_remuneration_regarded_as_compensation: 0

--- a/statutes/26/3231/d.yaml
+++ b/statutes/26/3231/d.yaml
@@ -1,0 +1,230 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: |-
+    For purposes of this chapter, an individual is in the service of an employer if subject to continuing authority, or rendering integrated professional/technical or other personal services, and renders such service for compensation; special only-if rules apply to certain non-U.S.-principal employers, local lodges/divisions, and general committees, with a noncitizen/nonresident foreign-service exception and a general-chairman remuneration proration rule.
+rules:
+  - name: general_chairman_minimum_compensation_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3231(d)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "less than 10 percent of his remuneration for such service"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.10
+
+  - name: basic_service_conditions_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d), paragraphs (1) and (2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "he renders such service for compensation"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+              subject_to_continuing_authority_of_employer_to_supervise_and_direct_manner_of_service
+              or (
+                  rendering_professional_or_technical_services
+                  and integrated_into_staff_of_employer
+              )
+              or (
+                  rendering_other_personal_services_on_property_used_in_employer_operations
+                  and rendition_integrated_into_employer_operations
+              )
+          )
+          and renders_service_for_compensation
+
+  - name: non_us_principal_non_labor_organization_employer_service_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d), non-U.S.-principal employer clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_not_conducting_principal_part_of_business_in_united_states
+          and not employer_is_local_lodge_or_division_of_railway_labor_organization_employer
+          and not employer_is_general_committee_of_railway_labor_organization_employer
+          and rendering_service_to_employer_in_united_states
+
+  - name: local_lodge_or_division_service_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d), paragraphs (3) and (4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_local_lodge_or_division_of_railway_labor_organization_employer
+          and (
+              all_or_substantially_all_members_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+              or headquarters_of_local_lodge_or_division_located_in_united_states
+          )
+
+  - name: general_committee_service_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d), paragraphs (5), (6), and (7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3231
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_general_committee_of_railway_labor_organization_employer
+          and (
+              representing_local_lodge_or_division_described_in_paragraph_3_or_4
+              or all_or_substantially_all_individuals_represented_are_employees_of_employer_conducting_principal_part_of_business_in_united_states
+              or acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+          )
+
+  - name: noncitizen_nonresident_foreign_required_hire_exception_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d), proviso
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_not_citizen_or_resident_of_united_states
+          and rendering_service_outside_united_states
+          and employer_required_under_laws_applicable_where_service_rendered_to_employ_citizens_or_residents_of_that_place
+
+  - name: service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#basic_service_conditions_satisfied
+              output: basic_service_conditions_satisfied
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#non_us_principal_non_labor_organization_employer_service_qualifies
+              output: non_us_principal_non_labor_organization_employer_service_qualifies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#local_lodge_or_division_service_qualifies
+              output: local_lodge_or_division_service_qualifies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#general_committee_service_qualifies
+              output: general_committee_service_qualifies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#noncitizen_nonresident_foreign_required_hire_exception_applies
+              output: noncitizen_nonresident_foreign_required_hire_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          basic_service_conditions_satisfied
+          and (
+              (
+                  not employer_not_conducting_principal_part_of_business_in_united_states
+                  and not employer_is_local_lodge_or_division_of_railway_labor_organization_employer
+                  and not employer_is_general_committee_of_railway_labor_organization_employer
+              )
+              or non_us_principal_non_labor_organization_employer_service_qualifies
+              or local_lodge_or_division_service_qualifies
+              or general_committee_service_qualifies
+          )
+          and not noncitizen_nonresident_foreign_required_hire_exception_applies
+
+  - name: general_chairman_service_remuneration_regarded_as_compensation
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3231(d)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3231
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/d#general_chairman_minimum_compensation_percentage
+              output: general_chairman_minimum_compensation_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if acts_as_general_chairman_or_assistant_general_chairman_of_general_committee_representing_individuals_rendering_service_in_united_states_to_employer
+             and office_or_headquarters_not_located_in_united_states
+             and individuals_represented_by_general_committee_are_employees_of_employer_not_conducting_principal_part_of_business_in_united_states:
+              if (if mileage_formula_applicable: remuneration_for_general_chairman_service * mileage_in_united_states_under_general_committee_jurisdiction / total_mileage_under_general_committee_jurisdiction else: compensation_amount_under_railroad_retirement_board_prescribed_other_formula) < general_chairman_minimum_compensation_percentage * remuneration_for_general_chairman_service: 0 else: if mileage_formula_applicable: remuneration_for_general_chairman_service * mileage_in_united_states_under_general_committee_jurisdiction / total_mileage_under_general_committee_jurisdiction else: compensation_amount_under_railroad_retirement_board_prescribed_other_formula
+          else:
+              remuneration_for_general_chairman_service


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3231(d) RRTA service definition and exceptions
- add generated companion tests for basic service, foreign-hire exception, local lodge/general committee service, and general chairman compensation treatment
- include the signed encoding manifest for provenance

## Generation
- command: `axiom-encode encode '26 USC 3231(d)' --apply`
- run ID: `1385bd18`
- model/backend: `gpt-5.5` / `openai`
- generator: `axiom-encode 0.2.279` at `ffd25222de8d85ecb490ea509c3ed537fe4bf6cb`
- apply note: encoder auto-repaired the generated zero-branch test before applying the signed artifacts

## Local checks
Run from merged encoder main after merging the 3231(d) PE oracle classification:
- `uv run axiom-encode validate statutes/26/3231/d.yaml --skip-reviewers` passed
- `uv run axiom-encode proof-validate statutes/26/3231/d.yaml` passed (`14` atoms)
- `uv run axiom-encode test --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3231/d.test.yaml` passed (`5` cases)
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3231d-20260526/rulespec-us --base-ref origin/main --head-ref HEAD --json` passed

## PolicyEngine oracle coverage
Using merged encoder main with the generated 26 USC 3231(d) artifacts:
- total outputs: 1163
- comparable: 226
- known not comparable: 937
- unmapped: 0
- untested comparable: 0
