### PR TITLE
Add generated section 3127 religious exemption

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3127.json
+++ b/.axiom/encoding-manifests/statutes/26/3127.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3127.yaml",
+      "sha256": "bb0d6851be80a9dd7e8b70dc0360eb1dd9fff523a02038bbec7920627d12abcd"
+    },
+    {
+      "path": "statutes/26/3127.test.yaml",
+      "sha256": "d45f06efe29d515e7c0324adf2f7ac640de84517a7a2662523de2f289cd29733"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed52727124db81cb2ae4cb09db3c7e7c7d6c3e69",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.301",
+    "version_commit": "ed52727124db81cb2ae4cb09db3c7e7c7d6c3e69"
+  },
+  "axiom_encode_version": "0.2.301",
+  "backend": "openai",
+  "citation": "26 USC 3127",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3127/workspace/context-manifest.json",
+  "context_manifest_sha256": "69e8414bfcbe9b65786ea2bca7427560c63641373d40ad25172b72f161ae997e",
+  "generated_at": "2026-05-26T23:53:33.747249+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3127.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "bb0d6851be80a9dd7e8b70dc0360eb1dd9fff523a02038bbec7920627d12abcd",
+  "generation_prompt_sha256": "75087cb11b38f4fffcfd1550dcba01a948cc3804d2ae662078dba083f63f0cec",
+  "model": "gpt-5.5",
+  "run_id": "5c8705fb",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fe0a2fdbbabf71afe94f0f9274b21cd38430418518157e79b8956dedb912c9e1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3127.json",
+  "trace_sha256": "ae61d76a76dfee9c47eb753be3380b392047c2f5ce86b08a498dd92404c3402b"
+}

--- a/statutes/26/3127.test.yaml
+++ b/statutes/26/3127.test.yaml
@@ -1,0 +1,89 @@
+- name: employer_wages_exempt_when_requirements_prerequisites_and_effective_period_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3127#input.employer_application_contains_required_section_1402_g_1_A_evidence: true
+    us:statutes/26/3127#input.employer_application_contains_required_section_1402_g_1_B_waiver: true
+    us:statutes/26/3127#input.commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect: true
+    ? us:statutes/26/3127#input.no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employer_applicant_at_or_before_filing
+    : true
+    ? us:statutes/26/3127#input.employer_or_each_partner_is_member_of_recognized_religious_sect_or_division_described_in_section_1402_g_1
+    : true
+    us:statutes/26/3127#input.employer_or_each_partner_is_adherent_of_established_tenets_or_teachings_of_sect: true
+    us:statutes/26/3127#input.employer_application_filed_and_approved_under_subsection_b: true
+    us:statutes/26/3127#input.wages_paid_on_or_after_commencement_calendar_quarter_described_in_subsection_c_1: true
+    us:statutes/26/3127#input.wages_paid_before_ending_calendar_quarter_described_in_subsection_c_2: true
+    us:statutes/26/3127#input.employee_meets_religious_exemption_requirements_for_wages_paid_by_employer: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer: 50000
+  output:
+    us:statutes/26/3127#employer_application_meets_statutory_approval_prerequisites: holds
+    us:statutes/26/3127#employer_meets_religious_exemption_requirements: holds
+    us:statutes/26/3127#wages_paid_during_section_3127_effective_period: holds
+    us:statutes/26/3127#wages_exempt_from_section_3111_taxes_under_section_3127: 50000
+- name: employer_wages_not_exempt_when_benefit_payable_blocks_approval_prerequisite
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3127#input.employer_application_contains_required_section_1402_g_1_A_evidence: true
+    us:statutes/26/3127#input.employer_application_contains_required_section_1402_g_1_B_waiver: true
+    us:statutes/26/3127#input.commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect: true
+    ? us:statutes/26/3127#input.no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employer_applicant_at_or_before_filing
+    : false
+    ? us:statutes/26/3127#input.employer_or_each_partner_is_member_of_recognized_religious_sect_or_division_described_in_section_1402_g_1
+    : true
+    us:statutes/26/3127#input.employer_or_each_partner_is_adherent_of_established_tenets_or_teachings_of_sect: true
+    us:statutes/26/3127#input.employer_application_filed_and_approved_under_subsection_b: true
+    us:statutes/26/3127#input.wages_paid_on_or_after_commencement_calendar_quarter_described_in_subsection_c_1: true
+    us:statutes/26/3127#input.wages_paid_before_ending_calendar_quarter_described_in_subsection_c_2: true
+    us:statutes/26/3127#input.employee_meets_religious_exemption_requirements_for_wages_paid_by_employer: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer: 50000
+  output:
+    us:statutes/26/3127#employer_application_meets_statutory_approval_prerequisites: not_holds
+    us:statutes/26/3127#employer_meets_religious_exemption_requirements: not_holds
+    us:statutes/26/3127#wages_exempt_from_section_3111_taxes_under_section_3127: 0
+- name: employee_wages_exempt_when_employee_and_employer_requirements_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3127#input.employee_application_contains_required_section_1402_g_1_A_evidence: true
+    us:statutes/26/3127#input.employee_application_contains_required_section_1402_g_1_B_waiver: true
+    us:statutes/26/3127#input.commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect: true
+    ? us:statutes/26/3127#input.no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employee_applicant_at_or_before_filing
+    : true
+    us:statutes/26/3127#input.employee_is_member_of_same_recognized_religious_sect_or_division: true
+    us:statutes/26/3127#input.employee_is_adherent_of_established_tenets_or_teachings_of_sect: true
+    us:statutes/26/3127#input.employee_identical_application_filed_and_approved_under_subsection_b: true
+    us:statutes/26/3127#input.employer_meets_religious_exemption_requirements_for_employee_wages: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer_during_section_3127_effective_period: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer: 40000
+  output:
+    us:statutes/26/3127#employee_application_meets_statutory_approval_prerequisites: holds
+    us:statutes/26/3127#employee_meets_religious_exemption_requirements: holds
+    us:statutes/26/3127#wages_exempt_from_section_3101_taxes_under_section_3127: 40000
+- name: employee_wages_not_exempt_when_identical_application_not_approved
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3127#input.employee_application_contains_required_section_1402_g_1_A_evidence: true
+    us:statutes/26/3127#input.employee_application_contains_required_section_1402_g_1_B_waiver: true
+    us:statutes/26/3127#input.commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect: true
+    ? us:statutes/26/3127#input.no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employee_applicant_at_or_before_filing
+    : true
+    us:statutes/26/3127#input.employee_is_member_of_same_recognized_religious_sect_or_division: true
+    us:statutes/26/3127#input.employee_is_adherent_of_established_tenets_or_teachings_of_sect: true
+    us:statutes/26/3127#input.employee_identical_application_filed_and_approved_under_subsection_b: false
+    us:statutes/26/3127#input.employer_meets_religious_exemption_requirements_for_employee_wages: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer_during_section_3127_effective_period: true
+    us:statutes/26/3127#input.wages_paid_to_employee_by_employer: 40000
+  output:
+    us:statutes/26/3127#employee_application_meets_statutory_approval_prerequisites: holds
+    us:statutes/26/3127#employee_meets_religious_exemption_requirements: not_holds
+    us:statutes/26/3127#wages_exempt_from_section_3101_taxes_under_section_3127: 0

--- a/statutes/26/3127.yaml
+++ b/statutes/26/3127.yaml
@@ -1,0 +1,260 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3127
+  summary: Notwithstanding any other provision of this chapter, if the employer (or
+    each partner) and the employee are members and adherents of the recognized religious
+    sect or division described in section 1402(g)(1), have filed and had approved
+    the required identical exemption applications, and the subsection (b) approval
+    prerequisites are met, the employer is exempt from section 3111 taxes and the
+    employee is exempt from section 3101 taxes with respect to wages paid by that
+    employer during the effective period described in subsection (c).
+rules:
+- name: employer_application_meets_statutory_approval_prerequisites
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3127(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: shall be approved only if
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: contains or is accompanied by the evidence described in section
+            1402(g)(1)(A) and a waiver described in section 1402(g)(1)(B)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: the Commissioner of Social Security makes the findings
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: no benefit or other payment referred to in section 1402(g)(1)(B)
+            became payable
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'employer_application_contains_required_section_1402_g_1_A_evidence
+
+      and employer_application_contains_required_section_1402_g_1_B_waiver
+
+      and commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect
+
+      and no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employer_applicant_at_or_before_filing'
+- name: employee_application_meets_statutory_approval_prerequisites
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3127(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: shall be approved only if
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: contains or is accompanied by the evidence described in section
+            1402(g)(1)(A) and a waiver described in section 1402(g)(1)(B)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: the Commissioner of Social Security makes the findings
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: no benefit or other payment referred to in section 1402(g)(1)(B)
+            became payable
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'employee_application_contains_required_section_1402_g_1_A_evidence
+
+      and employee_application_contains_required_section_1402_g_1_B_waiver
+
+      and commissioner_of_social_security_makes_required_section_1402_g_1_C_D_E_findings_for_sect
+
+      and no_section_1402_g_1_B_benefit_or_payment_became_payable_to_employee_applicant_at_or_before_filing'
+- name: employer_meets_religious_exemption_requirements
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3127(a)(1), 26 USC 3127(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: an employer (or, if the employer is a partnership, each partner
+            therein) is a member of a recognized religious sect or division
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: an adherent of established tenets or teachings
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: has filed and had approved under subsection (b) an application
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3127#employer_application_meets_statutory_approval_prerequisites
+          output: employer_application_meets_statutory_approval_prerequisites
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'employer_or_each_partner_is_member_of_recognized_religious_sect_or_division_described_in_section_1402_g_1
+
+      and employer_or_each_partner_is_adherent_of_established_tenets_or_teachings_of_sect
+
+      and employer_application_filed_and_approved_under_subsection_b
+
+      and employer_application_meets_statutory_approval_prerequisites'
+- name: employee_meets_religious_exemption_requirements
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3127(a)(2), 26 USC 3127(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: an employee of such employer who is also a member of such a religious
+            sect or division
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: an adherent of its established tenets or teachings
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: has filed and had approved under subsection (b) an identical application
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3127#employee_application_meets_statutory_approval_prerequisites
+          output: employee_application_meets_statutory_approval_prerequisites
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'employee_is_member_of_same_recognized_religious_sect_or_division
+
+      and employee_is_adherent_of_established_tenets_or_teachings_of_sect
+
+      and employee_identical_application_filed_and_approved_under_subsection_b
+
+      and employee_application_meets_statutory_approval_prerequisites'
+- name: wages_paid_during_section_3127_effective_period
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3127(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: commencing with the first day of the first calendar quarter, after
+            the quarter in which such application is filed
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: ending with the last day of the calendar quarter preceding the
+            first calendar quarter thereafter
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'wages_paid_on_or_after_commencement_calendar_quarter_described_in_subsection_c_1
+
+      and wages_paid_before_ending_calendar_quarter_described_in_subsection_c_2'
+- name: wages_exempt_from_section_3111_taxes_under_section_3127
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3127(a), 26 USC 3127(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: such employer shall be exempt from the taxes imposed by section
+            3111 with respect to wages paid
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3127#employer_meets_religious_exemption_requirements
+          output: employer_meets_religious_exemption_requirements
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3127#wages_paid_during_section_3127_effective_period
+          output: wages_paid_during_section_3127_effective_period
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if employer_meets_religious_exemption_requirements and employee_meets_religious_exemption_requirements_for_wages_paid_by_employer
+      and wages_paid_during_section_3127_effective_period: max(0, wages_paid_to_employee_by_employer)
+      else: 0'
+- name: wages_exempt_from_section_3101_taxes_under_section_3127
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3127(a), 26 USC 3127(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3127
+          excerpt: each such employee shall be exempt from the taxes imposed by section
+            3101 with respect to such wages paid to him by such employer
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3127#employee_meets_religious_exemption_requirements
+          output: employee_meets_religious_exemption_requirements
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if employer_meets_religious_exemption_requirements_for_employee_wages
+      and employee_meets_religious_exemption_requirements and wages_paid_to_employee_by_employer_during_section_3127_effective_period:
+      max(0, wages_paid_to_employee_by_employer) else: 0'


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3127 religious-sect employee/employer payroll-tax exemption rules
- add generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3127.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3127.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3127.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes