### PR TITLE
Add generated section 3309 coverage rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3309.json
+++ b/.axiom/encoding-manifests/statutes/26/3309.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3309.yaml",
+      "sha256": "e30fca9eb2bd97ebee6676519fcafafae9d393a751c9bee297c0bf8cbab33bb0"
+    },
+    {
+      "path": "statutes/26/3309.test.yaml",
+      "sha256": "17294484a9fda6c6e47b3ed15b68cc9a19eac22069324d9e2664b12318a26c05"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a363548727098eec8011b5a5bb0dc0f36e6079fe",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.345",
+    "version_commit": "a363548727098eec8011b5a5bb0dc0f36e6079fe"
+  },
+  "axiom_encode_version": "0.2.345",
+  "backend": "codex",
+  "citation": "26 USC 3309",
+  "context_manifest_file": "/private/tmp/axiom-encode-3309-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3309/workspace/context-manifest.json",
+  "context_manifest_sha256": "a2e2d6fe844f75105abd3a67fe915c4a3b04838a82693972e92a587c7da0f6ce",
+  "generated_at": "2026-05-27T22:57:35.602797+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3309-20260527/codex-gpt-5.5/statutes/26/3309.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3309-20260527",
+  "generated_output_sha256": "e30fca9eb2bd97ebee6676519fcafafae9d393a751c9bee297c0bf8cbab33bb0",
+  "generation_prompt_sha256": "9420b226dd30167120689180f1883cc7c6dc14b19c6dca5e933e169a7555fa52",
+  "model": "gpt-5.5",
+  "run_id": "67313d93",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "28309355e7a30095f9e98822a797ac97f949416f00d77148bdfb47e94dda9ac7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3309-20260527/traces/codex-gpt-5.5/26-USC-3309.json",
+  "trace_sha256": "5b7e109cea5eee2631c0c54f1e104d6c7b6da814709e176cc9ff4be747302a68"
+}

--- a/statutes/26/3309.test.yaml
+++ b/statutes/26/3309.test.yaml
@@ -1,0 +1,111 @@
+- name: religious employer service category excludes section application
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    us:statutes/26/3309#input.service_performed_in_employ_of_church_or_convention_or_association_of_churches: true
+    us:statutes/26/3309#input.service_performed_in_employ_of_religious_purpose_church_supported_organization: false
+    us:statutes/26/3309#input.service_performed_in_employ_of_religious_elementary_or_secondary_school: false
+    us:statutes/26/3309#input.employing_school_described_in_section_501_c_3: false
+    us:statutes/26/3309#input.employing_school_exempt_from_tax_under_section_501_a: false
+    us:statutes/26/3309#input.service_performed_by_minister_in_exercise_of_ministry: false
+    us:statutes/26/3309#input.service_performed_by_religious_order_member_in_exercise_of_required_duties: false
+    us:statutes/26/3309#input.service_performed_as_elected_official: false
+    ? us:statutes/26/3309#input.service_performed_as_member_of_legislative_body_or_judiciary_of_state_political_subdivision_or_indian_tribe
+    : false
+    us:statutes/26/3309#input.service_performed_as_member_of_state_national_guard_or_air_national_guard: false
+    ? us:statutes/26/3309#input.service_performed_as_temporary_emergency_employee_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+    : false
+    ? us:statutes/26/3309#input.service_performed_in_major_nontenured_policymaking_or_advisory_position_designated_under_state_or_tribal_law
+    : false
+    us:statutes/26/3309#input.service_performed_in_policymaking_or_advisory_position_designated_under_state_or_tribal_law: false
+    us:statutes/26/3309#input.ordinary_weekly_hours_required_for_position: 9
+    us:statutes/26/3309#input.service_performed_as_election_official_or_worker: false
+    us:statutes/26/3309#input.annual_remuneration_for_election_official_or_worker_services: 1000
+    us:statutes/26/3309#input.service_performed_in_rehabilitation_facility_program_for_impaired_earning_capacity: false
+    us:statutes/26/3309#input.individual_receiving_rehabilitation: false
+    us:statutes/26/3309#input.service_performed_in_remunerative_work_facility_program_for_impaired_capacity_individuals: false
+    us:statutes/26/3309#input.individual_receiving_remunerative_work: false
+    ? us:statutes/26/3309#input.service_performed_as_part_of_federally_state_or_tribally_assisted_unemployment_work_relief_or_work_training_program
+    : false
+    us:statutes/26/3309#input.individual_receiving_work_relief_or_work_training: false
+    us:statutes/26/3309#input.service_performed_by_inmate_of_custodial_or_penal_institution: false
+  output:
+    us:statutes/26/3309#policymaking_advisory_position_weekly_hours_limit: 8
+    us:statutes/26/3309#election_official_worker_remuneration_annual_limit: 1000
+    us:statutes/26/3309#service_category_excludes_section_application: holds
+- name: election worker at annual remuneration limit is not excluded by that category
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_state: true
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_political_subdivision_of_state: false
+    us:statutes/26/3306/c/7#input.service_performed_in_employ_of_indian_tribe: false
+    us:statutes/26/3309#input.service_performed_in_employ_of_church_or_convention_or_association_of_churches: false
+    us:statutes/26/3309#input.service_performed_in_employ_of_religious_purpose_church_supported_organization: false
+    us:statutes/26/3309#input.service_performed_in_employ_of_religious_elementary_or_secondary_school: false
+    us:statutes/26/3309#input.employing_school_described_in_section_501_c_3: false
+    us:statutes/26/3309#input.employing_school_exempt_from_tax_under_section_501_a: false
+    us:statutes/26/3309#input.service_performed_by_minister_in_exercise_of_ministry: false
+    us:statutes/26/3309#input.service_performed_by_religious_order_member_in_exercise_of_required_duties: false
+    us:statutes/26/3309#input.service_performed_as_elected_official: false
+    ? us:statutes/26/3309#input.service_performed_as_member_of_legislative_body_or_judiciary_of_state_political_subdivision_or_indian_tribe
+    : false
+    us:statutes/26/3309#input.service_performed_as_member_of_state_national_guard_or_air_national_guard: false
+    ? us:statutes/26/3309#input.service_performed_as_temporary_emergency_employee_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+    : false
+    ? us:statutes/26/3309#input.service_performed_in_major_nontenured_policymaking_or_advisory_position_designated_under_state_or_tribal_law
+    : false
+    us:statutes/26/3309#input.service_performed_in_policymaking_or_advisory_position_designated_under_state_or_tribal_law: false
+    us:statutes/26/3309#input.ordinary_weekly_hours_required_for_position: 9
+    us:statutes/26/3309#input.service_performed_as_election_official_or_worker: true
+    us:statutes/26/3309#input.annual_remuneration_for_election_official_or_worker_services: 1000
+    us:statutes/26/3309#input.service_performed_in_rehabilitation_facility_program_for_impaired_earning_capacity: false
+    us:statutes/26/3309#input.individual_receiving_rehabilitation: false
+    us:statutes/26/3309#input.service_performed_in_remunerative_work_facility_program_for_impaired_capacity_individuals: false
+    us:statutes/26/3309#input.individual_receiving_remunerative_work: false
+    ? us:statutes/26/3309#input.service_performed_as_part_of_federally_state_or_tribally_assisted_unemployment_work_relief_or_work_training_program
+    : false
+    us:statutes/26/3309#input.individual_receiving_work_relief_or_work_training: false
+    us:statutes/26/3309#input.service_performed_by_inmate_of_custodial_or_penal_institution: false
+  output:
+    us:statutes/26/3309#service_category_excludes_section_application: not_holds
+- name: organization meets minimum employment threshold for section application
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3309#input.counted_days_in_current_or_preceding_calendar_year_each_in_different_week: 20
+    us:statutes/26/3309#input.minimum_individuals_employed_in_counted_employment_on_each_counted_day: 4
+  output:
+    us:statutes/26/3309#organization_employment_days_threshold: 20
+    us:statutes/26/3309#organization_employed_individuals_threshold: 4
+    us:statutes/26/3309#organization_has_minimum_employment_for_section_application: holds
+- name: uncorrected tribal delinquency prevents governmental service exception
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-04-01'
+    end: '2024-04-01'
+  input:
+    ? us:statutes/26/3309#input.employer_is_indian_tribe_within_meaning_of_indian_self_determination_and_education_assistance_act
+    : true
+    us:statutes/26/3309#input.days_since_notice_of_delinquency: 90
+    us:statutes/26/3309#input.tribe_failed_to_make_contributions: true
+    us:statutes/26/3309#input.tribe_failed_to_make_payments_in_lieu_of_contributions: false
+    us:statutes/26/3309#input.tribe_failed_to_pay_assessed_penalties_or_interest_at_comparable_amounts_or_rates: false
+    us:statutes/26/3309#input.tribe_failed_to_post_required_payment_bond: false
+    us:statutes/26/3309#input.tribe_failure_corrected: false
+  output:
+    us:statutes/26/3309#tribal_delinquency_notice_cure_period_days: 90
+    us:statutes/26/3309#tribal_uncorrected_failure_prevents_governmental_service_exception: holds

--- a/statutes/26/3309.yaml
+++ b/statutes/26/3309.yaml
@@ -1,0 +1,215 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3309
+  summary: |-
+    For purposes of section 3304(a)(6), section 3309 covers services excluded from "employment" solely by section 3306(c)(8) or (7), except as provided in subsections (b) and (c). The section does not apply to enumerated religious, governmental-role, rehabilitation, work-relief or work-training, and inmate services. It also does not apply to an organization's service unless there are 20 days in different weeks with 4 or more counted employees. For Indian tribes, uncorrected failures after a 90-day delinquency notice, or failure to post a required bond, prevent the section 3306(c)(7) exception until corrected.
+  deferred_outputs:
+    - output: us:statutes/26/3309#state_law_reimbursing_employer_election_requirement
+      reason: Section 3309(a)(2) imposes a State-law election and reimbursement requirement for purposes of section 3304(a)(6), with the payment amount tied to compensation attributable under State law. The copied context lacks an executable section 3304(a)(6) target and RuleSpec has no StateLaw entity for certifying state-law content.
+rules:
+  - name: policymaking_advisory_position_weekly_hours_limit
+    kind: parameter
+    dtype: Count
+    source: 26 U.S.C. § 3309(b)(3)(E)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "ordinarily does not require more than 8 hours per week"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          8
+
+  - name: election_official_worker_remuneration_annual_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 U.S.C. § 3309(b)(3)(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "less than $1,000"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1000
+
+  - name: organization_employment_days_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 U.S.C. § 3309(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "on each of some 20 days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          20
+
+  - name: organization_employed_individuals_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 U.S.C. § 3309(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "was 4 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4
+
+  - name: tribal_delinquency_notice_cure_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 U.S.C. § 3309(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "within 90 days of having received a notice of delinquency"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          90
+
+  - name: service_category_excludes_section_application
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 U.S.C. § 3309(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3309
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/7#service_in_employ_of_state_political_subdivision_or_indian_tribe
+              output: service_in_employ_of_state_political_subdivision_or_indian_tribe
+              hash: sha256:e937fc3dd0cc3ec7ba690a1090f496f9ece46a2f8ca26c10e630e560d4d52c8c
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            service_performed_in_employ_of_church_or_convention_or_association_of_churches
+            or service_performed_in_employ_of_religious_purpose_church_supported_organization
+            or (
+              service_performed_in_employ_of_religious_elementary_or_secondary_school
+              and employing_school_described_in_section_501_c_3
+              and employing_school_exempt_from_tax_under_section_501_a
+            )
+            or service_performed_by_minister_in_exercise_of_ministry
+            or service_performed_by_religious_order_member_in_exercise_of_required_duties
+            or (
+              service_in_employ_of_state_political_subdivision_or_indian_tribe
+              and (
+                service_performed_as_elected_official
+                or service_performed_as_member_of_legislative_body_or_judiciary_of_state_political_subdivision_or_indian_tribe
+                or service_performed_as_member_of_state_national_guard_or_air_national_guard
+                or service_performed_as_temporary_emergency_employee_in_fire_storm_snow_earthquake_flood_or_similar_emergency
+                or service_performed_in_major_nontenured_policymaking_or_advisory_position_designated_under_state_or_tribal_law
+                or (
+                  service_performed_in_policymaking_or_advisory_position_designated_under_state_or_tribal_law
+                  and ordinary_weekly_hours_required_for_position <= policymaking_advisory_position_weekly_hours_limit
+                )
+                or (
+                  service_performed_as_election_official_or_worker
+                  and annual_remuneration_for_election_official_or_worker_services < election_official_worker_remuneration_annual_limit
+                )
+              )
+            )
+            or (
+              service_performed_in_rehabilitation_facility_program_for_impaired_earning_capacity
+              and individual_receiving_rehabilitation
+            )
+            or (
+              service_performed_in_remunerative_work_facility_program_for_impaired_capacity_individuals
+              and individual_receiving_remunerative_work
+            )
+            or (
+              service_performed_as_part_of_federally_state_or_tribally_assisted_unemployment_work_relief_or_work_training_program
+              and individual_receiving_work_relief_or_work_training
+            )
+            or service_performed_by_inmate_of_custodial_or_penal_institution
+          )
+
+  - name: organization_has_minimum_employment_for_section_application
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 U.S.C. § 3309(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "20 days during such calendar year or the preceding calendar year... was 4 or more"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          counted_days_in_current_or_preceding_calendar_year_each_in_different_week >= organization_employment_days_threshold
+          and minimum_individuals_employed_in_counted_employment_on_each_counted_day >= organization_employed_individuals_threshold
+
+  - name: tribal_uncorrected_failure_prevents_governmental_service_exception
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: 26 U.S.C. § 3309(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3309
+              excerpt: "service for the tribe shall not be excepted from employment under section 3306(c)(7) until any such failure is corrected"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_indian_tribe_within_meaning_of_indian_self_determination_and_education_assistance_act
+          and (
+            (
+              days_since_notice_of_delinquency >= tribal_delinquency_notice_cure_period_days
+              and (
+                tribe_failed_to_make_contributions
+                or tribe_failed_to_make_payments_in_lieu_of_contributions
+                or tribe_failed_to_pay_assessed_penalties_or_interest_at_comparable_amounts_or_rates
+              )
+            )
+            or tribe_failed_to_post_required_payment_bond
+          )
+          and not tribe_failure_corrected


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3309 FUTA coverage thresholds, service-category exceptions, and tribal delinquency predicates
- defer the State-law reimbursing-employer election requirement pending executable section 3304(a)(6) and State-law modeling context
- include generated companion tests and signed encoder apply manifest

## Validation
- `uv run axiom-encode test statutes/26/3309.test.yaml --root /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3309.yaml`
- `uv run axiom-encode compile --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine statutes/26/3309.yaml`
- `uv run axiom-encode validate --skip-reviewers statutes/26/3309.yaml`
- `uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification statutes/26/3309.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us`
