### PR TITLE
Add generated 26 USC 3231(f) company rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/f.yaml",
+      "sha256": "b9c13a9ebabd1e1a1627abb472c1b9a9e340c399acab2cda47069165e96d5614"
+    },
+    {
+      "path": "statutes/26/3231/f.test.yaml",
+      "sha256": "bc0a34bec6ac0e16c4807b36d3758fcbbb6a0d6dbbd29c991b6cadfc481438bd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a67465d029dca00eae3a552b33ced00688f1218b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.281",
+    "version_commit": "a67465d029dca00eae3a552b33ced00688f1218b"
+  },
+  "axiom_encode_version": "0.2.281",
+  "backend": "openai",
+  "citation": "26 USC 3231(f)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231f-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "6432a3bceb2d361f16fdee0b2d0b7481a1f2438aa2e489cb9953b96091b1607d",
+  "generated_at": "2026-05-26T13:57:44.198431+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231f-20260526/openai-gpt-5.5/statutes/26/3231/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231f-20260526",
+  "generated_output_sha256": "b9c13a9ebabd1e1a1627abb472c1b9a9e340c399acab2cda47069165e96d5614",
+  "generation_prompt_sha256": "86546a185a47c81fe243251598eacf364c17714b26c779f4bbc1a6a4456710ad",
+  "model": "gpt-5.5",
+  "run_id": "e4e5ece9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "69b5cb5f1e33788f195dda4e17996b0404296a47767efad054c52810042d3a7d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231f-20260526/traces/openai-gpt-5.5/26-USC-3231-f.json",
+  "trace_sha256": "024535e6441427b30a3f5b768d634a8f998c230ae2332beb9e73e0d5573b1182"
+}

--- a/statutes/26/3231/f.test.yaml
+++ b/statutes/26/3231/f.test.yaml
@@ -1,0 +1,44 @@
+- name: corporation_is_company
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/f#input.corporation: true
+    us:statutes/26/3231/f#input.association: false
+    us:statutes/26/3231/f#input.joint_stock_company: false
+  output:
+    us:statutes/26/3231/f#company: holds
+- name: association_is_company
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/f#input.corporation: false
+    us:statutes/26/3231/f#input.association: true
+    us:statutes/26/3231/f#input.joint_stock_company: false
+  output:
+    us:statutes/26/3231/f#company: holds
+- name: joint_stock_company_is_company
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/f#input.corporation: false
+    us:statutes/26/3231/f#input.association: false
+    us:statutes/26/3231/f#input.joint_stock_company: true
+  output:
+    us:statutes/26/3231/f#company: holds
+- name: non_enumerated_business_not_company_under_this_definition
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3231/f#input.corporation: false
+    us:statutes/26/3231/f#input.association: false
+    us:statutes/26/3231/f#input.joint_stock_company: false
+  output:
+    us:statutes/26/3231/f#company: not_holds

--- a/statutes/26/3231/f.yaml
+++ b/statutes/26/3231/f.yaml
@@ -1,0 +1,29 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: |-
+    For purposes of this chapter, “company” includes corporations, associations, and joint-stock companies.
+rules:
+  - name: company
+    kind: derived
+    entity: Business
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3231(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: "the term “company” includes corporations, associations, and joint-stock companies"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          corporation
+          or association
+          or joint_stock_company


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3231(f), defining company status for RRTA purposes.
- Includes the generated manifest and generated YAML tests.

## Provenance
- Generated with `axiom-encode encode '26 USC 3231(f)' --apply`.
- Run ID: `e4e5ece9`
- Model/backend: `gpt-5.5` / `openai`
- axiom-encode version: `0.2.281`
- axiom-encode commit: `a67465d029dca00eae3a552b33ced00688f1218b`

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-rulespec-3231f-20260526/rulespec-us/statutes/26/3231/f.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-rulespec-3231f-20260526/rulespec-us/statutes/26/3231/f.yaml`
- `uv run axiom-encode test /private/tmp/axiom-rulespec-3231f-20260526/rulespec-us/statutes/26/3231/f.test.yaml --root /private/tmp/axiom-rulespec-3231f-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-3231f-20260526/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3231f-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`
  - total outputs: 1165
  - comparable: 226
  - known not comparable: 939
  - unmapped: 0
  - untested comparable: 0

## Dependency
- PolicyEngine coverage classification was added and merged in TheAxiomFoundation/axiom-encode#297 before this PR.
