### PR TITLE
Add generated section 3241(c) payroll ratio definitions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3241/c.yaml",
+      "sha256": "0223aae22e344bf7778f7acc2ae58449e0725710e01d34efab053920abeedfdf"
+    },
+    {
+      "path": "statutes/26/3241/c.test.yaml",
+      "sha256": "31044a49839ed665d4afabd793185ff3ab457f6d8161fe1d0207121d8ccb2843"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "98788ebf58d0ebff5db959158931cb21ab6bdbe7",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.331",
+    "version_commit": "98788ebf58d0ebff5db959158931cb21ab6bdbe7"
+  },
+  "axiom_encode_version": "0.2.331",
+  "backend": "openai",
+  "citation": "us/statute/26/3241/c",
+  "context_manifest_file": "/private/tmp/axiom-encode-3241c-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3241-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "073677eb209e9c5021a2caaaba298bce51b7eb0601b9a39dad92b4f4f90a313e",
+  "generated_at": "2026-05-27T14:45:25.454035+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3241c-20260527/openai-gpt-5.5/statutes/26/3241/c.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3241c-20260527",
+  "generated_output_sha256": "0223aae22e344bf7778f7acc2ae58449e0725710e01d34efab053920abeedfdf",
+  "generation_prompt_sha256": "9221af5c860b3631d17a323d8044ec9b309981a36affeec1abcec952903656e6",
+  "model": "gpt-5.5",
+  "run_id": "495ac3af",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d4cb4c31a435496b3e569e3a3e00e8583799d1845caba2ed6eeaa20d905209eb"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3241c-20260527/traces/openai-gpt-5.5/us-statute-26-3241-c.json",
+  "trace_sha256": "6187b6c7075181e5467dc4165dcea5704d95e1e684109c56b0b454aa04c461a9"
+}

--- a/statutes/26/3241/c.test.yaml
+++ b/statutes/26/3241/c.test.yaml
@@ -1,0 +1,42 @@
+- name: account_benefits_ratio_after_cutoff_excludes_social_security_equivalent_assets
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/c#input.fair_market_value_of_assets_in_railroad_retirement_account_at_close_of_fiscal_year: 600
+    ? us:statutes/26/3241/c#input.fair_market_value_of_assets_in_national_railroad_retirement_investment_trust_at_close_of_fiscal_year
+    : 400
+    ? us:statutes/26/3241/c#input.fair_market_value_of_assets_in_social_security_equivalent_benefits_account_at_close_of_fiscal_year
+    : 999
+    us:statutes/26/3241/c#input.fiscal_year_ends_before_social_security_equivalent_benefits_account_cutoff: false
+    ? us:statutes/26/3241/c#input.total_benefits_and_administrative_expenses_paid_from_railroad_retirement_account_and_national_railroad_retirement_investment_trust_during_fiscal_year
+    : 500
+    us:statutes/26/3241/c#input.sum_of_account_benefits_ratios_for_most_recent_fiscal_years_ending_before_calendar_year: 32
+  output:
+    us:statutes/26/3241/c#most_recent_fiscal_year_count_for_average_account_benefits_ratio: 10
+    us:statutes/26/3241/c#average_account_benefits_ratio_rounding_multiple: 0.1
+    us:statutes/26/3241/c#account_benefits_ratio: 2
+    us:statutes/26/3241/c#unrounded_average_account_benefits_ratio: 3.2
+    us:statutes/26/3241/c#average_account_benefits_ratio: 3.2
+- name: account_benefits_ratio_before_cutoff_includes_social_security_equivalent_assets
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/c#input.fair_market_value_of_assets_in_railroad_retirement_account_at_close_of_fiscal_year: 600
+    ? us:statutes/26/3241/c#input.fair_market_value_of_assets_in_national_railroad_retirement_investment_trust_at_close_of_fiscal_year
+    : 400
+    ? us:statutes/26/3241/c#input.fair_market_value_of_assets_in_social_security_equivalent_benefits_account_at_close_of_fiscal_year
+    : 500
+    us:statutes/26/3241/c#input.fiscal_year_ends_before_social_security_equivalent_benefits_account_cutoff: true
+    ? us:statutes/26/3241/c#input.total_benefits_and_administrative_expenses_paid_from_railroad_retirement_account_and_national_railroad_retirement_investment_trust_during_fiscal_year
+    : 500
+    us:statutes/26/3241/c#input.sum_of_account_benefits_ratios_for_most_recent_fiscal_years_ending_before_calendar_year: 32.4
+  output:
+    us:statutes/26/3241/c#most_recent_fiscal_year_count_for_average_account_benefits_ratio: 10
+    us:statutes/26/3241/c#average_account_benefits_ratio_rounding_multiple: 0.1
+    us:statutes/26/3241/c#account_benefits_ratio: 3
+    us:statutes/26/3241/c#unrounded_average_account_benefits_ratio: 3.24
+    us:statutes/26/3241/c#average_account_benefits_ratio: 3.3

--- a/statutes/26/3241/c.yaml
+++ b/statutes/26/3241/c.yaml
@@ -1,0 +1,122 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+  summary: |-
+    Defines “average account benefits ratio” as the 10-year average of account benefits ratios, increased to the next highest multiple of 0.1 if needed; defines “account benefits ratio” as specified assets divided by benefits and administrative expenses paid.
+rules:
+  - name: most_recent_fiscal_year_count_for_average_account_benefits_ratio
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3241(c)(1), 10 most recent fiscal years
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "the 10 most recent fiscal years ending before such calendar year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: average_account_benefits_ratio_rounding_multiple
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(c)(1), rounding multiple
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "If the amount ... is not a multiple of 0.1, such amount shall be increased to the next highest multiple of 0.1."
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.1
+
+  - name: unrounded_average_account_benefits_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 26 USC 3241(c)(1), average before rounding
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "the average ... of the account benefits ratios for the 10 most recent fiscal years ending before such calendar year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/c#most_recent_fiscal_year_count_for_average_account_benefits_ratio
+              output: most_recent_fiscal_year_count_for_average_account_benefits_ratio
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          sum_of_account_benefits_ratios_for_most_recent_fiscal_years_ending_before_calendar_year / most_recent_fiscal_year_count_for_average_account_benefits_ratio
+
+  - name: average_account_benefits_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 26 USC 3241(c)(1), Average account benefits ratio
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "If the amount ... is not a multiple of 0.1, such amount shall be increased to the next highest multiple of 0.1."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/c#unrounded_average_account_benefits_ratio
+              output: unrounded_average_account_benefits_ratio
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3241/c#average_account_benefits_ratio_rounding_multiple
+              output: average_account_benefits_ratio_rounding_multiple
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          ceil(unrounded_average_account_benefits_ratio / average_account_benefits_ratio_rounding_multiple) * average_account_benefits_ratio_rounding_multiple
+
+  - name: account_benefits_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 26 USC 3241(c)(2), Account benefits ratio
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "dividing the fair market value of the assets ... as of the close of such fiscal year by the total benefits and administrative expenses paid"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3241
+              excerpt: "and for years before 2002, the Social Security Equivalent Benefits Account"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (fair_market_value_of_assets_in_railroad_retirement_account_at_close_of_fiscal_year + fair_market_value_of_assets_in_national_railroad_retirement_investment_trust_at_close_of_fiscal_year + (if fiscal_year_ends_before_social_security_equivalent_benefits_account_cutoff: fair_market_value_of_assets_in_social_security_equivalent_benefits_account_at_close_of_fiscal_year else: 0)) / total_benefits_and_administrative_expenses_paid_from_railroad_retirement_account_and_national_railroad_retirement_investment_trust_during_fiscal_year


### PR DESCRIPTION
## Summary
- add generated 26 USC 3241(c) RRTA average account benefits ratio definitions
- include generated companion tests and axiom-encode apply manifest

## Checks
- uv run axiom-encode test statutes/26/3241/c.test.yaml
- uv run axiom-encode proof-validate statutes/26/3241/c.yaml
- uv run axiom-encode compile statutes/26/3241/c.yaml
- uv run axiom-encode validate --skip-reviewers statutes/26/3241/c.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --json