### PR TITLE
Add generated section 3402(i) increased withholding

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/i.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/i.yaml",
+      "sha256": "f4c16397e880494a19106bfbddf77cc552c426768d7a2e5abc02d347e0782930"
+    },
+    {
+      "path": "statutes/26/3402/i.test.yaml",
+      "sha256": "faf1d90024e21352d6b2a1255cd80251039f95a9cd8e30219fe063ea6aa213bf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8a7ac2a5bc31c53a3c8b155eb30bfee761ae38fb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.313",
+    "version_commit": "8a7ac2a5bc31c53a3c8b155eb30bfee761ae38fb"
+  },
+  "axiom_encode_version": "0.2.313",
+  "backend": "openai",
+  "citation": "26 USC 3402(i)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-i/workspace/context-manifest.json",
+  "context_manifest_sha256": "3e264945ffe6c1a067a47450cde5715163ed2af958ae229b91a48febc7c0bb1c",
+  "generated_at": "2026-05-27T04:08:59.017017+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/i.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f4c16397e880494a19106bfbddf77cc552c426768d7a2e5abc02d347e0782930",
+  "generation_prompt_sha256": "fb9954315e2386601f014038e9f93aaba174b0e5b81f27b09df5e00d8a2609ea",
+  "model": "gpt-5.5",
+  "run_id": "b5c4e29e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "64e44fd83f61b9e5291dbf47508c9a0fcb0e62117fbbc473e54875afe39a7a93"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-i.json",
+  "trace_sha256": "730f00d0a679486e8003404e7b297fa27597e9c2bd61543daf305756a5f815a2"
+}

--- a/statutes/26/3402/i.test.yaml
+++ b/statutes/26/3402/i.test.yaml
@@ -1,0 +1,36 @@
+- name: employee_request_supports_regulatory_authority_for_increased_withholding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/i#input.employee_requests_increased_withholding_changes: true
+    us:statutes/26/3402/i#input.increased_withholding_is_under_paragraph_1: true
+    us:statutes/26/3402/i#input.increased_withholding_amount: 150
+  output:
+    us:statutes/26/3402/i#employee_requested_increased_withholding_regulatory_authority: holds
+    us:statutes/26/3402/i#increased_withholding_treated_as_required_withholding_tax: 150
+- name: no_employee_request_means_regulatory_authority_condition_not_met
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/i#input.employee_requests_increased_withholding_changes: false
+    us:statutes/26/3402/i#input.increased_withholding_is_under_paragraph_1: true
+    us:statutes/26/3402/i#input.increased_withholding_amount: 150
+  output:
+    us:statutes/26/3402/i#employee_requested_increased_withholding_regulatory_authority: not_holds
+    us:statutes/26/3402/i#increased_withholding_treated_as_required_withholding_tax: 150
+- name: withholding_not_under_paragraph_1_is_not_treated_by_subsection_i_as_required_withholding_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/i#input.employee_requests_increased_withholding_changes: true
+    us:statutes/26/3402/i#input.increased_withholding_is_under_paragraph_1: false
+    us:statutes/26/3402/i#input.increased_withholding_amount: 150
+  output:
+    us:statutes/26/3402/i#employee_requested_increased_withholding_regulatory_authority: holds
+    us:statutes/26/3402/i#increased_withholding_treated_as_required_withholding_tax: 0

--- a/statutes/26/3402/i.yaml
+++ b/statutes/26/3402/i.yaml
@@ -1,0 +1,57 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    26 USC 3402(i): the Secretary may by regulations provide for increases in withholding where the employee requests such changes; any increased withholding under paragraph (1) is treated for all purposes as tax required to be deducted and withheld under chapter 24.
+rules:
+  - name: employee_requested_increased_withholding_regulatory_authority
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(i)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "in cases where the employee requests such changes"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "The Secretary may by regulations provide for increases in the amount of withholding"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employee_requests_increased_withholding_changes
+
+  - name: increased_withholding_treated_as_required_withholding_tax
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(i)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "Any increased withholding under paragraph (1)"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall for all purposes be considered tax required to be deducted and withheld under this chapter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if increased_withholding_is_under_paragraph_1: increased_withholding_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3402(i) requested increased withholding
- include generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/i.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/i.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/i.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes