### PR TITLE
Add generated section 408(p)(2)(A)(i) SIMPLE election rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/408/p/2/A/i.json
+++ b/.axiom/encoding-manifests/statutes/26/408/p/2/A/i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/408/p/2/A/i.yaml",
+      "sha256": "a249ff71e6f2cbf6a88147116abc728e138b5a51c07375a01810c819755b4a19"
+    },
+    {
+      "path": "statutes/26/408/p/2/A/i.test.yaml",
+      "sha256": "5c13d257d56544eee06e1e08cc95e268afa02f48c90b7101d2c5b01818f7e9e2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 408(p)(2)(A)(i)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-408-p-2-A-i/workspace/context-manifest.json",
+  "context_manifest_sha256": "c8535afca6d6c0b82a8ab8ac7f79da176578872e707c13901561b283c094a058",
+  "generated_at": "2026-05-27T08:08:29.479167+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/408/p/2/A/i.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a249ff71e6f2cbf6a88147116abc728e138b5a51c07375a01810c819755b4a19",
+  "generation_prompt_sha256": "f523e5bdc04024444629490ca56e96581ea3a294dfb25fbd562cc893d9c039aa",
+  "model": "gpt-5.5",
+  "run_id": "4dae4fbe",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7ace469b0de8525af93c54e03a022e9d1988af40788824f06144bb440f4928ec"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-408-p-2-A-i.json",
+  "trace_sha256": "445758cfc24bddbb4f756aa39e8e55241e7339670bdf6c26ccd4bc9108a4e884"
+}

--- a/statutes/26/408/p/2/A/i.test.yaml
+++ b/statutes/26/408/p/2/A/i.test.yaml
@@ -1,0 +1,18 @@
+- name: eligible_employee_may_elect_employer_payments
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/408/p/2/A/i#input.employee_eligible_to_participate_in_arrangement: true
+  output:
+    us:statutes/26/408/p/2/A/i#employee_may_elect_employer_payments: holds
+- name: ineligible_employee_may_not_elect_under_this_clause
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/408/p/2/A/i#input.employee_eligible_to_participate_in_arrangement: false
+  output:
+    us:statutes/26/408/p/2/A/i#employee_may_elect_employer_payments: not_holds

--- a/statutes/26/408/p/2/A/i.yaml
+++ b/statutes/26/408/p/2/A/i.yaml
@@ -1,0 +1,26 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/408
+  summary: |-
+    an employee eligible to participate in the arrangement may elect to have the employer make payments—
+rules:
+  - name: employee_may_elect_employer_payments
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 408(p)(2)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/408
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employee_eligible_to_participate_in_arrangement


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 408(p)(2)(A)(i), covering eligible employee election availability under SIMPLE arrangements
- include generated tests and signed encoder apply manifest
- generated with axiom-encode 0.2.323 from merged encoder commit 60d80ac using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/408/p/2/A/i.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/408/p/2/A/i.yaml
- uv run axiom-encode test statutes/26/408/p/2/A/i.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1297; comparable 227; known_not_comparable 1070; untested comparable outputs 0.

Context: this is a cross-reference needed for 3121(a)(5)(H), which references elective contributions under 408(p)(2)(A)(i).