### PR TITLE
Refresh generated section 3241b payroll table

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a"
+      "sha256": "54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
@@ -10,44 +10,36 @@
     },
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "3172cbc30360e50af16165a1e7882996ca5de69751edb5ca2ba3639737f3eff6"
-    },
-    {
-      "path": "statutes/26/3211.yaml",
-      "sha256": "a863bcb8dbc1ff22f30c0526d5bfc03c693d38695dac6cdb2927f6b69b959edd"
-    },
-    {
-      "path": "statutes/26/3221.yaml",
-      "sha256": "099f43b59c0f599b2eb767b7f22a08105dda6d4e4b200673027b96d4969ebc5c"
+      "sha256": "11b59d83e47e20660a4c5b77c3dd33b3cf603afc25b894f04ff777a078269d7c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "606cd9c431649b854e8030aab7d658acf7cde0a8",
+    "commit": "50fd7ca9a076ff200249272f3cd7d3f97c600c41",
     "dirty_tracked": false,
     "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.273",
-    "version_commit": "606cd9c431649b854e8030aab7d658acf7cde0a8"
+    "version": "0.2.292",
+    "version_commit": "50fd7ca9a076ff200249272f3cd7d3f97c600c41"
   },
-  "axiom_encode_version": "0.2.273",
+  "axiom_encode_version": "0.2.292",
   "backend": "openai",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "e26b371818e9addcbf72284a8d2cb5771f8bb96d6e4082b8af07bd9ea66c8e45",
-  "generated_at": "2026-05-26T11:41:29.727105+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/openai-gpt-5.5/statutes/26/3241/b.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526",
-  "generated_output_sha256": "12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a",
-  "generation_prompt_sha256": "1f29e104cb5c1385a1beb08c26d07a422baf7aab5bd6d4e51e540c16e0795d10",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "44e2d01f110808ec62b12592659e84e9e44216653a861f87ee81781ad869e003",
+  "generated_at": "2026-05-26T19:46:21.052858+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3241/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc",
+  "generation_prompt_sha256": "7a4a1e1f4a086accda26a793cc1bb24fadabd8b1dc89a1ba4502592843ecef19",
   "model": "gpt-5.5",
-  "run_id": "ef67b7f9",
+  "run_id": "e0f7a767",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "940caeae4c4b959682e33af3459bc2e52357b8aaadaa39bce9771ce1aec4d336"
+    "value": "795aea99e13e3928417051feb2738436e63469f11776025a81a4694864856e18"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3241b-current-verify-output-20260526/traces/openai-gpt-5.5/26-USC-3241-b.json",
-  "trace_sha256": "a861e7776d94d49e893dada9ddac16d4b2b1edab6f4e1db89f8aa2a42013410f"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3241-b.json",
+  "trace_sha256": "3a6cf5934f427c824c19d18149dea8a54f18271dd984a3c13380101bdb9ffc8b"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -62,7 +62,7 @@ rules:
         import:
           target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
           output: applicable_percentage_for_section_3201_b
-          hash: sha256:12b52ccf6cdd72b44a0d5c61dc9c1007c1d8f954aeb4265e2e3b68c4208c191a
+          hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
   versions:
   - effective_from: '1990-01-01'
     formula: applicable_percentage_for_section_3201_b

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3241
   summary: |-
-    26 USC 3241(b) tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
+    26 USC 3241(b) Tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
 rules:
   - name: average_account_benefits_ratio_band
     kind: derived
@@ -42,7 +42,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
-              excerpt: "Applicable percentage for sections 3211(b) and 3221(b): 22.1, 18.1, 15.1, 14.1, 13.1, 12.6, 12.1, 11.6, 11.1, 10.1, 9.1, 8.2"
+              excerpt: "22.1, 18.1, 15.1, 14.1, 13.1, 12.6, 12.1, 11.6, 11.1, 10.1, 9.1, 8.2"
               table:
                 header: Tax rate schedule
                 row_key: Average account benefits ratio
@@ -75,7 +75,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
-              excerpt: "Applicable percentage for section 3201(b): 4.9, 4.4, 3.9, 3.4, 2.9, 1.9, 0.9, 0"
+              excerpt: "4.9, 4.9, 4.9, 4.9, 4.9, 4.4, 3.9, 3.4, 2.9, 1.9, 0.9, 0"
               table:
                 header: Tax rate schedule
                 row_key: Average account benefits ratio


### PR DESCRIPTION
## Summary
- refresh generated 26 USC 3241(b) table proof text from axiom-encode main
- update the generated 3201 import hash and apply manifest

## Validation
- uv run axiom-encode validate --skip-reviewers statutes/26/3241/b.yaml
- uv run axiom-encode validate --skip-reviewers statutes/26/3201.yaml
- uv run axiom-encode proof-validate statutes/26/3241/b.yaml
- uv run axiom-encode proof-validate statutes/26/3201.yaml
- uv run axiom-encode test --root .../rulespec-us --axiom-rules-engine-path ... statutes/26/3241/b.test.yaml
- uv run axiom-encode guard-generated --repo .../rulespec-us
- uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20

Oracle coverage: 1,171 executable tax outputs; 226 comparable; 945 known-not-comparable; 0 unmapped; 0 untested comparable.