### PR TITLE
Add generated section 3307 deduction treatment

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3307.json
+++ b/.axiom/encoding-manifests/statutes/26/3307.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3307.yaml",
+      "sha256": "51a811f8ff487aaf85232745b296274dde20643e4e368fb99ff4fb00f2bdd596"
+    },
+    {
+      "path": "statutes/26/3307.test.yaml",
+      "sha256": "f18491945c73f0756147068eb8749eaf634e36c8660731590f669d5913134b9f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ba6412f2f376a31435f909d25b7957e8ede05a8b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.337",
+    "version_commit": "ba6412f2f376a31435f909d25b7957e8ede05a8b"
+  },
+  "axiom_encode_version": "0.2.337",
+  "backend": "openai",
+  "citation": "us/statute/26/3307",
+  "context_manifest_file": "/private/tmp/axiom-encode-3307-rerun-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3307/workspace/context-manifest.json",
+  "context_manifest_sha256": "acadd4bd48fb1eaf43a6152e8bd756428a80861101ee83a226170f6697e32b74",
+  "generated_at": "2026-05-27T19:46:32.754387+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3307-rerun-20260527/openai-gpt-5.5/statutes/26/3307.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3307-rerun-20260527",
+  "generated_output_sha256": "51a811f8ff487aaf85232745b296274dde20643e4e368fb99ff4fb00f2bdd596",
+  "generation_prompt_sha256": "bfd6fd0b92d8315d99323614d568161e1607e3c09eea46207b734a7e5c7476d4",
+  "model": "gpt-5.5",
+  "run_id": "c90c8d1a",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0e8ce2343537e88db1a04ab35890b82bbdcb108dfdd1aaf839947bb4e6f007bf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3307-rerun-20260527/traces/openai-gpt-5.5/us-statute-26-3307.json",
+  "trace_sha256": "6242f8398316cb9fef8ef1fc734702fe8f60b1868762f2d3d2c4314b63121b0b"
+}

--- a/statutes/26/3307.test.yaml
+++ b/statutes/26/3307.test.yaml
@@ -1,0 +1,72 @@
+- name: qualifying_deduction_is_considered_paid_to_employee
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3307#input.employer_required_or_permitted_under_chapter_act_of_congress_or_state_law_to_deduct_amount: true
+      us:statutes/26/3307#input.amount_deducted_from_remuneration_of_employee: true
+      us:statutes/26/3307#input.amount_deducted_paid_to_united_states_state_or_political_subdivision: true
+      us:statutes/26/3307#input.amount_deducted_from_employee_remuneration: 250
+  output:
+    us:statutes/26/3307#remuneration_deduction_payment_treatment_applies:
+    - holds
+    us:statutes/26/3307#remuneration_deduction_considered_paid_to_employee_for_chapter:
+    - 250
+- name: deduction_not_required_or_permitted_by_referenced_law_is_not_treated_as_paid
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3307#input.employer_required_or_permitted_under_chapter_act_of_congress_or_state_law_to_deduct_amount: false
+      us:statutes/26/3307#input.amount_deducted_from_remuneration_of_employee: true
+      us:statutes/26/3307#input.amount_deducted_paid_to_united_states_state_or_political_subdivision: true
+      us:statutes/26/3307#input.amount_deducted_from_employee_remuneration: 250
+  output:
+    us:statutes/26/3307#remuneration_deduction_payment_treatment_applies:
+    - not_holds
+    us:statutes/26/3307#remuneration_deduction_considered_paid_to_employee_for_chapter:
+    - 0
+- name: amount_not_deducted_from_employee_remuneration_is_not_treated_as_paid
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3307#input.employer_required_or_permitted_under_chapter_act_of_congress_or_state_law_to_deduct_amount: true
+      us:statutes/26/3307#input.amount_deducted_from_remuneration_of_employee: false
+      us:statutes/26/3307#input.amount_deducted_paid_to_united_states_state_or_political_subdivision: true
+      us:statutes/26/3307#input.amount_deducted_from_employee_remuneration: 250
+  output:
+    us:statutes/26/3307#remuneration_deduction_payment_treatment_applies:
+    - not_holds
+    us:statutes/26/3307#remuneration_deduction_considered_paid_to_employee_for_chapter:
+    - 0
+- name: deducted_amount_not_paid_to_governmental_destination_is_not_treated_as_paid
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3307#input.employer_required_or_permitted_under_chapter_act_of_congress_or_state_law_to_deduct_amount: true
+      us:statutes/26/3307#input.amount_deducted_from_remuneration_of_employee: true
+      us:statutes/26/3307#input.amount_deducted_paid_to_united_states_state_or_political_subdivision: false
+      us:statutes/26/3307#input.amount_deducted_from_employee_remuneration: 250
+  output:
+    us:statutes/26/3307#remuneration_deduction_payment_treatment_applies:
+    - not_holds
+    us:statutes/26/3307#remuneration_deduction_considered_paid_to_employee_for_chapter:
+    - 0

--- a/statutes/26/3307.yaml
+++ b/statutes/26/3307.yaml
@@ -1,0 +1,54 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3307
+  summary: |-
+    Whenever an employer is required or permitted under this chapter, any act of Congress, or State law to deduct an amount from an employee's remuneration and pay it to the United States, a State, or a political subdivision, the deducted amount is considered paid to the employee at the time of deduction for purposes of this chapter.
+rules:
+  - name: remuneration_deduction_payment_treatment_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3307
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3307
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_required_or_permitted_under_chapter_act_of_congress_or_state_law_to_deduct_amount
+          and amount_deducted_from_remuneration_of_employee
+          and amount_deducted_paid_to_united_states_state_or_political_subdivision
+
+  - name: remuneration_deduction_considered_paid_to_employee_for_chapter
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3307
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3307
+              excerpt: "the amount so deducted shall be considered to have been paid to the employee at the time of such deduction"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3307#remuneration_deduction_payment_treatment_applies
+              output: remuneration_deduction_payment_treatment_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if remuneration_deduction_payment_treatment_applies: max(0, amount_deducted_from_employee_remuneration) else: 0


### PR DESCRIPTION
## Summary
- add generated 26 USC 3307 FUTA deduction-payment treatment RuleSpec artifact
- add generated companion tests and signed apply manifest

## Generation
- generated with axiom-encode 0.2.337 at ba6412f2f376a31435f909d25b7957e8ede05a8b
- command used `axiom-encode encode '26 USC 3307' --source-id us/statute/26/3307 --backend openai --model gpt-5.5 --mode repo-augmented --apply`
- run id: c90c8d1a

## Tests
- uv run axiom-encode test statutes/26/3307.test.yaml
- uv run axiom-encode proof-validate statutes/26/3307.yaml
- uv run axiom-encode compile --axiom-rules-engine-path ../axiom-rules-engine statutes/26/3307.yaml
- uv run axiom-encode validate --skip-reviewers statutes/26/3307.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3307.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --head-ref HEAD