### PR TITLE
Add generated section 3308 instrumentality exemption

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3308.json
+++ b/.axiom/encoding-manifests/statutes/26/3308.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3308.yaml",
+      "sha256": "ed985ee5801e874dfd46f2ac75a012ddc7c435598a472789a9c666c68d884413"
+    },
+    {
+      "path": "statutes/26/3308.test.yaml",
+      "sha256": "e0d1ee86b7836cf53209e8c12b04030db9d5a1eb66d9af9a08e83487de4e854e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "acd42a5da18b1daa28ab7a91318f79fdbbf4d0dd",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.338",
+    "version_commit": "acd42a5da18b1daa28ab7a91318f79fdbbf4d0dd"
+  },
+  "axiom_encode_version": "0.2.338",
+  "backend": "openai",
+  "citation": "us/statute/26/3308",
+  "context_manifest_file": "/private/tmp/axiom-encode-3308-rerun-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3308/workspace/context-manifest.json",
+  "context_manifest_sha256": "94d86e468638a43d78112913f6fd39e784b72b9139f458763c8cf3b7767d824c",
+  "generated_at": "2026-05-27T20:11:01.228284+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3308-rerun-20260527/openai-gpt-5.5/statutes/26/3308.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3308-rerun-20260527",
+  "generated_output_sha256": "ed985ee5801e874dfd46f2ac75a012ddc7c435598a472789a9c666c68d884413",
+  "generation_prompt_sha256": "1d23c0a48adcd8aff0f93da20851bece6b45e10368fc29aac007d604f2b5a88e",
+  "model": "gpt-5.5",
+  "run_id": "4f4b0947",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2aaf3747a37fc35a03057f618a2ad4a3cb38f1f2525684f4f09be0b90dcec860"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3308-rerun-20260527/traces/openai-gpt-5.5/us-statute-26-3308.json",
+  "trace_sha256": "eff2fc5b0d03c9f767dbc06e615459fa27ee174c18084b2dc8fd3c2bd854c932"
+}

--- a/statutes/26/3308.test.yaml
+++ b/statutes/26/3308.test.yaml
@@ -1,0 +1,56 @@
+- name: general_tax_exemption_without_specific_section_3301_reference_is_precluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3308#input.employer_is_instrumentality_of_united_states: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_instrumentality_exemption_from_taxation: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_section_3301: false
+    ? us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_corresponding_section_of_prior_law
+    : false
+  output:
+    us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: not_holds
+    us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: holds
+- name: specific_reference_to_section_3301_satisfies_requirement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3308#input.employer_is_instrumentality_of_united_states: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_instrumentality_exemption_from_taxation: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_section_3301: true
+    ? us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_corresponding_section_of_prior_law
+    : false
+  output:
+    us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: holds
+    us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: not_holds
+- name: specific_reference_to_corresponding_prior_law_satisfies_requirement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3308#input.employer_is_instrumentality_of_united_states: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_instrumentality_exemption_from_taxation: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_section_3301: false
+    ? us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_corresponding_section_of_prior_law
+    : true
+  output:
+    us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: holds
+    us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: not_holds
+- name: non_instrumentality_is_outside_preclusion_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3308#input.employer_is_instrumentality_of_united_states: false
+    us:statutes/26/3308#input.other_provision_of_law_grants_instrumentality_exemption_from_taxation: true
+    us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_section_3301: false
+    ? us:statutes/26/3308#input.other_provision_of_law_grants_specific_exemption_by_reference_to_corresponding_section_of_prior_law
+    : false
+  output:
+    us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: not_holds
+    us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: not_holds

--- a/statutes/26/3308.yaml
+++ b/statutes/26/3308.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3308
+  summary: |-
+    An instrumentality of the United States is not exempt from the tax imposed by section 3301 under another law's general tax exemption unless that other law grants a specific exemption, by reference to section 3301 or the corresponding prior-law section, from the tax imposed by section 3301.
+rules:
+  - name: other_law_specific_section_3301_exemption_requirement_met
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3308
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3308
+              excerpt: "unless such other provision of law grants a specific exemption, by reference to section 3301 (or the corresponding section of prior law)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          other_provision_of_law_grants_specific_exemption_by_reference_to_section_3301
+          or other_provision_of_law_grants_specific_exemption_by_reference_to_corresponding_section_of_prior_law
+
+  - name: united_states_instrumentality_section_3301_tax_exemption_precluded
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3308
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3308
+              excerpt: "such instrumentality shall not be exempt from the tax imposed by section 3301 unless"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met
+              output: other_law_specific_section_3301_exemption_requirement_met
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_instrumentality_of_united_states
+          and other_provision_of_law_grants_instrumentality_exemption_from_taxation
+          and not other_law_specific_section_3301_exemption_requirement_met


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3308 instrumentality exemption-preclusion rule
- include generated companion tests and signed apply manifest
- generated with axiom-encode 0.2.338 at TheAxiomFoundation/axiom-encode@acd42a5

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3308.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3308.yaml
- uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3308.yaml
- uv run axiom-encode validate --skip-reviewers /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3308.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3308.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us