### PR TITLE
Add generated section 3241a payroll percentages

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3241/a.yaml",
+      "sha256": "7304c244d837fb56f6ec2c53b0d5297ff3c433c9b05cf77ff23f15cc8c42a4cc"
+    },
+    {
+      "path": "statutes/26/3241/a.test.yaml",
+      "sha256": "4a9c13daf84e5c154007af63cea23d05c3e2cf10aa9a7fba3fdf4845da3c5758"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "022fa6d1e1cdb665ee55b91562aaa79742042357",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.293",
+    "version_commit": "022fa6d1e1cdb665ee55b91562aaa79742042357"
+  },
+  "axiom_encode_version": "0.2.293",
+  "backend": "openai",
+  "citation": "26 USC 3241(a)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3241-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "c1540120ea7d201ef9e33691e0200d3746b887514c4d51cd162b0ab35ae775d2",
+  "generated_at": "2026-05-26T20:14:43.490703+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3241/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7304c244d837fb56f6ec2c53b0d5297ff3c433c9b05cf77ff23f15cc8c42a4cc",
+  "generation_prompt_sha256": "dca89af0de74034721f7671ad77170bac6fe77b4358cf5e8f4ef490ccb60661c",
+  "model": "gpt-5.5",
+  "run_id": "ac65dff6",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1631deaa16463a9c9cf6c2e041dfbc6932a102e605698d128dc6662acf33da07"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3241-a.json",
+  "trace_sha256": "c1fa197f4afb51c916e10d81b1c74ac50ea9300cb899c61e8284de1002bf498f"
+}

--- a/statutes/26/3241/a.test.yaml
+++ b/statutes/26/3241/a.test.yaml
@@ -1,0 +1,20 @@
+- name: subsection_a_imports_table_percentages_for_low_ratio
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.4
+  output:
+    us:statutes/26/3241/a#applicable_percentage_for_section_3201_b_for_purposes_of_subsection_a: 0.049
+    us:statutes/26/3241/a#applicable_percentage_for_sections_3211_b_and_3221_b_for_purposes_of_subsection_a: 0.221
+- name: subsection_a_imports_table_percentages_for_high_ratio
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 9.0
+  output:
+    us:statutes/26/3241/a#applicable_percentage_for_section_3201_b_for_purposes_of_subsection_a: 0
+    us:statutes/26/3241/a#applicable_percentage_for_sections_3211_b_and_3221_b_for_purposes_of_subsection_a: 0.082

--- a/statutes/26/3241/a.yaml
+++ b/statutes/26/3241/a.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+  summary: |-
+    For purposes of sections 3201(b), 3211(b), and 3221(b), the applicable percentage for any calendar year is determined in accordance with the table in subsection (b).
+imports:
+  - us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
+  - us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
+rules:
+  - name: applicable_percentage_for_section_3201_b_for_purposes_of_subsection_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 3241(a), for purposes of section 3201(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "For purposes of sections 3201(b), 3211(b), and 3221(b), the applicable percentage ... is ... determined ... in subsection (b)."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
+              output: applicable_percentage_for_section_3201_b
+              hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          applicable_percentage_for_section_3201_b
+
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_for_purposes_of_subsection_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 3241(a), for purposes of sections 3211(b) and 3221(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "For purposes of sections 3201(b), 3211(b), and 3221(b), the applicable percentage ... is ... determined ... in subsection (b)."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
+              output: applicable_percentage_for_sections_3211_b_and_3221_b
+              hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          applicable_percentage_for_sections_3211_b_and_3221_b


### PR DESCRIPTION
## Summary
- add generated 26 USC 3241(a) applicable-percentage aliases for sections 3201(b), 3211(b), and 3221(b)
- include generated companion tests and apply manifest from axiom-encode 0.2.293

## Validation
- uv run axiom-encode validate --skip-reviewers statutes/26/3241/a.yaml
- uv run axiom-encode proof-validate statutes/26/3241/a.yaml
- uv run axiom-encode test --root .../rulespec-us --axiom-rules-engine-path ... statutes/26/3241/a.test.yaml
- uv run axiom-encode guard-generated --repo .../rulespec-us
- uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20

Oracle coverage: 1,173 executable tax outputs; 226 comparable; 947 known-not-comparable; 0 unmapped; 0 untested comparable.