### PR TITLE
Add generated section 3304 state-law approval rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3304.json
+++ b/.axiom/encoding-manifests/statutes/26/3304.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3304.yaml",
+      "sha256": "8d3fecbaac2527e7db2b241088d2cf53c68699f0ee895a966b95098757d444e9"
+    },
+    {
+      "path": "statutes/26/3304.test.yaml",
+      "sha256": "176c3362b2207a07026d950f58c1bd0d7a94e481a4352ce9e6c7f32d91d8d8b3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5be79ea7d814aa8c516ef3388725c1312fc6e666",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.343",
+    "version_commit": "5be79ea7d814aa8c516ef3388725c1312fc6e666"
+  },
+  "axiom_encode_version": "0.2.343",
+  "backend": "codex",
+  "citation": "26 USC 3304",
+  "context_manifest_file": "/private/tmp/axiom-encode-3304-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3304/workspace/context-manifest.json",
+  "context_manifest_sha256": "ea24f28f745da1c16679b7b9ec0c3cbc0d2a2eaf4dbd13c7409e3def56158f8b",
+  "generated_at": "2026-05-27T22:12:37.525238+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3304-20260527/codex-gpt-5.5/statutes/26/3304.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3304-20260527",
+  "generated_output_sha256": "8d3fecbaac2527e7db2b241088d2cf53c68699f0ee895a966b95098757d444e9",
+  "generation_prompt_sha256": "1160b3f0193d1d9cde491c1f52410faffab3f13874779cee3d1b7a2c0f860dfa",
+  "model": "gpt-5.5",
+  "run_id": "e0299a5f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "23356cd21725b8a7c1ce10370e77dbd42faf2b913b14cd5d522cb895dc3c55aa"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3304-20260527/traces/codex-gpt-5.5/26-USC-3304.json",
+  "trace_sha256": "266f320560a22dff93ce493f73b8a9ac1a9440be3a83fb3770d55bd1ef88ae4d"
+}

--- a/statutes/26/3304.test.yaml
+++ b/statutes/26/3304.test.yaml
@@ -1,0 +1,34 @@
+- name: qualifying_institution_of_higher_education
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3304#input.business_is_educational_institution_in_any_state: true
+    us:statutes/26/3304#input.business_admits_as_regular_students_only_high_school_graduates_or_equivalent: true
+    us:statutes/26/3304#input.business_legally_authorized_in_state_to_provide_beyond_high_school_program: true
+    us:statutes/26/3304#input.business_provides_program_awarding_bachelors_or_higher_degree: true
+    us:statutes/26/3304#input.business_provides_program_acceptable_for_full_credit_toward_bachelors_or_higher_degree: false
+    ? us:statutes/26/3304#input.business_offers_training_program_to_prepare_students_for_gainful_employment_in_recognized_occupation
+    : false
+    us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: true
+  output:
+    us:statutes/26/3304#institution_of_higher_education: holds
+- name: missing_public_or_nonprofit_status
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3304#input.business_is_educational_institution_in_any_state: true
+    us:statutes/26/3304#input.business_admits_as_regular_students_only_high_school_graduates_or_equivalent: true
+    us:statutes/26/3304#input.business_legally_authorized_in_state_to_provide_beyond_high_school_program: true
+    us:statutes/26/3304#input.business_provides_program_awarding_bachelors_or_higher_degree: true
+    us:statutes/26/3304#input.business_provides_program_acceptable_for_full_credit_toward_bachelors_or_higher_degree: false
+    ? us:statutes/26/3304#input.business_offers_training_program_to_prepare_students_for_gainful_employment_in_recognized_occupation
+    : false
+    us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: false
+  output:
+    us:statutes/26/3304#institution_of_higher_education: not_holds

--- a/statutes/26/3304.yaml
+++ b/statutes/26/3304.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3304
+  summary: |-
+    26 USC 3304(a) requires the Secretary of Labor to approve State unemployment laws meeting enumerated requirements; subsection (f) defines "institution of higher education" for purposes of subsection (a)(6).
+  deferred_outputs:
+    - output: us:statutes/26/3304/a#state_law_approval_requirements
+      reason: Subsection (a) is a broad State-law approval and certification standard with administrative duties and multiple unresolved cross-references, including sections 3305(b), 903, 3306(t), 3306(v), 3309(a)(1), 3309(a)(2), and 6402(f). It is not faithfully representable as a single executable output without encoding those dependencies and State-law compliance process mechanics.
+rules:
+  - name: institution_of_higher_education
+    kind: derived
+    entity: Business
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3304(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3304
+              excerpt: "the term “institution of higher education” means an educational institution in any State which—"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3304
+              excerpt: "admits as regular students only individuals having a certificate of graduation from a high school, or the recognized equivalent"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3304
+              excerpt: "is legally authorized within such State to provide a program of education beyond high school"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3304
+              excerpt: "awards a bachelor’s or higher degree... acceptable for full credit toward such a degree... training to prepare students for gainful employment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3304
+              excerpt: "is a public or other nonprofit institution"
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          business_is_educational_institution_in_any_state
+          and business_admits_as_regular_students_only_high_school_graduates_or_equivalent
+          and business_legally_authorized_in_state_to_provide_beyond_high_school_program
+          and (
+            business_provides_program_awarding_bachelors_or_higher_degree
+            or business_provides_program_acceptable_for_full_credit_toward_bachelors_or_higher_degree
+            or business_offers_training_program_to_prepare_students_for_gainful_employment_in_recognized_occupation
+          )
+          and business_is_public_or_nonprofit_institution


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3304(f)'s institution-of-higher-education definition
- defer broad subsection 3304(a) State-law approval requirements pending dependent cross-reference coverage
- include generated companion tests and signed encoder apply manifest

## Validation
- `uv run axiom-encode test statutes/26/3304.test.yaml --root /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3304.yaml`
- `uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine statutes/26/3304.yaml`
- `uv run axiom-encode validate --skip-reviewers statutes/26/3304.yaml`
- `uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3304.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us`
