### PR TITLE
Add generated section 3402(e) wage deeming

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/e.yaml",
+      "sha256": "ed1d0a72f915c661243ae273e557a52763ba660253e9c04524ea0692e4eb62ba"
+    },
+    {
+      "path": "statutes/26/3402/e.test.yaml",
+      "sha256": "fd855809da49cd1f0a7036a15f293c7d778c40f6db18046c84d42bae9810de21"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1ee38a9f55b3906598ee330d70400989cb03e454",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.308",
+    "version_commit": "1ee38a9f55b3906598ee330d70400989cb03e454"
+  },
+  "axiom_encode_version": "0.2.308",
+  "backend": "openai",
+  "citation": "26 USC 3402(e)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "b6f7a1ab5cdc9e372bd4f3640cb8fb7684e378e85135866757518daa29808840",
+  "generated_at": "2026-05-27T01:58:38.603566+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "ed1d0a72f915c661243ae273e557a52763ba660253e9c04524ea0692e4eb62ba",
+  "generation_prompt_sha256": "36b47282fce9ad9306e038995009b926e0de1205f07b6015c17cff0d91c02439",
+  "model": "gpt-5.5",
+  "run_id": "dcda3db1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6bb3079896d684828fb4cbdc18b1bd8136b5110f9c508b88600f8bfe271f2873"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-e.json",
+  "trace_sha256": "a883179113585797992662ed54e858dfeab8b0994223581d13c02cccf739b550"
+}

--- a/statutes/26/3402/e.test.yaml
+++ b/statutes/26/3402/e.test.yaml
@@ -1,0 +1,64 @@
+- name: half_or_more_wage_services_in_short_payroll_period_deems_all_remuneration_wages
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/b#input.payment_of_wages_is_ordinarily_made_to_employee_by_employer_for_period: true
+    us:statutes/26/3402/e#input.payroll_period_consecutive_days: 31
+    us:statutes/26/3402/e#input.remuneration_for_services_during_one_half_or_more_of_period_constitutes_wages: true
+    us:statutes/26/3402/e#input.remuneration_for_services_during_more_than_one_half_of_period_does_not_constitute_wages: false
+    us:statutes/26/3402/e#input.remuneration_paid_by_employer_to_employee_for_period: 2000
+  output:
+    us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit: holds
+    us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period: holds
+    us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#remuneration_amount_deemed_wages_for_period: 2000
+- name: more_than_half_nonwage_services_in_short_payroll_period_deems_no_remuneration_wages
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/b#input.payment_of_wages_is_ordinarily_made_to_employee_by_employer_for_period: true
+    us:statutes/26/3402/e#input.payroll_period_consecutive_days: 30
+    us:statutes/26/3402/e#input.remuneration_for_services_during_one_half_or_more_of_period_constitutes_wages: false
+    us:statutes/26/3402/e#input.remuneration_for_services_during_more_than_one_half_of_period_does_not_constitute_wages: true
+    us:statutes/26/3402/e#input.remuneration_paid_by_employer_to_employee_for_period: 2000
+  output:
+    us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit: holds
+    us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period: holds
+    us:statutes/26/3402/e#remuneration_amount_deemed_wages_for_period: 0
+- name: period_over_day_limit_prevents_subsection_e_deeming
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/b#input.payment_of_wages_is_ordinarily_made_to_employee_by_employer_for_period: true
+    us:statutes/26/3402/e#input.payroll_period_consecutive_days: 32
+    us:statutes/26/3402/e#input.remuneration_for_services_during_one_half_or_more_of_period_constitutes_wages: true
+    us:statutes/26/3402/e#input.remuneration_for_services_during_more_than_one_half_of_period_does_not_constitute_wages: false
+    us:statutes/26/3402/e#input.remuneration_paid_by_employer_to_employee_for_period: 2000
+  output:
+    us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit: not_holds
+    us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#remuneration_amount_deemed_wages_for_period: 0
+- name: nonpayroll_period_prevents_subsection_e_deeming
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/b#input.payment_of_wages_is_ordinarily_made_to_employee_by_employer_for_period: false
+    us:statutes/26/3402/e#input.payroll_period_consecutive_days: 30
+    us:statutes/26/3402/e#input.remuneration_for_services_during_one_half_or_more_of_period_constitutes_wages: true
+    us:statutes/26/3402/e#input.remuneration_for_services_during_more_than_one_half_of_period_does_not_constitute_wages: false
+    us:statutes/26/3402/e#input.remuneration_paid_by_employer_to_employee_for_period: 2000
+  output:
+    us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit: not_holds
+    us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period: not_holds
+    us:statutes/26/3402/e#remuneration_amount_deemed_wages_for_period: 0

--- a/statutes/26/3402/e.yaml
+++ b/statutes/26/3402/e.yaml
@@ -1,0 +1,153 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    26 USC 3402(e): for a payroll period of not more than 31 consecutive days, if remuneration for services during one-half or more of the period constitutes wages, all remuneration for the period is deemed wages; if remuneration for services during more than one-half of the period does not constitute wages, none is deemed wages.
+imports:
+  - us:statutes/26/3401/b#payroll_period
+rules:
+  - name: maximum_consecutive_days_for_payroll_period_deeming_rule
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "payroll period of not more than 31 consecutive days"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          31
+
+  - name: payroll_period_within_deeming_rule_day_limit
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3401/b#payroll_period
+              output: payroll_period
+              hash: sha256:3c3c9322e48201b138adc220cfcde7691bf2c278e7e7ebfe29be8f970a2be492
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "payroll period of not more than 31 consecutive days"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/e#maximum_consecutive_days_for_payroll_period_deeming_rule
+              output: maximum_consecutive_days_for_payroll_period_deeming_rule
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payroll_period
+          and payroll_period_consecutive_days <= maximum_consecutive_days_for_payroll_period_deeming_rule
+
+  - name: all_remuneration_deemed_wages_for_period
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit
+              output: payroll_period_within_deeming_rule_day_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "remuneration ... for services performed during one-half or more ... constitutes wages"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "all the remuneration ... shall be deemed to be wages"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payroll_period_within_deeming_rule_day_limit
+          and remuneration_for_services_during_one_half_or_more_of_period_constitutes_wages
+
+  - name: no_remuneration_deemed_wages_for_period
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit
+              output: payroll_period_within_deeming_rule_day_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "remuneration ... for services performed during more than one-half ... does not constitute wages"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "none of the remuneration ... shall be deemed to be wages"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payroll_period_within_deeming_rule_day_limit
+          and remuneration_for_services_during_more_than_one_half_of_period_does_not_constitute_wages
+
+  - name: remuneration_amount_deemed_wages_for_period
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period
+              output: all_remuneration_deemed_wages_for_period
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period
+              output: no_remuneration_deemed_wages_for_period
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "all ... or none ... shall be deemed to be wages"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if all_remuneration_deemed_wages_for_period: remuneration_paid_by_employer_to_employee_for_period else: if no_remuneration_deemed_wages_for_period: 0 else: 0


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(e) payroll-period wage-deeming rules.
- Add generated companion tests and signed encoder apply manifest.

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/e.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/e.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/e.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50