### PR TITLE
Add generated section 3233 short title

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3233.json
+++ b/.axiom/encoding-manifests/statutes/26/3233.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3233.yaml",
+      "sha256": "ebf5201bdfaefaa33d4690a605ab70d1054d8ce48d2e4d27eb267e21027ff846"
+    },
+    {
+      "path": "statutes/26/3233.test.yaml",
+      "sha256": "82891ecc0cbe9077ebb06b523e2858f72361980c03a7605c0509e9a16d0af45e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "openai",
+  "citation": "us/statute/26/3233",
+  "context_manifest_file": "/private/tmp/axiom-encode-3233-rerun2-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3233/workspace/context-manifest.json",
+  "context_manifest_sha256": "3d941ef2bcb407ce3bc174edbcb924435d6c13f1bc483258ed4b1105c32b39ae",
+  "generated_at": "2026-05-27T18:22:17.150002+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3233-rerun2-20260527/openai-gpt-5.5/statutes/26/3233.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3233-rerun2-20260527",
+  "generated_output_sha256": "ebf5201bdfaefaa33d4690a605ab70d1054d8ce48d2e4d27eb267e21027ff846",
+  "generation_prompt_sha256": "e5fc6877fa9d7c02b02dc3ddf10066aed9443e9a11c174f68a7b2a3ffd3275e9",
+  "model": "gpt-5.5",
+  "run_id": "c39e7d34",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f21b3cda3b68eb79a7e288c449d7c392744f531ee7543a2e1e9c063f151a082d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3233-rerun2-20260527/traces/openai-gpt-5.5/us-statute-26-3233.json",
+  "trace_sha256": "ab28a8ac553f351d7ced4585b5678581ad21fbb44f2c5e4940370372b392c362"
+}

--- a/statutes/26/3233.test.yaml
+++ b/statutes/26/3233.test.yaml
@@ -1,0 +1,8 @@
+- name: chapter_may_be_cited_by_short_title
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3233#chapter_short_title: Railroad Retirement Tax Act

--- a/statutes/26/3233.yaml
+++ b/statutes/26/3233.yaml
@@ -1,0 +1,25 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3233
+  summary: |-
+    This chapter may be cited as the “Railroad Retirement Tax Act.”
+rules:
+  - name: chapter_short_title
+    kind: parameter
+    dtype: String
+    source: 26 USC 3233
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3233
+              excerpt: "may be cited as the “Railroad Retirement Tax Act.”"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          "Railroad Retirement Tax Act"


### PR DESCRIPTION
## Summary
- add generated 26 USC 3233 short-title RuleSpec artifact
- add generated companion test and signed apply manifest

## Generation
- generated with axiom-encode 0.2.336 at 89652fa32ecfa9f496c76d5a3821796c79540380
- command used `axiom-encode encode '26 USC 3233' --source-id us/statute/26/3233 --backend openai --model gpt-5.5 --mode repo-augmented --apply`
- run id: c39e7d34

## Tests
- uv run axiom-encode test statutes/26/3233.test.yaml
- uv run axiom-encode proof-validate statutes/26/3233.yaml
- uv run axiom-encode compile --axiom-rules-engine-path ../axiom-rules-engine statutes/26/3233.yaml
- uv run axiom-encode validate --skip-reviewers statutes/26/3233.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3233.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --head-ref HEAD