### PR TITLE
Add generated section 3121(a)(5)(B) payroll wage rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/B.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/B.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/B.yaml",
+      "sha256": "0369eeb14862df893ac9435f1d9e012915deb5c90e8dcb5574343c06e738de98"
+    },
+    {
+      "path": "statutes/26/3121/a/5/B.test.yaml",
+      "sha256": "9a328be425f4909f583fbad046b45f07d45cea11daae5610921cc6c9662c9ffd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(B)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-B/workspace/context-manifest.json",
+  "context_manifest_sha256": "4c24d135f6ceb380a0cf190233c97ce25bddc12e98db6bf89b43b8d81a261a26",
+  "generated_at": "2026-05-27T08:23:06.282612+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/B.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "0369eeb14862df893ac9435f1d9e012915deb5c90e8dcb5574343c06e738de98",
+  "generation_prompt_sha256": "1fa245affcd550f5b2acff2eaffe1ea5610e65def66391b67a57a23d85cd7b27",
+  "model": "gpt-5.5",
+  "run_id": "6f2e62d3",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aa82fdaeccf06468c5a09a9c8e2a44d3af22744949fffac98eb2f73bd191272c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-B.json",
+  "trace_sha256": "a3f7aface3107142526ee2624853a3d9c45d8cd5d528307d82211b5be373e454"
+}

--- a/statutes/26/3121/a/5/B.test.yaml
+++ b/statutes/26/3121/a/5/B.test.yaml
@@ -1,0 +1,39 @@
+- name: payment_under_403a_annuity_plan_satisfies_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/B#input.payment_made_under_annuity_plan_described_in_section_403_a_at_time_of_payment: true
+      us:statutes/26/3121/a/5/B#input.payment_made_to_annuity_plan_described_in_section_403_a_at_time_of_payment: false
+  output:
+    us:statutes/26/3121/a/5/B#annuity_plan_403a_payment_exclusion_branch_applies:
+    - holds
+- name: payment_to_403a_annuity_plan_satisfies_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/B#input.payment_made_under_annuity_plan_described_in_section_403_a_at_time_of_payment: false
+      us:statutes/26/3121/a/5/B#input.payment_made_to_annuity_plan_described_in_section_403_a_at_time_of_payment: true
+  output:
+    us:statutes/26/3121/a/5/B#annuity_plan_403a_payment_exclusion_branch_applies:
+    - holds
+- name: payment_neither_under_nor_to_403a_annuity_plan_does_not_satisfy_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/B#input.payment_made_under_annuity_plan_described_in_section_403_a_at_time_of_payment: false
+      us:statutes/26/3121/a/5/B#input.payment_made_to_annuity_plan_described_in_section_403_a_at_time_of_payment: false
+  output:
+    us:statutes/26/3121/a/5/B#annuity_plan_403a_payment_exclusion_branch_applies:
+    - not_holds

--- a/statutes/26/3121/a/5/B.yaml
+++ b/statutes/26/3121/a/5/B.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(B): “under or to an annuity plan which, at the time of such payment, is a plan described in section 403(a)”
+rules:
+  - name: annuity_plan_403a_payment_exclusion_branch_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under or to an annuity plan"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "at the time of such payment, is a plan described in section 403(a)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_under_annuity_plan_described_in_section_403_a_at_time_of_payment
+          or payment_made_to_annuity_plan_described_in_section_403_a_at_time_of_payment


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(B), covering the section 403(a) annuity-plan branch of the FICA wage exclusions
- include generated tests and signed encoder apply manifest
- generated with axiom-encode 0.2.323 from merged encoder commit 60d80ac using gpt-5.5

## Validation
- uv run axiom-encode validate statutes/26/3121/a/5/B.yaml --skip-reviewers
- uv run axiom-encode proof-validate statutes/26/3121/a/5/B.yaml
- uv run axiom-encode test statutes/26/3121/a/5/B.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

PolicyEngine oracle coverage after this addition: executable outputs 1298; comparable 227; known_not_comparable 1071; untested comparable outputs 0.