### PR TITLE
Add generated section 3121(a)(5)(C) payroll wage rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/C.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/C.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/C.yaml",
+      "sha256": "9615f474c4392b91206b21acfcf3ea379a14c4db486fc81ee59093db08276ca6"
+    },
+    {
+      "path": "statutes/26/3121/a/5/C.test.yaml",
+      "sha256": "a50773819492518a919587d5095c72f083dca53d1e2c553aac330f41c627da4f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(C)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-C/workspace/context-manifest.json",
+  "context_manifest_sha256": "1cee0c2397af301d7289cce72be88ef914efe478eda2da4fc9948c084fd543b0",
+  "generated_at": "2026-05-27T08:43:53.084891+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/C.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9615f474c4392b91206b21acfcf3ea379a14c4db486fc81ee59093db08276ca6",
+  "generation_prompt_sha256": "949bfca99617a388adf1fc1001e55ac54574457e64713ec0ef620a9f7c48de5e",
+  "model": "gpt-5.5",
+  "run_id": "cf4c19f0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7e086f1b602b351a07ad1ddea712f9c86e76881c23d328a4b5192a85c5b28924"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-C.json",
+  "trace_sha256": "72e776cb01ba45373517926830fd7c7d9f840523f38a465ac1fe201e98e77904"
+}

--- a/statutes/26/3121/a/5/C.test.yaml
+++ b/statutes/26/3121/a/5/C.test.yaml
@@ -1,0 +1,68 @@
+- name: qualifying_simplified_employee_pension_payment_is_excluded_from_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/C#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/C#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/C#input.payment_made_under_simplified_employee_pension_as_defined_in_section_408_k_1: true
+      us:statutes/26/3121/a/5/C#input.contribution_described_in_section_408_k_6: false
+  output:
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_branch_applies:
+    - holds
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_excluded_from_wages:
+    - 5000
+- name: payment_not_to_or_on_behalf_of_employee_or_beneficiary_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/C#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/C#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: false
+      us:statutes/26/3121/a/5/C#input.payment_made_under_simplified_employee_pension_as_defined_in_section_408_k_1: true
+      us:statutes/26/3121/a/5/C#input.contribution_described_in_section_408_k_6: false
+  output:
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_branch_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_excluded_from_wages:
+    - 0
+- name: payment_not_under_simplified_employee_pension_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/C#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/C#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/C#input.payment_made_under_simplified_employee_pension_as_defined_in_section_408_k_1: false
+      us:statutes/26/3121/a/5/C#input.contribution_described_in_section_408_k_6: false
+  output:
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_branch_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_excluded_from_wages:
+    - 0
+- name: section_408_k_6_contribution_exception_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/C#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/C#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/C#input.payment_made_under_simplified_employee_pension_as_defined_in_section_408_k_1: true
+      us:statutes/26/3121/a/5/C#input.contribution_described_in_section_408_k_6: true
+  output:
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_branch_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/5/C.yaml
+++ b/statutes/26/3121/a/5/C.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(C): the term “wages” shall not include any payment made to, or on behalf of, an employee or his beneficiary under a simplified employee pension (as defined in section 408(k)(1)), other than any contributions described in section 408(k)(6).
+rules:
+  - name: simplified_employee_pension_payment_branch_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made to, or on behalf of, an employee or his beneficiary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under a simplified employee pension"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than any contributions described in section 408(k)(6)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_on_behalf_of_employee_or_beneficiary
+          and payment_made_under_simplified_employee_pension_as_defined_in_section_408_k_1
+          and not contribution_described_in_section_408_k_6
+
+  - name: simplified_employee_pension_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(5)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the term shall not include ... under a simplified employee pension"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_branch_applies
+              output: simplified_employee_pension_payment_branch_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if simplified_employee_pension_payment_branch_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(C), the simplified employee pension payroll wage exclusion branch
- add generated companion cases for qualifying SEP payments, non-employee/beneficiary payments, non-SEP payments, and the 408(k)(6) contribution exception
- include signed axiom-encode apply manifest from gpt-5.5 / axiom-encode 0.2.323

Note: 408(k) itself is not yet encoded, so the generated rule keeps the 408(k)(1)/(6) concepts as explicit local predicates rather than importing deeper 408(k) outputs.

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/C.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/C.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/C.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

PE oracle coverage after this addition: 1303 executable outputs; comparable=227; known_not_comparable=1076; untested comparable outputs=0.