### PR TITLE
Add generated section 3402(l) withholding status rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/l.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/l.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/l.yaml",
+      "sha256": "b90606a81556d25e0d1a1839fa3fb1b20f7936181094dfbbb3d2c42f1f521d91"
+    },
+    {
+      "path": "statutes/26/3402/l.test.yaml",
+      "sha256": "7683e8e3dafc8e8dbb0b7b576bd4237b01334812adfecc444c7d0e1a4706b556"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "953778b9ba744257f1696cd0d5da02be922db606",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.347",
+    "version_commit": "953778b9ba744257f1696cd0d5da02be922db606"
+  },
+  "axiom_encode_version": "0.2.347",
+  "backend": "codex",
+  "citation": "26 USC 3402(l)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3402-l-20260527-main/_eval_workspaces/codex-gpt-5.5/26-USC-3402-l/workspace/context-manifest.json",
+  "context_manifest_sha256": "04b8067ba0cedd6e1e51ea113eb9f12e3279dc25faadb4df2e856577c60133a2",
+  "generated_at": "2026-05-27T23:40:47.272580+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3402-l-20260527-main/codex-gpt-5.5/statutes/26/3402/l.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3402-l-20260527-main",
+  "generated_output_sha256": "b90606a81556d25e0d1a1839fa3fb1b20f7936181094dfbbb3d2c42f1f521d91",
+  "generation_prompt_sha256": "d80337916bd04f18a2e7c85c7d88e71867d6d50cf64ce9e9a208b15563689655",
+  "model": "gpt-5.5",
+  "run_id": "26d22dac",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aaccf13dadc817ace7e89af9b9eda008baa2fe90c90356e75b0c93366a2aee55"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3402-l-20260527-main/traces/codex-gpt-5.5/26-USC-3402-l.json",
+  "trace_sha256": "6c38ecd3b63c644e7b8cc0255a19527ef46cf392ccb42ef4be96a42d77510200"
+}

--- a/statutes/26/3402/l.test.yaml
+++ b/statutes/26/3402/l.test.yaml
@@ -1,0 +1,51 @@
+- name: current_year_spouse_death_counts_as_married_when_subparagraph_a_disqualifiers_absent
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-02-01'
+    end: '2024-02-01'
+  input:
+    us:statutes/26/3402/l#input.legally_separated_from_spouse_under_decree_of_divorce_or_separate_maintenance: false
+    us:statutes/26/3402/l#input.employee_or_spouse_is_nonresident_alien_on_day_or_preceding_day_within_calendar_year: false
+    us:statutes/26/3402/l#input.spouse_died_within_taxable_year_before_day: true
+    us:statutes/26/3402/l#input.employee_marital_status_changed_from_married_to_single: true
+    us:statutes/26/3402/l#input.time_prescribed_by_secretary_regulations_for_married_to_single_new_certificate_has_arrived: true
+    us:statutes/26/3402/l#input.new_withholding_allowance_certificate_furnished_to_employer: true
+  output:
+    us:statutes/26/3402/l#employee_considered_not_married_for_married_certificate_disclosure: not_holds
+    us:statutes/26/3402/l#employee_considered_married_after_current_year_spouse_death: holds
+    us:statutes/26/3402/l#married_to_single_new_certificate_requirement_satisfied: holds
+- name: legal_separation_disqualifies_current_year_spouse_death_branch
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-02-01'
+    end: '2024-02-01'
+  input:
+    us:statutes/26/3402/l#input.legally_separated_from_spouse_under_decree_of_divorce_or_separate_maintenance: true
+    us:statutes/26/3402/l#input.employee_or_spouse_is_nonresident_alien_on_day_or_preceding_day_within_calendar_year: false
+    us:statutes/26/3402/l#input.spouse_died_within_taxable_year_before_day: true
+    us:statutes/26/3402/l#input.employee_marital_status_changed_from_married_to_single: true
+    us:statutes/26/3402/l#input.time_prescribed_by_secretary_regulations_for_married_to_single_new_certificate_has_arrived: true
+    us:statutes/26/3402/l#input.new_withholding_allowance_certificate_furnished_to_employer: false
+  output:
+    us:statutes/26/3402/l#employee_considered_not_married_for_married_certificate_disclosure: holds
+    us:statutes/26/3402/l#employee_considered_married_after_current_year_spouse_death: not_holds
+    us:statutes/26/3402/l#married_to_single_new_certificate_requirement_satisfied: not_holds
+- name: nonresident_alien_status_disqualifies_current_year_spouse_death_branch
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-02-01'
+    end: '2024-02-01'
+  input:
+    us:statutes/26/3402/l#input.legally_separated_from_spouse_under_decree_of_divorce_or_separate_maintenance: false
+    us:statutes/26/3402/l#input.employee_or_spouse_is_nonresident_alien_on_day_or_preceding_day_within_calendar_year: true
+    us:statutes/26/3402/l#input.spouse_died_within_taxable_year_before_day: true
+    us:statutes/26/3402/l#input.employee_marital_status_changed_from_married_to_single: false
+    us:statutes/26/3402/l#input.time_prescribed_by_secretary_regulations_for_married_to_single_new_certificate_has_arrived: false
+    us:statutes/26/3402/l#input.new_withholding_allowance_certificate_furnished_to_employer: false
+  output:
+    us:statutes/26/3402/l#employee_considered_not_married_for_married_certificate_disclosure: holds
+    us:statutes/26/3402/l#employee_considered_married_after_current_year_spouse_death: not_holds
+    us:statutes/26/3402/l#married_to_single_new_certificate_requirement_satisfied: holds

--- a/statutes/26/3402/l.yaml
+++ b/statutes/26/3402/l.yaml
@@ -1,0 +1,106 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+  - output: us:statutes/26/3402/l#employee_considered_married_for_married_certificate_disclosure
+    reason: The complete paragraph (3) married-status determination includes the branch
+      for a spouse who died during one of the two taxable years immediately preceding
+      the current taxable year, conditioned on a reasonable expectation of being a
+      surviving spouse as defined in section 2(a). The copied context for section
+      2(a) is deferred and exports no executable surviving-spouse definition.
+  - output: us:statutes/26/3402/l#employee_entitled_to_furnish_married_certificate
+    reason: Paragraph (2) entitlement depends on the complete paragraph (3) marital-status
+      determination, including the deferred surviving-spouse branch defined by section
+      2(a).
+  - output: us:statutes/26/3402/l#employee_treated_as_single_for_withholding_tables
+    reason: Generated rule treated a filing-status or marital-status legal classification
+      as a local fact. This output is deferred until the upstream status source can
+      be encoded or imported without inventing local tax-status component inputs.
+  summary: '26 USC 3402(l): the employer shall treat the employee as a single person
+    unless a post-enactment withholding allowance certificate in effect indicates
+    married; an employee may furnish a married certificate only if married on that
+    day; the employee is considered not married if legally separated or if either
+    spouse is or was a nonresident alien in the calendar year, and considered married
+    after current-year spouse death or the deferred surviving-spouse branch.'
+rules:
+- name: employee_considered_not_married_for_married_certificate_disclosure
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(l)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: as not married, if ... legally separated from his spouse under
+            a decree of divorce or separate maintenance
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: either he or his spouse is, or on any preceding day within the
+            calendar year was, a nonresident alien
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'legally_separated_from_spouse_under_decree_of_divorce_or_separate_maintenance
+
+      or employee_or_spouse_is_nonresident_alien_on_day_or_preceding_day_within_calendar_year'
+- name: employee_considered_married_after_current_year_spouse_death
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(l)(3)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: as married, if ... his spouse ... died within the portion of his
+            taxable year which precedes such day
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: other than a spouse referred to in subparagraph (A)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'spouse_died_within_taxable_year_before_day
+
+      and not legally_separated_from_spouse_under_decree_of_divorce_or_separate_maintenance
+
+      and not employee_or_spouse_is_nonresident_alien_on_day_or_preceding_day_within_calendar_year'
+- name: married_to_single_new_certificate_requirement_satisfied
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(l)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: An employee whose marital status changes from married to single
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: shall, at such time as the Secretary may by regulations prescribe,
+            furnish the employer with a new withholding allowance certificate
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "not (\n    employee_marital_status_changed_from_married_to_single\n\
+      \    and time_prescribed_by_secretary_regulations_for_married_to_single_new_certificate_has_arrived\n\
+      )\nor new_withholding_allowance_certificate_furnished_to_employer"


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3402(l) marital-status withholding certificate rules
- defer the complete married-certificate and employer treat-as-single surfaces where upstream status/certificate mechanics are not executable yet
- include signed axiom-encode apply manifest and companion tests

## Generated by
- axiom-encode 0.2.347, run_id 26d22dac, model gpt-5.5
- encoder apply repair: TheAxiomFoundation/axiom-encode#372
- oracle classification: TheAxiomFoundation/axiom-encode#373

## Local validation
- uv run axiom-encode test statutes/26/3402/l.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate statutes/26/3402/l.yaml
- uv run axiom-encode compile statutes/26/3402/l.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode validate statutes/26/3402/l.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20