### PR TITLE
Add generated section 3310 review timing

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3310.json
+++ b/.axiom/encoding-manifests/statutes/26/3310.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3310.yaml",
+      "sha256": "53be87724a157115b5e4118f41747d64a514a95352d5849d0843e6fc338c9431"
+    },
+    {
+      "path": "statutes/26/3310.test.yaml",
+      "sha256": "9b629603429aed0df846e3811f4ce56a1c16db89a1a8bc1092502998287bc200"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "94725b47a37f9ffe0fdaddef494f4724d08b8a2a",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.340",
+    "version_commit": "94725b47a37f9ffe0fdaddef494f4724d08b8a2a"
+  },
+  "axiom_encode_version": "0.2.340",
+  "backend": "openai",
+  "citation": "us/statute/26/3310",
+  "context_manifest_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3310/workspace/context-manifest.json",
+  "context_manifest_sha256": "83d199856fe649f20471dcdbbdf8837b45487e86db1023812c6b5ac1e4712e79",
+  "generated_at": "2026-05-27T21:05:24.177580+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/openai-gpt-5.5/statutes/26/3310.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3310-rerun-signed-20260527",
+  "generated_output_sha256": "53be87724a157115b5e4118f41747d64a514a95352d5849d0843e6fc338c9431",
+  "generation_prompt_sha256": "79bf587fc47ed024f80d75bcaee11ce404f00714301c49ed0f1dd73bc6e08e14",
+  "model": "gpt-5.5",
+  "run_id": "121f9616",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b1fd3624f0db94d6c598be3b094caf1902f5e08d44f79b7f2d501cd7bd05f958"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/traces/openai-gpt-5.5/us-statute-26-3310.json",
+  "trace_sha256": "6f654485a882f2d12e242de9e8a6f431eb5eebbfb4feb2bc94a7e4a48cf52f66"
+}

--- a/statutes/26/3310.test.yaml
+++ b/statutes/26/3310.test.yaml
@@ -1,0 +1,11 @@
+- name: statutory_review_and_stay_periods
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3310#state_petition_for_review_deadline_days: 60
+    us:statutes/26/3310#secretary_certification_withholding_notice_period_days: 60
+    us:statutes/26/3310#judicial_proceedings_stay_period_days: 30

--- a/statutes/26/3310.yaml
+++ b/statutes/26/3310.yaml
@@ -1,0 +1,59 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3310
+  summary: |-
+    A State may file a petition for review "within 60 days after the Governor of the State has been notified" of the Secretary of Labor's action. The Secretary "shall not withhold any certification" until the earlier of the expiration of 60 days after notice or the State's filing of a petition. Judicial proceedings "shall stay the Secretary of Labor’s action for a period of 30 days," with possible interim relief thereafter.
+rules:
+  - name: state_petition_for_review_deadline_days
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 3310(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3310
+              excerpt: "within 60 days after the Governor of the State has been notified"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          60
+
+  - name: secretary_certification_withholding_notice_period_days
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 3310(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3310
+              excerpt: "until the expiration of 60 days after the Governor of the State has been notified"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          60
+
+  - name: judicial_proceedings_stay_period_days
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 3310(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3310
+              excerpt: "shall stay the Secretary of Labor’s action for a period of 30 days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30


### PR DESCRIPTION
## Summary
- add generated 26 USC 3310 review deadline and stay timing parameters
- add companion test and signed encoder apply manifest

Generated with axiom-encode 0.2.340 at 94725b4. Run id: 121f9616.

## Validation
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3310.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3310.yaml
- uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3310.yaml
- uv run axiom-encode validate --skip-reviewers /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3310.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3310.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us