### PR TITLE
Add generated section 3311 short title

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3311.json
+++ b/.axiom/encoding-manifests/statutes/26/3311.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3311.yaml",
+      "sha256": "1c904f1903f852bf5e5be5605bd51441a0efe948b863a3e2d7e6f7b24b7aa7ee"
+    },
+    {
+      "path": "statutes/26/3311.test.yaml",
+      "sha256": "824048256461c1e3369d8dac62671989bc9e7e207df1b64389d1757301ae0967"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "000a206808e3c5ea5e5ed1d46720115449e98ca4",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.339",
+    "version_commit": "000a206808e3c5ea5e5ed1d46720115449e98ca4"
+  },
+  "axiom_encode_version": "0.2.339",
+  "backend": "openai",
+  "citation": "us/statute/26/3311",
+  "context_manifest_file": "/private/tmp/axiom-encode-3311-rerun-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3311/workspace/context-manifest.json",
+  "context_manifest_sha256": "d232c475ec281dce5e0341f2c9e0cddc61e04149ea3382cb4d560ea22e75ba4b",
+  "generated_at": "2026-05-27T20:38:47.858023+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3311-rerun-20260527/openai-gpt-5.5/statutes/26/3311.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3311-rerun-20260527",
+  "generated_output_sha256": "1c904f1903f852bf5e5be5605bd51441a0efe948b863a3e2d7e6f7b24b7aa7ee",
+  "generation_prompt_sha256": "4b31d4b94e23aca9392d031e34a753a8c64533a7a120f0984392b34740bca434",
+  "model": "gpt-5.5",
+  "run_id": "1160b90c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "34111c9da8195af1bc628fb48a75a20ea2738c39f05208eae14b705b2b2a7b22"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3311-rerun-20260527/traces/openai-gpt-5.5/us-statute-26-3311.json",
+  "trace_sha256": "7b3197dd4c4f0a743386c9f5c7939d926ef1a462f8ffdb726d9a78c034aa2be6"
+}

--- a/statutes/26/3311.test.yaml
+++ b/statutes/26/3311.test.yaml
@@ -1,0 +1,10 @@
+- name: chapter_short_title_is_federal_unemployment_tax_act
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3311#federal_unemployment_tax_act_short_title: Federal Unemployment
+      Tax Act

--- a/statutes/26/3311.yaml
+++ b/statutes/26/3311.yaml
@@ -1,0 +1,25 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3311
+  summary: |-
+    This chapter may be cited as the “Federal Unemployment Tax Act.”
+rules:
+  - name: federal_unemployment_tax_act_short_title
+    kind: parameter
+    dtype: String
+    source: 26 USC 3311
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3311
+              excerpt: "may be cited as the “Federal Unemployment Tax Act”"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          "Federal Unemployment Tax Act"


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3311 short title
- include generated companion test and signed apply manifest
- generated with axiom-encode 0.2.339 at TheAxiomFoundation/axiom-encode@000a206

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3311.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3311.yaml
- uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3311.yaml
- uv run axiom-encode validate --skip-reviewers /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3311.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3311.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us