### PR TITLE
Add generated section 3121(a)(5)(I) payroll wage rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3121/a/5/I.json
+++ b/.axiom/encoding-manifests/statutes/26/3121/a/5/I.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3121/a/5/I.yaml",
+      "sha256": "2f152721f42d4642aae7a755ff6e39997a899c76acf5313a626fbc5036bd955d"
+    },
+    {
+      "path": "statutes/26/3121/a/5/I.test.yaml",
+      "sha256": "f49ce6bbd37503f8ac0b995a093bf4de267d4638aac9291e607089724ef6a51f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "60d80ac20736315075a604a6ad4b07fec32f4348",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
+    "version": "0.2.323",
+    "version_commit": "60d80ac20736315075a604a6ad4b07fec32f4348"
+  },
+  "axiom_encode_version": "0.2.323",
+  "backend": "openai",
+  "citation": "26 USC 3121(a)(5)(I)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3121-a-5-I/workspace/context-manifest.json",
+  "context_manifest_sha256": "7418bf9054b5ef54926328ca5e84d5416a1e71ca7d587ba4a8d6af19c9f3fd13",
+  "generated_at": "2026-05-27T08:48:38.106987+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3121/a/5/I.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "2f152721f42d4642aae7a755ff6e39997a899c76acf5313a626fbc5036bd955d",
+  "generation_prompt_sha256": "02aeb67f00cf7c713caa8cca0d3ffbc7d9739b139c33ff9d9fd527b31c8fbc36",
+  "model": "gpt-5.5",
+  "run_id": "9b9a7d77",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "324902b52418f808f3be37cbb23962ce2f42cf1d92a40ba34b2219b2363f5299"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3121-a-5-I.json",
+  "trace_sha256": "9c7572c52b162cfb4dc8b5e75c1dfd72154e1cd277096c26cc4b27c211fe3698"
+}

--- a/statutes/26/3121/a/5/I.test.yaml
+++ b/statutes/26/3121/a/5/I.test.yaml
@@ -1,0 +1,68 @@
+- name: qualifying_section_457_e_11_A_ii_eligible_employer_plan_payment_is_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/I#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/I#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/I#input.payment_made_under_plan_described_in_section_457_e_11_A_ii: true
+      us:statutes/26/3121/a/5/I#input.plan_maintained_by_eligible_employer_as_defined_in_section_457_e_1: true
+  output:
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_excluded_from_wages:
+    - 5000
+- name: payment_not_to_or_on_behalf_of_employee_or_beneficiary_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/I#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/I#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: false
+      us:statutes/26/3121/a/5/I#input.payment_made_under_plan_described_in_section_457_e_11_A_ii: true
+      us:statutes/26/3121/a/5/I#input.plan_maintained_by_eligible_employer_as_defined_in_section_457_e_1: true
+  output:
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_excluded_from_wages:
+    - 0
+- name: payment_not_under_section_457_e_11_A_ii_plan_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/I#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/I#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/I#input.payment_made_under_plan_described_in_section_457_e_11_A_ii: false
+      us:statutes/26/3121/a/5/I#input.plan_maintained_by_eligible_employer_as_defined_in_section_457_e_1: true
+  output:
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_excluded_from_wages:
+    - 0
+- name: plan_not_maintained_by_eligible_employer_is_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3121/a/5/I#input.payment_amount: 5000
+      us:statutes/26/3121/a/5/I#input.payment_made_to_or_on_behalf_of_employee_or_beneficiary: true
+      us:statutes/26/3121/a/5/I#input.payment_made_under_plan_described_in_section_457_e_11_A_ii: true
+      us:statutes/26/3121/a/5/I#input.plan_maintained_by_eligible_employer_as_defined_in_section_457_e_1: false
+  output:
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3121/a/5/I.yaml
+++ b/statutes/26/3121/a/5/I.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    26 USC 3121(a)(5)(I): the term "wages" shall not include any payment made to, or on behalf of, an employee or his beneficiary under a plan described in section 457(e)(11)(A)(ii) and maintained by an eligible employer (as defined in section 457(e)(1)).
+rules:
+  - name: section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(a)(5)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "any payment made to, or on behalf of, an employee or his beneficiary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "under a plan described in section 457(e)(11)(A)(ii)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "maintained by an eligible employer (as defined in section 457(e)(1))"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_on_behalf_of_employee_or_beneficiary
+          and payment_made_under_plan_described_in_section_457_e_11_A_ii
+          and plan_maintained_by_eligible_employer_as_defined_in_section_457_e_1
+
+  - name: section_457_e_11_A_ii_eligible_employer_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3121(a)(5)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "the term shall not include ... under a plan described in section 457(e)(11)(A)(ii)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3121/a/5/I#section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies
+              output: section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if section_457_e_11_A_ii_eligible_employer_plan_payment_exclusion_applies: payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3121(a)(5)(I), the 457(e)(11)(A)(ii) eligible-employer plan payroll wage exclusion branch
- add generated companion cases for qualifying payments, non-employee/beneficiary payments, non-457-plan payments, and non-eligible-employer plans
- include signed axiom-encode apply manifest from gpt-5.5 / axiom-encode 0.2.323

Note: section 457 is not yet encoded in rulespec-us, so the generated rule keeps the 457(e)(11)(A)(ii) and 457(e)(1) concepts as explicit local predicates rather than importing deeper 457 outputs.

## Validation
- `uv run axiom-encode validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/I.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/I.yaml`
- `uv run axiom-encode test /private/tmp/axiom-night-20260526190810/rulespec-us/statutes/26/3121/a/5/I.test.yaml --axiom-rules-engine-path /private/tmp/axiom-night-20260526190810/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-night-20260526190810/rulespec-us`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable`

PE oracle coverage after this addition: 1305 executable outputs; comparable=227; known_not_comparable=1078; untested comparable outputs=0.