### PR TITLE
Add generated section 3102(f)(2) payroll tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/f/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/f/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/f/2.yaml",
+      "sha256": "d7d5b1a5c9153c09a6911fb2fa3522868f51e988790ea3a0bbadf774d7c9b827"
+    },
+    {
+      "path": "statutes/26/3102/f/2.test.yaml",
+      "sha256": "14bd8028bfad5c8d024d82b7a6f95caecf8350f015ae53e3a560e6b71caa110c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "76b9d93e6fb1d2da33fda213600c371bc99443fc",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.321",
+    "version_commit": "76b9d93e6fb1d2da33fda213600c371bc99443fc"
+  },
+  "axiom_encode_version": "0.2.321",
+  "backend": "openai",
+  "citation": "26 USC 3102(f)(2)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-f-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "b43b2d64cfb4c7b92d3106b24b2c93452fcd0aec32cbe79f57f3e8a4b8667521",
+  "generated_at": "2026-05-27T07:13:05.255432+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/f/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d7d5b1a5c9153c09a6911fb2fa3522868f51e988790ea3a0bbadf774d7c9b827",
+  "generation_prompt_sha256": "a7ec46b740aed5293952a68f76817be22f0d37bcd4cd8138d40d5437494c551d",
+  "model": "gpt-5.5",
+  "run_id": "f9813742",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d5f5aae518599f679adf50c72ee75bddd696fb109f510e47173a3394c83b8092"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-f-2.json",
+  "trace_sha256": "89d08dd7ae7c1769541ce153151f8f3fc07e73714e6de14e9ca7b15c0743a630"
+}

--- a/statutes/26/3102/f/2.test.yaml
+++ b/statutes/26/3102/f/2.test.yaml
@@ -1,0 +1,20 @@
+- name: employee_pays_uncollected_additional_medicare_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/2#input.additional_medicare_tax_imposed_by_section_3101_b_2_not_collected_by_employer: 250
+  output:
+    us:statutes/26/3102/f/2#employee_uncollected_additional_medicare_tax_liability: 250
+    us:statutes/26/3102/f/2#employee_must_pay_uncollected_additional_medicare_tax: holds
+- name: no_employee_liability_when_no_additional_medicare_tax_uncollected
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/2#input.additional_medicare_tax_imposed_by_section_3101_b_2_not_collected_by_employer: 0
+  output:
+    us:statutes/26/3102/f/2#employee_uncollected_additional_medicare_tax_liability: 0
+    us:statutes/26/3102/f/2#employee_must_pay_uncollected_additional_medicare_tax: not_holds

--- a/statutes/26/3102/f/2.yaml
+++ b/statutes/26/3102/f/2.yaml
@@ -1,0 +1,62 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  summary: |-
+    To the extent that tax imposed by section 3101(b)(2) is not collected by the employer, the tax shall be paid by the employee.
+rules:
+  - name: employee_uncollected_additional_medicare_tax_liability
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 26 USC 3102(f)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: amount of any tax imposed by section 3101(b)(2) is not collected by the employer
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: such tax shall be paid by the employee
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          max(0, additional_medicare_tax_imposed_by_section_3101_b_2_not_collected_by_employer)
+  - name: employee_must_pay_uncollected_additional_medicare_tax
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(f)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: To the extent that the amount of any tax imposed by section 3101(b)(2) is not collected by the employer
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: such tax shall be paid by the employee
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3102/f/2#employee_uncollected_additional_medicare_tax_liability
+              output: employee_uncollected_additional_medicare_tax_liability
+              hash: sha256:local
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          employee_uncollected_additional_medicare_tax_liability > 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3102(f)(2), assigning uncollected Additional Medicare Tax liability to the employee
- include companion generated tests and signed encoder apply manifest
- generated with axiom-encode 0.2.321 from merged encoder commit 76b9d93 using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/3102/f/2.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3102/f/2.yaml
- uv run axiom-encode test statutes/26/3102/f/2.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1289; comparable 227; known_not_comparable 1062; untested comparable outputs 0.