### PR TITLE
Add generated section 3305 state-law compliance rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3305.json
+++ b/.axiom/encoding-manifests/statutes/26/3305.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3305.yaml",
+      "sha256": "59a2273232c38334104056f870588b425e3687e461011f3e794843cda79eedcc"
+    },
+    {
+      "path": "statutes/26/3305.test.yaml",
+      "sha256": "b633c013be2a13e48196537faade237f8c59f4ab6b7cc8fc4543cf77ff00ca35"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "779bf699686dc32fcb1143aeb9e86a4913c33982",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.344",
+    "version_commit": "779bf699686dc32fcb1143aeb9e86a4913c33982"
+  },
+  "axiom_encode_version": "0.2.344",
+  "backend": "codex",
+  "citation": "26 USC 3305",
+  "context_manifest_file": "/private/tmp/axiom-encode-3305-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3305/workspace/context-manifest.json",
+  "context_manifest_sha256": "f25ffe6163f048bdae44c8162c6db78ea1a6af9697ed3bb42209103f83b24eab",
+  "generated_at": "2026-05-27T22:32:20.055983+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3305-20260527/codex-gpt-5.5/statutes/26/3305.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3305-20260527",
+  "generated_output_sha256": "59a2273232c38334104056f870588b425e3687e461011f3e794843cda79eedcc",
+  "generation_prompt_sha256": "4aee716450dfc91c917edc109269ae0b91146100a334015ffd2195dfd8a8ec8b",
+  "model": "gpt-5.5",
+  "run_id": "6f52d582",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e23e621d9166da0f0931adc95920dd5e7ecf0f605382b071ba8c994e327f8a5d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3305-20260527/traces/codex-gpt-5.5/26-USC-3305.json",
+  "trace_sha256": "3e3c8683439becc1c8344f7225fd595afcdccb30f878e54c9ca2a002d16820c3"
+}

--- a/statutes/26/3305.test.yaml
+++ b/statutes/26/3305.test.yaml
@@ -1,0 +1,76 @@
+- name: commerce_federal_property_and_credit_denial_rules_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3305#input.employer_required_under_state_law_to_make_payments_to_unemployment_fund: true
+    us:statutes/26/3305#input.employer_engaged_in_interstate_or_foreign_commerce: true
+    ? us:statutes/26/3305#input.state_law_does_not_distinguish_interstate_or_foreign_commerce_employees_from_intrastate_commerce_employees
+    : false
+    us:statutes/26/3305#input.employer_subject_to_state_unemployment_compensation_law: true
+    us:statutes/26/3305#input.services_performed_on_land_or_premises_owned_held_or_possessed_by_united_states: true
+    ? us:statutes/26/3305#input.employer_required_pursuant_to_section_permission_to_make_unemployment_fund_contributions_under_approved_state_law
+    : true
+    us:statutes/26/3305#input.secretary_of_labor_certified_permission_condition_failure_for_state_law: true
+  output:
+    us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: holds
+    us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: holds
+    us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: holds
+- name: nondistinguishing_state_law_alternative_applies_without_federal_property_ground
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3305#input.employer_required_under_state_law_to_make_payments_to_unemployment_fund: true
+    us:statutes/26/3305#input.employer_engaged_in_interstate_or_foreign_commerce: false
+    ? us:statutes/26/3305#input.state_law_does_not_distinguish_interstate_or_foreign_commerce_employees_from_intrastate_commerce_employees
+    : true
+    us:statutes/26/3305#input.employer_subject_to_state_unemployment_compensation_law: true
+    us:statutes/26/3305#input.services_performed_on_land_or_premises_owned_held_or_possessed_by_united_states: false
+    ? us:statutes/26/3305#input.employer_required_pursuant_to_section_permission_to_make_unemployment_fund_contributions_under_approved_state_law
+    : true
+    us:statutes/26/3305#input.secretary_of_labor_certified_permission_condition_failure_for_state_law: true
+  output:
+    us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: holds
+    us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: not_holds
+    us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: holds
+- name: requirements_absent_make_rules_inapplicable
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3305#input.employer_required_under_state_law_to_make_payments_to_unemployment_fund: false
+    us:statutes/26/3305#input.employer_engaged_in_interstate_or_foreign_commerce: true
+    ? us:statutes/26/3305#input.state_law_does_not_distinguish_interstate_or_foreign_commerce_employees_from_intrastate_commerce_employees
+    : false
+    us:statutes/26/3305#input.employer_subject_to_state_unemployment_compensation_law: false
+    us:statutes/26/3305#input.services_performed_on_land_or_premises_owned_held_or_possessed_by_united_states: true
+    ? us:statutes/26/3305#input.employer_required_pursuant_to_section_permission_to_make_unemployment_fund_contributions_under_approved_state_law
+    : false
+    us:statutes/26/3305#input.secretary_of_labor_certified_permission_condition_failure_for_state_law: true
+  output:
+    us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: not_holds
+    us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: not_holds
+    us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: not_holds
+- name: no_commerce_ground_and_no_certification_prevent_denial
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3305#input.employer_required_under_state_law_to_make_payments_to_unemployment_fund: true
+    us:statutes/26/3305#input.employer_engaged_in_interstate_or_foreign_commerce: false
+    ? us:statutes/26/3305#input.state_law_does_not_distinguish_interstate_or_foreign_commerce_employees_from_intrastate_commerce_employees
+    : false
+    us:statutes/26/3305#input.employer_subject_to_state_unemployment_compensation_law: true
+    us:statutes/26/3305#input.services_performed_on_land_or_premises_owned_held_or_possessed_by_united_states: true
+    ? us:statutes/26/3305#input.employer_required_pursuant_to_section_permission_to_make_unemployment_fund_contributions_under_approved_state_law
+    : true
+    us:statutes/26/3305#input.secretary_of_labor_certified_permission_condition_failure_for_state_law: false
+  output:
+    us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: not_holds
+    us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: holds
+    us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: not_holds

--- a/statutes/26/3305.yaml
+++ b/statutes/26/3305.yaml
@@ -1,0 +1,98 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3305
+  summary: |-
+    (a) No person required under a State law to make payments to an unemployment fund shall be relieved from compliance therewith on the ground that he is engaged in interstate or foreign commerce...
+    (d) No person shall be relieved from compliance with a State unemployment compensation law on the ground that services were performed on land or premises owned, held, or possessed by the United States...
+    (j) Any person required, pursuant to the permission granted by this section, to make contributions... shall not be entitled to the credits permitted... by subsections (a) and (b) of section 3302... if... the Secretary of Labor certifies...
+rules:
+  - name: state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3305(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "No person required under a State law to make payments to an unemployment fund shall be relieved from compliance therewith"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "on the ground that he is engaged in interstate or foreign commerce"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "or that the State law does not distinguish between employees engaged in interstate or foreign commerce and those engaged in intrastate commerce"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_required_under_state_law_to_make_payments_to_unemployment_fund
+          and (
+            employer_engaged_in_interstate_or_foreign_commerce
+            or state_law_does_not_distinguish_interstate_or_foreign_commerce_employees_from_intrastate_commerce_employees
+          )
+
+  - name: state_unemployment_compensation_compliance_not_relieved_by_federal_property_services
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3305(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "No person shall be relieved from compliance with a State unemployment compensation law"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "on the ground that services were performed on land or premises owned, held, or possessed by the United States"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_subject_to_state_unemployment_compensation_law
+          and services_performed_on_land_or_premises_owned_held_or_possessed_by_united_states
+
+  - name: state_unemployment_contribution_credits_denied_for_permission_condition_failure
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3305(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "Any person required, pursuant to the permission granted by this section, to make contributions to an unemployment fund under a State unemployment compensation law approved by the Secretary of Labor"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "if, on October 31 of such taxable year, the Secretary of Labor certifies to the Secretary of the Treasury his finding"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3305
+              excerpt: "shall not be entitled to the credits permitted... by subsections (a) and (b) of section 3302 against the tax imposed by section 3301"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_required_pursuant_to_section_permission_to_make_unemployment_fund_contributions_under_approved_state_law
+          and secretary_of_labor_certified_permission_condition_failure_for_state_law


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3305 State unemployment-law compliance and credit-denial predicates
- include generated companion tests and signed encoder apply manifest
- generated by axiom-encode 0.2.344 and validated after section 3305 oracle classifier 0.2.345 landed

## Validation
- `uv run axiom-encode test statutes/26/3305.test.yaml --root /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3305.yaml`
- `uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine statutes/26/3305.yaml`
- `uv run axiom-encode validate --skip-reviewers statutes/26/3305.yaml`
- `uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3305.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us`
