### PR TITLE
Add generated 26 USC 3231(g) carrier rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/g.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/g.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/g.yaml",
+      "sha256": "7cbe9ce218a1cf1352c137176f31b88279f09ea1fa75f1dc3c2880046e2bc764"
+    },
+    {
+      "path": "statutes/26/3231/g.test.yaml",
+      "sha256": "edffe84480a639a7d1952d0201ae19a534f5d473f48c79b3caef227ea85e1832"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a26f6e8365e9079480c087b70ac7b8d48bfa8938",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.280",
+    "version_commit": "a26f6e8365e9079480c087b70ac7b8d48bfa8938"
+  },
+  "axiom_encode_version": "0.2.280",
+  "backend": "openai",
+  "citation": "26 USC 3231(g)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231g-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "7c0ce47dab85e668a817c6abb1ef872d0120f1a2fac192503c8ebbdb4af5994b",
+  "generated_at": "2026-05-26T13:32:59.195814+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231g-20260526/openai-gpt-5.5/statutes/26/3231/g.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231g-20260526",
+  "generated_output_sha256": "7cbe9ce218a1cf1352c137176f31b88279f09ea1fa75f1dc3c2880046e2bc764",
+  "generation_prompt_sha256": "fdd377dafee2c0ef38526a810141a57c9456a1a9b227399380be9a08105bdcd1",
+  "model": "gpt-5.5",
+  "run_id": "0e9ebfc9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d1cdbe5383900d8c97aec6ff68989b74be521f04f0c31ec1a7b1ae354a8c229d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231g-20260526/traces/openai-gpt-5.5/26-USC-3231-g.json",
+  "trace_sha256": "4e9d72a147d811256956fbb62328cd5aa18f9b808485c246338f725b5fbd5f89"
+}

--- a/statutes/26/3231/g.test.yaml
+++ b/statutes/26/3231/g.test.yaml
@@ -1,0 +1,30 @@
+- name: rail_carrier_subject_to_title_49_part_a_is_carrier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/g#input.rail_carrier: true
+    us:statutes/26/3231/g#input.subject_to_part_a_of_subtitle_iv_of_title_49: true
+  output:
+    us:statutes/26/3231/g#carrier: holds
+- name: non_rail_carrier_is_not_carrier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/g#input.rail_carrier: false
+    us:statutes/26/3231/g#input.subject_to_part_a_of_subtitle_iv_of_title_49: true
+  output:
+    us:statutes/26/3231/g#carrier: not_holds
+- name: rail_carrier_not_subject_to_title_49_part_a_is_not_carrier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/g#input.rail_carrier: true
+    us:statutes/26/3231/g#input.subject_to_part_a_of_subtitle_iv_of_title_49: false
+  output:
+    us:statutes/26/3231/g#carrier: not_holds

--- a/statutes/26/3231/g.yaml
+++ b/statutes/26/3231/g.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: |-
+    For purposes of this chapter, “carrier” means a rail carrier subject to part A of subtitle IV of title 49.
+rules:
+  - name: carrier
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the term “carrier” means a rail carrier subject to part A of subtitle IV of title 49"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          rail_carrier
+          and subject_to_part_a_of_subtitle_iv_of_title_49


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3231(g), defining RRTA carrier status.
- Includes the generated manifest and generated YAML tests.

## Provenance
- Generated with `axiom-encode encode '26 USC 3231(g)' --apply`.
- Run ID: `0e9ebfc9`
- Model/backend: `gpt-5.5` / `openai`
- axiom-encode version: `0.2.280`
- axiom-encode commit: `a26f6e8365e9079480c087b70ac7b8d48bfa8938`

## Validation
- `uv run axiom-encode policyengine-coverage --country us --program tax --policy-repo-path /private/tmp/axiom-rulespec-3231g-20260526/rulespec-us --format json`
  - total outputs: 1164
  - comparable: 226
  - known not comparable: 938
  - unmapped: 0
  - untested comparable: 0
- `uv run axiom-rules validate --root /private/tmp/axiom-rulespec-3231g-20260526/rulespec-us`
- `uv run axiom-rules proof-validate --root /private/tmp/axiom-rulespec-3231g-20260526/rulespec-us`
- `uv run axiom-rules test --root /private/tmp/axiom-rulespec-3231g-20260526/rulespec-us`
- `uv run axiom-encode guard-generated --policy-repo-path /private/tmp/axiom-rulespec-3231g-20260526/rulespec-us`
