### PR TITLE
Add generated section 3102(c) payroll tip tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/c.yaml",
+      "sha256": "a49d7b3b6aeada61401878b1e9eae7af4b56ae43265c7352e3fd703603a00c48"
+    },
+    {
+      "path": "statutes/26/3102/c.test.yaml",
+      "sha256": "1908a11485f8da1c230a47f9dabf6f1847806cfedd71f7211e47605ea1d53bf0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d1eded284ed7492e37225888fe5afcd4a7513b67",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.319",
+    "version_commit": "d1eded284ed7492e37225888fe5afcd4a7513b67"
+  },
+  "axiom_encode_version": "0.2.319",
+  "backend": "openai",
+  "citation": "26 USC 3102(c)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "1b2141f1e7f6e40b226ff0b0a3c4c4194e2019ee54b8f55e1b58d36877160cf4",
+  "generated_at": "2026-05-27T05:50:27.317491+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a49d7b3b6aeada61401878b1e9eae7af4b56ae43265c7352e3fd703603a00c48",
+  "generation_prompt_sha256": "7ef6318db0f21b221e830a6f1e7bfdbf2ac7eaeafb360ee20023467e717f3775",
+  "model": "gpt-5.5",
+  "run_id": "47966e5d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f454f8c43ee357fb88f6a422c15029590ffb67c6ed2fc08c4d8c26dcfcb5388a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-c.json",
+  "trace_sha256": "cccf9ae642009b39318386ef1d56076bb7e8524de963acbb04b796a8cff53d5a"
+}

--- a/statutes/26/3102/c.test.yaml
+++ b/statutes/26/3102/c.test.yaml
@@ -1,0 +1,12 @@
+- name: statutory_tip_tax_deadline_day_counts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3102/c#employer_monthly_tip_tax_collection_deadline_days_after_month: 10
+    us:statutes/26/3102/c#employer_annual_tip_tax_collection_deadline_days_after_year: 30
+    us:statutes/26/3102/c#employee_monthly_tip_tax_excess_furnishing_deadline_days_after_month: 10
+    us:statutes/26/3102/c#employee_annual_tip_tax_excess_furnishing_deadline_days_after_year: 30
+    us:statutes/26/3102/c#annual_tip_withholding_adjustment_period_days_after_year: 30

--- a/statutes/26/3102/c.yaml
+++ b/statutes/26/3102/c.yaml
@@ -1,0 +1,135 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  deferred_outputs:
+    - output: us:statutes/26/3102/c#employer_collection_of_section_3101_tax_on_reported_tips_limited_to_controlled_non_tip_wages
+      reason: >-
+        Paragraph (1) applies subsection (a) only to tips included in a written statement
+        furnished pursuant to section 6053(a) and to the extent collection can be made
+        from wages under the employer's control within the stated deadline. No copied
+        RuleSpec context provides section 6053(a), and the copied section 3101 parent has
+        no executable aggregate output for the tax imposed by section 3101 with respect
+        to tips.
+      source_values:
+        - us:statutes/26/3102/c#employer_monthly_tip_tax_collection_deadline_days_after_month
+        - us:statutes/26/3102/c#employer_annual_tip_tax_collection_deadline_days_after_year
+    - output: us:statutes/26/3102/c#employee_may_furnish_money_for_tip_tax_excess_over_collectible_non_tip_wages
+      reason: >-
+        Paragraph (2) depends on the tax imposed by section 3101 with respect to tips
+        included in written statements furnished pursuant to section 6053(a), and on the
+        excess of that tax over wages from which the employer is required to collect
+        under paragraph (1). The section 6053(a) furnishing requirement is unavailable,
+        and the paragraph (1) collection surface is deferred.
+      source_values:
+        - us:statutes/26/3102/c#employee_monthly_tip_tax_excess_furnishing_deadline_days_after_month
+        - us:statutes/26/3102/c#employee_annual_tip_tax_excess_furnishing_deadline_days_after_year
+    - output: us:statutes/26/3102/c#secretary_may_authorize_annual_estimated_tip_withholding_adjustment
+      reason: >-
+        Paragraph (3) authorizes regulatory estimation, per-wage deduction, and
+        adjustment mechanics for tips reported pursuant to section 6053(a). No copied
+        RuleSpec context provides the section 6053(a) reported-tip dependency or the
+        regulatory authorization mechanics.
+      source_values:
+        - us:statutes/26/3102/c#annual_tip_withholding_adjustment_period_days_after_year
+    - output: us:statutes/26/3102/c#employee_pays_tip_tax_excess_not_collectible_by_employer
+      reason: >-
+        Paragraph (4) requires the employee to pay the excess of the section 3101 tax
+        on tips constituting wages over the portion collectible by the employer under
+        paragraph (1) or (3). The section 3101 aggregate tip-tax computation and the
+        paragraph (1) and paragraph (3) collection surfaces are not executable from the
+        copied context.
+  summary: |-
+    In the case of tips constituting wages, subsection (a) applies only to tips included in a written statement furnished to the employer pursuant to section 6053(a) and only to the extent collection can be made by deduction before the close of the 10th day following the calendar month, or if paragraph (3) applies, the 30th day following the year. Paragraphs (2) through (4) address employee furnishing of excess tax money, regulatory annual estimated-tip withholding and adjustment within 30 days thereafter, and employee payment of any section 3101 tip-tax excess not collectible by the employer.
+rules:
+  - name: employer_monthly_tip_tax_collection_deadline_days_after_month
+    kind: parameter
+    dtype: Integer
+    period: Month
+    source: 26 USC 3102(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "before the close of the 10th day following the calendar month"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: employer_annual_tip_tax_collection_deadline_days_after_year
+    kind: parameter
+    dtype: Integer
+    period: Year
+    source: 26 USC 3102(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "if paragraph (3) applies, the 30th day following the year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: employee_monthly_tip_tax_excess_furnishing_deadline_days_after_month
+    kind: parameter
+    dtype: Integer
+    period: Month
+    source: 26 USC 3102(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "on or before the 10th day of the following month"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: employee_annual_tip_tax_excess_furnishing_deadline_days_after_year
+    kind: parameter
+    dtype: Integer
+    period: Year
+    source: 26 USC 3102(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "if paragraph (3) applies, on or before the 30th day of the following year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: annual_tip_withholding_adjustment_period_days_after_year
+    kind: parameter
+    dtype: Integer
+    period: Year
+    source: 26 USC 3102(c)(3)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "during such year (and within 30 days thereafter)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3102(c) tip-tax collection deadlines
- add generated companion tests and signed encoder manifest
- defer non-executable tip-tax collection surfaces that depend on missing 6053(a) and section 3101 tip-tax mechanics

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/c.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/c.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/c.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable
