### PR TITLE
Add generated section 3102(d) payroll tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/d.yaml",
+      "sha256": "38396886e5da5f28410badec6898f87e3918e6b22c093781ab31998dab335843"
+    },
+    {
+      "path": "statutes/26/3102/d.test.yaml",
+      "sha256": "ee4f05f7b74dba4e68de4007c4441b2242787a356118e3a4a2b4e9c4c2f62b71"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d1eded284ed7492e37225888fe5afcd4a7513b67",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.319",
+    "version_commit": "d1eded284ed7492e37225888fe5afcd4a7513b67"
+  },
+  "axiom_encode_version": "0.2.319",
+  "backend": "openai",
+  "citation": "26 USC 3102(d)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "f69f366af70d712e6cd5bf61ee6f546187153bf398e7e3dbc7d8aad73ecb67ae",
+  "generated_at": "2026-05-27T05:57:33.588177+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "38396886e5da5f28410badec6898f87e3918e6b22c093781ab31998dab335843",
+  "generation_prompt_sha256": "07c53ce364a4cba6afd7ec37e47b272ac836e2ff3743011346b829fdc44ba1c0",
+  "model": "gpt-5.5",
+  "run_id": "43558cdd",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c9c8fb902cba9e7fe08d751632918d4cf3301c2568c49583fc9f36e15d9b4b04"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-d.json",
+  "trace_sha256": "731eb41c3a3d0a0d54e1bb3b9ef50a3e535b8898bbffab245f9444675ae5ec47"
+}

--- a/statutes/26/3102/d.test.yaml
+++ b/statutes/26/3102/d.test.yaml
@@ -1,0 +1,76 @@
+- name: post_employment_group_term_life_wage_payment_triggers_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/d#input.payment_is_for_group_term_life_insurance: true
+      us:statutes/26/3102/d#input.payment_constitutes_wages: true
+      ? us:statutes/26/3102/d#input.coverage_period_during_which_employment_relationship_no_longer_exists_between_employee_and_employer
+      : true
+  output:
+    us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment:
+    - holds
+    us:statutes/26/3102/d#subsection_a_collection_rule_not_applicable_to_taxable_post_employment_group_term_life_payment:
+    - holds
+    us:statutes/26/3102/d#employee_pays_section_3101_tax_on_taxable_post_employment_group_term_life_payment:
+    - holds
+- name: non_group_term_life_payment_does_not_trigger_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/d#input.payment_is_for_group_term_life_insurance: false
+      us:statutes/26/3102/d#input.payment_constitutes_wages: true
+      ? us:statutes/26/3102/d#input.coverage_period_during_which_employment_relationship_no_longer_exists_between_employee_and_employer
+      : true
+  output:
+    us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#subsection_a_collection_rule_not_applicable_to_taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#employee_pays_section_3101_tax_on_taxable_post_employment_group_term_life_payment:
+    - not_holds
+- name: group_term_life_payment_that_is_not_wages_does_not_trigger_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/d#input.payment_is_for_group_term_life_insurance: true
+      us:statutes/26/3102/d#input.payment_constitutes_wages: false
+      ? us:statutes/26/3102/d#input.coverage_period_during_which_employment_relationship_no_longer_exists_between_employee_and_employer
+      : true
+  output:
+    us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#subsection_a_collection_rule_not_applicable_to_taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#employee_pays_section_3101_tax_on_taxable_post_employment_group_term_life_payment:
+    - not_holds
+- name: coverage_during_existing_employment_relationship_does_not_trigger_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/d#input.payment_is_for_group_term_life_insurance: true
+      us:statutes/26/3102/d#input.payment_constitutes_wages: true
+      ? us:statutes/26/3102/d#input.coverage_period_during_which_employment_relationship_no_longer_exists_between_employee_and_employer
+      : false
+  output:
+    us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#subsection_a_collection_rule_not_applicable_to_taxable_post_employment_group_term_life_payment:
+    - not_holds
+    us:statutes/26/3102/d#employee_pays_section_3101_tax_on_taxable_post_employment_group_term_life_payment:
+    - not_holds

--- a/statutes/26/3102/d.yaml
+++ b/statutes/26/3102/d.yaml
@@ -1,0 +1,101 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  deferred_outputs:
+    - output: us:statutes/26/3102/d#employer_section_6051_statement_must_separately_include_group_term_life_wages
+      reason: >-
+        Subparagraph (B)(i) requires separate inclusion on the statement required under
+        section 6051, but no copied RuleSpec context provides section 6051 statement
+        mechanics.
+    - output: us:statutes/26/3102/d#employer_section_6051_statement_must_separately_include_section_3101_tax_amount
+      reason: >-
+        Subparagraph (B)(ii) requires separate inclusion of the amount of the tax imposed
+        by section 3101 on the applicable payments. The copied parent section 3101 target
+        has no executable aggregate output for the tax imposed by section 3101, and the
+        section 6051 statement mechanics are unavailable.
+  summary: |-
+    For a payment for group-term life insurance to which subsection (d) applies,
+    subsection (a) shall not apply; the employer shall separately include specified
+    wage and section 3101 tax information on the section 6051 statement; and the
+    section 3101 tax on such payments shall be paid by the employee. Subsection (d)
+    applies to the extent the payment constitutes wages and is for coverage for
+    periods during which the employment relationship no longer exists.
+rules:
+  - name: taxable_post_employment_group_term_life_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "any payment for group-term life insurance to the extent— (A) such payment constitutes wages"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "for coverage for periods during which an employment relationship no longer exists between the employee and the employer"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_for_group_term_life_insurance
+          and payment_constitutes_wages
+          and coverage_period_during_which_employment_relationship_no_longer_exists_between_employee_and_employer
+
+  - name: subsection_a_collection_rule_not_applicable_to_taxable_post_employment_group_term_life_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(d)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "In the case of any payment for group-term life insurance to which this subsection applies— (A) subsection (a) shall not apply"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment
+              output: taxable_post_employment_group_term_life_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          taxable_post_employment_group_term_life_payment
+
+  - name: employee_pays_section_3101_tax_on_taxable_post_employment_group_term_life_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(d)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: "the tax imposed by section 3101 on such payments shall be paid by the employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/d#taxable_post_employment_group_term_life_payment
+              output: taxable_post_employment_group_term_life_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          taxable_post_employment_group_term_life_payment


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3102(d) post-employment group-term life payroll-tax responsibility
- add generated companion tests and signed encoder manifest
- defer section 6051 statement-reporting outputs that lack imported statement mechanics

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/d.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/d.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/d.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable
