### PR TITLE
Add generated section 3402(m) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/m.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/m.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/m.yaml",
+      "sha256": "63ce61f684b1b2864b76db52efccf8ad9295335ab2d0ea68005da0e7e84fcbc0"
+    },
+    {
+      "path": "statutes/26/3402/m.test.yaml",
+      "sha256": "d8a6e8005dec3df3130e461d2b91ffc9b5b75257598767ddc96b4cba5c0fb54d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a66fb9b5fada5fc64dc4de8263cb802c039eb45b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.348",
+    "version_commit": "a66fb9b5fada5fc64dc4de8263cb802c039eb45b"
+  },
+  "axiom_encode_version": "0.2.348",
+  "backend": "codex",
+  "citation": "26 USC 3402(m)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3402-m-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3402-m/workspace/context-manifest.json",
+  "context_manifest_sha256": "a53d936cd4c6d11298960246465c3383de78ceb26acc268ca3ac426ec9c85401",
+  "generated_at": "2026-05-28T00:02:51.814993+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3402-m-20260527/codex-gpt-5.5/statutes/26/3402/m.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3402-m-20260527",
+  "generated_output_sha256": "63ce61f684b1b2864b76db52efccf8ad9295335ab2d0ea68005da0e7e84fcbc0",
+  "generation_prompt_sha256": "ac661649629a108afd7132beb0352661cc1b72d137a7626d0f8ee178fc1da8e8",
+  "model": "gpt-5.5",
+  "run_id": "7df6e932",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4579ecf2a78e2c3cf5b355a39b97dcaf1a9443915802ce7ee85ef5f74fc5ca2f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3402-m-20260527/traces/codex-gpt-5.5/26-USC-3402-m.json",
+  "trace_sha256": "76f14e3695ed872cbfc1792497cf7ab0a83395485d488e7f1cc9ff38a986d031"
+}

--- a/statutes/26/3402/m.test.yaml
+++ b/statutes/26/3402/m.test.yaml
@@ -1,0 +1,30 @@
+- name: employee_entitled_when_employee_and_regulations_apply
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/m#input.person_is_employee: true
+    us:statutes/26/3402/m#input.secretary_regulations_prescribe_additional_withholding_allowance_or_reductions: true
+  output:
+    us:statutes/26/3402/m#employee_entitled_to_additional_withholding_adjustment: holds
+- name: non_employee_not_entitled_under_employee_rule
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/m#input.person_is_employee: false
+    us:statutes/26/3402/m#input.secretary_regulations_prescribe_additional_withholding_allowance_or_reductions: true
+  output:
+    us:statutes/26/3402/m#employee_entitled_to_additional_withholding_adjustment: not_holds
+- name: employee_not_entitled_without_prescribed_regulations
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/m#input.person_is_employee: true
+    us:statutes/26/3402/m#input.secretary_regulations_prescribe_additional_withholding_allowance_or_reductions: false
+  output:
+    us:statutes/26/3402/m#employee_entitled_to_additional_withholding_adjustment: not_holds

--- a/statutes/26/3402/m.yaml
+++ b/statutes/26/3402/m.yaml
@@ -1,0 +1,49 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/m#additional_withholding_allowance
+      reason: >-
+        Section 3402(m) entitles an employee to an additional withholding
+        allowance under Secretary-prescribed regulations, and states categories
+        of deductions, credits, and other items that may be considered only to
+        the extent and in the manner provided by those regulations. The supplied
+        source does not provide the regulatory computation for the allowance.
+    - output: us:statutes/26/3402/m#additional_reductions_in_withholding
+      reason: >-
+        Section 3402(m) entitles an employee to additional reductions in
+        withholding under Secretary-prescribed regulations, and states
+        categories of deductions, credits, and other items that may be
+        considered only to the extent and in the manner provided by those
+        regulations. The supplied source does not provide the regulatory
+        computation for the reduction amount.
+  summary: |-
+    Under regulations prescribed by the Secretary, an employee shall be entitled to an additional withholding allowance or additional reductions in withholding. In determining them, the employee may take into account, to the extent and in the manner provided by regulations, estimated itemized deductions and the section 199A deduction, estimated chapter 1 tax credits, and additional deductions or other items specified by the Secretary.
+rules:
+  - name: employee_entitled_to_additional_withholding_adjustment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(m)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "Under regulations prescribed by the Secretary"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "an employee shall be entitled to an additional withholding allowance or additional reductions in withholding"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_is_employee
+          and secretary_regulations_prescribe_additional_withholding_allowance_or_reductions


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3402(m)
- add generated companion tests and signed encoding manifest
- defer additional allowance/reduction amount computations to the Secretary-prescribed regulations not present in the source

Generated by axiom-encode 0.2.348 from run 7df6e932; no direct RuleSpec hand edits.

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/m.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/m.yaml
- uv run axiom-encode compile /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/m.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/m.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20