### PR TITLE
Refresh generated section 3241(b) payroll table

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc"
+      "sha256": "f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
@@ -10,36 +10,40 @@
     },
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "11b59d83e47e20660a4c5b77c3dd33b3cf603afc25b894f04ff777a078269d7c"
+      "sha256": "f1a78c4d072248eaab3e4ed7c2908323a03172743723b435def41ff624cba4eb"
+    },
+    {
+      "path": "statutes/26/3241/a.yaml",
+      "sha256": "dfa38cc46ca8805c3f301ed25e3187d440c47bce5891cc5ff94f0fb99af4cfb6"
     }
   ],
   "axiom_encode_git": {
-    "commit": "50fd7ca9a076ff200249272f3cd7d3f97c600c41",
+    "commit": "44d4cca8f7797dcc553ebe4f3bc084cef7b3de2f",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.292",
-    "version_commit": "50fd7ca9a076ff200249272f3cd7d3f97c600c41"
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.320",
+    "version_commit": "44d4cca8f7797dcc553ebe4f3bc084cef7b3de2f"
   },
-  "axiom_encode_version": "0.2.292",
+  "axiom_encode_version": "0.2.320",
   "backend": "openai",
   "citation": "26 USC 3241(b)",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "44e2d01f110808ec62b12592659e84e9e44216653a861f87ee81781ad869e003",
-  "generated_at": "2026-05-26T19:46:21.052858+00:00",
+  "context_manifest_sha256": "b088f9c989f85727935d0ee60e91763f0ef25ea0a3dc538e1184ed109966218c",
+  "generated_at": "2026-05-27T06:51:04.832233+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3241/b.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc",
-  "generation_prompt_sha256": "7a4a1e1f4a086accda26a793cc1bb24fadabd8b1dc89a1ba4502592843ecef19",
+  "generated_output_sha256": "f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878",
+  "generation_prompt_sha256": "9ea88bfa6a1317aaf06b29b1e3ca8b303694b576a81e35c1162717d96f5dc909",
   "model": "gpt-5.5",
-  "run_id": "e0f7a767",
+  "run_id": "0bc3acc8",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "795aea99e13e3928417051feb2738436e63469f11776025a81a4694864856e18"
+    "value": "6f367c40976510c706aa9e4aaa2232836ac5405a234f109c49872245960f2872"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3241-b.json",
-  "trace_sha256": "3a6cf5934f427c824c19d18149dea8a54f18271dd984a3c13380101bdb9ffc8b"
+  "trace_sha256": "101508e95ffe65ce2f6963d2e59dcf1c70166974bfcd1319b8ab7c78c12cd883"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -62,7 +62,7 @@ rules:
         import:
           target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
           output: applicable_percentage_for_section_3201_b
-          hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
+          hash: sha256:f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878
   versions:
   - effective_from: '1990-01-01'
     formula: applicable_percentage_for_section_3201_b

--- a/statutes/26/3241/a.yaml
+++ b/statutes/26/3241/a.yaml
@@ -29,7 +29,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
               output: applicable_percentage_for_section_3201_b
-              hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
+              hash: sha256:f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -54,7 +54,7 @@ rules:
             import:
               target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b
               output: applicable_percentage_for_sections_3211_b_and_3221_b
-              hash: sha256:54c2b0a32e744462a20d8580afd414a36311d987e028b24aa0983caaf0ce0cbc
+              hash: sha256:f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3241
   summary: |-
-    26 USC 3241(b) Tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
+    26 USC 3241(b) tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
 rules:
   - name: average_account_benefits_ratio_band
     kind: derived
@@ -20,7 +20,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/3241
-              excerpt: "Average account benefits ratio: At least / But less than"
+              excerpt: "Average account benefits ratio | At least | But less than"
               table:
                 header: Tax rate schedule
                 row_key: Average account benefits ratio


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3241(b) with axiom-encode 0.2.320 from generated output
- refresh the generated apply manifest and dependent import hashes in 3201 and 3241(a)
- preserve generated-only RuleSpec artifacts; no hand edits

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3241/b.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3241/b.test.yaml /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3241/a.test.yaml /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3201.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage: 1,287 executable tax outputs; 227 comparable, 1,060 known-not-comparable, 0 untested comparable outputs.
