### PR TITLE
Add generated section 3504 payroll agent rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3504.json
+++ b/.axiom/encoding-manifests/statutes/26/3504.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3504.yaml",
+      "sha256": "da65366e0b33cb8fdbbfa36eb046b78d1d9d8fde5f0ae223a6cd22df2edd4a6f"
+    },
+    {
+      "path": "statutes/26/3504.test.yaml",
+      "sha256": "c55472580bfa5c0e7c6d23dcf7f6c336d32923994340b96c50db8cdb666ec425"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4bd1dff74d2e346d9d6fb718667ab67e4331e490",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.302",
+    "version_commit": "4bd1dff74d2e346d9d6fb718667ab67e4331e490"
+  },
+  "axiom_encode_version": "0.2.302",
+  "backend": "openai",
+  "citation": "26 USC 3504",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3504/workspace/context-manifest.json",
+  "context_manifest_sha256": "4d4ce5a01435bcf939d9931709f9d0150c747f4c3c2fb454c0cbc98029bd651b",
+  "generated_at": "2026-05-27T00:11:01.278003+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3504.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "da65366e0b33cb8fdbbfa36eb046b78d1d9d8fde5f0ae223a6cd22df2edd4a6f",
+  "generation_prompt_sha256": "bf14e6216d8789c24d7f31f2fd8ec332d2d0b521048471dfb83fad5ecf17199b",
+  "model": "gpt-5.5",
+  "run_id": "1c4b95aa",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b68f308b43268ba053e5ea17dd37a8ea1dee2f7a48e9e8b48c57df3149bfeb50"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3504.json",
+  "trace_sha256": "b31315fbe0b069d20e67c944b3cea0a277066d6ac80a9ab3ea89f65a734e6a2c"
+}

--- a/statutes/26/3504.test.yaml
+++ b/statutes/26/3504.test.yaml
@@ -1,0 +1,54 @@
+- name: secretary_designation_authorized_when_wage_control_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.person_is_fiduciary_agent_or_other_person: true
+    us:statutes/26/3504#input.person_has_control_receipt_custody_or_disposal_of_employee_wages: true
+    us:statutes/26/3504#input.wages_are_of_employee_or_group_employed_by_one_or_more_employers: true
+    us:statutes/26/3504#input.designation_is_under_secretary_regulations: true
+  output:
+    us:statutes/26/3504#secretary_may_designate_wage_control_person_to_perform_employer_acts: holds
+- name: secretary_designation_not_authorized_without_wage_control_or_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.person_is_fiduciary_agent_or_other_person: true
+    us:statutes/26/3504#input.person_has_control_receipt_custody_or_disposal_of_employee_wages: false
+    us:statutes/26/3504#input.wages_are_of_employee_or_group_employed_by_one_or_more_employers: true
+    us:statutes/26/3504#input.designation_is_under_secretary_regulations: true
+  output:
+    us:statutes/26/3504#secretary_may_designate_wage_control_person_to_perform_employer_acts: not_holds
+- name: designated_person_subject_to_employer_provisions_unless_secretary_otherwise_prescribes
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.person_is_designated_by_secretary_under_section_3504: true
+    us:statutes/26/3504#input.secretary_otherwise_prescribes_employer_law_provisions_not_applicable: false
+  output:
+    us:statutes/26/3504#designated_person_subject_to_employer_law_provisions: holds
+- name: secretary_otherwise_prescribes_designated_person_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.person_is_designated_by_secretary_under_section_3504: true
+    us:statutes/26/3504#input.secretary_otherwise_prescribes_employer_law_provisions_not_applicable: true
+  output:
+    us:statutes/26/3504#designated_person_subject_to_employer_law_provisions: not_holds
+- name: employer_remains_subject_to_employer_provisions_unless_secretary_provides_otherwise
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.designated_person_acts_for_employer: true
+    us:statutes/26/3504#input.secretary_provides_employer_not_subject_to_employer_law_provisions: false
+  output:
+    us:statutes/26/3504#employer_remains_subject_to_employer_law_provisions: holds

--- a/statutes/26/3504.yaml
+++ b/statutes/26/3504.yaml
@@ -1,0 +1,100 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3504
+  summary: |-
+    In case a fiduciary, agent, or other person has the control, receipt, custody, or disposal of, or pays the wages of an employee or group of employees, employed by one or more employers, the Secretary, under regulations prescribed by him, is authorized to designate such fiduciary, agent, or other person to perform such acts as are required of employers under this title and as the Secretary may specify. Except as may be otherwise prescribed by the Secretary, all provisions of law (including penalties) applicable in respect of an employer shall be applicable to a fiduciary, agent, or other person so designated but, except as so provided, the employer for whom such fiduciary, agent, or other person acts shall remain subject to the provisions of law (including penalties) applicable in respect of employers.
+rules:
+  - name: secretary_may_designate_wage_control_person_to_perform_employer_acts
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3504
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "a fiduciary, agent, or other person has the control, receipt, custody, or disposal of, or pays the wages"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "employed by one or more employers"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "the Secretary, under regulations prescribed by him, is authorized to designate such fiduciary, agent, or other person to perform such acts as are required of employers under this title and as the Secretary may specify"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_is_fiduciary_agent_or_other_person
+          and person_has_control_receipt_custody_or_disposal_of_employee_wages
+          and wages_are_of_employee_or_group_employed_by_one_or_more_employers
+          and designation_is_under_secretary_regulations
+
+  - name: designated_person_subject_to_employer_law_provisions
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3504
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "a fiduciary, agent, or other person so designated"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "all provisions of law (including penalties) applicable in respect of an employer shall be applicable"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "Except as may be otherwise prescribed by the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_is_designated_by_secretary_under_section_3504
+          and not secretary_otherwise_prescribes_employer_law_provisions_not_applicable
+
+  - name: employer_remains_subject_to_employer_law_provisions
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3504
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "the employer for whom such fiduciary, agent, or other person acts"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "shall remain subject to the provisions of law (including penalties) applicable in respect of employers"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3504
+              excerpt: "except as so provided"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          designated_person_acts_for_employer
+          and not secretary_provides_employer_not_subject_to_employer_law_provisions


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3504 payroll-agent designation and employer-responsibility rules
- add generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3504.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3504.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3504.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes