### PR TITLE
Add generated section 3121(a)(5)(F) payroll wage rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/F.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/F.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/F.yaml",
+      "sha256": "1b5e568fa4deb093fe7973a0f07686e09956fd0922d74ad24a0351b7292d531e"
+    },
+    {
+      "path": "statutes/26/3121/a/5/F.test.yaml",
+      "sha256": "e6a063764288fd8d6e32f00cf3d6104038fe322d1f30a3f24f5781ecc19d533b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(F)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-F/workspace/context-manifest.json",
+  "context_manifest_sha256": "bd8d85553ede0d3c72e9f186bd9ff3f0077172202eadd2fec47141c3b3fccad9",
+  "generated_at": "2026-05-27T08:38:15.161647+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/F.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1b5e568fa4deb093fe7973a0f07686e09956fd0922d74ad24a0351b7292d531e",
+  "generation_prompt_sha256": "771b849b6d5500b825b871979093a971aeee08b9cbfd3dcd6170a7cd71abeba9",
+  "model": "gpt-5.5",
+  "run_id": "3de94cc6",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "741a4f845fdc00efa331190c360ba4c804297a1fa48ff3798298c964aca6eb11"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-F.json",
+  "trace_sha256": "3bace4290156442516d2c5166d0fd9d88251d59aadc488074c296545e034bbbc"
+}

--- a/statutes/26/3121/a/5/F.test.yaml
+++ b/statutes/26/3121/a/5/F.test.yaml
@@ -1,0 +1,109 @@
+- name: qualifying_cost_of_living_pension_supplement_payment_is_excluded_from_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : true
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: true
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: true
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: true
+  output:
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_excluded_from_wages:
+    - 4000
+- name: payment_not_to_or_on_behalf_of_employee_or_beneficiary_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: false
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : true
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: true
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: true
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: true
+  output:
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_excluded_from_wages:
+    - 0
+- name: payment_not_supplementing_foregoing_pension_plan_benefits_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : false
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: true
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: true
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: true
+  output:
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_excluded_from_wages:
+    - 0
+- name: payment_not_taking_cost_of_living_increase_into_account_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : true
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: false
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: true
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: true
+  output:
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_excluded_from_wages:
+    - 0
+- name: secretary_of_labor_determination_and_erisa_welfare_plan_requirements_are_required
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : true
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: true
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: false
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: true
+    - us:statutes/26/3121/a/5/F#input.payment_amount: 4000
+      us:statutes/26/3121/a/5/F#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      ? us:statutes/26/3121/a/5/F#input.payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+      : true
+      us:statutes/26/3121/a/5/F#input.supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement: true
+      us:statutes/26/3121/a/5/F#input.cost_of_living_increase_determined_by_secretary_of_labor: true
+      us:statutes/26/3121/a/5/F#input.supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii: false
+  output:
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies:
+    - not_holds
+    - not_holds
+    us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_excluded_from_wages:
+    - 0
+    - 0

--- a/statutes/26/3121/a/5/F.yaml
+++ b/statutes/26/3121/a/5/F.yaml
@@ -1,0 +1,77 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(F) excludes from “wages” any payment made to, or on behalf of, an employee or beneficiary to supplement pension benefits under a plan or trust described in the foregoing provisions of paragraph (5), to take into account some portion or all of the increase in the cost of living since retirement as determined by the Secretary of Labor, but only if the supplemental payments are under a plan treated as a welfare plan under section 3(2)(B)(ii) of ERISA.
+rules:
+  - name: cost_of_living_pension_supplement_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: any payment made to, or on behalf of, an employee or his beneficiary
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: to supplement pension benefits under a plan or trust described in any of the foregoing provisions of this paragraph
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: to take into account some portion or all of the increase in the cost of living
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: as determined by the Secretary of Labor
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: but only if such supplemental payments are under a plan which is treated as a welfare plan under section 3(2)(B)(ii) of the Employee Retirement Income Security Act of 1974
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_on_behalf_of_employee_or_beneficiary
+          and payment_to_supplement_pension_benefits_under_plan_or_trust_described_in_foregoing_provisions_of_paragraph_5
+          and supplement_takes_into_account_some_or_all_increase_in_cost_of_living_since_retirement
+          and cost_of_living_increase_determined_by_secretary_of_labor
+          and supplemental_payments_under_plan_treated_as_welfare_plan_under_erisa_section_3_2_B_ii
+
+  - name: cost_of_living_pension_supplement_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(5)(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: the term “wages” ... shall not include ... any payment ... to supplement pension benefits
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/F#cost_of_living_pension_supplement_payment_exclusion_applies
+              output: cost_of_living_pension_supplement_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if cost_of_living_pension_supplement_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(F), the cost-of-living pension supplement payroll wage exclusion
- add generated companion cases covering each required condition and excluded wage amount
- include signed axiom-encode apply manifest from gpt-5.5 / axiom-encode 0.2.323

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/F.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/F.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/F.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

PE oracle coverage after this addition: 1301 executable outputs; comparable=227; known_not_comparable=1074; untested comparable outputs=0.