### PR TITLE
Add generated section 3402(k) tip withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/k.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/k.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/k.yaml",
+      "sha256": "9a60f829bc4f9e91a3bea13eb9574aca47dd3b3ce53ff171b8c0ce0a323e796f"
+    },
+    {
+      "path": "statutes/26/3402/k.test.yaml",
+      "sha256": "b36d95177d259bb9e518938d3cfa24b7b19b4d5ede2dc83b689c0b6cb1eb60de"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8d791c611feb70b4d6f79664fce38bfeb47b42d4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.316",
+    "version_commit": "8d791c611feb70b4d6f79664fce38bfeb47b42d4"
+  },
+  "axiom_encode_version": "0.2.316",
+  "backend": "openai",
+  "citation": "26 USC 3402(k)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3402-k/workspace/context-manifest.json",
+  "context_manifest_sha256": "2f1aa1eb0fd5a9927dc334b7a9842e9cdac4e9f260c4b35928593beabcb00921",
+  "generated_at": "2026-05-27T04:53:46.688321+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3402/k.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9a60f829bc4f9e91a3bea13eb9574aca47dd3b3ce53ff171b8c0ce0a323e796f",
+  "generation_prompt_sha256": "250ce99b212ff3b42a1dc9ea863111c1e0aa05c342d09bec4c2397b6d585fc7b",
+  "model": "gpt-5.5",
+  "run_id": "b1f9ee95",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6d703858315961894dad4ccd0a75fd6cf6142c571abe9138d6fd81ed0a388315"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3402-k.json",
+  "trace_sha256": "5b729781a667b73417af3f9a42ae6303e67738f0d107298a354412e21f77cac9"
+}

--- a/statutes/26/3402/k.test.yaml
+++ b/statutes/26/3402/k.test.yaml
@@ -1,0 +1,92 @@
+- name: reported_wage_tips_are_subject_to_subsection_a_and_cap_is_available_wages_minus_required_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/k#input.tips_constitute_wages: true
+    us:statutes/26/3402/k#input.tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a: true
+    ? us:statutes/26/3402/k#input.aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+    : 500
+    us:statutes/26/3402/k#input.tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds: 100
+  output:
+    us:statutes/26/3402/k#maximum_tip_tax_deduction_and_withholding_amount: 400
+- name: tips_not_in_section_6053_a_statement_are_not_subject_to_subsection_a_and_cap_is_zero
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/k#input.tips_constitute_wages: true
+    us:statutes/26/3402/k#input.tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a: false
+    ? us:statutes/26/3402/k#input.aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+    : 500
+    us:statutes/26/3402/k#input.tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds: 100
+  output:
+    us:statutes/26/3402/k#maximum_tip_tax_deduction_and_withholding_amount: 0
+- name: required_section_3102_or_3202_tax_can_exhaust_available_wages_and_funds
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/k#input.tips_constitute_wages: true
+    us:statutes/26/3402/k#input.tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a: true
+    ? us:statutes/26/3402/k#input.aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+    : 100
+    us:statutes/26/3402/k#input.tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds: 150
+  output:
+    us:statutes/26/3402/k#maximum_tip_tax_deduction_and_withholding_amount: 0
+- name: paragraph_16_b_tip_withholding_permitted_even_when_monthly_statements_are_less_than_threshold
+  period:
+    period_kind: custom
+    name: calendar_month
+    start: '2024-03-01'
+    end: '2024-03-31'
+  input:
+    ? us:statutes/26/3402/k#input.employee_furnished_written_statement_of_tips_received_in_calendar_month_pursuant_to_section_6053_a
+    : true
+    us:statutes/26/3402/k#input.tips_are_category_to_which_section_3401_a_16_b_is_applicable: true
+    us:statutes/26/3402/k#input.employee_wages_excluding_tips_under_employer_control_are_available_for_withholding: true
+    ? us:statutes/26/3402/k#input.total_tips_in_monthly_statements_furnished_to_employer_for_employee_employment_in_calendar_month
+    : 10
+  output:
+    us:statutes/26/3402/k#monthly_tip_statement_threshold_for_paragraph_16_b_permission: 20
+- name: auto_output_tips_withholding_under_subsection_a_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/k#input.aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+    : 0
+    ? us:statutes/26/3402/k#input.employee_furnished_written_statement_of_tips_received_in_calendar_month_pursuant_to_section_6053_a
+    : false
+    us:statutes/26/3402/k#input.employee_wages_excluding_tips_under_employer_control_are_available_for_withholding: false
+    us:statutes/26/3402/k#input.tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds: 0
+    us:statutes/26/3402/k#input.tips_are_category_to_which_section_3401_a_16_b_is_applicable: false
+    us:statutes/26/3402/k#input.tips_constitute_wages: false
+    us:statutes/26/3402/k#input.tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a: false
+    ? us:statutes/26/3402/k#input.total_tips_in_monthly_statements_furnished_to_employer_for_employee_employment_in_calendar_month
+    : 0
+  output:
+    us:statutes/26/3402/k#tips_withholding_under_subsection_a_applies: not_holds
+- name: auto_output_low_monthly_tip_statement_withholding_permitted_for_paragraph_16_b_tips
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3402/k#input.aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+    : 0
+    ? us:statutes/26/3402/k#input.employee_furnished_written_statement_of_tips_received_in_calendar_month_pursuant_to_section_6053_a
+    : false
+    us:statutes/26/3402/k#input.employee_wages_excluding_tips_under_employer_control_are_available_for_withholding: false
+    us:statutes/26/3402/k#input.tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds: 0
+    us:statutes/26/3402/k#input.tips_are_category_to_which_section_3401_a_16_b_is_applicable: false
+    us:statutes/26/3402/k#input.tips_constitute_wages: false
+    us:statutes/26/3402/k#input.tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a: false
+    ? us:statutes/26/3402/k#input.total_tips_in_monthly_statements_furnished_to_employer_for_employee_employment_in_calendar_month
+    : 0
+  output:
+    us:statutes/26/3402/k#low_monthly_tip_statement_withholding_permitted_for_paragraph_16_b_tips: not_holds

--- a/statutes/26/3402/k.yaml
+++ b/statutes/26/3402/k.yaml
@@ -1,0 +1,138 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/k#tax_to_deduct_and_withhold_on_tips
+      reason: >-
+        Section 3402(k) applies subsection (a) withholding to tips only when
+        stated conditions are met and only to the extent tax can be deducted
+        from employer-controlled wages and funds. The actual subsection (a) tax
+        is determined under Secretary-prescribed tables or procedures and is
+        deferred in the copied subsection (a) context, so the final tax to
+        deduct and withhold on tips cannot be computed here.
+      source_values:
+        - us:statutes/26/3402/k#tips_withholding_under_subsection_a_applies
+        - us:statutes/26/3402/k#maximum_tip_tax_deduction_and_withholding_amount
+        - us:statutes/26/3402/k#low_monthly_tip_statement_withholding_permitted_for_paragraph_16_b_tips
+  summary: |-
+    26 USC 3402(k): subsection (a) applies to tips constituting wages only when included in a written statement furnished under section 6053(a), and only to the extent withholding can be made from employer-controlled wages excluding tips and employee-turned-over funds before calendar-year close; for section 3401(a)(16)(B) tips, withholding may occur even when monthly statements total less than $20; withholding may not exceed the aggregate wages and funds minus section 3102(a) or 3202(a) tax required to be collected.
+rules:
+  - name: monthly_tip_statement_threshold_for_paragraph_16_b_permission
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3402(k)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "less than $20"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20
+
+  - name: tips_withholding_under_subsection_a_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(k)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "In the case of tips which constitute wages"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "only to such tips as are included in a written statement furnished to the employer pursuant to section 6053(a)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tips_constitute_wages
+          and tips_in_written_statement_furnished_to_employer_pursuant_to_section_6053_a
+
+  - name: maximum_tip_tax_deduction_and_withholding_amount
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3402(k)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "only to the extent that the tax can be deducted and withheld by the employer"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "from such wages of the employee (excluding tips, but including funds turned over by the employee to the employer for the purpose of such deduction and withholding) as are under the control of the employer"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "shall not at any time be deducted and withheld in an amount which exceeds the aggregate of such wages and funds ... minus any tax required by section 3102(a) or section 3202(a)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tips_withholding_under_subsection_a_applies:
+            max(
+              0,
+              aggregate_employer_controlled_wages_excluding_tips_and_employee_turned_over_funds_for_tip_withholding
+              - tax_required_by_section_3102_a_or_3202_a_to_be_collected_from_wages_and_funds
+            )
+          else: 0
+
+  - name: low_monthly_tip_statement_withholding_permitted_for_paragraph_16_b_tips
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    source: 26 USC 3402(k)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "furnished by an employee a written statement of tips (received in a calendar month) pursuant to section 6053(a)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "to which paragraph (16)(B) of section 3401(a) is applicable"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "may deduct and withhold the tax with respect to such tips from any wages of the employee (excluding tips) under his control"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/k#monthly_tip_statement_threshold_for_paragraph_16_b_permission
+              output: monthly_tip_statement_threshold_for_paragraph_16_b_permission
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employee_furnished_written_statement_of_tips_received_in_calendar_month_pursuant_to_section_6053_a
+          and tips_are_category_to_which_section_3401_a_16_b_is_applicable
+          and employee_wages_excluding_tips_under_employer_control_are_available_for_withholding
+          and total_tips_in_monthly_statements_furnished_to_employer_for_employee_employment_in_calendar_month < monthly_tip_statement_threshold_for_paragraph_16_b_permission


### PR DESCRIPTION
## Summary
- add generated 26 USC 3402(k) RuleSpec encoding for withholding on tips
- add generated companion tests and signed encoder apply manifest

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/k.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/k.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3402/k.test.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD`