### PR TITLE
Add generated section 3232 court jurisdiction rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3232.json
+++ b/.axiom/encoding-manifests/statutes/26/3232.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3232.yaml",
+      "sha256": "2215100584b850ab784b92d11c84b3f73dc9e2cb7e8954b2a3067fdf299efb33"
+    },
+    {
+      "path": "statutes/26/3232.test.yaml",
+      "sha256": "92be7d7f1432aeb0e6715ee8330719f5c1adf4bbf72b961507f6e803ababd683"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "19593ab2ff4e24d5b09464768a0c06fc72e0792b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.333",
+    "version_commit": "19593ab2ff4e24d5b09464768a0c06fc72e0792b"
+  },
+  "axiom_encode_version": "0.2.333",
+  "backend": "openai",
+  "citation": "us/statute/26/3232",
+  "context_manifest_file": "/private/tmp/axiom-encode-3232-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3232/workspace/context-manifest.json",
+  "context_manifest_sha256": "69fe468d20816a40bf312af47daa25a64b86ad1b0ce1e9922f54c38c9907c198",
+  "generated_at": "2026-05-27T16:27:12.338366+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3232-20260527/openai-gpt-5.5/statutes/26/3232.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3232-20260527",
+  "generated_output_sha256": "2215100584b850ab784b92d11c84b3f73dc9e2cb7e8954b2a3067fdf299efb33",
+  "generation_prompt_sha256": "a3f84a22dbebcb9aa83cd6b0a659e6b98609ce0a446545cc8b9c900b91c2e120",
+  "model": "gpt-5.5",
+  "run_id": "59b137ca",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f684897d1b10d399c155f8ce94d49d14f4dd157b016c371389378ed09ed4abc5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3232-20260527/traces/openai-gpt-5.5/us-statute-26-3232.json",
+  "trace_sha256": "240c23f3ae1f806a4bfea2797aa365eba55d7dc23133d54640ca30bb08b9f02f"
+}

--- a/statutes/26/3232.test.yaml
+++ b/statutes/26/3232.test.yaml
@@ -1,0 +1,50 @@
+- name: person_within_jurisdiction_and_chapter_obligation_can_be_compelled
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3232#input.attorney_general_application_on_behalf_of_secretary_to_compel_compliance: true
+    us:statutes/26/3232#input.employee_or_other_person_resides_within_court_jurisdiction: true
+    us:statutes/26/3232#input.chapter_obligation_imposed_on_employee_or_other_person: true
+    us:statutes/26/3232#input.federal_court_otherwise_possesses_jurisdiction_to_entertain_civil_action: true
+    us:statutes/26/3232#input.civil_action_in_aid_of_enforcement_of_chapter_rights_or_obligations: true
+  output:
+    us:statutes/26/3232#district_court_jurisdiction_to_compel_employee_or_other_person: holds
+    us:statutes/26/3232#conferred_federal_court_jurisdiction_not_exclusive: holds
+- name: person_not_residing_within_court_jurisdiction_not_within_compulsion_jurisdiction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3232#input.attorney_general_application_on_behalf_of_secretary_to_compel_compliance: true
+    us:statutes/26/3232#input.employee_or_other_person_resides_within_court_jurisdiction: false
+    us:statutes/26/3232#input.chapter_obligation_imposed_on_employee_or_other_person: true
+    us:statutes/26/3232#input.federal_court_otherwise_possesses_jurisdiction_to_entertain_civil_action: true
+    us:statutes/26/3232#input.civil_action_in_aid_of_enforcement_of_chapter_rights_or_obligations: false
+  output:
+    us:statutes/26/3232#district_court_jurisdiction_to_compel_employee_or_other_person: not_holds
+    us:statutes/26/3232#conferred_federal_court_jurisdiction_not_exclusive: not_holds
+- name: employer_subject_to_service_and_chapter_obligation_can_be_compelled
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3232#input.attorney_general_application_on_behalf_of_secretary_to_compel_compliance: true
+    us:statutes/26/3232#input.employer_subject_to_service_of_process_within_court_jurisdiction: true
+    us:statutes/26/3232#input.chapter_obligation_imposed_on_employer: true
+  output:
+    us:statutes/26/3232#district_court_jurisdiction_to_compel_employer: holds
+- name: employer_without_chapter_obligation_not_within_compulsion_jurisdiction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3232#input.attorney_general_application_on_behalf_of_secretary_to_compel_compliance: true
+    us:statutes/26/3232#input.employer_subject_to_service_of_process_within_court_jurisdiction: true
+    us:statutes/26/3232#input.chapter_obligation_imposed_on_employer: false
+  output:
+    us:statutes/26/3232#district_court_jurisdiction_to_compel_employer: not_holds

--- a/statutes/26/3232.yaml
+++ b/statutes/26/3232.yaml
@@ -1,0 +1,95 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3232
+  summary: |-
+    District courts of the United States have jurisdiction to entertain an application by the Attorney General on behalf of the Secretary to compel an employee or other person residing within the court's jurisdiction, or an employer subject to service of process within its jurisdiction, to comply with obligations imposed under this chapter; the conferred jurisdiction is not exclusive of otherwise possessed civil-action jurisdiction aiding enforcement of rights or obligations under this chapter.
+rules:
+  - name: district_court_jurisdiction_to_compel_employee_or_other_person
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3232, first sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "an application by the Attorney General on behalf of the Secretary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "an employee or other person residing within the jurisdiction of the court"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "to comply with any obligations imposed on such employee ... or other person under the provisions of this chapter"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          attorney_general_application_on_behalf_of_secretary_to_compel_compliance
+          and employee_or_other_person_resides_within_court_jurisdiction
+          and chapter_obligation_imposed_on_employee_or_other_person
+
+  - name: district_court_jurisdiction_to_compel_employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3232, first sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "an application by the Attorney General on behalf of the Secretary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "an employer subject to service of process within its jurisdiction"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "to comply with any obligations imposed on such ... employer ... under the provisions of this chapter"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          attorney_general_application_on_behalf_of_secretary_to_compel_compliance
+          and employer_subject_to_service_of_process_within_court_jurisdiction
+          and chapter_obligation_imposed_on_employer
+
+  - name: conferred_federal_court_jurisdiction_not_exclusive
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3232, second sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "shall not be held exclusive of any jurisdiction otherwise possessed by such courts"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3232
+              excerpt: "to entertain civil actions, whether legal or equitable in nature, in aid of the enforcement of rights or obligations arising under the provisions of this chapter"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          federal_court_otherwise_possesses_jurisdiction_to_entertain_civil_action
+          and civil_action_in_aid_of_enforcement_of_chapter_rights_or_obligations


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3232 district-court enforcement jurisdiction predicates
- include generated companion tests and signed apply manifest
- relies on axiom-encode #356 for PolicyEngine not-comparable oracle classification

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3232.test.yaml
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3232.yaml
- uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3232.yaml
- uv run axiom-encode validate --skip-reviewers /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3232.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3232.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --limit 10 --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --head-ref HEAD