### PR TITLE
Add generated section 3402(b) withholding periods

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/b.yaml",
+      "sha256": "fc6c3db673ea67d1827c86384784e32da18cc373669762dd08b0c0650f79d8ce"
+    },
+    {
+      "path": "statutes/26/3402/b.test.yaml",
+      "sha256": "e5edf80933a48e2804a88925bbc50db7e08d04d94b198338f5c4f475790d1c9b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "972da65ec2660bc4a4ec031da8acfcd8a043d1ce",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.305",
+    "version_commit": "972da65ec2660bc4a4ec031da8acfcd8a043d1ce"
+  },
+  "axiom_encode_version": "0.2.305",
+  "backend": "openai",
+  "citation": "26 USC 3402(b)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "16f25fdc4a36974d6201f1919dc70aa92a683b138e9de165c8b3f3ff65fd442a",
+  "generated_at": "2026-05-27T00:59:43.493653+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "fc6c3db673ea67d1827c86384784e32da18cc373669762dd08b0c0650f79d8ce",
+  "generation_prompt_sha256": "7e7ad1ecfd4888068cc64df1b1786f970d7e579d6b91507c3b32a73ef972af61",
+  "model": "gpt-5.5",
+  "run_id": "2cfe8dd5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "adbbf83e40cb507df6210e33b15f9b9ae582f8160d134def3679141dc7c3f4e4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-b.json",
+  "trace_sha256": "aa752c99dcb3c30cf518156e228a270d2d93668739647f4ed2de0ade4c6d3557"
+}

--- a/statutes/26/3402/b.test.yaml
+++ b/statutes/26/3402/b.test.yaml
@@ -1,0 +1,75 @@
+- name: nonpayroll_period_wages_use_equal_miscellaneous_allowance_days
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/b#input.wages_paid_with_respect_to_period_not_payroll_period: true
+    us:statutes/26/3402/b#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: 10
+  output:
+    us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_nonpayroll_period_wages: 10
+- name: wages_paid_without_regard_to_period_use_elapsed_days_since_later_reference_date
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/b#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: true
+    ? us:statutes/26/3402/b#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : 15
+  output:
+    us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period: 15
+- name: less_than_one_week_period_allows_secretary_authorized_weekly_aggregate_computation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/b#input.period_or_paragraph_2_time_in_respect_of_wages_is_less_than_one_week: true
+  output:
+    us:statutes/26/3402/b#secretary_may_authorize_weekly_aggregate_computation: holds
+- name: employer_election_uses_nearest_dollar_wages_for_withholding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/b#input.employer_elects_to_compute_wages_to_nearest_dollar: true
+    us:statutes/26/3402/b#input.wages_computed_to_nearest_dollar: 1235
+    us:statutes/26/3402/b#input.wages: 1234.56
+  output:
+    us:statutes/26/3402/b#wages_computed_for_withholding_under_percentage_method: 1235
+- name: auto_zero_miscellaneous_allowance_period_days_for_nonpayroll_period_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/b#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : false
+    us:statutes/26/3402/b#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: false
+    us:statutes/26/3402/b#input.employer_elects_to_compute_wages_to_nearest_dollar: false
+    us:statutes/26/3402/b#input.period_or_paragraph_2_time_in_respect_of_wages_is_less_than_one_week: false
+    us:statutes/26/3402/b#input.wages: 0
+    us:statutes/26/3402/b#input.wages_computed_to_nearest_dollar: 0
+    us:statutes/26/3402/b#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: false
+    us:statutes/26/3402/b#input.wages_paid_with_respect_to_period_not_payroll_period: false
+  output:
+    us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_nonpayroll_period_wages: 0
+- name: auto_zero_miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/b#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : false
+    us:statutes/26/3402/b#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: false
+    us:statutes/26/3402/b#input.employer_elects_to_compute_wages_to_nearest_dollar: false
+    us:statutes/26/3402/b#input.period_or_paragraph_2_time_in_respect_of_wages_is_less_than_one_week: false
+    us:statutes/26/3402/b#input.wages: 0
+    us:statutes/26/3402/b#input.wages_computed_to_nearest_dollar: 0
+    us:statutes/26/3402/b#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: false
+    us:statutes/26/3402/b#input.wages_paid_with_respect_to_period_not_payroll_period: false
+  output:
+    us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period: 0

--- a/statutes/26/3402/b.yaml
+++ b/statutes/26/3402/b.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: '26 USC 3402(b): withholding allowance for wages paid outside a payroll
+    period, or without regard to any period, is the allowance for a miscellaneous
+    payroll period containing the specified number of days; if the period or elapsed
+    time is less than one week, the Secretary may authorize weekly aggregate computation;
+    wages may be computed to the nearest dollar at the employer''s election.'
+rules:
+- name: miscellaneous_allowance_period_days_for_nonpayroll_period_wages
+  kind: derived
+  entity: Payment
+  dtype: Count
+  period: Year
+  source: 26 USC 3402(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: containing a number of days (including Sundays and holidays) equal
+            to the number of days in the period
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if wages_paid_with_respect_to_period_not_payroll_period: days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays
+      else: 0'
+- name: miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period
+  kind: derived
+  entity: Payment
+  dtype: Count
+  period: Year
+  source: 26 USC 3402(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: equal to the number of days (including Sundays and holidays) which
+            have elapsed since ... whichever is the later
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period:
+      days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+      else: 0'
+- name: secretary_may_authorize_weekly_aggregate_computation
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3402(b)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: the period, or the time described in paragraph (2), in respect
+            of any wages is less than one week
+  versions:
+  - effective_from: '0001-01-01'
+    formula: period_or_paragraph_2_time_in_respect_of_wages_is_less_than_one_week
+- name: wages_computed_for_withholding_under_percentage_method
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3402(b)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: the wages may, at the election of the employer, be computed to
+            the nearest dollar
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if employer_elects_to_compute_wages_to_nearest_dollar: wages_computed_to_nearest_dollar
+      else: wages'


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(b) withholding period computations.
- Add generated companion tests and signed encoder apply manifest.

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/b.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/b.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/b.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50