### PR TITLE
Add generated section 3102(f)(1) payroll tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/f/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/f/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/f/1.yaml",
+      "sha256": "1938b6a79bae1cfb3cbfb7bcf775ffd79cf58bd11df0b59c75e4fb3d251893b9"
+    },
+    {
+      "path": "statutes/26/3102/f/1.test.yaml",
+      "sha256": "57a445905f163d6ae933f6e1bda5e5d25b909d8cef96ca67734dad33f448c938"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6e05b230b404261879b4249ab60f8f5908327b7b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.320",
+    "version_commit": "6e05b230b404261879b4249ab60f8f5908327b7b"
+  },
+  "axiom_encode_version": "0.2.320",
+  "backend": "openai",
+  "citation": "26 USC 3102(f)(1)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-f-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "4cd50ba8692dd1db3a5d75bfecee1c0930c825c5cdae69f63b07a25d018d2d4d",
+  "generated_at": "2026-05-27T06:43:00.780213+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/f/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1938b6a79bae1cfb3cbfb7bcf775ffd79cf58bd11df0b59c75e4fb3d251893b9",
+  "generation_prompt_sha256": "4257ac179dcb078bc3a34d94742809541f6f93a24da69a4469031489cb8e684e",
+  "model": "gpt-5.5",
+  "run_id": "56dabee0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2a0eb9637a2152876eb9afeeb59f0e05c14f43d5813ed719bb6fa3e3e10df67f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-f-1.json",
+  "trace_sha256": "049ecaab5f189ade26496ae412d9ebe2e239e1fcd0383569534e3ba2ed88a253"
+}

--- a/statutes/26/3102/f/1.test.yaml
+++ b/statutes/26/3102/f/1.test.yaml
@@ -1,0 +1,63 @@
+- name: additional_medicare_withholding_applies_only_to_employer_wages_above_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3102/f/1#input.payment_is_for_tax_imposed_by_section_3101_b_2: true
+      us:statutes/26/3102/f/1#input.taxpayer_wages_received_from_employer: 250000
+  output:
+    us:statutes/26/3102/f/1#additional_medicare_withholding_wages_subject_to_subsection_a:
+    - 50000
+    us:statutes/26/3102/f/1#employer_may_disregard_taxpayer_spouse_wages_for_additional_medicare_withholding:
+    - holds
+- name: additional_medicare_withholding_zero_at_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3102/f/1#input.payment_is_for_tax_imposed_by_section_3101_b_2: true
+      us:statutes/26/3102/f/1#input.taxpayer_wages_received_from_employer: 200000
+  output:
+    us:statutes/26/3102/f/1#additional_medicare_withholding_employer_wage_threshold: 200000
+- name: subsection_a_limitation_not_triggered_for_non_section_3101_b_2_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3102/f/1#input.payment_is_for_tax_imposed_by_section_3101_b_2: false
+      us:statutes/26/3102/f/1#input.taxpayer_wages_received_from_employer: 250000
+  output:
+    us:statutes/26/3102/f/1#additional_medicare_withholding_wages_subject_to_subsection_a:
+    - 0
+    us:statutes/26/3102/f/1#employer_may_disregard_taxpayer_spouse_wages_for_additional_medicare_withholding:
+    - not_holds
+- name: subsection_a_limitation_not_triggered_without_subsection_a_collection_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: false
+      us:statutes/26/3102/f/1#input.payment_is_for_tax_imposed_by_section_3101_b_2: true
+      us:statutes/26/3102/f/1#input.taxpayer_wages_received_from_employer: 250000
+  output:
+    us:statutes/26/3102/f/1#additional_medicare_withholding_wages_subject_to_subsection_a:
+    - 0

--- a/statutes/26/3102/f/1.yaml
+++ b/statutes/26/3102/f/1.yaml
@@ -1,0 +1,91 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  summary: "In the case of any tax imposed by section 3101(b)(2), subsection (a) shall\
+    \ only apply to the extent the taxpayer receives wages from the employer in excess\
+    \ of $200,000, and the employer may disregard wages received by the taxpayer\u2019\
+    s spouse."
+rules:
+- name: additional_medicare_withholding_employer_wage_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3102(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3102
+          excerpt: wages from the employer in excess of $200,000
+  versions:
+  - effective_from: '2013-01-01'
+    formula: '200000'
+- name: additional_medicare_withholding_wages_subject_to_subsection_a
+  kind: derived
+  entity: Payment
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 3102(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3102
+          excerpt: only apply to the extent to which the taxpayer receives wages from
+            the employer in excess of $200,000
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3102
+          excerpt: In the case of any tax imposed by section 3101(b)(2)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+          output: employer_required_to_collect_section_3101_tax_by_wage_deduction
+          hash: sha256:311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3102/f/1#additional_medicare_withholding_employer_wage_threshold
+          output: additional_medicare_withholding_employer_wage_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '2013-01-01'
+    formula: 'if employer_required_to_collect_section_3101_tax_by_wage_deduction and
+      payment_is_for_tax_imposed_by_section_3101_b_2: max(0, taxpayer_wages_received_from_employer
+      - additional_medicare_withholding_employer_wage_threshold) else: 0'
+- name: employer_may_disregard_taxpayer_spouse_wages_for_additional_medicare_withholding
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3102(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3102
+          excerpt: "the employer may disregard the amount of wages received by such\
+            \ taxpayer\u2019s spouse"
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3102
+          excerpt: In the case of any tax imposed by section 3101(b)(2)
+  versions:
+  - effective_from: '2013-01-01'
+    formula: payment_is_for_tax_imposed_by_section_3101_b_2


### PR DESCRIPTION
## Summary
- add generated 26 USC 3102(f)(1) Additional Medicare withholding threshold rules
- import 3102(a) collection applicability and compute wages subject to subsection (a) above the $200,000 employer threshold
- include companion tests for positive, threshold, non-3101(b)(2), and disabled 3102(a) cases

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/f/1.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/f/1.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3102/f/1.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage after this change: 1,287 executable tax outputs; 227 comparable, 1,060 known-not-comparable, 0 untested comparable outputs.
