### PR TITLE
Add generated section 3102(f)(3) payroll tax rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3102/f/3.json
+++ b/.axiom/encoding-manifests/statutes/26/3102/f/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3102/f/3.yaml",
+      "sha256": "1406b228aab80bd989e73e6e561974720f0af56d92571d89bee51bf9bd85b03b"
+    },
+    {
+      "path": "statutes/26/3102/f/3.test.yaml",
+      "sha256": "8bbf469f92dc32da481934590c9316426d4f20e622a304b7211c0c4f7c682192"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "76b9d93e6fb1d2da33fda213600c371bc99443fc",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.321",
+    "version_commit": "76b9d93e6fb1d2da33fda213600c371bc99443fc"
+  },
+  "axiom_encode_version": "0.2.321",
+  "backend": "openai",
+  "citation": "26 USC 3102(f)(3)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3102-f-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "3df249c2a05cdf00db1c1287bd41de3e94b6df6f3de27f179354f4a7ba416e99",
+  "generated_at": "2026-05-27T07:19:18.354333+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3102/f/3.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1406b228aab80bd989e73e6e561974720f0af56d92571d89bee51bf9bd85b03b",
+  "generation_prompt_sha256": "965d2575faef3b3881c3ab08fa5b8b394445d0cf40d9e334df8c585c3e8d3f59",
+  "model": "gpt-5.5",
+  "run_id": "a9f19627",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bcd93f767c7fc39644970972e74a7f71d3b1db7ee848218ea790c56a3f4c6b24"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3102-f-3.json",
+  "trace_sha256": "b1f42f7c698b49c12dfad54991f26ad3cbb612814e7063ac40740a159de8f5c0"
+}

--- a/statutes/26/3102/f/3.test.yaml
+++ b/statutes/26/3102/f/3.test.yaml
@@ -1,0 +1,48 @@
+- name: employee_payment_bars_collection_from_employer_but_preserves_penalties
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/3#input.employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter: true
+    us:statutes/26/3102/f/3#input.employee_thereafter_paid_section_3101_b_2_tax: true
+    us:statutes/26/3102/f/3#input.penalty_or_addition_to_tax_otherwise_applicable_for_failure_to_deduct_and_withhold: true
+  output:
+    us:statutes/26/3102/f/3#additional_medicare_tax_not_collected_from_employer_after_employee_payment: holds
+    us:statutes/26/3102/f/3#employer_penalty_or_addition_liability_not_relieved_by_employee_payment: holds
+- name: no_collection_bar_without_employer_withholding_failure
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/3#input.employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter: false
+    us:statutes/26/3102/f/3#input.employee_thereafter_paid_section_3101_b_2_tax: true
+    us:statutes/26/3102/f/3#input.penalty_or_addition_to_tax_otherwise_applicable_for_failure_to_deduct_and_withhold: true
+  output:
+    us:statutes/26/3102/f/3#additional_medicare_tax_not_collected_from_employer_after_employee_payment: not_holds
+    us:statutes/26/3102/f/3#employer_penalty_or_addition_liability_not_relieved_by_employee_payment: not_holds
+- name: no_collection_bar_without_employee_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/3#input.employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter: true
+    us:statutes/26/3102/f/3#input.employee_thereafter_paid_section_3101_b_2_tax: false
+    us:statutes/26/3102/f/3#input.penalty_or_addition_to_tax_otherwise_applicable_for_failure_to_deduct_and_withhold: true
+  output:
+    us:statutes/26/3102/f/3#additional_medicare_tax_not_collected_from_employer_after_employee_payment: not_holds
+    us:statutes/26/3102/f/3#employer_penalty_or_addition_liability_not_relieved_by_employee_payment: not_holds
+- name: employee_payment_rule_does_not_create_penalty_liability_when_none_otherwise_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3102/f/3#input.employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter: true
+    us:statutes/26/3102/f/3#input.employee_thereafter_paid_section_3101_b_2_tax: true
+    us:statutes/26/3102/f/3#input.penalty_or_addition_to_tax_otherwise_applicable_for_failure_to_deduct_and_withhold: false
+  output:
+    us:statutes/26/3102/f/3#additional_medicare_tax_not_collected_from_employer_after_employee_payment: holds
+    us:statutes/26/3102/f/3#employer_penalty_or_addition_liability_not_relieved_by_employee_payment: not_holds

--- a/statutes/26/3102/f/3.yaml
+++ b/statutes/26/3102/f/3.yaml
@@ -1,0 +1,68 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3102
+  summary: |-
+    If an employer, in violation of this chapter, fails to deduct and withhold the tax imposed by section 3101(b)(2) and thereafter the tax is paid by the employee, that required tax shall not be collected from the employer; this does not relieve the employer from otherwise applicable penalties or additions to tax.
+rules:
+  - name: additional_medicare_tax_not_collected_from_employer_after_employee_payment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(f)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: employer, in violation of this chapter, fails to deduct and withhold the tax imposed by section 3101(b)(2)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: thereafter the tax is paid by the employee
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: shall not be collected from the employer
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter
+          and employee_thereafter_paid_section_3101_b_2_tax
+  - name: employer_penalty_or_addition_liability_not_relieved_by_employee_payment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(f)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: employer, in violation of this chapter, fails to deduct and withhold the tax imposed by section 3101(b)(2)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: thereafter the tax is paid by the employee
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3102
+              excerpt: shall in no case relieve the employer from liability for any penalties or additions to tax otherwise applicable
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_section_3101_b_2_tax_in_violation_of_chapter
+          and employee_thereafter_paid_section_3101_b_2_tax
+          and penalty_or_addition_to_tax_otherwise_applicable_for_failure_to_deduct_and_withhold


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3102(f)(3), covering the collection bar from employers after employee payment and preservation of applicable employer penalties/additions
- include companion generated tests and signed encoder apply manifest
- generated with axiom-encode 0.2.321 from merged encoder commit 76b9d93 using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/3102/f/3.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3102/f/3.yaml
- uv run axiom-encode test statutes/26/3102/f/3.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1291; comparable 227; known_not_comparable 1064; untested comparable outputs 0.