### PR TITLE
Add generated section 3231(e)(2) contribution base rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3231/e/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3231/e/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3231/e/2.yaml",
+      "sha256": "d70dd5ab9421227cfa2863f346cdbcf76347a0ec48c0f2d379aa52b26d38f4cd"
+    },
+    {
+      "path": "statutes/26/3231/e/2.test.yaml",
+      "sha256": "a001c30c98839de4671bb11b14b6dcc5e57a161c5a092770cbbbc413e31e1292"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "59d105366a5e048378f27226cde8f4f7ce0d4c3b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.286",
+    "version_commit": "59d105366a5e048378f27226cde8f4f7ce0d4c3b"
+  },
+  "axiom_encode_version": "0.2.286",
+  "backend": "openai",
+  "citation": "26 USC 3231(e)(2)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3231-e-2-apply-guarded-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3231-e-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "dc7909360257bc8fe75ffb88abd4a066478d5b6a2ee288c691520b8c9914eebb",
+  "generated_at": "2026-05-26T16:50:19.990599+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3231-e-2-apply-guarded-20260526/openai-gpt-5.5/statutes/26/3231/e/2.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3231-e-2-apply-guarded-20260526",
+  "generated_output_sha256": "d70dd5ab9421227cfa2863f346cdbcf76347a0ec48c0f2d379aa52b26d38f4cd",
+  "generation_prompt_sha256": "05307ffb5a3b6a5e1a2da7369a33e4e06403d2e4bf37fcba865d44773e4a94e6",
+  "model": "gpt-5.5",
+  "run_id": "237fefc0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "71dcd7814c64b45b6c57b82fee06931aa48bf45bd944df0fbac7cacd052e48f6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3231-e-2-apply-guarded-20260526/traces/openai-gpt-5.5/26-USC-3231-e-2.json",
+  "trace_sha256": "b9771d76424fb82415c8c1b737261d0d407ba9a9ab0a7625c1f67cea5b2646ef"
+}

--- a/statutes/26/3231/e/2.test.yaml
+++ b/statutes/26/3231/e/2.test.yaml
@@ -1,0 +1,132 @@
+- name: payment_partly_exceeds_applicable_base
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year
+      : false
+      ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_property_used_in_separate_unit_of_predecessor_trade_or_business_during_calendar_year
+      : false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_successor_immediately_after_acquisition: false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_predecessor_immediately_before_acquisition: false
+      ? us:statutes/26/3231/e/2#input.predecessor_compensation_paid_or_considered_paid_to_individual_before_acquisition_during_calendar_year
+      : 0
+      ? us:statutes/26/3231/e/2#input.compensation_without_clause_i_paid_to_individual_by_employer_during_calendar_year_before_payment
+      : 90000
+      ? us:statutes/26/3231/e/2#input.contribution_and_benefit_base_determined_under_section_230_of_social_security_act_for_calendar_year
+      : 100000
+      us:statutes/26/3231/e/2#input.remuneration_paid_during_calendar_year_to_individual_by_employer_for_services_as_employee: 30000
+      us:statutes/26/3231/e/2#input.remuneration_without_clause_i_treated_as_compensation_under_this_subsection: true
+  output:
+    us:statutes/26/3231/e/2#successor_employer_compensation_base_continuity_applies:
+    - not_holds
+    us:statutes/26/3231/e/2#predecessor_compensation_counted_for_successor_applicable_base:
+    - 0
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 90000
+    us:statutes/26/3231/e/2#remaining_applicable_base_before_payment:
+    - 10000
+    us:statutes/26/3231/e/2#compensation_excess_excluded_before_hospital_insurance_carveout:
+    - 20000
+- name: remuneration_not_otherwise_compensation_is_not_counted_or_excluded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year
+      : false
+      ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_property_used_in_separate_unit_of_predecessor_trade_or_business_during_calendar_year
+      : false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_successor_immediately_after_acquisition: false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_predecessor_immediately_before_acquisition: false
+      ? us:statutes/26/3231/e/2#input.predecessor_compensation_paid_or_considered_paid_to_individual_before_acquisition_during_calendar_year
+      : 0
+      ? us:statutes/26/3231/e/2#input.compensation_without_clause_i_paid_to_individual_by_employer_during_calendar_year_before_payment
+      : 100000
+      ? us:statutes/26/3231/e/2#input.contribution_and_benefit_base_determined_under_section_230_of_social_security_act_for_calendar_year
+      : 100000
+      us:statutes/26/3231/e/2#input.remuneration_paid_during_calendar_year_to_individual_by_employer_for_services_as_employee: 30000
+      us:statutes/26/3231/e/2#input.remuneration_without_clause_i_treated_as_compensation_under_this_subsection: false
+  output:
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 100000
+    us:statutes/26/3231/e/2#remaining_applicable_base_before_payment:
+    - 0
+    us:statutes/26/3231/e/2#compensation_excess_excluded_before_hospital_insurance_carveout:
+    - 0
+- name: successor_trade_or_business_acquisition_counts_predecessor_compensation
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year
+      : true
+      ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_property_used_in_separate_unit_of_predecessor_trade_or_business_during_calendar_year
+      : false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_successor_immediately_after_acquisition: true
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_predecessor_immediately_before_acquisition: true
+      ? us:statutes/26/3231/e/2#input.predecessor_compensation_paid_or_considered_paid_to_individual_before_acquisition_during_calendar_year
+      : 50000
+      ? us:statutes/26/3231/e/2#input.compensation_without_clause_i_paid_to_individual_by_employer_during_calendar_year_before_payment
+      : 60000
+      ? us:statutes/26/3231/e/2#input.contribution_and_benefit_base_determined_under_section_230_of_social_security_act_for_calendar_year
+      : 100000
+      us:statutes/26/3231/e/2#input.remuneration_paid_during_calendar_year_to_individual_by_employer_for_services_as_employee: 20000
+      us:statutes/26/3231/e/2#input.remuneration_without_clause_i_treated_as_compensation_under_this_subsection: true
+  output:
+    us:statutes/26/3231/e/2#successor_employer_compensation_base_continuity_applies:
+    - holds
+    us:statutes/26/3231/e/2#predecessor_compensation_counted_for_successor_applicable_base:
+    - 50000
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 110000
+    us:statutes/26/3231/e/2#remaining_applicable_base_before_payment:
+    - 0
+    us:statutes/26/3231/e/2#compensation_excess_excluded_before_hospital_insurance_carveout:
+    - 20000
+- name: successor_continuity_requires_immediate_successor_service
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year
+      : true
+      ? us:statutes/26/3231/e/2#input.successor_employer_acquired_substantially_all_property_used_in_separate_unit_of_predecessor_trade_or_business_during_calendar_year
+      : false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_successor_immediately_after_acquisition: false
+      us:statutes/26/3231/e/2#input.individual_rendered_services_to_predecessor_immediately_before_acquisition: true
+      ? us:statutes/26/3231/e/2#input.predecessor_compensation_paid_or_considered_paid_to_individual_before_acquisition_during_calendar_year
+      : 50000
+      ? us:statutes/26/3231/e/2#input.compensation_without_clause_i_paid_to_individual_by_employer_during_calendar_year_before_payment
+      : 60000
+      ? us:statutes/26/3231/e/2#input.contribution_and_benefit_base_determined_under_section_230_of_social_security_act_for_calendar_year
+      : 100000
+      us:statutes/26/3231/e/2#input.remuneration_paid_during_calendar_year_to_individual_by_employer_for_services_as_employee: 20000
+      us:statutes/26/3231/e/2#input.remuneration_without_clause_i_treated_as_compensation_under_this_subsection: true
+  output:
+    us:statutes/26/3231/e/2#successor_employer_compensation_base_continuity_applies:
+    - not_holds
+    us:statutes/26/3231/e/2#predecessor_compensation_counted_for_successor_applicable_base:
+    - 0
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 60000
+    us:statutes/26/3231/e/2#remaining_applicable_base_before_payment:
+    - 40000
+    us:statutes/26/3231/e/2#compensation_excess_excluded_before_hospital_insurance_carveout:
+    - 0

--- a/statutes/26/3231/e/2.yaml
+++ b/statutes/26/3231/e/2.yaml
@@ -1,0 +1,186 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  summary: "26 USC 3231(e)(2) excludes from \u201Ccompensation\u201D remuneration\
+    \ paid during a calendar year after the employer has paid remuneration equal to\
+    \ the applicable base, disregards remuneration not otherwise treated as compensation,\
+    \ excepts specified hospital-insurance rate portions, defines the applicable base\
+    \ for tier 1 and tier 2 purposes, and applies the section 3121(a)(1) successor-employer\
+    \ rule with substitutions."
+  deferred_outputs:
+  - output: us:statutes/26/3231/e/2#compensation_excess_excluded_for_section_3201_a_or_3221_a_rate_portion
+    reason: Clause (iii)(I) requires comparing the rate applicable under section 3201(a)
+      or 3221(a) with the rate of tax in effect under section 3101(b). No copied RuleSpec
+      context provides the rates applicable under section 3201(a) or section 3221(a),
+      so the purpose-specific hospital-insurance carve-out cannot be computed faithfully
+      here.
+    blocked_by:
+    - us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate
+  - output: us:statutes/26/3231/e/2#compensation_excess_excluded_for_section_3211_a_rate_portion
+    reason: Clause (iii)(II) requires comparing the rate applicable under section
+      3211(a) with the rate of tax in effect under section 1401(b). No copied RuleSpec
+      context provides the rate applicable under section 3211(a), so the purpose-specific
+      hospital-insurance carve-out cannot be computed faithfully here.
+    blocked_by:
+    - us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+  - output: us:statutes/26/3231/e/2#applicable_base_for_tier_2_taxes_and_average_monthly_compensation
+    reason: Subparagraph (B)(ii) requires applying section 230 of the Social Security
+      Act while disregarding clause (2) of the first sentence and the second sentence
+      of section 230(c). No copied RuleSpec context provides that section 230 computation,
+      so the adjusted tier 2 applicable base is left deferred.
+rules:
+- name: successor_employer_compensation_base_continuity_applies
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3231(e)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: the second sentence of section 3121(a)(1) (relating to successor
+            employers) shall apply
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: "\u201Cservices\u201D shall be substituted for \u201Cemployment\u201D"
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: "\u201Ccompensation\u201D shall be substituted for \u201Cremuneration\u201D"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "(\n    successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year\n\
+      \    or successor_employer_acquired_substantially_all_property_used_in_separate_unit_of_predecessor_trade_or_business_during_calendar_year\n\
+      )\nand individual_rendered_services_to_successor_immediately_after_acquisition\n\
+      and individual_rendered_services_to_predecessor_immediately_before_acquisition"
+- name: predecessor_compensation_counted_for_successor_applicable_base
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3231(e)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: the second sentence of section 3121(a)(1) ... shall apply
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3231/e/2#successor_employer_compensation_base_continuity_applies
+          output: successor_employer_compensation_base_continuity_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if successor_employer_compensation_base_continuity_applies: predecessor_compensation_paid_or_considered_paid_to_individual_before_acquisition_during_calendar_year
+      else: 0'
+- name: compensation_counted_toward_applicable_base_before_payment
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3231(e)(2)(A)(i), (A)(ii), and (C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: after remuneration equal to the applicable base has been paid
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: remuneration which ... is not treated as compensation under this
+            subsection
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3231/e/2#predecessor_compensation_counted_for_successor_applicable_base
+          output: predecessor_compensation_counted_for_successor_applicable_base
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'compensation_without_clause_i_paid_to_individual_by_employer_during_calendar_year_before_payment
+
+      + predecessor_compensation_counted_for_successor_applicable_base'
+- name: remaining_applicable_base_before_payment
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3231(e)(2)(A)(i) and (B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: after remuneration equal to the applicable base has been paid
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: applicable base means ... the contribution and benefit base determined
+            under section 230 of the Social Security Act
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment
+          output: compensation_counted_toward_applicable_base_before_payment
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n    0,\n    contribution_and_benefit_base_determined_under_section_230_of_social_security_act_for_calendar_year\n\
+      \    - compensation_counted_toward_applicable_base_before_payment\n)"
+- name: compensation_excess_excluded_before_hospital_insurance_carveout
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3231(e)(2)(A)(i)-(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: "The term \u201Ccompensation\u201D does not include that part of\
+            \ remuneration"
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3231
+          excerpt: There shall not be taken into account ... remuneration which ...
+            is not treated as compensation
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3231/e/2#remaining_applicable_base_before_payment
+          output: remaining_applicable_base_before_payment
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if remuneration_without_clause_i_treated_as_compensation_under_this_subsection:
+      max(0, remuneration_paid_during_calendar_year_to_individual_by_employer_for_services_as_employee
+      - remaining_applicable_base_before_payment) else: 0'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3231(e)(2) contribution-base mechanics
- cover successor-employer base continuity, counted compensation before a payment, remaining contribution base, and excess compensation excluded before the hospital-insurance carveout
- include generated companion tests and signed axiom-encode apply manifest

## Provenance
- generated with axiom-encode 0.2.286 from commit 59d105366a5e048378f27226cde8f4f7ce0d4c3b
- backend/model: openai / gpt-5.5
- run_id: 237fefc0
- applied files only: statutes/26/3231/e/2.yaml, statutes/26/3231/e/2.test.yaml, .axiom/encoding-manifests/statutes/26/3231/e/2.json

## Validation
- axiom-encode validate statutes/26/3231/e/2.yaml --skip-reviewers: passed
- axiom-encode proof-validate statutes/26/3231/e/2.yaml: passed, 14 atoms checked
- axiom-encode test statutes/26/3231/e/2.test.yaml: passed, 4 cases
- axiom-encode guard-generated: passed with signed apply manifest
- axiom-encode oracle-coverage --oracle policyengine --program tax: no comparable mapped outputs for this section