### PR TITLE
Add generated section 3402(n) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/n.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/n.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/n.yaml",
+      "sha256": "be2d459d2c6e00024cfeb08e5980ac6f2028aba1cf962ecea0010db9fa893939"
+    },
+    {
+      "path": "statutes/26/3402/n.test.yaml",
+      "sha256": "ed1213a858c064bae0fe982e8f8c01f39f1a6ee5dea55b1477a9f767acbdefb4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "67f32f20ddab9857174d43f0653a85a5f41dcd66",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.349",
+    "version_commit": "67f32f20ddab9857174d43f0653a85a5f41dcd66"
+  },
+  "axiom_encode_version": "0.2.349",
+  "backend": "codex",
+  "citation": "26 USC 3402(n)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3402-n-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3402-n/workspace/context-manifest.json",
+  "context_manifest_sha256": "e3d8a7bb0df1ae0a483ff9d5d6e0f97346ca863214d70589c178a65b9865e102",
+  "generated_at": "2026-05-28T00:27:16.431210+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3402-n-20260527/codex-gpt-5.5/statutes/26/3402/n.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3402-n-20260527",
+  "generated_output_sha256": "be2d459d2c6e00024cfeb08e5980ac6f2028aba1cf962ecea0010db9fa893939",
+  "generation_prompt_sha256": "72958edfb86f345aca38411becca13cd3e9a14ecc7b0081f315d5faada728e14",
+  "model": "gpt-5.5",
+  "run_id": "0a9a3f03",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "22d35c73ee51fdabd316afdaa192b48f09086eb38734ede247596de39ef1816b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3402-n-20260527/traces/codex-gpt-5.5/26-USC-3402-n.json",
+  "trace_sha256": "2313d9621139ee7938b598e1ceaab2fc6341dd163c2c076d4c7cc864bedf7002"
+}

--- a/statutes/26/3402/n.test.yaml
+++ b/statutes/26/3402/n.test.yaml
@@ -1,0 +1,90 @@
+- name: no_liability_certificate_payment_withholding_not_required
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/n#input.payment_is_wages_to_employee: true
+      us:statutes/26/3402/n#input.withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment: true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+      : true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year
+      : true
+  output:
+    us:statutes/26/3402/n#employer_withholding_not_required_for_no_liability_certificate_payment:
+    - holds
+- name: non_wage_payment_does_not_trigger_payment_rule
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/n#input.payment_is_wages_to_employee: false
+      us:statutes/26/3402/n#input.withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment: true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+      : true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year
+      : true
+  output:
+    us:statutes/26/3402/n#employer_withholding_not_required_for_no_liability_certificate_payment:
+    - not_holds
+- name: no_certificate_in_effect_keeps_withholding_requirement_available
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/n#input.payment_is_wages_to_employee: true
+      us:statutes/26/3402/n#input.withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment: false
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+      : true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year
+      : true
+  output:
+    us:statutes/26/3402/n#employer_withholding_not_required_for_no_liability_certificate_payment:
+    - not_holds
+- name: prior_year_liability_certification_missing
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/n#input.payment_is_wages_to_employee: true
+      us:statutes/26/3402/n#input.withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment: true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+      : false
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year
+      : true
+  output:
+    us:statutes/26/3402/n#employer_withholding_not_required_for_no_liability_certificate_payment:
+    - not_holds
+- name: current_year_no_liability_anticipation_missing
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/n#input.payment_is_wages_to_employee: true
+      us:statutes/26/3402/n#input.withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment: true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+      : true
+      ? us:statutes/26/3402/n#input.certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year
+      : false
+  output:
+    us:statutes/26/3402/n#employer_withholding_not_required_for_no_liability_certificate_payment:
+    - not_holds

--- a/statutes/26/3402/n.yaml
+++ b/statutes/26/3402/n.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    Notwithstanding any other provision of section 3402, an employer is not required to deduct and withhold tax on a wage payment when an employee-furnished withholding allowance certificate is in effect for the payment and certifies no preceding-year subtitle A income tax liability and anticipated no current-year subtitle A income tax liability.
+rules:
+  - name: employer_withholding_not_required_for_no_liability_certificate_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(n)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "an employer shall not be required to deduct and withhold any tax under this chapter upon a payment of wages"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "if there is in effect with respect to such payment a withholding allowance certificate"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "incurred no liability for income tax imposed under subtitle A for his preceding taxable year"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "anticipates that he will incur no liability for income tax imposed under subtitle A for his current taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payment_is_wages_to_employee
+          and withholding_allowance_certificate_furnished_by_employee_is_in_effect_for_payment
+          and certificate_certifies_employee_incurred_no_subtitle_a_income_tax_liability_for_preceding_taxable_year
+          and certificate_certifies_employee_anticipates_no_subtitle_a_income_tax_liability_for_current_taxable_year


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3402(n)
- add generated companion tests and signed encoding manifest
- encode the no-liability withholding certificate exception at Payment scope

Generated by axiom-encode 0.2.349 from run 0a9a3f03; no direct RuleSpec hand edits.

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/n.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/n.yaml
- uv run axiom-encode compile /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/n.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/n.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20