### PR TITLE
Add generated section 3102(b) payroll tax collection rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/b.yaml",
+      "sha256": "acdce8c67f50105cdf7ea46b87d32fee4382f73eb14ac43a50a9c007616d73b1"
+    },
+    {
+      "path": "statutes/26/3102/b.test.yaml",
+      "sha256": "65681fa0d883713c83c0d8f8d3ce03d7bf25cc6fdf719a3a088446987f1b2c22"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "763f6cab864383c86fc2392dfe3276f468bded9d",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.318",
+    "version_commit": "763f6cab864383c86fc2392dfe3276f468bded9d"
+  },
+  "axiom_encode_version": "0.2.318",
+  "backend": "openai",
+  "citation": "26 USC 3102(b)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "13391289fec52059918e5cc2c0646b8bb3a3f02df84b0414508fd0cae59486ad",
+  "generated_at": "2026-05-27T05:36:18.583697+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "acdce8c67f50105cdf7ea46b87d32fee4382f73eb14ac43a50a9c007616d73b1",
+  "generation_prompt_sha256": "ff2564e15f4d1897fdbd266477b60ef3eb59de265fa54d7436874b36006e5f2f",
+  "model": "gpt-5.5",
+  "run_id": "4fafcb48",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9940436bd342b1617e6ee0773b8e586e4fb5b58c24f5f93bf9b3b3953ea164ae"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-b.json",
+  "trace_sha256": "fdb9d60851fc1f9ba8fd08eed44ce2ad4f92dab11bbd06cd72c93c2d1265acc9"
+}

--- a/statutes/26/3102/b.test.yaml
+++ b/statutes/26/3102/b.test.yaml
@@ -1,0 +1,48 @@
+- name: employer_required_to_deduct_is_liable_and_indemnified_after_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3102/b#input.employer_made_payment_of_deducted_tax: true
+  output:
+    us:statutes/26/3102/b#employer_liable_for_payment_of_deducted_tax:
+    - holds
+    us:statutes/26/3102/b#employer_indemnified_against_claims_for_deducted_tax_payment:
+    - holds
+- name: employer_required_to_deduct_is_liable_but_not_indemnified_before_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3102/b#input.employer_made_payment_of_deducted_tax: false
+  output:
+    us:statutes/26/3102/b#employer_liable_for_payment_of_deducted_tax:
+    - holds
+    us:statutes/26/3102/b#employer_indemnified_against_claims_for_deducted_tax_payment:
+    - not_holds
+- name: employer_not_required_to_deduct_is_not_liable_or_indemnified_under_this_clause
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: false
+      us:statutes/26/3102/b#input.employer_made_payment_of_deducted_tax: true
+  output:
+    us:statutes/26/3102/b#employer_liable_for_payment_of_deducted_tax:
+    - not_holds
+    us:statutes/26/3102/b#employer_indemnified_against_claims_for_deducted_tax_payment:
+    - not_holds

--- a/statutes/26/3102/b.yaml
+++ b/statutes/26/3102/b.yaml
@@ -1,0 +1,66 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  summary: |-
+    “Every employer required so to deduct the tax shall be liable for the payment of such tax,” and indemnified against claims for payments made.
+rules:
+  - name: employer_liable_for_payment_of_deducted_tax
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(b), first clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+              output: employer_required_to_collect_section_3101_tax_by_wage_deduction
+              hash: sha256:311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "Every employer required so to deduct the tax shall be liable for the payment of such tax"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_required_to_collect_section_3101_tax_by_wage_deduction
+
+  - name: employer_indemnified_against_claims_for_deducted_tax_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(b), second clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+              output: employer_required_to_collect_section_3101_tax_by_wage_deduction
+              hash: sha256:311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "any such payment made by such employer"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "shall be indemnified against the claims and demands of any person"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_required_to_collect_section_3101_tax_by_wage_deduction
+          and employer_made_payment_of_deducted_tax


### PR DESCRIPTION
## Summary
- add generated 26 USC 3102(b) RuleSpec encoding for employer liability and indemnity on deducted employee payroll tax
- add generated companion tests and signed encoder apply manifest

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/b.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/b.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/b.test.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`
- `uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us --base-ref origin/main --head-ref HEAD`