### PR TITLE
Add generated 2024 SSA contribution base

### DIFF
--- a/.axiom/encoding-manifests/policies/ssa/contribution-and-benefit-base/2024.json
+++ b/.axiom/encoding-manifests/policies/ssa/contribution-and-benefit-base/2024.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ssa/contribution-and-benefit-base/2024.yaml",
+      "sha256": "9c382d4a7b16e7dd7369fe7d91cd682a67cdc48a05ed4085e55ac2577704e246"
+    },
+    {
+      "path": "policies/ssa/contribution-and-benefit-base/2024.test.yaml",
+      "sha256": "ffd6dbcd53e4d6765460e33a815da947be6f68c974a6a4f1f4bb5a852e0d898f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8ea63ac9ac5547b6e63a73093699894a0eb4ae37",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-main-payroll-20260526",
+    "version": "0.2.297",
+    "version_commit": "bc1b350ca7cc378f21da0441a5bcc527bf92b978"
+  },
+  "axiom_encode_version": "0.2.297",
+  "backend": "openai",
+  "citation": "us/policies/ssa/contribution-and-benefit-base/2024",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-policies-ssa-contribution-and-benefit-base-2024/workspace/context-manifest.json",
+  "context_manifest_sha256": "34a88a3a86bc253b97cf2507ecace41d494adf5795b3d15de008bc0f0866feb8",
+  "generated_at": "2026-05-26T22:25:03.927728+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/policies/ssa/contribution-and-benefit-base/2024.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9c382d4a7b16e7dd7369fe7d91cd682a67cdc48a05ed4085e55ac2577704e246",
+  "generation_prompt_sha256": "34c6261b82f4f1cd62ed70c7db6da81341700b51b6599c921a62536f896a3d60",
+  "model": "gpt-5.5",
+  "run_id": "c3ccc83b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "699657cecf62720402e7c8844e48d5c72aab9a7e947fc39ecb1d9078984746c7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-policies-ssa-contribution-and-benefit-base-2024.json",
+  "trace_sha256": "971a758dab91a0e16f81cfb323ec4d214506d2399da1421869e63d6d543c6315"
+}

--- a/policies/ssa/contribution-and-benefit-base/2024.test.yaml
+++ b/policies/ssa/contribution-and-benefit-base/2024.test.yaml
@@ -1,0 +1,9 @@
+- name: 2024_contribution_and_benefit_base_amount
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base: 168600

--- a/policies/ssa/contribution-and-benefit-base/2024.yaml
+++ b/policies/ssa/contribution-and-benefit-base/2024.yaml
@@ -1,0 +1,27 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/contribution-and-benefit-base/2024/block-1
+  summary: |-
+    OASDI program limits the amount of earnings subject to taxation for a given year; the same annual limit applies when those earnings are used in a benefit computation. Contribution and benefit base table. Year 2024: $168,600.
+rules:
+  - name: contribution_and_benefit_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Contribution and Benefit Base table, Year 2024
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/contribution-and-benefit-base/2024/block-1
+              excerpt: "Year 2024: $168,600."
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          168600


### PR DESCRIPTION
## Summary
- add generated RuleSpec for the 2024 SSA contribution and benefit base
- include generated companion test asserting the ,600 annual base
- include the signed axiom-encode apply manifest

## Validation
- AXIOM_CORPUS_REPO=/private/tmp/axiom-corpus-main-payroll-20260526 uv run axiom-encode validate --skip-reviewers /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us/policies/ssa/contribution-and-benefit-base/2024.yaml
- AXIOM_CORPUS_REPO=/private/tmp/axiom-corpus-main-payroll-20260526 uv run axiom-encode proof-validate /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us/policies/ssa/contribution-and-benefit-base/2024.yaml
- uv run axiom-encode test --root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us/policies/ssa/contribution-and-benefit-base/2024.test.yaml
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employee-oasdi --fail-on-mismatch
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employer-oasdi --fail-on-mismatch
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employee-medicare --fail-on-mismatch
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employer-medicare --fail-on-mismatch

Note: the PolicyEngine ECPS commands warn that installed policyengine-us 1.705.16 differs from the bundled policyengine.py manifest 1.700.0; these were the pinned versions used for the comparisons.