### PR TITLE
Add generated section 3102(e) payroll tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/e.yaml",
+      "sha256": "d5502eb4e239710020a982f32f66b46e27a89b6d0e1063a60d586d29acdbb564"
+    },
+    {
+      "path": "statutes/26/3102/e.test.yaml",
+      "sha256": "806ab5e35c3addce2e88cb592d6a98c575cc03974b000347ff3a24608a7c0d6a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d1eded284ed7492e37225888fe5afcd4a7513b67",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.319",
+    "version_commit": "d1eded284ed7492e37225888fe5afcd4a7513b67"
+  },
+  "axiom_encode_version": "0.2.319",
+  "backend": "openai",
+  "citation": "26 USC 3102(e)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "d8855c38606fedf8697f9e2febe37dc808def286d05ec5af83b44816e1ed6554",
+  "generated_at": "2026-05-27T06:01:48.367652+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d5502eb4e239710020a982f32f66b46e27a89b6d0e1063a60d586d29acdbb564",
+  "generation_prompt_sha256": "88b6828ab752fe2572acc1a01f08ddea00139cf2d392612de9f58e9d42e46aa1",
+  "model": "gpt-5.5",
+  "run_id": "0be9f4e8",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "08c1e8593b237a0e68d91f9f6c8362a7eb62999c1e9399f2e4f65499eeba1393"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-e.json",
+  "trace_sha256": "0357465a15c5da6b205f508231c1841ca223acde8780347bc6b06765807c0e53"
+}

--- a/statutes/26/3102/e.test.yaml
+++ b/statutes/26/3102/e.test.yaml
@@ -1,0 +1,75 @@
+- name: qualifying_transferred_employee_international_organization_wage_payment_triggers_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/e#input.payment_is_payment_of_wages_for_service_performed_in_employ_of_international_organization: true
+      ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+      : true
+      us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+      ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+      : true
+      ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+      : true
+      ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+      : true
+  output:
+    us:statutes/26/3102/e#transferred_federal_employee_international_organization_wage_payment:
+    - holds
+    ? us:statutes/26/3102/e#subsection_a_collection_rule_not_applicable_to_transferred_employee_international_organization_wage_payment
+    : - holds
+    us:statutes/26/3102/e#employee_pays_section_3101_tax_on_transferred_employee_international_organization_wage_payment:
+    - holds
+- name: payment_not_wages_for_international_organization_service_does_not_trigger_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/e#input.payment_is_payment_of_wages_for_service_performed_in_employ_of_international_organization: false
+      ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+      : true
+      us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: true
+      ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+      : true
+      ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+      : true
+      ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+      : true
+  output:
+    us:statutes/26/3102/e#transferred_federal_employee_international_organization_wage_payment:
+    - not_holds
+    ? us:statutes/26/3102/e#subsection_a_collection_rule_not_applicable_to_transferred_employee_international_organization_wage_payment
+    : - not_holds
+    us:statutes/26/3102/e#employee_pays_section_3101_tax_on_transferred_employee_international_organization_wage_payment:
+    - not_holds
+- name: transfer_not_to_which_section_3121_y_applies_does_not_trigger_special_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/e#input.payment_is_payment_of_wages_for_service_performed_in_employ_of_international_organization: true
+      ? us:statutes/26/3121/y#input.service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+      : true
+      us:statutes/26/3121/y#input.transfer_to_international_organization_pursuant_to_section_3582_of_title_5: false
+      ? us:statutes/26/3121/y#input.immediately_before_transfer_individual_performed_service_with_federal_agency_within_meaning_of_section_3581_1_of_title_5
+      : true
+      ? us:statutes/26/3121/y#input.prior_federal_agency_service_constituted_employment_under_subsection_b_for_purposes_of_sections_3101_a_and_3111_a_taxes
+      : true
+      ? us:statutes/26/3121/y#input.individual_entitled_upon_separation_and_proper_application_to_reemployment_with_federal_agency_under_section_3582_of_title_5
+      : true
+  output:
+    us:statutes/26/3102/e#transferred_federal_employee_international_organization_wage_payment:
+    - not_holds
+    ? us:statutes/26/3102/e#subsection_a_collection_rule_not_applicable_to_transferred_employee_international_organization_wage_payment
+    : - not_holds
+    us:statutes/26/3102/e#employee_pays_section_3101_tax_on_transferred_employee_international_organization_wage_payment:
+    - not_holds

--- a/statutes/26/3102/e.yaml
+++ b/statutes/26/3102/e.yaml
@@ -1,0 +1,108 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  deferred_outputs:
+    - output: us:statutes/26/3102/e#federal_agency_head_section_6051_statement_must_separately_include_transferred_employee_service_wages
+      reason: >-
+        Paragraph (2)(A) requires the head of the transferring Federal agency to separately include the
+        amount determined to be wages for the service on the statement required under section 6051, but no
+        copied RuleSpec context provides section 6051 statement mechanics.
+      blocked_by: []
+    - output: us:statutes/26/3102/e#federal_agency_head_section_6051_statement_must_separately_include_section_3101_tax_amount
+      reason: >-
+        Paragraph (2)(B) requires separate inclusion of the amount of the tax imposed by section 3101
+        on the payments. The copied parent section 3101 target has no executable aggregate output for
+        the tax imposed by section 3101, and no copied RuleSpec context provides section 6051 statement
+        mechanics.
+      blocked_by: []
+  summary: |-
+    In the case of payments of wages for service performed in the employ of an international organization
+    pursuant to a transfer to which section 3121(y) applies: subsection (a) shall not apply, specified
+    wage and section 3101 tax amounts must be separately included on the section 6051 statement, and the
+    section 3101 tax on the payments shall be paid by the employee.
+rules:
+  - name: transferred_federal_employee_international_organization_wage_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(e), flush language
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: payments of wages for service performed in the employ of an international organization
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: pursuant to a transfer to which the provisions of section 3121(y) are applicable
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment
+              output: transferred_federal_employee_international_organization_service_constitutes_employment
+              hash: sha256:6a75fb832688d9d8a6c78d2c9c88b7b8a75bc059893339cf7b8b127e14847e25
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_payment_of_wages_for_service_performed_in_employ_of_international_organization
+          and transferred_federal_employee_international_organization_service_constitutes_employment
+
+  - name: subsection_a_collection_rule_not_applicable_to_transferred_employee_international_organization_wage_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(e)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: subsection (a) shall not apply
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/e#transferred_federal_employee_international_organization_wage_payment
+              output: transferred_federal_employee_international_organization_wage_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          transferred_federal_employee_international_organization_wage_payment
+
+  - name: employee_pays_section_3101_tax_on_transferred_employee_international_organization_wage_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(e)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: the tax imposed by section 3101 on such payments shall be paid by the employee
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/e#transferred_federal_employee_international_organization_wage_payment
+              output: transferred_federal_employee_international_organization_wage_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          transferred_federal_employee_international_organization_wage_payment


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3102(e) transferred federal employee international organization payroll-tax responsibility
- add generated companion tests and signed encoder manifest
- import the generated section 3121(y) service rule and defer missing section 6051 statement mechanics

## Validation
- uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/e.yaml --skip-reviewers
- uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/e.yaml
- uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/e.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable
