### PR TITLE
Add generated section 3121(a)(5)(G) payroll wage rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/G.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/G.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/G.yaml",
+      "sha256": "d9795be00fd8bc96621f675adda3b6077859c9f87b9649bf5b8b209bb02d15b3"
+    },
+    {
+      "path": "statutes/26/3121/a/5/G.test.yaml",
+      "sha256": "e903af69ba0716c3498fca42167a3397307d7c3e8aefe47094d25693c0323724"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e44e7ab90136b298b03a14f7c9486d0121fea0cb",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.322",
+    "version_commit": "e44e7ab90136b298b03a14f7c9486d0121fea0cb"
+  },
+  "axiom_encode_version": "0.2.322",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(G)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-G/workspace/context-manifest.json",
+  "context_manifest_sha256": "bde8680db19ebe5908c7cf3cbabead8868086054de87b8b82168b31be8332346",
+  "generated_at": "2026-05-27T07:45:56.141339+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/G.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d9795be00fd8bc96621f675adda3b6077859c9f87b9649bf5b8b209bb02d15b3",
+  "generation_prompt_sha256": "536511b1e29aa4d3f8401546f51b549752538280bfe7ac27a912a9cde2ea259d",
+  "model": "gpt-5.5",
+  "run_id": "d99b0169",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "11ead311d8b44da89145cc53713c635c10867e98bc31bec6df5285450f8680e1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-G.json",
+  "trace_sha256": "ef1b023f6b73faea20521c5d6a929e60926efa7864fca7bf9ca235968d490685"
+}

--- a/statutes/26/3121/a/5/G.test.yaml
+++ b/statutes/26/3121/a/5/G.test.yaml
@@ -1,0 +1,72 @@
+- name: cafeteria_plan_payment_is_excluded_from_wages_when_all_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/G#input.payment_amount: 2500
+      us:statutes/26/3121/a/5/G#input.payment_made_under_cafeteria_plan_within_meaning_of_section_125: true
+      us:statutes/26/3121/a/5/G#input.payment_would_not_be_treated_as_wages_without_regard_to_cafeteria_plan: true
+      ? us:statutes/26/3121/a/5/G#input.reasonable_to_believe_section_125_would_not_treat_any_wages_as_constructively_received_for_this_section
+      : true
+  output:
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_excluded_from_wages:
+    - 2500
+- name: payment_not_under_cafeteria_plan_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/G#input.payment_amount: 2500
+      us:statutes/26/3121/a/5/G#input.payment_made_under_cafeteria_plan_within_meaning_of_section_125: false
+      us:statutes/26/3121/a/5/G#input.payment_would_not_be_treated_as_wages_without_regard_to_cafeteria_plan: true
+      ? us:statutes/26/3121/a/5/G#input.reasonable_to_believe_section_125_would_not_treat_any_wages_as_constructively_received_for_this_section
+      : true
+  output:
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_excluded_from_wages:
+    - 0
+- name: payment_that_would_be_wages_without_regard_to_plan_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/G#input.payment_amount: 2500
+      us:statutes/26/3121/a/5/G#input.payment_made_under_cafeteria_plan_within_meaning_of_section_125: true
+      us:statutes/26/3121/a/5/G#input.payment_would_not_be_treated_as_wages_without_regard_to_cafeteria_plan: false
+      ? us:statutes/26/3121/a/5/G#input.reasonable_to_believe_section_125_would_not_treat_any_wages_as_constructively_received_for_this_section
+      : true
+  output:
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_excluded_from_wages:
+    - 0
+- name: no_reasonable_belief_about_constructive_receipt_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/G#input.payment_amount: 2500
+      us:statutes/26/3121/a/5/G#input.payment_made_under_cafeteria_plan_within_meaning_of_section_125: true
+      us:statutes/26/3121/a/5/G#input.payment_would_not_be_treated_as_wages_without_regard_to_cafeteria_plan: true
+      ? us:statutes/26/3121/a/5/G#input.reasonable_to_believe_section_125_would_not_treat_any_wages_as_constructively_received_for_this_section
+      : false
+  output:
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/G#cafeteria_plan_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/5/G.yaml
+++ b/statutes/26/3121/a/5/G.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(G): excludes a payment “under a cafeteria plan (within the meaning of section 125)” if it would not be treated as wages without regard to the plan and it is reasonable to believe section 125 would not treat wages as constructively received.
+rules:
+  - name: cafeteria_plan_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(G)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under a cafeteria plan (within the meaning of section 125)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "if such payment would not be treated as wages without regard to such plan"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "it is reasonable to believe that ... section 125 would not treat any wages as constructively received"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_under_cafeteria_plan_within_meaning_of_section_125
+          and payment_would_not_be_treated_as_wages_without_regard_to_cafeteria_plan
+          and reasonable_to_believe_section_125_would_not_treat_any_wages_as_constructively_received_for_this_section
+
+  - name: cafeteria_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(5)(G)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the term shall not include ... under a cafeteria plan"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/G#cafeteria_plan_payment_exclusion_applies
+              output: cafeteria_plan_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if cafeteria_plan_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(G), covering cafeteria-plan wage exclusion conditions
- include generated tests distinguishing valid section 125/cafeteria exclusions from payments that would otherwise be wages or lack the constructive-receipt reasonable-belief condition
- include signed encoder apply manifest generated with axiom-encode 0.2.322 from merged encoder commit e44e7ab using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/3121/a/5/G.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3121/a/5/G.yaml
- uv run axiom-encode test statutes/26/3121/a/5/G.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1296; comparable 227; known_not_comparable 1069; untested comparable outputs 0.

Context: this advances the 3121(a) FICA wage-base path needed to catch the PolicyEngine #8374 class of payroll wage bugs.