### PR TITLE
Add generated section 3402(c) wage brackets

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/c.yaml",
+      "sha256": "61279d101bd5ea8210374c399d0424b1407e1b4faa8af7feb272a6d075602738"
+    },
+    {
+      "path": "statutes/26/3402/c.test.yaml",
+      "sha256": "84603eb6ecb0e57a4d4d571d4f6c6750b840aa0c02ea8469fd3bb68a63967f38"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4e90b8b57d0cfb413493998cf576f14a071481b4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.306",
+    "version_commit": "4e90b8b57d0cfb413493998cf576f14a071481b4"
+  },
+  "axiom_encode_version": "0.2.306",
+  "backend": "openai",
+  "citation": "26 USC 3402(c)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "194f0f780ffef292367d0a21b036d33009c7fecd33135999db0bcd33259efdbe",
+  "generated_at": "2026-05-27T01:25:52.309522+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "61279d101bd5ea8210374c399d0424b1407e1b4faa8af7feb272a6d075602738",
+  "generation_prompt_sha256": "619f9e6a65ccee2adb0850de79e152fc6e3eaae610f5714c42e4e4b40cb06b77",
+  "model": "gpt-5.5",
+  "run_id": "2bf9c5e3",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7a28e42d86e819ecf17afc2402397e37f9b93a625a95e5edc53bba59badaa288"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-c.json",
+  "trace_sha256": "8ea2e8e287c279c34a7414e3595938f517c6ce3903d2d7aa6bd563dd32e2a638"
+}

--- a/statutes/26/3402/c.test.yaml
+++ b/statutes/26/3402/c.test.yaml
@@ -1,0 +1,78 @@
+- name: nonpayroll_period_wages_use_equal_miscellaneous_period_days
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/c#input.wages_paid_with_respect_to_period_not_payroll_period: true
+    us:statutes/26/3402/c#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: 10
+  output:
+    us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages: 10
+- name: wages_paid_without_regard_to_period_use_elapsed_days_since_later_reference_date
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/c#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: true
+    ? us:statutes/26/3402/c#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : 15
+  output:
+    us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period: 15
+- name: less_than_one_week_period_allows_wage_bracket_weekly_aggregate_computation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/c#input.period_or_paragraph_3_time_in_respect_of_wages_is_less_than_one_week: true
+  output:
+    us:statutes/26/3402/c#wage_bracket_weekly_aggregate_computation_authorized: holds
+- name: employer_election_uses_nearest_dollar_wages_only_when_wages_exceed_highest_bracket
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/c#input.wages_exceed_highest_wage_bracket: true
+    us:statutes/26/3402/c#input.employer_elects_to_compute_wages_to_nearest_dollar: true
+    us:statutes/26/3402/c#input.wages_computed_to_nearest_dollar: 1235
+    us:statutes/26/3402/c#input.wages: 1234.56
+  output:
+    us:statutes/26/3402/c#wages_computed_for_wage_bracket_withholding: 1235
+- name: auto_zero_wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/c#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : false
+    us:statutes/26/3402/c#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: false
+    us:statutes/26/3402/c#input.employer_elects_to_compute_wages_to_nearest_dollar: false
+    us:statutes/26/3402/c#input.period_or_paragraph_3_time_in_respect_of_wages_is_less_than_one_week: false
+    us:statutes/26/3402/c#input.wages: 0
+    us:statutes/26/3402/c#input.wages_computed_to_nearest_dollar: 0
+    us:statutes/26/3402/c#input.wages_exceed_highest_wage_bracket: false
+    us:statutes/26/3402/c#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: false
+    us:statutes/26/3402/c#input.wages_paid_with_respect_to_period_not_payroll_period: false
+  output:
+    us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages: 0
+- name: auto_zero_wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/c#input.days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays
+    : false
+    us:statutes/26/3402/c#input.days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays: false
+    us:statutes/26/3402/c#input.employer_elects_to_compute_wages_to_nearest_dollar: false
+    us:statutes/26/3402/c#input.period_or_paragraph_3_time_in_respect_of_wages_is_less_than_one_week: false
+    us:statutes/26/3402/c#input.wages: 0
+    us:statutes/26/3402/c#input.wages_computed_to_nearest_dollar: 0
+    us:statutes/26/3402/c#input.wages_exceed_highest_wage_bracket: false
+    us:statutes/26/3402/c#input.wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: false
+    us:statutes/26/3402/c#input.wages_paid_with_respect_to_period_not_payroll_period: false
+  output:
+    us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period: 0

--- a/statutes/26/3402/c.yaml
+++ b/statutes/26/3402/c.yaml
@@ -1,0 +1,95 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/c#wage_bracket_tax_to_deduct_and_withhold
+      reason: >-
+        Section 3402(c)(1) and (6) require the wage-bracket withholding tax to
+        be determined in accordance with tables prescribed by the Secretary. The
+        Secretary-prescribed tables are not included in the supplied source text
+        or executable context, so the final tax amount is not computable in this
+        artifact.
+      source_values:
+        - us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages
+        - us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period
+        - us:statutes/26/3402/c#wage_bracket_weekly_aggregate_computation_authorized
+        - us:statutes/26/3402/c#wages_computed_for_wage_bracket_withholding
+  summary: |-
+    26 USC 3402(c): at the employer's election, wage-bracket withholding is in lieu of subsection (a) withholding and is determined under Secretary-prescribed tables; nonpayroll-period and no-period wages use miscellaneous payroll periods with specified day counts; periods less than one week may use weekly aggregate computation; wages exceeding the highest wage bracket may be computed to the nearest dollar.
+rules:
+  - name: wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages
+    kind: derived
+    entity: Payment
+    dtype: Count
+    period: Year
+    source: 26 USC 3402(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "containing a number of days (including Sundays and holidays) equal to the number of days in the period"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if wages_paid_with_respect_to_period_not_payroll_period: days_in_period_with_respect_to_which_wages_are_paid_including_sundays_and_holidays else: 0
+  - name: wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period
+    kind: derived
+    entity: Payment
+    dtype: Count
+    period: Year
+    source: 26 USC 3402(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "equal to the number of days (including Sundays and holidays) which have elapsed since ... whichever is the later"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if wages_paid_by_employer_without_regard_to_any_payroll_period_or_other_period: days_elapsed_since_later_of_last_payment_commencement_or_january_first_including_sundays_and_holidays else: 0
+  - name: wage_bracket_weekly_aggregate_computation_authorized
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(c)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "the period, or the time described in paragraph (3), in respect of any wages is less than one week"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          period_or_paragraph_3_time_in_respect_of_wages_is_less_than_one_week
+  - name: wages_computed_for_wage_bracket_withholding
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "If the wages exceed the highest wage bracket ... at the election of the employer, be computed to the nearest dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if wages_exceed_highest_wage_bracket and employer_elects_to_compute_wages_to_nearest_dollar: wages_computed_to_nearest_dollar else: wages


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(c) wage-bracket withholding mechanics.
- Add generated companion tests and signed encoder apply manifest.

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/c.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/c.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/c.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50