### PR TITLE
Add generated section 3111e payroll credit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3111/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3111/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3111/e.yaml",
+      "sha256": "369f7adc6ffcfb6ec0db7223b348f205e0585d9b875aed6cbf3de5f25ed1983d"
+    },
+    {
+      "path": "statutes/26/3111/e.test.yaml",
+      "sha256": "c6ea5ba999ca8f923849105a86d659ecc6b3788723fcfc80526da9511bd7a30a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f5497431a73bc9d67928ec41eddd5902e296617e",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.296",
+    "version_commit": "f5497431a73bc9d67928ec41eddd5902e296617e"
+  },
+  "axiom_encode_version": "0.2.296",
+  "backend": "openai",
+  "citation": "26 USC 3111(e)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3111-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "35e30769729192eeb696c0e2217a5b8975aa834fd75cab7a2df13769479d7f15",
+  "generated_at": "2026-05-26T21:25:11.255200+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3111/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "369f7adc6ffcfb6ec0db7223b348f205e0585d9b875aed6cbf3de5f25ed1983d",
+  "generation_prompt_sha256": "10dc61e69c5835dded87d04aea3aba42d153e68b9ef16f2f658cae8ce1a48994",
+  "model": "gpt-5.5",
+  "run_id": "e6a2c12f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "66cd6bbde175b0fd55e86ad9ae986b0805ede206b4b009696bf683f7857b10e5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3111-e.json",
+  "trace_sha256": "b8e84f6d46c5a963568d07d1a621e0ef03ebc223c3ea7b2c2564e35d09ba5727"
+}

--- a/statutes/26/3111/e.test.yaml
+++ b/statutes/26/3111/e.test.yaml
@@ -1,0 +1,169 @@
+- name: credit_allowed_and_below_subsection_a_tax_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_tax_exempt_organization: holds
+    us:statutes/26/3111/e#section_51_full_rate_after_subsection_e_modification: 0.26
+    us:statutes/26/3111/e#section_51_partial_rate_after_subsection_e_modification: 0.1625
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 3000
+- name: credit_allowed_and_below_subsection_a_tax_limit_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_veteran_for_employment_credit: holds
+    us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account: 20000
+- name: aggregate_credit_limited_to_subsection_a_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 10000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 6200
+- name: organization_not_described_in_section_501_c_is_not_qualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: false
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_tax_exempt_organization: not_holds
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 0
+- name: organization_not_exempt_under_section_501_a_is_not_qualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: false
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_tax_exempt_organization: not_holds
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 0
+- name: no_credit_when_organization_does_not_hire_qualified_veteran
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: false
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 0
+- name: no_credit_when_section_38_by_reason_of_section_51_credit_would_not_be_allowable
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : false
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax: 0
+- name: qualified_veteran_status_and_applicable_period_gate_wages_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: false
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: true
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_veteran_for_employment_credit: not_holds
+    us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account: 0
+- name: wages_outside_applicable_period_are_not_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/e#input.organization_described_in_section_501_c: true
+    us:statutes/26/3111/e#input.organization_exempt_from_taxation_under_section_501_a: true
+    us:statutes/26/3111/e#input.organization_hires_qualified_veteran: true
+    ? us:statutes/26/3111/e#input.credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization
+    : true
+    us:statutes/26/3111/e#input.qualified_veteran_under_section_51_d_3: true
+    us:statutes/26/3111/e#input.wages_paid_during_applicable_period: false
+    us:statutes/26/3111/e#input.wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose: 20000
+    us:statutes/26/3111/e#input.credit_determined_under_section_51_after_subsection_e_modifications: 3000
+    us:statutes/26/3111/a#input.wages: 100000
+  output:
+    us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account: 0

--- a/statutes/26/3111/e.yaml
+++ b/statutes/26/3111/e.yaml
@@ -1,0 +1,181 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3111/a#employer_oasdi_excise_tax
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3111
+  summary: "Credit allowed to a qualified tax-exempt organization that hires a qualified\
+    \ veteran, against subsection (a) tax, equal to the section 51 credit as modified;\
+    \ aggregate credit shall not exceed subsection (a) tax. Section 51 is modified\
+    \ by substituting \u201C26 percent\u201D for \u201C40 percent,\u201D \u201C16.25\
+    \ percent\u201D for \u201C25 percent,\u201D and by only taking into account wages\
+    \ for services furthering the organization\u2019s exempt purpose. Applicable period\
+    \ is the 1-year period beginning when the veteran begins work."
+rules:
+- name: modified_section_51_full_wage_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3111(e)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: "substituting \u201C26 percent\u201D for \u201C40 percent\u201D"
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '0.26'
+- name: modified_section_51_partial_wage_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3111(e)(3)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: "substituting \u201C16.25 percent\u201D for \u201C25 percent\u201D"
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '0.1625'
+- name: applicable_period_years
+  kind: parameter
+  dtype: Count
+  source: 26 USC 3111(e)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: the 1-year period beginning with the day such qualified veteran
+            begins work
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '1'
+- name: qualified_tax_exempt_organization
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3111(e)(5)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3111
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'organization_described_in_section_501_c
+
+      and organization_exempt_from_taxation_under_section_501_a'
+- name: qualified_veteran_for_employment_credit
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3111(e)(5)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3111
+  versions:
+  - effective_from: '2026-01-01'
+    formula: qualified_veteran_under_section_51_d_3
+- name: qualified_veteran_wages_taken_into_account
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(e)(3)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3111
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if qualified_veteran_for_employment_credit and wages_paid_during_applicable_period:
+      wages_paid_to_qualified_veteran_for_services_furthering_exempt_purpose else:
+      0'
+- name: section_51_full_rate_after_subsection_e_modification
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3111(e)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/e#modified_section_51_full_wage_credit_rate
+          output: modified_section_51_full_wage_credit_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2026-01-01'
+    formula: modified_section_51_full_wage_credit_rate
+- name: section_51_partial_rate_after_subsection_e_modification
+  kind: derived
+  entity: Employer
+  dtype: Rate
+  period: Year
+  source: 26 USC 3111(e)(3)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/e#modified_section_51_partial_wage_credit_rate
+          output: modified_section_51_partial_wage_credit_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2026-01-01'
+    formula: modified_section_51_partial_wage_credit_rate
+- name: veteran_employment_credit_against_subsection_a_tax
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(e)(1), (2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/a#employer_oasdi_excise_tax
+          output: employer_oasdi_excise_tax
+          hash: sha256:efb33150d9a178e184a16c1d9fd99bd56e789343f781eedb42228d1359df25ca
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if qualified_tax_exempt_organization and organization_hires_qualified_veteran
+      and credit_would_be_allowable_under_section_38_by_reason_of_section_51_if_organization_were_not_qualified_tax_exempt_organization:
+      min(max(0, credit_determined_under_section_51_after_subsection_e_modifications),
+      employer_oasdi_excise_tax) else: 0'


### PR DESCRIPTION
## Summary
- add generated 26 USC 3111(e) qualified-veteran employment credit rules
- include companion cases for qualification gates, wage gating, modified section 51 rates, and subsection (a) tax cap
- include the encoder apply manifest for generated provenance

## Validation
- uv run axiom-encode validate --skip-reviewers statutes/26/3111/e.yaml
- uv run axiom-encode proof-validate statutes/26/3111/e.yaml
- uv run axiom-encode test --root rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3111/e.test.yaml
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3111e-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20