### PR TITLE
Add generated section 3402(h) alternative withholding methods

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/h.yaml",
+      "sha256": "4d186764724b5cfcae0c12005e70c3f30e9ecc3cb17ed7e2d644cde509598140"
+    },
+    {
+      "path": "statutes/26/3402/h.test.yaml",
+      "sha256": "5b912d714cbf1942a1736a5c4917b0d52f2164cd4e2090875b7be434dc55e6b7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f81aa3c5b0b5e82201651abbd64ac8e5b7b09be7",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.312",
+    "version_commit": "f81aa3c5b0b5e82201651abbd64ac8e5b7b09be7"
+  },
+  "axiom_encode_version": "0.2.312",
+  "backend": "openai",
+  "citation": "26 USC 3402(h)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "9e47e5c1fc6813b830f2dae6076519f4eb3f06ed3bc455c2484f771e5d3f20cf",
+  "generated_at": "2026-05-27T03:31:25.634270+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "4d186764724b5cfcae0c12005e70c3f30e9ecc3cb17ed7e2d644cde509598140",
+  "generation_prompt_sha256": "a7cb644a8783ef04dfc0ca138166817ca11951205df36f2875c2fc8189b7a16f",
+  "model": "gpt-5.5",
+  "run_id": "231f379f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "95b050bd34c60da2cbef566526d95484c53574d977f252daf9af57d7b99916e3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-h.json",
+  "trace_sha256": "671c21b6213a424e02a773d65c751580d9db3cdde568ba1c74655fa1bb76385b"
+}

--- a/statutes/26/3402/h.test.yaml
+++ b/statutes/26/3402/h.test.yaml
@@ -1,0 +1,92 @@
+- name: average_wage_adjustment_and_tips_deadline_apply
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/h#input.payment_is_tips_referred_to_in_subsection_k: true
+    us:statutes/26/3402/h#input.amount_required_to_be_deducted_and_withheld_during_quarter_without_regard_to_subsection_h: 1200
+    us:statutes/26/3402/h#input.amount_actually_deducted_and_withheld_during_quarter: 900
+  output:
+    us:statutes/26/3402/h#average_wage_method_tips_adjustment_deadline_days: 30
+    us:statutes/26/3402/h#average_wage_method_quarterly_adjustment_amount: 300
+- name: annualized_wage_method_divides_annualized_tax_by_payroll_periods
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/h#input.employee_wages_for_payroll_period: 1000
+    us:statutes/26/3402/h#input.number_of_such_payroll_periods_in_calendar_year: 12
+    us:statutes/26/3402/h#input.tax_required_on_annualized_wages_if_actual_calendar_year_wages_and_annual_payroll_period: 2400
+  output:
+    us:statutes/26/3402/h#annualized_wages_for_withholding_method: 12000
+    us:statutes/26/3402/h#annualized_wage_method_tax_to_withhold_on_payment: 200
+- name: cumulative_wage_method_with_employee_request_withholds_excess
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/h#input.employee_requests_cumulative_wage_withholding_computation: true
+    us:statutes/26/3402/h#input.wages_to_be_paid_to_employee_for_payroll_period: 1000
+    us:statutes/26/3402/h#input.total_wages_paid_by_employer_to_employee_during_calendar_year_before_payment: 5000
+    us:statutes/26/3402/h#input.number_of_payroll_periods_to_which_aggregate_wages_relate: 6
+    us:statutes/26/3402/h#input.total_tax_required_under_subsection_a_on_average_wages_for_related_payroll_periods: 900
+    us:statutes/26/3402/h#input.total_tax_deducted_and_withheld_from_employee_wages_during_calendar_year_before_payment: 700
+  output:
+    us:statutes/26/3402/h#cumulative_wage_method_aggregate_wages: 6000
+    us:statutes/26/3402/h#cumulative_wage_method_average_wages: 1000
+    us:statutes/26/3402/h#cumulative_wage_method_excess_tax: 200
+    us:statutes/26/3402/h#cumulative_wage_method_tax_to_withhold_on_payment: 200
+- name: cumulative_request_absent_and_other_method_not_substantially_same
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/h#input.employee_requests_cumulative_wage_withholding_computation: false
+    us:statutes/26/3402/h#input.wages_to_be_paid_to_employee_for_payroll_period: 1000
+    us:statutes/26/3402/h#input.total_wages_paid_by_employer_to_employee_during_calendar_year_before_payment: 5000
+    us:statutes/26/3402/h#input.number_of_payroll_periods_to_which_aggregate_wages_relate: 6
+    us:statutes/26/3402/h#input.total_tax_required_under_subsection_a_on_average_wages_for_related_payroll_periods: 900
+    us:statutes/26/3402/h#input.total_tax_deducted_and_withheld_from_employee_wages_during_calendar_year_before_payment: 700
+    us:statutes/26/3402/h#input.other_method_requires_substantially_same_amount_as_applying_subsection_a_or_c: false
+  output:
+    us:statutes/26/3402/h#cumulative_wage_method_tax_to_withhold_on_payment: 0
+- name: cumulative_request_absent_and_other_method_not_substantially_same_employer_outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/h#input.employee_requests_cumulative_wage_withholding_computation: false
+    us:statutes/26/3402/h#input.wages_to_be_paid_to_employee_for_payroll_period: 1000
+    us:statutes/26/3402/h#input.total_wages_paid_by_employer_to_employee_during_calendar_year_before_payment: 5000
+    us:statutes/26/3402/h#input.number_of_payroll_periods_to_which_aggregate_wages_relate: 6
+    us:statutes/26/3402/h#input.total_tax_required_under_subsection_a_on_average_wages_for_related_payroll_periods: 900
+    us:statutes/26/3402/h#input.total_tax_deducted_and_withheld_from_employee_wages_during_calendar_year_before_payment: 700
+    us:statutes/26/3402/h#input.other_method_requires_substantially_same_amount_as_applying_subsection_a_or_c: false
+  output:
+    us:statutes/26/3402/h#other_substantially_same_method_authorizable: not_holds
+- name: auto_zero_average_wage_method_tips_adjustment_deadline_days
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3402/h#input.amount_actually_deducted_and_withheld_during_quarter: 0
+    us:statutes/26/3402/h#input.amount_required_to_be_deducted_and_withheld_during_quarter_without_regard_to_subsection_h: 0
+    us:statutes/26/3402/h#input.employee_requests_cumulative_wage_withholding_computation: false
+    us:statutes/26/3402/h#input.employee_wages_for_payroll_period: 0
+    us:statutes/26/3402/h#input.number_of_payroll_periods_to_which_aggregate_wages_relate: 0
+    us:statutes/26/3402/h#input.number_of_such_payroll_periods_in_calendar_year: 0
+    us:statutes/26/3402/h#input.other_method_requires_substantially_same_amount_as_applying_subsection_a_or_c: 0
+    us:statutes/26/3402/h#input.payment_is_tips_referred_to_in_subsection_k: false
+    us:statutes/26/3402/h#input.tax_required_on_annualized_wages_if_actual_calendar_year_wages_and_annual_payroll_period: 0
+    us:statutes/26/3402/h#input.total_tax_deducted_and_withheld_from_employee_wages_during_calendar_year_before_payment: 0
+    us:statutes/26/3402/h#input.total_tax_required_under_subsection_a_on_average_wages_for_related_payroll_periods: 0
+    us:statutes/26/3402/h#input.total_wages_paid_by_employer_to_employee_during_calendar_year_before_payment: 0
+    us:statutes/26/3402/h#input.wages_to_be_paid_to_employee_for_payroll_period: 0
+  output:
+    us:statutes/26/3402/h#average_wage_method_tips_adjustment_deadline_days: 0

--- a/statutes/26/3402/h.yaml
+++ b/statutes/26/3402/h.yaml
@@ -1,0 +1,241 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/h#average_wage_method_tax_to_withhold_on_each_payment
+      reason: >-
+        Section 3402(h)(1)(B) refers to the amount to be deducted and withheld
+        as if the appropriate average of estimated quarterly wages constituted
+        the actual wages paid. The source does not provide the Secretary-prescribed
+        withholding tables or computational procedure needed to compute that tax.
+      source_values:
+        - us:statutes/26/3402/h#average_wage_method_quarterly_adjustment_amount
+    - output: us:statutes/26/3402/h#other_substantially_same_method_tax_to_withhold
+      reason: >-
+        Section 3402(h)(4) permits other methods requiring substantially the same
+        amount as subsection (a) or (c), but the source and copied context do not
+        provide the Secretary-prescribed subsection (a) or (c) tax tables needed
+        to compute the alternative amount.
+  summary: |-
+    26 USC 3402(h): the Secretary may authorize alternative methods of computing withholding, including average wages with quarter-end adjustment and a 30-day tips timing rule, annualized wages, cumulative wages at employee request, and other methods producing substantially the same withholding as subsection (a) or (c).
+rules:
+  - name: tips_adjustment_deadline_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(h)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "in the case of tips referred to in subsection (k), within 30 days thereafter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: average_wage_method_tips_adjustment_deadline_days
+    kind: derived
+    entity: Payment
+    dtype: Count
+    period: Year
+    source: 26 USC 3402(h)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/h#tips_adjustment_deadline_days
+              output: tips_adjustment_deadline_days
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "in the case of tips referred to in subsection (k), within 30 days thereafter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if payment_is_tips_referred_to_in_subsection_k: tips_adjustment_deadline_days else: 0
+
+  - name: average_wage_method_quarterly_adjustment_amount
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "such amount as may be necessary to adjust the amount actually deducted and withheld ... to the amount required ... without regard to this subsection"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, amount_required_to_be_deducted_and_withheld_during_quarter_without_regard_to_subsection_h - amount_actually_deducted_and_withheld_during_quarter)
+
+  - name: annualized_wages_for_withholding_method
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "multiplying the amount of an employee’s wages for a payroll period by the number of such payroll periods in the calendar year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employee_wages_for_payroll_period * number_of_such_payroll_periods_in_calendar_year
+
+  - name: annualized_wage_method_tax_to_withhold_on_payment
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(2)(B)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "dividing the amount of tax determined under subparagraph (B) by the number of payroll periods"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_required_on_annualized_wages_if_actual_calendar_year_wages_and_annual_payroll_period / number_of_such_payroll_periods_in_calendar_year
+
+  - name: cumulative_wage_method_aggregate_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "add the amount of the wages to be paid ... to the total amount of wages paid ... during the calendar year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          wages_to_be_paid_to_employee_for_payroll_period + total_wages_paid_by_employer_to_employee_during_calendar_year_before_payment
+
+  - name: cumulative_wage_method_average_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/h#cumulative_wage_method_aggregate_wages
+              output: cumulative_wage_method_aggregate_wages
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "divide the aggregate amount of wages ... by the number of payroll periods to which such aggregate amount of wages relates"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cumulative_wage_method_aggregate_wages / number_of_payroll_periods_to_which_aggregate_wages_relate
+
+  - name: cumulative_wage_method_excess_tax
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(3)(C)-(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "determine the excess, if any, of the amount of tax computed ... over the total amount of tax deducted and withheld"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, total_tax_required_under_subsection_a_on_average_wages_for_related_payroll_periods - total_tax_deducted_and_withheld_from_employee_wages_during_calendar_year_before_payment)
+
+  - name: cumulative_wage_method_tax_to_withhold_on_payment
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(h)(3)(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/h#cumulative_wage_method_excess_tax
+              output: cumulative_wage_method_excess_tax
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "in the case of any employee who requests to have the amount of tax ... computed on the basis of his cumulative wages"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "deduct and withhold ... an amount equal to the excess (if any)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if employee_requests_cumulative_wage_withholding_computation: cumulative_wage_method_excess_tax else: 0
+
+  - name: other_substantially_same_method_authorizable
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(h)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "any other method which will require the employer to deduct and withhold ... substantially the same amount as would be required ... by applying subsection (a) or (c)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          other_method_requires_substantially_same_amount_as_applying_subsection_a_or_c


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3402(h) alternative withholding methods
- include generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/h.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/h.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/h.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes