### PR TITLE
Add generated section 3121(a)(5)(E) payroll wage rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/E.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/E.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/E.yaml",
+      "sha256": "d7e1a889538e2eb39de73649afd249a5a2fe1102105714d0d85270b09ae492ea"
+    },
+    {
+      "path": "statutes/26/3121/a/5/E.test.yaml",
+      "sha256": "93cffd9de010f62d3036b7bdfe15629ba968ba0fc5abc0d3e0fec5a150a38749"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(E)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-E/workspace/context-manifest.json",
+  "context_manifest_sha256": "6f8c4835c8a10752544ae87bed58ee14fe3c92546ede22fb4f29b29b5e3c0c03",
+  "generated_at": "2026-05-27T08:30:31.143447+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/E.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d7e1a889538e2eb39de73649afd249a5a2fe1102105714d0d85270b09ae492ea",
+  "generation_prompt_sha256": "a023b58329859be762f372fdaa6824e8d34008c0e9ae3464b95d1415c6bb1827",
+  "model": "gpt-5.5",
+  "run_id": "61eff00d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4ae84d47a3be58fcda21df1d75fcf2d5dd7637ae4911df4ff8900415df4573e4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-E.json",
+  "trace_sha256": "7449f784d9f7ad4f3303e490d00c97952c4433e47a67af81d0a2b5c79300c830"
+}

--- a/statutes/26/3121/a/5/E.test.yaml
+++ b/statutes/26/3121/a/5/E.test.yaml
@@ -1,0 +1,92 @@
+- name: payment_under_exempt_governmental_deferred_compensation_plan_satisfies_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/E#input.payment_made_under_governmental_deferred_compensation_plan: true
+      us:statutes/26/3121/a/5/E#input.payment_made_to_governmental_deferred_compensation_plan: false
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/a/5/E#exempt_governmental_deferred_compensation_plan_payment_exclusion_branch_applies:
+    - holds
+- name: payment_to_exempt_governmental_deferred_compensation_plan_satisfies_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/E#input.payment_made_under_governmental_deferred_compensation_plan: false
+      us:statutes/26/3121/a/5/E#input.payment_made_to_governmental_deferred_compensation_plan: true
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/a/5/E#exempt_governmental_deferred_compensation_plan_payment_exclusion_branch_applies:
+    - holds
+- name: payment_neither_under_nor_to_plan_does_not_satisfy_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/E#input.payment_made_under_governmental_deferred_compensation_plan: false
+      us:statutes/26/3121/a/5/E#input.payment_made_to_governmental_deferred_compensation_plan: false
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/a/5/E#exempt_governmental_deferred_compensation_plan_payment_exclusion_branch_applies:
+    - not_holds
+- name: payment_under_non_exempt_governmental_deferred_compensation_plan_does_not_satisfy_branch
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/E#input.payment_made_under_governmental_deferred_compensation_plan: true
+      us:statutes/26/3121/a/5/E#input.payment_made_to_governmental_deferred_compensation_plan: false
+      us:statutes/26/3121/v#input.plan_provides_for_deferral_of_compensation: true
+      ? us:statutes/26/3121/v#input.plan_established_and_maintained_for_employees_by_united_states_state_political_subdivision_agency_or_instrumentality
+      : true
+      us:statutes/26/3121/v#input.plan_to_which_section_83_applies: true
+      us:statutes/26/3121/v#input.plan_to_which_section_402_b_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_403_c_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_a_applies: false
+      us:statutes/26/3121/v#input.plan_to_which_section_457_f_1_applies: false
+      us:statutes/26/3121/v#input.annuity_contract_described_in_section_403_b: false
+      us:statutes/26/3121/v#input.thrift_savings_fund_within_meaning_of_subchapter_III_of_chapter_84_of_title_5: false
+  output:
+    us:statutes/26/3121/a/5/E#exempt_governmental_deferred_compensation_plan_payment_exclusion_branch_applies:
+    - not_holds

--- a/statutes/26/3121/a/5/E.yaml
+++ b/statutes/26/3121/a/5/E.yaml
@@ -1,0 +1,44 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(E): “under or to an exempt governmental deferred compensation plan (as defined in subsection (v)(3))”
+rules:
+  - name: exempt_governmental_deferred_compensation_plan_payment_exclusion_branch_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under or to an exempt governmental deferred compensation plan"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "as defined in subsection (v)(3)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/v#exempt_governmental_deferred_compensation_plan
+              output: exempt_governmental_deferred_compensation_plan
+              hash: sha256:6ec35b93bf860b6a33ca7ce8c5547ddface37026e0ec358a7f80c0df0e1cb956
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          exempt_governmental_deferred_compensation_plan
+          and (
+            payment_made_under_governmental_deferred_compensation_plan
+            or payment_made_to_governmental_deferred_compensation_plan
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(E), the exempt governmental deferred compensation plan payroll wage exclusion branch
- add generated companion cases for payments under/to exempt plans, non-plan payments, and non-exempt plan payments
- include signed axiom-encode apply manifest from gpt-5.5 / axiom-encode 0.2.323

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/E.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/E.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/E.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

PE oracle coverage after this addition: 1299 executable outputs; comparable=227; known_not_comparable=1072; untested comparable outputs=0.