### PR TITLE
Add generated section 3402(a) withholding wages

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/a.yaml",
+      "sha256": "f9facf3737b27df1ceb4af84b1f3212a61107e70b029bc13a68b5880832386e4"
+    },
+    {
+      "path": "statutes/26/3402/a.test.yaml",
+      "sha256": "cecec47971204cd196460ea0be059032dbf86487cfebc6247e3b10eb4eb5df25"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "27ff29a8d7af0908ece02386a01f952319c82e48",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.304",
+    "version_commit": "27ff29a8d7af0908ece02386a01f952319c82e48"
+  },
+  "axiom_encode_version": "0.2.304",
+  "backend": "openai",
+  "citation": "26 USC 3402(a)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "b267300dad1eca9bc1e809ca23cadb15563c88d602a3b7c1f8fa0505c8c525eb",
+  "generated_at": "2026-05-27T00:43:46.121643+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f9facf3737b27df1ceb4af84b1f3212a61107e70b029bc13a68b5880832386e4",
+  "generation_prompt_sha256": "c1afb2ccc0930c6ebeb0f77ab826cb32b7240b9692d4ebbfc05b48d618b658f5",
+  "model": "gpt-5.5",
+  "run_id": "15855930",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc3c660d261705a15fb44cdc633c1dec851e260fc81168fde6bdbfbf4b5beca0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-a.json",
+  "trace_sha256": "6e3ba1277f0ac60bebf8249bf6fc9a838ea759b9cd23ab2c4f157e7f504dd6db"
+}

--- a/statutes/26/3402/a.test.yaml
+++ b/statutes/26/3402/a.test.yaml
@@ -1,0 +1,20 @@
+- name: wages_exceed_prorated_withholding_allowance
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/a#input.wages: 2500
+    us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 500
+  output:
+    us:statutes/26/3402/a#amount_of_wages_for_withholding_tables: 2000
+- name: prorated_withholding_allowance_exceeds_wages
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/a#input.wages: 400
+    us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 600
+  output:
+    us:statutes/26/3402/a#amount_of_wages_for_withholding_tables: 0

--- a/statutes/26/3402/a.yaml
+++ b/statutes/26/3402/a.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/a#tax_to_deduct_and_withhold_on_wages
+      reason: >-
+        Section 3402(a)(1) requires withholding of a tax determined in accordance
+        with tables or computational procedures prescribed by the Secretary, and
+        is subject to other provisions of section 3402. The Secretary-prescribed
+        tables/procedures and same-section exceptions are not included in the
+        supplied source text or copied executable context, so the final tax to
+        deduct and withhold is not computable in this artifact.
+      source_values:
+        - us:statutes/26/3402/a#amount_of_wages_for_withholding_tables
+  summary: |-
+    26 USC 3402(a): every employer making payment of wages shall deduct and withhold a tax determined under Secretary-prescribed tables or computational procedures; for applying those tables or procedures, “the amount of wages” means wages exceeding the taxpayer’s withholding allowance, prorated to the payroll period.
+rules:
+  - name: amount_of_wages_for_withholding_tables
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "the amount by which the wages exceed the taxpayer’s withholding allowance, prorated to the payroll period"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(
+              0,
+              wages
+              - taxpayer_withholding_allowance_prorated_to_payroll_period
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3402(a) withholding table wage amount
- defer final withholding tax because Secretary-prescribed tables/procedures and same-section exceptions are not available in executable context
- add generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/a.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/a.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/a.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes