### PR TITLE
Add generated section 3402(j) retail commission withholding

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/j.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/j.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/j.yaml",
+      "sha256": "266d8e852f851f49727371b117d562202b9c94426653edbb716245fc25f67554"
+    },
+    {
+      "path": "statutes/26/3402/j.test.yaml",
+      "sha256": "29faeba584460f4828d376ab1a16d7407807c9398a39f2d5635cff93214c7217"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e191542036ab02c1033ae0a49b5c8bb0db58a6d4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.314",
+    "version_commit": "e191542036ab02c1033ae0a49b5c8bb0db58a6d4"
+  },
+  "axiom_encode_version": "0.2.314",
+  "backend": "openai",
+  "citation": "26 USC 3402(j)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-j/workspace/context-manifest.json",
+  "context_manifest_sha256": "fce6640b2898de5cfe1b18d0087e788c7c4fca95fc2fd38d07eac5a5d05193f4",
+  "generated_at": "2026-05-27T04:23:54.370460+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/j.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "266d8e852f851f49727371b117d562202b9c94426653edbb716245fc25f67554",
+  "generation_prompt_sha256": "d5471bc7fd57441ab85d1f3290a4d6c8bc59c86d15e8e6ca7a6e30ce5b8e1485",
+  "model": "gpt-5.5",
+  "run_id": "68814904",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "78c8f3b8ff810abdc8314e433c4854915a1acdd08af3f345a4c2c0775067ad6e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-j.json",
+  "trace_sha256": "f3aa4b399feec405682f98ff60dde6c2fc42703facc661bb86e588f70981e0bd"
+}

--- a/statutes/26/3402/j.test.yaml
+++ b/statutes/26/3402/j.test.yaml
@@ -1,0 +1,60 @@
+- name: noncash_retail_cash_commission_remuneration_with_prescribed_filing_needs_no_withholding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/j#input.remuneration_paid_in_medium_other_than_cash: true
+    us:statutes/26/3402/j#input.services_performed_by_individual_as_retail_salesman_for_person: true
+    us:statutes/26/3402/j#input.service_ordinarily_performed_for_remuneration_solely_by_cash_commission: true
+    us:statutes/26/3402/j#input.employer_files_secretary_prescribed_information_with_respect_to_remuneration: true
+  output:
+    us:statutes/26/3402/j#retail_commission_noncash_remuneration_withholding_not_required: holds
+- name: cash_remuneration_does_not_receive_subsection_j_withholding_relief
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/j#input.remuneration_paid_in_medium_other_than_cash: false
+    us:statutes/26/3402/j#input.services_performed_by_individual_as_retail_salesman_for_person: true
+    us:statutes/26/3402/j#input.service_ordinarily_performed_for_remuneration_solely_by_cash_commission: true
+    us:statutes/26/3402/j#input.employer_files_secretary_prescribed_information_with_respect_to_remuneration: true
+  output:
+    us:statutes/26/3402/j#retail_commission_noncash_remuneration_withholding_not_required: not_holds
+- name: non_retail_salesman_services_do_not_receive_subsection_j_withholding_relief
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/j#input.remuneration_paid_in_medium_other_than_cash: true
+    us:statutes/26/3402/j#input.services_performed_by_individual_as_retail_salesman_for_person: false
+    us:statutes/26/3402/j#input.service_ordinarily_performed_for_remuneration_solely_by_cash_commission: true
+    us:statutes/26/3402/j#input.employer_files_secretary_prescribed_information_with_respect_to_remuneration: true
+  output:
+    us:statutes/26/3402/j#retail_commission_noncash_remuneration_withholding_not_required: not_holds
+- name: services_not_ordinarily_cash_commission_only_do_not_receive_subsection_j_withholding_relief
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/j#input.remuneration_paid_in_medium_other_than_cash: true
+    us:statutes/26/3402/j#input.services_performed_by_individual_as_retail_salesman_for_person: true
+    us:statutes/26/3402/j#input.service_ordinarily_performed_for_remuneration_solely_by_cash_commission: false
+    us:statutes/26/3402/j#input.employer_files_secretary_prescribed_information_with_respect_to_remuneration: true
+  output:
+    us:statutes/26/3402/j#retail_commission_noncash_remuneration_withholding_not_required: not_holds
+- name: employer_prescribed_information_not_filed_do_not_receive_subsection_j_withholding_relief
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/j#input.remuneration_paid_in_medium_other_than_cash: true
+    us:statutes/26/3402/j#input.services_performed_by_individual_as_retail_salesman_for_person: true
+    us:statutes/26/3402/j#input.service_ordinarily_performed_for_remuneration_solely_by_cash_commission: true
+    us:statutes/26/3402/j#input.employer_files_secretary_prescribed_information_with_respect_to_remuneration: false
+  output:
+    us:statutes/26/3402/j#retail_commission_noncash_remuneration_withholding_not_required: not_holds

--- a/statutes/26/3402/j.yaml
+++ b/statutes/26/3402/j.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    26 USC 3402(j): in the case of noncash remuneration for services by an individual as a retail salesman, where the service is ordinarily performed for remuneration solely by cash commission, an employer is not required to deduct or withhold tax under this subchapter if the employer files Secretary-prescribed information with respect to the remuneration.
+rules:
+  - name: retail_commission_noncash_remuneration_withholding_not_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "remuneration paid in any medium other than cash"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "services performed by an individual as a retail salesman for a person"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "ordinarily performed for remuneration solely by way of cash commission"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "employer files with the Secretary such information ... as the Secretary may by regulation prescribe"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "an employer shall not be required to deduct or withhold any tax under this subchapter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          remuneration_paid_in_medium_other_than_cash
+          and services_performed_by_individual_as_retail_salesman_for_person
+          and service_ordinarily_performed_for_remuneration_solely_by_cash_commission
+          and employer_files_secretary_prescribed_information_with_respect_to_remuneration


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3402(j) noncash retail commission remuneration withholding
- include generated companion tests and encoder apply manifest

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/j.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/j.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/j.test.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100
- axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD --roots statutes