### PR TITLE
Add generated section 3402(f) withholding certificates

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/f.yaml",
+      "sha256": "54413492205efa896b755bf3a814ad0fc88bad7b3dc76e0d22bf537e1f6bb4cd"
+    },
+    {
+      "path": "statutes/26/3402/f.test.yaml",
+      "sha256": "646f7c5be850d977c69aac1d9ef4e7665165d1fe8cced7fbd48d88eea81830db"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "295e965dd621e43b8937f9041c11572f32d1c964",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.309",
+    "version_commit": "295e965dd621e43b8937f9041c11572f32d1c964"
+  },
+  "axiom_encode_version": "0.2.309",
+  "backend": "openai",
+  "citation": "26 USC 3402(f)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "e0b2b109e8fe427d4f710638e69d4aebf206aa0e9a7e191538c1dc5af96218eb",
+  "generated_at": "2026-05-27T02:18:19.607959+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "54413492205efa896b755bf3a814ad0fc88bad7b3dc76e0d22bf537e1f6bb4cd",
+  "generation_prompt_sha256": "b4eb2f2a28009e0c7bab1d0b3e1c2b9e821dfe727ea812a8f72047b80281843a",
+  "model": "gpt-5.5",
+  "run_id": "0f4c74ad",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "29601ebb1d25ab58237fc439cc60e61adbbe2ff46a87e7e48ae4e54791e844f9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-f.json",
+  "trace_sha256": "6caeecd2a57b5c5d30c6f007a62d5deb73659b4229bca79f12d0547530345a8c"
+}

--- a/statutes/26/3402/f.test.yaml
+++ b/statutes/26/3402/f.test.yaml
@@ -1,0 +1,239 @@
+- name: commencement_certificate_requirement_satisfied_when_certificate_timely_signed_and_within_entitlement
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: true
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: true
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: true
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: true
+  output:
+    us:statutes/26/3402/f#change_status_new_certificate_due_days: 10
+    us:statutes/26/3402/f#replacement_certificate_default_wait_days: 30
+    us:statutes/26/3402/f#nonresident_alien_withholding_exemption_limit: 1
+    us:statutes/26/3402/f#commencement_certificate_requirement_satisfied: holds
+- name: commencement_certificate_requirement_not_satisfied_when_claim_exceeds_entitlement
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: true
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: true
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: true
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+  output:
+    us:statutes/26/3402/f#commencement_certificate_requirement_satisfied: not_holds
+- name: excess_allowance_requires_new_certificate_within_due_days
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-02-01'
+    end: '2024-02-01'
+  input:
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: true
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+  output:
+    us:statutes/26/3402/f#excess_allowance_new_certificate_violation: holds
+- name: replacement_and_next_year_certificate_effect_rules
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-03-15'
+    end: '2024-03-15'
+  input:
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: true
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: true
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : true
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: true
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: true
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+  output:
+    us:statutes/26/3402/f#replacement_certificate_default_effective_for_payment: holds
+    us:statutes/26/3402/f#replacement_certificate_employer_election_earlier_effective_for_payment: holds
+    us:statutes/26/3402/f#next_year_certificate_not_effective_for_current_year_payment: not_holds
+- name: auto_output_increased_allowance_new_certificate_permitted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/f#input.allowance_under_other_employer_certificate_was_claimed_under_first_certificate: false
+    us:statutes/26/3402/f#input.another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: false
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.new_certificate_relates_to_allowance_to_which_employee_is_entitled: false
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+    us:statutes/26/3402/f#input.next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement: false
+    us:statutes/26/3402/f#input.next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement: false
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.secretary_regulations_prescribe_certificate_for_case_and_time: false
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_one_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_other_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day: false
+    us:statutes/26/3402/f#input.withholding_allowance_entitlement_greater_than_allowance_claimed: false
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: false
+  output:
+    us:statutes/26/3402/f#increased_allowance_new_certificate_permitted: not_holds
+- name: auto_output_next_taxable_year_certificate_required
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/f#input.allowance_under_other_employer_certificate_was_claimed_under_first_certificate: false
+    us:statutes/26/3402/f#input.another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: false
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.new_certificate_relates_to_allowance_to_which_employee_is_entitled: false
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+    us:statutes/26/3402/f#input.next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement: false
+    us:statutes/26/3402/f#input.next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement: false
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.secretary_regulations_prescribe_certificate_for_case_and_time: false
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_one_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_other_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day: false
+    us:statutes/26/3402/f#input.withholding_allowance_entitlement_greater_than_allowance_claimed: false
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: false
+  output:
+    us:statutes/26/3402/f#next_taxable_year_certificate_required: not_holds
+- name: auto_output_first_certificate_effective_for_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/f#input.allowance_under_other_employer_certificate_was_claimed_under_first_certificate: false
+    us:statutes/26/3402/f#input.another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: false
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.new_certificate_relates_to_allowance_to_which_employee_is_entitled: false
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+    us:statutes/26/3402/f#input.next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement: false
+    us:statutes/26/3402/f#input.next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement: false
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.secretary_regulations_prescribe_certificate_for_case_and_time: false
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_one_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_other_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day: false
+    us:statutes/26/3402/f#input.withholding_allowance_entitlement_greater_than_allowance_claimed: false
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: false
+  output:
+    us:statutes/26/3402/f#first_certificate_effective_for_payment: not_holds
+- name: auto_output_certificate_continues_in_effect
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/f#input.allowance_under_other_employer_certificate_was_claimed_under_first_certificate: false
+    us:statutes/26/3402/f#input.another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: false
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.new_certificate_relates_to_allowance_to_which_employee_is_entitled: false
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+    us:statutes/26/3402/f#input.next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement: false
+    us:statutes/26/3402/f#input.next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement: false
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.secretary_regulations_prescribe_certificate_for_case_and_time: false
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_one_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_other_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day: false
+    us:statutes/26/3402/f#input.withholding_allowance_entitlement_greater_than_allowance_claimed: false
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: false
+  output:
+    us:statutes/26/3402/f#certificate_continues_in_effect: not_holds
+- name: auto_output_duplicate_allowance_claim_with_other_employer_disallowed
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/f#input.allowance_under_other_employer_certificate_was_claimed_under_first_certificate: false
+    us:statutes/26/3402/f#input.another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    us:statutes/26/3402/f#input.certificate_relates_to_withholding_allowance_claimed_by_employee: false
+    us:statutes/26/3402/f#input.employee_commences_employment_with_employer: false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.new_certificate_relates_to_allowance_to_which_employee_is_entitled: false
+    us:statutes/26/3402/f#input.new_withholding_allowance_certificate_furnished_within_change_status_due_days: false
+    us:statutes/26/3402/f#input.next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement: false
+    us:statutes/26/3402/f#input.next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement: false
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.secretary_regulations_prescribe_certificate_for_case_and_time: false
+    us:statutes/26/3402/f#input.signed_withholding_allowance_certificate_furnished_on_or_before_commencement: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_has_taken_effect_with_respect_to_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_one_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_in_effect_with_other_employer: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement: false
+    us:statutes/26/3402/f#input.withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day: false
+    us:statutes/26/3402/f#input.withholding_allowance_entitlement_greater_than_allowance_claimed: false
+    us:statutes/26/3402/f#input.withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day: false
+  output:
+    us:statutes/26/3402/f#duplicate_allowance_claim_with_other_employer_disallowed: not_holds

--- a/statutes/26/3402/f.yaml
+++ b/statutes/26/3402/f.yaml
@@ -1,0 +1,351 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/f#withholding_allowance
+      reason: >-
+        Section 3402(f)(1) provides that the employee's withholding allowance is
+        determined under rules determined by the Secretary and based on several
+        cross-referenced factors, including section 151, section 24 as modified
+        by subsection 24(h), subsection (m), section 7703 marital status, and
+        multiple-employer certificates. The Secretary-determined computational
+        rules and subsection (m) are not included in the supplied source or
+        copied executable context, so the final allowance amount is deferred.
+    - output: us:statutes/26/3402/f#nonresident_alien_withholding_exemptions
+      reason: >-
+        Section 3402(f)(6) limits a nonresident alien individual to one
+        withholding exemption except for an individual described in section
+        3401(a)(6)(A) or (B). No copied RuleSpec context provides section
+        3401(a)(6)(A) or (B), so the exception-dependent exemption surface is
+        deferred.
+      source_values:
+        - us:statutes/26/3402/f#nonresident_alien_withholding_exemption_limit
+  summary: |-
+    26 USC 3402(f): an employee receiving wages is entitled to a withholding
+    allowance determined under Secretary rules based on listed factors; employees
+    must furnish signed withholding allowance certificates on commencement and
+    after status changes; replacement certificates generally take effect after
+    the 30th day, may be made effective earlier by the employer, and next-year
+    certificates do not affect current-year wage payments; certificates continue
+    until replaced; a nonresident alien is entitled to only one withholding
+    exemption subject to section 3401(a)(6)(A) or (B); an allowance claimed with
+    one employer may not also be claimed with another.
+rules:
+  - name: change_status_new_certificate_due_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(f)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "within 10 days thereafter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: replacement_certificate_default_wait_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(f)(3)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "on or after the 30th day after the day on which such certificate is so furnished"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: nonresident_alien_withholding_exemption_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(f)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall be entitled to only one withholding exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: commencement_certificate_requirement_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "On or before the date of the commencement of employment"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "furnish the employer with a signed withholding allowance certificate"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "which shall in no event exceed the amount to which the employee is entitled"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employee_commences_employment_with_employer
+          and signed_withholding_allowance_certificate_furnished_on_or_before_commencement
+          and certificate_relates_to_withholding_allowance_claimed_by_employee
+          and withholding_allowance_claimed_on_certificate_does_not_exceed_employee_entitlement
+
+  - name: excess_allowance_new_certificate_violation
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "employee’s withholding allowance is in excess of the withholding allowance to which the employee would be entitled"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall within 10 days thereafter furnish the employer with a new withholding allowance certificate"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_exceeds_true_and_accurate_certificate_entitlement_on_day
+          and not new_withholding_allowance_certificate_furnished_within_change_status_due_days
+
+  - name: increased_allowance_new_certificate_permitted
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "employee’s withholding allowance is greater than the withholding allowance claimed"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "may furnish the employer with a new withholding allowance certificate"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "which shall in no event exceed the amount to which the employee is entitled on such day"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_entitlement_greater_than_allowance_claimed
+          and new_certificate_relates_to_allowance_to_which_employee_is_entitled
+          and withholding_allowance_claimed_on_new_certificate_does_not_exceed_employee_entitlement_on_day
+
+  - name: next_taxable_year_certificate_required
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "withholding allowance to which the employee will be, or may reasonably be expected to be, entitled at the beginning of the employee’s next taxable year"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall ... furnish the employer with a withholding allowance certificate"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "which shall in no event exceed the withholding allowance to which the employee will be, or may reasonably be expected to be, so entitled"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          next_taxable_year_expected_withholding_allowance_differs_from_current_day_entitlement
+          and secretary_regulations_prescribe_certificate_for_case_and_time
+          and next_year_certificate_claim_does_not_exceed_expected_next_year_entitlement
+
+  - name: first_certificate_effective_for_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "no previous such certificate is in effect"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall take effect as of the beginning of the first payroll period ending ... on or after the date"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_certificate_furnished_to_employer
+          and no_previous_withholding_allowance_certificate_in_effect
+          and payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+
+  - name: replacement_certificate_default_effective_for_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(3)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "a previous such certificate is in effect"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "on or after the 30th day after the day on which such certificate is so furnished"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_certificate_furnished_to_employer
+          and previous_withholding_allowance_certificate_in_effect
+          and not certificate_furnished_pursuant_to_next_taxable_year_change_rule
+          and payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+
+  - name: replacement_certificate_employer_election_earlier_effective_for_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(3)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "At the election of the employer"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "any payment of wages made on or after the day on which the certificate is so furnished and before the 30th day"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_certificate_furnished_to_employer
+          and previous_withholding_allowance_certificate_in_effect
+          and employer_elects_earlier_effective_date_for_replacement_certificate
+          and payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day
+
+  - name: next_year_certificate_not_effective_for_current_year_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(3)(B)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall not take effect, and may not be made effective, with respect to any payment of wages made in the calendar year in which the certificate is furnished"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          certificate_furnished_pursuant_to_next_taxable_year_change_rule
+          and payment_of_wages_made_in_calendar_year_in_which_certificate_is_furnished
+
+  - name: certificate_continues_in_effect
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall continue in effect with respect to the employer until another such certificate takes effect"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_certificate_has_taken_effect_with_respect_to_employer
+          and not another_withholding_allowance_certificate_has_taken_effect_with_respect_to_employer
+
+  - name: duplicate_allowance_claim_with_other_employer_disallowed
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(f)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "If a withholding allowance certificate is in effect with respect to one employer"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall not be entitled under a certificate in effect with any other employer to any withholding allowance which he has claimed under such first certificate"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withholding_allowance_certificate_in_effect_with_one_employer
+          and withholding_allowance_certificate_in_effect_with_other_employer
+          and allowance_under_other_employer_certificate_was_claimed_under_first_certificate


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(f) withholding allowance certificate administration.
- Add generated companion tests and signed encoder apply manifest.

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/f.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/f.yaml
- uv run axiom-encode test --root /private/tmp/axiom-night-20260526190810/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/f.test.yaml
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100