### PR TITLE
Add generated section 3402(d) withholding liability

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/d.yaml",
+      "sha256": "b1a5034e97fe6c8aa6113e31518d71cc7ed79a8d5cfc657b38a0b88e2382239c"
+    },
+    {
+      "path": "statutes/26/3402/d.test.yaml",
+      "sha256": "48090a250eb424fd8a71b005aaf05c40dccadfcdc6a246dc201869de4c3b57fd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6ed96a64954dcd17a365536721b44da53530cd17",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.307",
+    "version_commit": "6ed96a64954dcd17a365536721b44da53530cd17"
+  },
+  "axiom_encode_version": "0.2.307",
+  "backend": "openai",
+  "citation": "26 USC 3402(d)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "2347236fb1246f3d395e3d9b7a2018b3120629c3997f6c31f2e9cc0a65694c4d",
+  "generated_at": "2026-05-27T01:41:44.590882+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b1a5034e97fe6c8aa6113e31518d71cc7ed79a8d5cfc657b38a0b88e2382239c",
+  "generation_prompt_sha256": "2079cf8924c00fc5ecdfe7df1d96bb31625275c33a3d1cda09773ec429eb5653",
+  "model": "gpt-5.5",
+  "run_id": "2eef30c7",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "00fa2194734cb27e8dde071e254d66429271292bd6c773dff1fb6585a1bff350"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-d.json",
+  "trace_sha256": "d363838e035c9a17bcfcc74e5ef9ec86851b1141c96af25ff1aa497e58062935"
+}

--- a/statutes/26/3402/d.test.yaml
+++ b/statutes/26/3402/d.test.yaml
@@ -1,0 +1,48 @@
+- name: recipient_tax_paid_blocks_collection_from_employer_but_penalties_remain
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/d#input.employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter: true
+    us:statutes/26/3402/d#input.tax_against_which_required_withholding_tax_may_be_credited_is_paid: true
+    us:statutes/26/3402/d#input.penalties_or_additions_to_tax_otherwise_applicable_for_withholding_failure: true
+  output:
+    us:statutes/26/3402/d#required_withholding_tax_not_collected_from_employer: holds
+    us:statutes/26/3402/d#employer_remains_liable_for_penalties_or_additions_for_withholding_failure: holds
+- name: recipient_tax_not_paid_allows_collection_rule_to_fail_but_penalty_liability_remains
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/d#input.employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter: true
+    us:statutes/26/3402/d#input.tax_against_which_required_withholding_tax_may_be_credited_is_paid: false
+    us:statutes/26/3402/d#input.penalties_or_additions_to_tax_otherwise_applicable_for_withholding_failure: true
+  output:
+    us:statutes/26/3402/d#required_withholding_tax_not_collected_from_employer: not_holds
+    us:statutes/26/3402/d#employer_remains_liable_for_penalties_or_additions_for_withholding_failure: holds
+- name: no_withholding_failure_no_subsection_d_relief_or_penalty_liability_rule
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/d#input.employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter: false
+    us:statutes/26/3402/d#input.tax_against_which_required_withholding_tax_may_be_credited_is_paid: true
+    us:statutes/26/3402/d#input.penalties_or_additions_to_tax_otherwise_applicable_for_withholding_failure: true
+  output:
+    us:statutes/26/3402/d#required_withholding_tax_not_collected_from_employer: not_holds
+    us:statutes/26/3402/d#employer_remains_liable_for_penalties_or_additions_for_withholding_failure: not_holds
+- name: no_otherwise_applicable_penalties_leaves_noncollection_rule_intact
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/d#input.employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter: true
+    us:statutes/26/3402/d#input.tax_against_which_required_withholding_tax_may_be_credited_is_paid: true
+    us:statutes/26/3402/d#input.penalties_or_additions_to_tax_otherwise_applicable_for_withholding_failure: false
+  output:
+    us:statutes/26/3402/d#required_withholding_tax_not_collected_from_employer: holds
+    us:statutes/26/3402/d#employer_remains_liable_for_penalties_or_additions_for_withholding_failure: not_holds

--- a/statutes/26/3402/d.yaml
+++ b/statutes/26/3402/d.yaml
@@ -1,0 +1,57 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    26 USC 3402(d): if an employer fails to deduct and withhold tax under this chapter and the recipient later pays the tax against which the withholding tax may be credited, the required withholding tax shall not be collected from the employer; the subsection does not relieve penalties or additions otherwise applicable for the failure.
+rules:
+  - name: required_withholding_tax_not_collected_from_employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "If the employer ... fails to deduct and withhold ... and thereafter the tax ... is paid"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "the tax so required to be deducted and withheld shall not be collected from the employer"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter
+          and tax_against_which_required_withholding_tax_may_be_credited_is_paid
+  - name: employer_remains_liable_for_penalties_or_additions_for_withholding_failure
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "in respect of such failure to deduct and withhold"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall in no case relieve the employer from liability for any penalties or additions to the tax otherwise applicable"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_tax_under_chapter_in_violation_of_chapter
+          and penalties_or_additions_to_tax_otherwise_applicable_for_withholding_failure


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(d) employer collection relief and penalty liability.
- Add generated companion tests and signed encoder apply manifest.

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/d.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/d.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/d.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50