### PR TITLE
Add generated section 3111f payroll research credit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3111/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3111/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3111/f.yaml",
+      "sha256": "c951fa160b627f8729d6fcf8041d66cca0cfe83a631cc809abb7688d61decfa4"
+    },
+    {
+      "path": "statutes/26/3111/f.test.yaml",
+      "sha256": "4dfecd100adbebcae8a75b2c89fe8ed8588908a66e38e4e2db62a7e1f9ec469b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1064a6f6d6b0b5ea1c81d8ef398767c6b8c05475",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
+    "version": "0.2.297",
+    "version_commit": "1064a6f6d6b0b5ea1c81d8ef398767c6b8c05475"
+  },
+  "axiom_encode_version": "0.2.297",
+  "backend": "openai",
+  "citation": "26 USC 3111(f)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3111-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "f57ad1126ed9d1a1ea941517e832035fdf85e36ded5167a1ff33ed53f5286640",
+  "generated_at": "2026-05-26T21:47:46.229197+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3111/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "c951fa160b627f8729d6fcf8041d66cca0cfe83a631cc809abb7688d61decfa4",
+  "generation_prompt_sha256": "cb4689978f34a8fd791de222d3a95d7ac47c4008b3908a6d1b28289d956dc692",
+  "model": "gpt-5.5",
+  "run_id": "1ee28df4",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5f6a0a1bb5c0a6a183d935a33f0211c26e918a9633704674469490e437c82568"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3111-f.json",
+  "trace_sha256": "6995f6202b02d4b2906af5ace8e340df4de5c71132f21b042f35ada4994a43c4"
+}

--- a/statutes/26/3111/f.test.yaml
+++ b/statutes/26/3111/f.test.yaml
@@ -1,0 +1,88 @@
+- name: first_quarter_credit_split_between_subsection_a_and_b_with_no_tax_limit_excess
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/f#input.election_made_under_section_41_h: true
+    us:statutes/26/3111/f#input.calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed: true
+    us:statutes/26/3111/f#input.payroll_tax_credit_portion_determined_under_section_41_h_2: 10000
+    us:statutes/26/3111/f#input.limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II: 6000
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_a_for_calendar_quarter_on_wages_of_all_employees: 7000
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_b_for_calendar_quarter_on_wages_of_all_employees: 5000
+  output:
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit: 6000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax: 6000
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_a_tax_limit: 0
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit: 4000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax: 4000
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_b_tax_limit: 0
+    us:statutes/26/3111/f#research_credit_amounts_disregarded_for_chapter_1_payroll_tax_deductions: 10000
+- name: quarterly_tax_limits_create_carryovers
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/f#input.election_made_under_section_41_h: true
+    us:statutes/26/3111/f#input.calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed: true
+    us:statutes/26/3111/f#input.payroll_tax_credit_portion_determined_under_section_41_h_2: 10000
+    us:statutes/26/3111/f#input.limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II: 6000
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_a_for_calendar_quarter_on_wages_of_all_employees: 5000
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_b_for_calendar_quarter_on_wages_of_all_employees: 3000
+  output:
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit: 6000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax: 5000
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_a_tax_limit: 1000
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit: 4000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax: 3000
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_b_tax_limit: 1000
+    us:statutes/26/3111/f#research_credit_amounts_disregarded_for_chapter_1_payroll_tax_deductions: 8000
+- name: succeeding_quarter_allows_prior_carryover_without_new_first_quarter_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/f#input.election_made_under_section_41_h: true
+    us:statutes/26/3111/f#input.calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed: false
+    us:statutes/26/3111/f#input.payroll_tax_credit_portion_determined_under_section_41_h_2: 10000
+    us:statutes/26/3111/f#input.limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II: 6000
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter: 1000
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter: 1000
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_a_for_calendar_quarter_on_wages_of_all_employees: 700
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_b_for_calendar_quarter_on_wages_of_all_employees: 1200
+  output:
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit: 1000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax: 700
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_a_tax_limit: 300
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit: 1000
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax: 1000
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_b_tax_limit: 0
+    us:statutes/26/3111/f#research_credit_amounts_disregarded_for_chapter_1_payroll_tax_deductions: 1700
+- name: no_election_allows_only_existing_carryover_amounts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/f#input.election_made_under_section_41_h: false
+    us:statutes/26/3111/f#input.calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed: true
+    us:statutes/26/3111/f#input.payroll_tax_credit_portion_determined_under_section_41_h_2: 10000
+    us:statutes/26/3111/f#input.limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II: 6000
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter: 0
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_a_for_calendar_quarter_on_wages_of_all_employees: 7000
+    us:statutes/26/3111/f#input.tax_imposed_by_subsection_b_for_calendar_quarter_on_wages_of_all_employees: 5000
+  output:
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit: 0
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax: 0
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_a_tax_limit: 0
+    us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit: 0
+    us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax: 0
+    us:statutes/26/3111/f#unused_research_credit_carryover_from_subsection_b_tax_limit: 0
+    us:statutes/26/3111/f#research_credit_amounts_disregarded_for_chapter_1_payroll_tax_deductions: 0

--- a/statutes/26/3111/f.yaml
+++ b/statutes/26/3111/f.yaml
@@ -1,0 +1,252 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3111
+  summary: In the case of a taxpayer who has made an election under section 41(h),
+    credits are allowed against subsection (a) and subsection (b) taxes for the first
+    calendar quarter after the specified return is filed, subject to quarterly tax
+    limitations; excess is carried to the succeeding calendar quarter, and credited
+    amounts are not taken into account for chapter 1 deductions for subsection (a)
+    or (b) taxes.
+rules:
+- name: research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(1)(A), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: taxpayer who has made an election under section 41(h)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: so much of the payroll tax credit portion determined under section
+            41(h)(2) as does not exceed the limitation of subclause (I)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: first calendar quarter which begins after the date on which the
+            taxpayer files the return
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: such excess shall be carried to the succeeding calendar quarter
+            and allowed as a credit under paragraph (1)
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if election_made_under_section_41_h and calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed:
+      min(max(0, payroll_tax_credit_portion_determined_under_section_41_h_2), max(0,
+      limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II)) + max(0,
+      unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter)
+      else: max(0, unused_research_payroll_credit_carried_to_subsection_a_from_prior_calendar_quarter)'
+- name: research_credit_allowed_against_subsection_a_tax
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(1)(A), (2), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+          output: research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: allowed as a credit against the tax imposed by subsection (a)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: shall not exceed the tax imposed by subsection (a) for any calendar
+            quarter
+  versions:
+  - effective_from: '2026-01-01'
+    formula: min(research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit,
+      max(0, tax_imposed_by_subsection_a_for_calendar_quarter_on_wages_of_all_employees))
+- name: unused_research_credit_carryover_from_subsection_a_tax_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(2), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+          output: research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax
+          output: research_credit_allowed_against_subsection_a_tax
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: If the amount of any credit under paragraph (1) exceeds the limitation
+            of paragraph (2) for any calendar quarter, such excess shall be carried
+            to the succeeding calendar quarter
+  versions:
+  - effective_from: '2026-01-01'
+    formula: max(0, research_payroll_credit_portion_for_subsection_a_before_quarterly_tax_limit
+      - research_credit_allowed_against_subsection_a_tax)
+- name: research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(1)(B), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: taxpayer who has made an election under section 41(h)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: as is not allowed as a credit under subparagraph (A)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: first calendar quarter which begins after the date on which the
+            taxpayer files the return
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: such excess shall be carried to the succeeding calendar quarter
+            and allowed as a credit under paragraph (1)
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if election_made_under_section_41_h and calendar_quarter_is_first_after_return_specified_in_section_41_h_4_A_ii_filed:
+      max(0, payroll_tax_credit_portion_determined_under_section_41_h_2 - min(max(0,
+      payroll_tax_credit_portion_determined_under_section_41_h_2), max(0, limitation_under_section_41_h_4_B_i_I_applied_without_subclause_II)))
+      + max(0, unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter)
+      else: max(0, unused_research_payroll_credit_carried_to_subsection_b_from_prior_calendar_quarter)'
+- name: research_credit_allowed_against_subsection_b_tax
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(1)(B), (2), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+          output: research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: allowed as a credit against the tax imposed by subsection (b)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: shall not exceed the tax imposed by subsection (b) for any calendar
+            quarter
+  versions:
+  - effective_from: '2026-01-01'
+    formula: min(research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit,
+      max(0, tax_imposed_by_subsection_b_for_calendar_quarter_on_wages_of_all_employees))
+- name: unused_research_credit_carryover_from_subsection_b_tax_limit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(2), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+          output: research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax
+          output: research_credit_allowed_against_subsection_b_tax
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: If the amount of any credit under paragraph (1) exceeds the limitation
+            of paragraph (2) for any calendar quarter, such excess shall be carried
+            to the succeeding calendar quarter
+  versions:
+  - effective_from: '2026-01-01'
+    formula: max(0, research_payroll_credit_portion_for_subsection_b_before_quarterly_tax_limit
+      - research_credit_allowed_against_subsection_b_tax)
+- name: research_credit_amounts_disregarded_for_chapter_1_payroll_tax_deductions
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3111(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax
+          output: research_credit_allowed_against_subsection_a_tax
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/f#research_credit_allowed_against_subsection_b_tax
+          output: research_credit_allowed_against_subsection_b_tax
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3111
+          excerpt: credits allowed under paragraph (1) shall not be taken into account
+            for purposes of determining the amount of any deduction allowed under
+            chapter 1
+  versions:
+  - effective_from: '2026-01-01'
+    formula: research_credit_allowed_against_subsection_a_tax + research_credit_allowed_against_subsection_b_tax


### PR DESCRIPTION
## Summary
- add generated 26 USC 3111(f) research-credit payroll offset rules
- include companion cases for first-quarter allocation, quarterly tax caps, carryovers, and no-election behavior
- include the encoder apply manifest for generated provenance

## Validation
- uv run axiom-encode validate --skip-reviewers statutes/26/3111/f.yaml
- uv run axiom-encode proof-validate statutes/26/3111/f.yaml
- uv run axiom-encode test --root rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 statutes/26/3111/f.test.yaml
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3111f-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20