### PR TITLE
Add generated section 3403 withholding liability

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3403.json
+++ b/.axiom/encoding-manifests/statutes/26/3403.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3403.yaml",
+      "sha256": "8c8164eb226ffa31e3b381d0513429823d8507fd9b230fbd8c0f200028054382"
+    },
+    {
+      "path": "statutes/26/3403.test.yaml",
+      "sha256": "5f660f1f51c60f4964d204e68eef1ea24e6d9cf77cfbcdb260c525dc2ca27500"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "87792af309ac78d81d77f7b6c00596d5888d1c64",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.300",
+    "version_commit": "87792af309ac78d81d77f7b6c00596d5888d1c64"
+  },
+  "axiom_encode_version": "0.2.300",
+  "backend": "openai",
+  "citation": "26 USC 3403",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3403/workspace/context-manifest.json",
+  "context_manifest_sha256": "78912383d3fc671281742d2d4cc6ddc1467c41ba1f74056c1384ae8a9d322b88",
+  "generated_at": "2026-05-26T23:36:36.448482+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3403.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "8c8164eb226ffa31e3b381d0513429823d8507fd9b230fbd8c0f200028054382",
+  "generation_prompt_sha256": "89a4be4132f77fcdc96242a48046c25a476e16372bfba0cde908bbecabf171b7",
+  "model": "gpt-5.5",
+  "run_id": "1b8ba0b9",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c973de7dc1f5234e6ecd365adba7909d5718867cdb6803bdcf56788c50cbeb09"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3403.json",
+  "trace_sha256": "d5bfb1f082f8923e0c56dd9ff4347bd0f6f12d2a4d7bf3ecca0d71630b7ecfc0"
+}

--- a/statutes/26/3403.test.yaml
+++ b/statutes/26/3403.test.yaml
@@ -1,0 +1,20 @@
+- name: employer_is_liable_for_required_withholding_tax_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 5000
+  output:
+    us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment: 5000
+    us:statutes/26/3403#employer_liability_to_any_person_for_chapter_withholding_tax_payment: 0
+- name: employer_with_no_required_withholding_tax_has_no_payment_liability
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 0
+  output:
+    us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment: 0
+    us:statutes/26/3403#employer_liability_to_any_person_for_chapter_withholding_tax_payment: 0

--- a/statutes/26/3403.yaml
+++ b/statutes/26/3403.yaml
@@ -1,0 +1,46 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3403
+  summary: |-
+    The employer shall be liable for the payment of the tax required to be deducted and withheld under this chapter, and shall not be liable to any person for the amount of any such payment.
+rules:
+  - name: employer_liability_for_chapter_withholding_tax_payment
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3403
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3403
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, tax_required_to_be_deducted_and_withheld_under_this_chapter)
+
+  - name: employer_liability_to_any_person_for_chapter_withholding_tax_payment
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3403
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3403
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3403 employer withholding-payment liability
- add generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3403.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3403.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3403.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes