### PR TITLE
Add generated section 3303 state standards

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3303.json
+++ b/.axiom/encoding-manifests/statutes/26/3303.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3303.yaml",
+      "sha256": "010a30663b64b9ff19e2c5bf2b84d281601eb4e86fc023105a77c77d4c4f298f"
+    },
+    {
+      "path": "statutes/26/3303.test.yaml",
+      "sha256": "93c8a6f4bff23f5fc5d620688309ea93b58492b2c57780ffe157367e082ed352"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ff9689dd45ebeae2d6d495b9fb753b8701fd2e13",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.342",
+    "version_commit": "ff9689dd45ebeae2d6d495b9fb753b8701fd2e13"
+  },
+  "axiom_encode_version": "0.2.342",
+  "backend": "openai",
+  "citation": "us/statute/26/3303",
+  "context_manifest_file": "/private/tmp/axiom-encode-3303-rerun2-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3303/workspace/context-manifest.json",
+  "context_manifest_sha256": "3748a23e65c472b058b95cec1ae847f80e4f4e748ca276998f1779eac5171dcd",
+  "generated_at": "2026-05-27T21:53:30.571561+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3303-rerun2-20260527/openai-gpt-5.5/statutes/26/3303.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3303-rerun2-20260527",
+  "generated_output_sha256": "010a30663b64b9ff19e2c5bf2b84d281601eb4e86fc023105a77c77d4c4f298f",
+  "generation_prompt_sha256": "8b600e7a0db24fb530dcc0f16584175829a013f1f97f7ea526ac9fcff90d2d6b",
+  "model": "gpt-5.5",
+  "run_id": "f1f3fdfc",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e50ad387b036d35472f7ad95e95e85799e42475523b7f70bcc746b8b32695411"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3303-rerun2-20260527/traces/openai-gpt-5.5/us-statute-26-3303.json",
+  "trace_sha256": "9efe4c0ae7c7e0cc87d436c34ee18d683a2fa8da3a335162122f73d1e9f94a8a"
+}

--- a/statutes/26/3303.test.yaml
+++ b/statutes/26/3303.test.yaml
@@ -1,0 +1,140 @@
+- name: reserve_account_definition_and_balance_without_other_moneys
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+      us:statutes/26/3303#input.account_is_separate_account_in_unemployment_fund: true
+      us:statutes/26/3303#input.account_maintained_with_respect_to_person_or_group_having_individuals_in_employ: true
+      us:statutes/26/3303#input.unless_account_exhausted_pays_all_compensation_based_on_services_for_person_or_group: true
+      us:statutes/26/3303#input.unless_account_exhausted_pays_only_compensation_based_on_services_for_person_or_group: true
+      us:statutes/26/3303#input.moneys_paid_or_credited_after_january_1_1940_other_than_employer_payments: false
+      us:statutes/26/3303#input.amount_standing_to_credit_of_account_as_of_computation_date: 10000
+      us:statutes/26/3303#input.total_other_moneys_paid_or_credited_after_january_1_1940: 0
+  output:
+    us:statutes/26/3303#section_3303_year_months: 12
+    us:statutes/26/3303#computation_date_maximum_weeks_before_new_rates: 27
+    us:statutes/26/3303#reserve_account:
+    - holds
+    us:statutes/26/3303#account_balance_for_section_3303:
+    - 10000
+- name: pooled_fund_definition_excludes_reserve_and_guaranteed_accounts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+      us:statutes/26/3303#input.account_is_separate_account_in_unemployment_fund: false
+      us:statutes/26/3303#input.account_maintained_with_respect_to_person_or_group_having_individuals_in_employ: false
+      us:statutes/26/3303#input.unless_account_exhausted_pays_all_compensation_based_on_services_for_person_or_group: false
+      us:statutes/26/3303#input.unless_account_exhausted_pays_only_compensation_based_on_services_for_person_or_group: false
+      us:statutes/26/3303#input.advance_guaranty_hours_of_work_per_week: 0
+      us:statutes/26/3303#input.advance_guaranty_weeks_in_year: 0
+      us:statutes/26/3303#input.remuneration_for_guaranteed_work_paid_at_not_less_than_stated_rates: false
+      ? us:statutes/26/3303#input.guaranty_applies_to_all_individuals_in_employ_in_distinct_establishments_available_for_suitable_work
+      : false
+      us:statutes/26/3303#input.probationary_period_weeks_before_guaranty_commences: 0
+      us:statutes/26/3303#input.security_or_assurance_for_guaranties_satisfactory_to_state_agency: false
+      ? us:statutes/26/3303#input.unless_exhausted_or_terminated_pays_all_and_only_compensation_to_guaranteed_employees_for_services_for_person_or_group
+      : false
+      us:statutes/26/3303#input.total_contributions_of_persons_contributing_are_payable_into_fund: true
+      us:statutes/26/3303#input.all_contributions_are_mingled_and_undivided: true
+      us:statutes/26/3303#input.compensation_payable_to_all_individuals_eligible_for_compensation_from_fund: true
+  output:
+    us:statutes/26/3303#pooled_or_partially_pooled_minimum_experience_years: 3
+    us:statutes/26/3303#newly_subject_minimum_experience_years: 1
+    us:statutes/26/3303#alternative_newly_subject_reduced_rate_floor: 0.01
+    us:statutes/26/3303#guaranteed_employment_work_hours_per_week_minimum: 30
+    us:statutes/26/3303#guaranteed_employment_weeks_threshold: 40
+    us:statutes/26/3303#guaranteed_employment_probationary_period_limit_weeks: 11
+    us:statutes/26/3303#pooled_fund:
+    - holds
+    us:statutes/26/3303#reserve_account:
+    - not_holds
+    us:statutes/26/3303#guaranteed_employment_account:
+    - not_holds
+- name: guaranteed_and_partially_pooled_account_definitions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+      us:statutes/26/3303#input.account_is_separate_account_in_unemployment_fund: true
+      us:statutes/26/3303#input.account_maintained_with_respect_to_person_or_group_having_individuals_in_employ: true
+      us:statutes/26/3303#input.advance_guaranty_hours_of_work_per_week: 30
+      us:statutes/26/3303#input.advance_guaranty_weeks_in_year: 40
+      us:statutes/26/3303#input.remuneration_for_guaranteed_work_paid_at_not_less_than_stated_rates: true
+      ? us:statutes/26/3303#input.guaranty_applies_to_all_individuals_in_employ_in_distinct_establishments_available_for_suitable_work
+      : true
+      us:statutes/26/3303#input.probationary_period_weeks_before_guaranty_commences: 11
+      us:statutes/26/3303#input.security_or_assurance_for_guaranties_satisfactory_to_state_agency: true
+      ? us:statutes/26/3303#input.unless_exhausted_or_terminated_pays_all_and_only_compensation_to_guaranteed_employees_for_services_for_person_or_group
+      : true
+      us:statutes/26/3303#input.account_is_part_of_unemployment_fund: false
+      us:statutes/26/3303#input.all_contributions_to_part_are_mingled_and_undivided: false
+      ? us:statutes/26/3303#input.compensation_from_part_payable_only_to_individuals_payable_from_reserve_or_guaranteed_account_but_for_exhaustion_or_termination
+      : false
+    - us:statutes/26/3306/f#input.fund_is_special_fund_established_under_state_law: true
+      us:statutes/26/3306/f#input.fund_administered_by_state_agency: true
+      us:statutes/26/3306/f#input.fund_for_payment_of_compensation: true
+      us:statutes/26/3303#input.account_is_separate_account_in_unemployment_fund: false
+      us:statutes/26/3303#input.account_maintained_with_respect_to_person_or_group_having_individuals_in_employ: false
+      us:statutes/26/3303#input.advance_guaranty_hours_of_work_per_week: 0
+      us:statutes/26/3303#input.advance_guaranty_weeks_in_year: 0
+      us:statutes/26/3303#input.remuneration_for_guaranteed_work_paid_at_not_less_than_stated_rates: false
+      ? us:statutes/26/3303#input.guaranty_applies_to_all_individuals_in_employ_in_distinct_establishments_available_for_suitable_work
+      : false
+      us:statutes/26/3303#input.probationary_period_weeks_before_guaranty_commences: 0
+      us:statutes/26/3303#input.security_or_assurance_for_guaranties_satisfactory_to_state_agency: false
+      ? us:statutes/26/3303#input.unless_exhausted_or_terminated_pays_all_and_only_compensation_to_guaranteed_employees_for_services_for_person_or_group
+      : false
+      us:statutes/26/3303#input.account_is_part_of_unemployment_fund: true
+      us:statutes/26/3303#input.all_contributions_to_part_are_mingled_and_undivided: true
+      ? us:statutes/26/3303#input.compensation_from_part_payable_only_to_individuals_payable_from_reserve_or_guaranteed_account_but_for_exhaustion_or_termination
+      : true
+  output:
+    us:statutes/26/3303#guaranteed_employment_balance_payroll_percentage: 0.025
+    us:statutes/26/3303#reserve_balance_compensation_multiple: 5
+    us:statutes/26/3303#reserve_balance_payroll_percentage: 0.025
+    us:statutes/26/3303#guaranteed_employment_account:
+    - holds
+    - not_holds
+    us:statutes/26/3303#partially_pooled_account:
+    - not_holds
+    - holds
+- name: employer_reduced_rate_voluntary_contribution_and_noncharging_rules
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3303#input.contribution_rate_under_state_law: 0.02
+    us:statutes/26/3303#input.standard_rate_applicable_under_state_law: 0.04
+    us:statutes/26/3303#input.state_law_permits_voluntary_contributions_for_reduced_rate_computation: true
+    us:statutes/26/3303#input.voluntary_contributions_paid_days_after_beginning_of_year: 100
+    us:statutes/26/3303#input.state_agency_determines_payment_from_state_unemployment_fund: true
+    us:statutes/26/3303#input.payment_made_because_employer_or_agent_at_fault_for_failing_to_respond_timely_or_adequately: true
+    us:statutes/26/3303#input.employer_or_agent_has_established_pattern_of_failing_to_respond_timely_or_adequately: true
+    ? us:statutes/26/3303#input.state_provides_employer_account_not_relieved_for_reasons_other_than_fault_pattern_described_in_paragraph_1
+    : true
+  output:
+    us:statutes/26/3303#voluntary_contribution_deadline_days_after_year_beginning: 120
+    us:statutes/26/3303#reduced_rate: holds
+    us:statutes/26/3303#voluntary_contributions_may_be_used_for_reduced_rate_computation_without_violating_state_standards: holds
+    us:statutes/26/3303#employer_account_not_relieved_due_to_fault_pattern: holds
+    us:statutes/26/3303#stricter_noncharging_standards_allowed: holds

--- a/statutes/26/3303.yaml
+++ b/statutes/26/3303.yaml
@@ -1,0 +1,470 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3306/f#unemployment_fund
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3303
+  deferred_outputs:
+  - output: us:statutes/26/3303/a#state_law_reduced_rate_standards_satisfied
+    reason: The full subsection (a) standard depends on the Secretary of Labor's findings
+      under State law, section 3302(b) additional-credit mechanics, section 7705 certified
+      professional employer organization status, and account-history facts across
+      multiple fund/account types. Section 7705 is not available as copied RuleSpec
+      context, and the Secretary-of-Labor certification process is administrative
+      rather than a direct taxpayer computation.
+    blocked_by:
+    - us:statutes/26/3302/b#additional_credit_rate_differential_amount
+    source_values:
+    - us:statutes/26/3303#pooled_or_partially_pooled_minimum_experience_years
+    - us:statutes/26/3303#newly_subject_minimum_experience_years
+    - us:statutes/26/3303#alternative_newly_subject_reduced_rate_floor
+  - output: us:statutes/26/3303/b#secretary_of_labor_certification_to_secretary_of_treasury
+    reason: Subsection (b) prescribes administrative certification duties of the Secretary
+      of Labor, including cross-reference to section 3304 certification, which is
+      not available as copied RuleSpec context. This surface is therefore preserved
+      as documentary/deferred rather than encoded as taxpayer-level computation.
+  - output: us:statutes/26/3303/e#nonprofit_reimbursement_election_allowed_without_violating_state_standards
+    reason: Subsection (e) depends on determining whether an organization is described
+      in section 501(c)(3) and exempt under section 501(a). Those cited sources are
+      not available as copied RuleSpec context, so the affected option is deferred.
+  summary: Section 3303 allows additional credit under section 3302(b) with respect
+    to reduced State contribution rates only if the Secretary of Labor finds the reduced-rate
+    standards satisfied; defines reserve account, pooled fund, partially pooled account,
+    guaranteed employment account, year, balance, computation date, and reduced rate;
+    allows timely voluntary contributions without violating subsection (a); allows
+    certain nonprofit reimbursement elections; and requires State laws meeting subsection
+    (a)(1) to prohibit relieving an employer account of charges when payments result
+    from employer fault plus a pattern of inadequate or untimely responses.
+rules:
+- name: pooled_or_partially_pooled_minimum_experience_years
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: during not less than the 3 consecutive years immediately preceding
+            the computation date
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '3'
+- name: newly_subject_minimum_experience_years
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(a), flush text
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: but in no case less than 1 year immediately preceding the computation
+            date
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1'
+- name: alternative_newly_subject_reduced_rate_floor
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3303(a), flush text clause (ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: a reduced rate (not less than 1 percent)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.01'
+- name: guaranteed_employment_balance_payroll_percentage
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3303(a)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: "not less than 2\xBD percent"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.025'
+- name: reserve_balance_compensation_multiple
+  kind: parameter
+  dtype: Decimal
+  source: 26 USC 3303(a)(3)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: not less than five times the largest amount of compensation paid
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '5'
+- name: reserve_balance_payroll_percentage
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3303(a)(3)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: "not less than 2\xBD percent"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.025'
+- name: guaranteed_employment_work_hours_per_week_minimum
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(c)(4)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: guarantees in advance at least 30 hours of work
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '30'
+- name: guaranteed_employment_weeks_threshold
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(c)(4)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: for each of 40 weeks
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '40'
+- name: guaranteed_employment_probationary_period_limit_weeks
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(c)(4)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: within the 11 or less consecutive weeks immediately following the
+            first week
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '11'
+- name: section_3303_year_months
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(c)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: "The term \u201Cyear\u201D means any 12 consecutive calendar months."
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '12'
+- name: computation_date_maximum_weeks_before_new_rates
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(c)(7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: within 27 weeks prior to the effective date of new rates of contributions
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '27'
+- name: voluntary_contribution_deadline_days_after_year_beginning
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3303(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: prior to the expiration of 120 days after the beginning of the
+            year
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '120'
+- name: reserve_account
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(c)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/f#unemployment_fund
+          output: unemployment_fund
+          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'unemployment_fund
+
+      and account_is_separate_account_in_unemployment_fund
+
+      and account_maintained_with_respect_to_person_or_group_having_individuals_in_employ
+
+      and unless_account_exhausted_pays_all_compensation_based_on_services_for_person_or_group
+
+      and unless_account_exhausted_pays_only_compensation_based_on_services_for_person_or_group'
+- name: guaranteed_employment_account
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(c)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/f#unemployment_fund
+          output: unemployment_fund
+          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'unemployment_fund
+
+      and account_is_separate_account_in_unemployment_fund
+
+      and account_maintained_with_respect_to_person_or_group_having_individuals_in_employ
+
+      and advance_guaranty_hours_of_work_per_week >= guaranteed_employment_work_hours_per_week_minimum
+
+      and advance_guaranty_weeks_in_year >= guaranteed_employment_weeks_threshold
+
+      and remuneration_for_guaranteed_work_paid_at_not_less_than_stated_rates
+
+      and guaranty_applies_to_all_individuals_in_employ_in_distinct_establishments_available_for_suitable_work
+
+      and probationary_period_weeks_before_guaranty_commences <= guaranteed_employment_probationary_period_limit_weeks
+
+      and security_or_assurance_for_guaranties_satisfactory_to_state_agency
+
+      and unless_exhausted_or_terminated_pays_all_and_only_compensation_to_guaranteed_employees_for_services_for_person_or_group'
+- name: pooled_fund
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/f#unemployment_fund
+          output: unemployment_fund
+          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3303#reserve_account
+          output: reserve_account
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3303#guaranteed_employment_account
+          output: guaranteed_employment_account
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'unemployment_fund
+
+      and not reserve_account
+
+      and not guaranteed_employment_account
+
+      and total_contributions_of_persons_contributing_are_payable_into_fund
+
+      and all_contributions_are_mingled_and_undivided
+
+      and compensation_payable_to_all_individuals_eligible_for_compensation_from_fund'
+- name: partially_pooled_account
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(c)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/f#unemployment_fund
+          output: unemployment_fund
+          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'unemployment_fund
+
+      and account_is_part_of_unemployment_fund
+
+      and all_contributions_to_part_are_mingled_and_undivided
+
+      and compensation_from_part_payable_only_to_individuals_payable_from_reserve_or_guaranteed_account_but_for_exhaustion_or_termination'
+- name: reduced_rate
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(c)(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: "The term \u201Creduced rate\u201D means a rate of contributions\
+            \ lower than the standard rate applicable under the State law"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: contribution_rate_under_state_law < standard_rate_applicable_under_state_law
+- name: account_balance_for_section_3303
+  kind: derived
+  entity: Asset
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3303(c)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: amount in such account as of the computation date less the total
+            of such other moneys
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if moneys_paid_or_credited_after_january_1_1940_other_than_employer_payments:
+      max( 0, amount_standing_to_credit_of_account_as_of_computation_date - total_other_moneys_paid_or_credited_after_january_1_1940
+      ) else: max(0, amount_standing_to_credit_of_account_as_of_computation_date)'
+- name: voluntary_contributions_may_be_used_for_reduced_rate_computation_without_violating_state_standards
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: permit voluntary contributions to be used in the computation of
+            reduced rates if such contributions are paid prior to the expiration of
+            120 days
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3303#voluntary_contribution_deadline_days_after_year_beginning
+          output: voluntary_contribution_deadline_days_after_year_beginning
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'state_law_permits_voluntary_contributions_for_reduced_rate_computation
+
+      and voluntary_contributions_paid_days_after_beginning_of_year < voluntary_contribution_deadline_days_after_year_beginning'
+- name: employer_account_not_relieved_due_to_fault_pattern
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: "an employer\u2019s account shall not be relieved of charges"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'state_agency_determines_payment_from_state_unemployment_fund
+
+      and payment_made_because_employer_or_agent_at_fault_for_failing_to_respond_timely_or_adequately
+
+      and employer_or_agent_has_established_pattern_of_failing_to_respond_timely_or_adequately'
+- name: stricter_noncharging_standards_allowed
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3303(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3303
+          excerpt: Nothing in paragraph (1) shall limit the authority of a State
+  versions:
+  - effective_from: '1990-01-01'
+    formula: state_provides_employer_account_not_relieved_for_reasons_other_than_fault_pattern_described_in_paragraph_1


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3303 FUTA State reduced-rate standards and account definitions
- include generated companion tests and signed encoder apply manifest
- generated by axiom-encode 0.2.342 from merged encoder commit ff9689d; validated after oracle classifier 0.2.343 landed

## Validation
- uv run axiom-encode test statutes/26/3303.test.yaml --root /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate statutes/26/3303.yaml
- uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine statutes/26/3303.yaml
- uv run axiom-encode validate --skip-reviewers statutes/26/3303.yaml
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3303.yaml
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us
