### PR TITLE
Encode 7 USC 2014(e)(2)(B) — SNAP earned income deduction rate

### DIFF
--- a/.axiom/encoding-manifests/statutes/7/2014/e/2/B.json
+++ b/.axiom/encoding-manifests/statutes/7/2014/e/2/B.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7/2014/e/2/B.yaml",
+      "sha256": "f6df3554f1b7dfc588d313652f77c9331ae2272e3086a537fd72bbdebd7cfe66"
+    },
+    {
+      "path": "statutes/7/2014/e/2/B.test.yaml",
+      "sha256": "ed992813d755eb9ecadbb1c713ad6610458a5543fb38b8b94d9311e8270f66c9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "codex",
+  "citation": "us/statute/7/2014/e/2/B",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.4/us-statute-7-2014-e-2-B/workspace/context-manifest.json",
+  "context_manifest_sha256": "b8d6e7b7e87856dd291b54527012927d34e3c35b079065c3d5bac17e34e6c95a",
+  "generated_at": "2026-05-27T19:09:36.317187+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.4/statutes/7/2014/e/2/B.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f6df3554f1b7dfc588d313652f77c9331ae2272e3086a537fd72bbdebd7cfe66",
+  "generation_prompt_sha256": "9de75d6992551253bfad143b52e3e1cee6112708cbefeea0fa0a74e1f9fc6b58",
+  "model": "gpt-5.4",
+  "run_id": "abd3925c",
+  "runner": "codex-gpt-5.4",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9f48451d667f4cb11b44011247857f8d952d78d0bab577b1c43134a1c99bef64"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.4/us-statute-7-2014-e-2-B.json",
+  "trace_sha256": "34c62e81ed374b342211e1eccd4d4a4d1bb6777a73726340d6580089a28ea297"
+}

--- a/statutes/7/2014/e/2/B.test.yaml
+++ b/statutes/7/2014/e/2/B.test.yaml
@@ -1,0 +1,5 @@
+- name: earned_income_deduction_rate_is_twenty_percent
+  period: 2026-01
+  input: {}
+  output:
+    us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate: 0.2

--- a/statutes/7/2014/e/2/B.yaml
+++ b/statutes/7/2014/e/2/B.yaml
@@ -1,0 +1,30 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: |-
+    Except as provided in subparagraph (C), a household with earned income shall be allowed a deduction of 20 percent of all earned income.
+  deferred_outputs:
+    - output: us:statutes/7/2014/e/2/B#snap_earned_income_deduction
+      reason: Subparagraph (B) makes the deduction amount subject to the same-section exception in subparagraph (C), but no copied RuleSpec source for 7 USC 2014(e)(2)(C) is available in this workspace to compute the adjusted earned-income base faithfully.
+      source_values:
+        - us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 USC 2014(e)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "20 percent of all earned income"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          0.20


### PR DESCRIPTION
Adds the 20% SNAP earned-income deduction rate from 7 USC § 2014(e)(2)(B). First concrete federal SNAP subsection encoded via the Tier 1 chain.

Produced by axiom-encode 0.2.336 via encode --apply after axiom-encode#355 and #357 landed.

Module shape (honest partial):
- snap_earned_income_deduction_rate = 0.20, encoded with full proof grounding
- snap_earned_income_deduction recorded under module.deferred_outputs because (e)(2)(C) exception isn't in scope

Validators: compile ✅, CI ✅, generalist 8.5/10, zero ungrounded, signed manifest.

🤖 Generated with Claude Code