### PR TITLE
Add generated section 3121(a)(5)(D) payroll wage rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/D.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/D.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/D.yaml",
+      "sha256": "f2bfbd6804fe379b831e0f79c326c84851e34e216083f335d80b8e8124156e1d"
+    },
+    {
+      "path": "statutes/26/3121/a/5/D.test.yaml",
+      "sha256": "912160a627e00cec47d9ed2e483ba492b95106a99b761aff15cc5eab462b8f77"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e44e7ab90136b298b03a14f7c9486d0121fea0cb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.322",
+    "version_commit": "e44e7ab90136b298b03a14f7c9486d0121fea0cb"
+  },
+  "axiom_encode_version": "0.2.322",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(D)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-D/workspace/context-manifest.json",
+  "context_manifest_sha256": "f6e73a4cc04354352e2cd2cbf761d91348c65d748c027c5b20500bf6b29d2f92",
+  "generated_at": "2026-05-27T07:41:11.635546+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/D.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f2bfbd6804fe379b831e0f79c326c84851e34e216083f335d80b8e8124156e1d",
+  "generation_prompt_sha256": "cf4aee1312bda9946f69323ed93f43555ed7335896fc71341d896a9fa21e0519",
+  "model": "gpt-5.5",
+  "run_id": "bc36ee87",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4689e9f93564a113b37207860c2c1f80f8a2901207beb807e0002ffcd53bfd8b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-D.json",
+  "trace_sha256": "bbbf17d20eaafd77d5365e9f1e3071c6fe6613e20ae808844f1b97e293812678"
+}

--- a/statutes/26/3121/a/5/D.test.yaml
+++ b/statutes/26/3121/a/5/D.test.yaml
@@ -1,0 +1,84 @@
+- name: payment_under_403b_annuity_contract_is_excluded_from_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/D#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/D#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/D#input.payment_made_under_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_to_annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/a/5/D#input.payment_for_purchase_of_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_by_reason_of_salary_reduction_agreement: false
+  output:
+    us:statutes/26/3121/a/5/D#salary_reduction_purchase_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_excluded_from_wages:
+    - 5000
+- name: payment_to_403b_annuity_contract_is_excluded_from_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/D#input.payment_amount: 3000
+      us:statutes/26/3121/a/5/D#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/D#input.payment_made_under_annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/a/5/D#input.payment_made_to_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_for_purchase_of_annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/a/5/D#input.payment_made_by_reason_of_salary_reduction_agreement: false
+  output:
+    us:statutes/26/3121/a/5/D#salary_reduction_purchase_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_excluded_from_wages:
+    - 3000
+- name: payment_not_to_or_on_behalf_of_employee_or_beneficiary_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/D#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/D#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: false
+      us:statutes/26/3121/a/5/D#input.payment_made_under_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_to_annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/a/5/D#input.payment_for_purchase_of_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_by_reason_of_salary_reduction_agreement: false
+  output:
+    us:statutes/26/3121/a/5/D#salary_reduction_purchase_exception_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_excluded_from_wages:
+    - 0
+- name: salary_reduction_purchase_exception_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/D#input.payment_amount: 6000
+      us:statutes/26/3121/a/5/D#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/D#input.payment_made_under_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_to_annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/a/5/D#input.payment_for_purchase_of_annuity_contract_described_in_section_403_b: true
+      us:statutes/26/3121/a/5/D#input.payment_made_by_reason_of_salary_reduction_agreement: true
+  output:
+    us:statutes/26/3121/a/5/D#salary_reduction_purchase_exception_applies:
+    - holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/5/D.yaml
+++ b/statutes/26/3121/a/5/D.yaml
@@ -1,0 +1,104 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(D) excludes from “wages” any payment made to, or on behalf of, an employee or beneficiary under or to an annuity contract described in section 403(b), other than a payment for the purchase of such contract made by reason of a salary reduction agreement, whether evidenced by a written instrument or otherwise.
+rules:
+  - name: salary_reduction_purchase_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(D), exception clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than a payment for the purchase of such contract which is made by reason of a salary reduction agreement"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "whether evidenced by a written instrument or otherwise"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_for_purchase_of_annuity_contract_described_in_section_403_b
+          and payment_made_by_reason_of_salary_reduction_agreement
+
+  - name: annuity_contract_403b_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made to, or on behalf of, an employee or his beneficiary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under or to an annuity contract described in section 403(b)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than a payment for the purchase of such contract which is made by reason of a salary reduction agreement"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/D#salary_reduction_purchase_exception_applies
+              output: salary_reduction_purchase_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_on_behalf_of_employee_or_beneficiary
+          and (
+            payment_made_under_annuity_contract_described_in_section_403_b
+            or payment_made_to_annuity_contract_described_in_section_403_b
+          )
+          and not salary_reduction_purchase_exception_applies
+
+  - name: annuity_contract_403b_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(5)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the term shall not include ... any payment ... under or to an annuity contract described in section 403(b)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than a payment for the purchase of such contract which is made by reason of a salary reduction agreement"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/D#annuity_contract_403b_payment_exclusion_applies
+              output: annuity_contract_403b_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if annuity_contract_403b_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(D), covering the 403(b) annuity-contract wage exclusion and salary-reduction exception
- include generated tests proving salary-reduction 403(b) purchases are not excluded from FICA wages
- include signed encoder apply manifest generated with axiom-encode 0.2.322 from merged encoder commit e44e7ab using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/3121/a/5/D.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3121/a/5/D.yaml
- uv run axiom-encode test statutes/26/3121/a/5/D.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1294; comparable 227; known_not_comparable 1067; untested comparable outputs 0.

Context: this is one step toward making the 3121(a) FICA wage base executable enough to catch the PolicyEngine #8374 class of 401(k)/403(b) payroll wage bugs.