### PR TITLE
Add generated section 3102(a) payroll tax collection rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/a.yaml",
+      "sha256": "311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9"
+    },
+    {
+      "path": "statutes/26/3102/a.test.yaml",
+      "sha256": "f6126212672b0e9e0b1b8c306fb6a9b1eb67922b772e98b02cb74e78821e9188"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "31e9984670731862a434740b404437953b5943bb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.317",
+    "version_commit": "31e9984670731862a434740b404437953b5943bb"
+  },
+  "axiom_encode_version": "0.2.317",
+  "backend": "openai",
+  "citation": "26 USC 3102(a)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "a5fd49fd5a1e1a59808c3bf87cd96b3d49f71416dad9f5842faf982a6970f8a9",
+  "generated_at": "2026-05-27T05:18:16.394521+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9",
+  "generation_prompt_sha256": "1b8938872e9acba1e41aa3c8ad786552f9c6a8bf54ebe67ea062e150417c6eae",
+  "model": "gpt-5.5",
+  "run_id": "6656fb94",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a4f53de4585005b24037067811e04cf8cfc84f761a0900b419a03d90a722f68a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-a.json",
+  "trace_sha256": "2b046db8d8ab4498cb9b4a8c0903220e1d61065dec761c738bc58d4ff40c1776"
+}

--- a/statutes/26/3102/a.test.yaml
+++ b/statutes/26/3102/a.test.yaml
@@ -1,0 +1,129 @@
+- name: section_3101_tax_collection_required_when_employer_pays_wages
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+  output:
+    us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction:
+    - holds
+- name: section_3101_tax_collection_not_triggered_without_wages_paid
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: false
+  output:
+    us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction:
+    - not_holds
+- name: special_cash_remuneration_deduction_permissions_below_thresholds
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : true
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : false
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 900
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : true
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : false
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 99
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : true
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 149
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+  output:
+    us:statutes/26/3102/a#paragraph_7C_or_10_cash_remuneration_deduction_threshold: 100
+    us:statutes/26/3102/a#paragraph_8B_cash_remuneration_deduction_threshold: 150
+    us:statutes/26/3102/a#tips_statement_monthly_cash_tip_deduction_threshold: 20
+    us:statutes/26/3102/a#paragraph_7B_cash_remuneration_tax_deduction_permitted_when_below_applicable_threshold:
+    - holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3102/a#paragraph_7C_or_10_cash_remuneration_tax_deduction_permitted_when_below_threshold:
+    - not_holds
+    - holds
+    - not_holds
+    us:statutes/26/3102/a#paragraph_8B_cash_remuneration_tax_deduction_permitted_when_below_threshold:
+    - not_holds
+    - not_holds
+    - holds
+- name: special_cash_remuneration_deduction_permissions_not_available_at_thresholds_or_without_category
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : true
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : false
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 1000
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : true
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : false
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 100
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+    - ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+      : false
+      ? us:statutes/26/3102/a#input.employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+      : true
+      us:statutes/26/3102/a#input.total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment: 150
+      us:statutes/26/3121/x#input.calendar_year_after_base_year_for_adjustment: false
+      us:statutes/26/3121/x#input.social_security_act_adjusted_threshold_before_rounding: 0
+  output:
+    us:statutes/26/3102/a#paragraph_7B_cash_remuneration_tax_deduction_permitted_when_below_applicable_threshold:
+    - not_holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3102/a#paragraph_7C_or_10_cash_remuneration_tax_deduction_permitted_when_below_threshold:
+    - not_holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3102/a#paragraph_8B_cash_remuneration_tax_deduction_permitted_when_below_threshold:
+    - not_holds
+    - not_holds
+    - not_holds

--- a/statutes/26/3102/a.yaml
+++ b/statutes/26/3102/a.yaml
@@ -1,0 +1,189 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3121/x#applicable_dollar_threshold
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  deferred_outputs:
+    - output: us:statutes/26/3102/a#tips_statement_tax_deduction_from_non_tip_wages_permitted_when_monthly_tips_below_threshold
+      reason: >-
+        The tips-statement branch depends on a written statement of tips furnished pursuant to
+        section 6053(a), but no copied RuleSpec context provides the exact section 6053(a)
+        furnishing requirement. The executable surface for that branch is deferred rather than
+        replacing the missing cited requirement with a local cross-reference placeholder.
+      source_values:
+        - us:statutes/26/3102/a#tips_statement_monthly_cash_tip_deduction_threshold
+  summary: |-
+    The tax imposed by section 3101 shall be collected by the employer of the taxpayer by deducting the amount of the tax from wages as and when paid. Certain cash-remuneration payments to which section 3121(a)(7)(B), (7)(C), (10), or (8)(B) applies may be deducted from even before the referenced annual threshold is reached; a tips-statement branch under sections 6053(a) and 3121(a)(12)(B) is stated but deferred.
+rules:
+  - name: paragraph_7C_or_10_cash_remuneration_deduction_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3102(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "paragraph (7)(C) or (10) of section 3121(a) ... less than $100"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          100
+
+  - name: paragraph_8B_cash_remuneration_deduction_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3102(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "paragraph (8)(B) of section 3121(a) ... less than $150"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          150
+
+  - name: tips_statement_monthly_cash_tip_deduction_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 26 USC 3102(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "tips included in statements ... in such calendar month ... less than $20"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: employer_required_to_collect_section_3101_tax_by_wage_deduction
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(a), first sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "The tax imposed by section 3101 shall be collected by the employer of the taxpayer, by deducting the amount of the tax from the wages as and when paid."
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_employer_of_taxpayer
+          and wages_are_paid
+
+  - name: paragraph_7B_cash_remuneration_tax_deduction_permitted_when_below_applicable_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(a), second sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "cash remuneration to which paragraph (7)(B) of section 3121(a) is applicable"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "less than the applicable dollar threshold (as defined in section 3121(x))"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/x#applicable_dollar_threshold
+              output: applicable_dollar_threshold
+              hash: sha256:428ca248f56bec98b7228e63b8aec1e1572e511508f72a268ce8218e2f5b52cb
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_B_is_applicable
+          and total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment < applicable_dollar_threshold
+
+  - name: paragraph_7C_or_10_cash_remuneration_tax_deduction_permitted_when_below_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(a), third clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "cash remuneration to which paragraph (7)(C) or (10) of section 3121(a) is applicable"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "less than $100"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/a#paragraph_7C_or_10_cash_remuneration_deduction_threshold
+              output: paragraph_7C_or_10_cash_remuneration_deduction_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_7_C_or_10_is_applicable
+          and total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment < paragraph_7C_or_10_cash_remuneration_deduction_threshold
+
+  - name: paragraph_8B_cash_remuneration_tax_deduction_permitted_when_below_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(a), fourth clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "cash remuneration to which paragraph (8)(B) of section 3121(a) is applicable"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "less than $150"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/a#paragraph_8B_cash_remuneration_deduction_threshold
+              output: paragraph_8B_cash_remuneration_deduction_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_in_calendar_year_pays_employee_cash_remuneration_to_which_section_3121_a_8_B_is_applicable
+          and total_cash_remuneration_paid_to_employee_by_employer_in_calendar_year_at_time_of_payment < paragraph_8B_cash_remuneration_deduction_threshold


### PR DESCRIPTION
## Summary
- add generated 26 USC 3102(a) RuleSpec encoding for employee payroll-tax collection by wage deduction
- add generated companion tests and signed encoder apply manifest

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/a.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/a.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/a.test.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD`