### PR TITLE
Add generated section 3402(o) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/o.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/o.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/o.yaml",
+      "sha256": "ee3910be1762bec9311b0d2f8009a85eb36e3b4fa049fbbfe61a9f0f91352288"
+    },
+    {
+      "path": "statutes/26/3402/o.test.yaml",
+      "sha256": "c6f635f0b4d6337259794ce141365ab784f4555db8cdfc28e99e35b62b7b8bff"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8cd6cd2452cca06547ba5dbddc9f0a34394f6e92",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
+    "version": "0.2.350",
+    "version_commit": "8cd6cd2452cca06547ba5dbddc9f0a34394f6e92"
+  },
+  "axiom_encode_version": "0.2.350",
+  "backend": "codex",
+  "citation": "26 USC 3402(o)",
+  "context_manifest_file": "/private/tmp/axiom-encode-3402-o-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3402-o/workspace/context-manifest.json",
+  "context_manifest_sha256": "35a99fd9d96d37266592e58758cc1be17db09bb7755be3486659577f6159b0bd",
+  "generated_at": "2026-05-28T00:50:14.221839+00:00",
+  "generated_output_file": "/private/tmp/axiom-encode-3402-o-20260527/codex-gpt-5.5/statutes/26/3402/o.yaml",
+  "generated_output_root": "/private/tmp/axiom-encode-3402-o-20260527",
+  "generated_output_sha256": "ee3910be1762bec9311b0d2f8009a85eb36e3b4fa049fbbfe61a9f0f91352288",
+  "generation_prompt_sha256": "f7e164035e39af33feaeb3bc04d0e447bb9ddd5c8b4e12dac7653e15d8d91d4f",
+  "model": "gpt-5.5",
+  "run_id": "1a727dc0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "671aa30b7f076f70fdcae1a3873916e6ea96dcc018f3a5d4ce024a3037e171dd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-encode-3402-o-20260527/traces/codex-gpt-5.5/26-USC-3402-o.json",
+  "trace_sha256": "bf68587941f49f1043db71a2c6ae3e912515b566b50a8e23edc2ebe4a91e0186"
+}

--- a/statutes/26/3402/o.test.yaml
+++ b/statutes/26/3402/o.test.yaml
@@ -1,0 +1,178 @@
+- name: covered payment categories and request amount calculations
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  output:
+    us:statutes/26/3402/o#sick_pay_request_effective_wait_days: 7
+    us:statutes/26/3402/o#supplemental_unemployment_compensation_benefit_amount:
+    - 500
+    - 0
+    - 0
+    - 0
+    us:statutes/26/3402/o#supplemental_unemployment_compensation_benefit:
+    - holds
+    - not_holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3402/o#annuity:
+    - not_holds
+    - holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3402/o#sick_pay:
+    - not_holds
+    - not_holds
+    - holds
+    - holds
+    us:statutes/26/3402/o#sick_pay_not_constituting_wages:
+    - not_holds
+    - not_holds
+    - holds
+    - holds
+    us:statutes/26/3402/o#withholding_request_form_requirements_satisfied:
+    - not_holds
+    - holds
+    - holds
+    - not_holds
+    us:statutes/26/3402/o#sick_pay_request_timing_satisfied:
+    - not_holds
+    - not_holds
+    - holds
+    - not_holds
+    us:statutes/26/3402/o#annuity_request_timing_satisfied:
+    - not_holds
+    - holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3402/o#sick_pay_withholding_request_in_effect_for_payment:
+    - not_holds
+    - not_holds
+    - holds
+    - not_holds
+    us:statutes/26/3402/o#annuity_withholding_request_in_effect_for_payment:
+    - not_holds
+    - holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3402/o#annuity_or_sick_pay_withholding_request_applies_to_payment:
+    - not_holds
+    - holds
+    - holds
+    - not_holds
+    us:statutes/26/3402/o#request_specified_amount_satisfies_regulatory_minimum:
+    - not_holds
+    - holds
+    - holds
+    - not_holds
+    us:statutes/26/3402/o#request_specified_withholding_amount_for_payment:
+    - 0
+    - 120
+    - 45
+    - 0
+    us:statutes/26/3402/o#collective_bargaining_sick_pay_special_rule_applies:
+    - not_holds
+    - not_holds
+    - not_holds
+    - holds
+    us:statutes/26/3402/o#subsection_o_payment_category_before_designated_distribution_coordination:
+    - holds
+    - holds
+    - holds
+    - holds
+  tables:
+    Payment:
+    - ? us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_employer_party_plan_because_of_qualifying_involuntary_separation
+      : true
+      us:statutes/26/3402/o#input.supplemental_unemployment_compensation_benefit_includible_in_employee_gross_income_amount: 500
+      us:statutes/26/3402/o#input.amount_paid_to_individual_as_pension_or_annuity: false
+      us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_plan_to_which_employer_is_party: false
+      us:statutes/26/3402/o#input.payment_is_remuneration_or_in_lieu_for_temporary_absence_due_to_sickness_or_personal_injuries: false
+      us:statutes/26/3402/o#input.sick_pay_does_not_constitute_wages_determined_without_regard_to_subsection: false
+      us:statutes/26/3402/o#input.request_made_by_payee_in_writing_to_person_making_payments: false
+      us:statutes/26/3402/o#input.request_contains_payee_social_security_number: false
+      us:statutes/26/3402/o#input.request_specifies_amount_to_deduct_from_each_full_payment: false
+      us:statutes/26/3402/o#input.days_after_sick_pay_request_furnished_to_payor: 0
+      us:statutes/26/3402/o#input.payor_elects_request_effective_earlier_than_default: false
+      us:statutes/26/3402/o#input.annuity_request_effective_time_prescribed_by_secretary_has_arrived: false
+      us:statutes/26/3402/o#input.specified_withholding_amount_in_request: 0
+      us:statutes/26/3402/o#input.minimum_withholding_amount_under_secretary_regulations: 10
+      us:statutes/26/3402/o#input.payment_is_greater_or_less_than_full_payment: false
+      us:statutes/26/3402/o#input.payment_amount: 1000
+      us:statutes/26/3402/o#input.full_payment_amount: 1000
+      ? us:statutes/26/3402/o#input.sick_pay_paid_pursuant_to_collective_bargaining_agreement_between_employee_representatives_and_one_or_more_employers
+      : false
+      us:statutes/26/3402/o#input.collective_bargaining_agreement_specifies_paragraph_applies_and_determines_withholding_amount: false
+      us:statutes/26/3402/o#input.individual_social_security_number_furnished_to_payor: false
+      us:statutes/26/3402/o#input.payor_furnished_information_needed_for_collective_bargaining_sick_pay_withholding: false
+    - ? us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_employer_party_plan_because_of_qualifying_involuntary_separation
+      : false
+      us:statutes/26/3402/o#input.supplemental_unemployment_compensation_benefit_includible_in_employee_gross_income_amount: 0
+      us:statutes/26/3402/o#input.amount_paid_to_individual_as_pension_or_annuity: true
+      us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_plan_to_which_employer_is_party: false
+      us:statutes/26/3402/o#input.payment_is_remuneration_or_in_lieu_for_temporary_absence_due_to_sickness_or_personal_injuries: false
+      us:statutes/26/3402/o#input.sick_pay_does_not_constitute_wages_determined_without_regard_to_subsection: false
+      us:statutes/26/3402/o#input.request_made_by_payee_in_writing_to_person_making_payments: true
+      us:statutes/26/3402/o#input.request_contains_payee_social_security_number: true
+      us:statutes/26/3402/o#input.request_specifies_amount_to_deduct_from_each_full_payment: true
+      us:statutes/26/3402/o#input.days_after_sick_pay_request_furnished_to_payor: 0
+      us:statutes/26/3402/o#input.payor_elects_request_effective_earlier_than_default: false
+      us:statutes/26/3402/o#input.annuity_request_effective_time_prescribed_by_secretary_has_arrived: true
+      us:statutes/26/3402/o#input.specified_withholding_amount_in_request: 120
+      us:statutes/26/3402/o#input.minimum_withholding_amount_under_secretary_regulations: 10
+      us:statutes/26/3402/o#input.payment_is_greater_or_less_than_full_payment: false
+      us:statutes/26/3402/o#input.payment_amount: 1000
+      us:statutes/26/3402/o#input.full_payment_amount: 1000
+      ? us:statutes/26/3402/o#input.sick_pay_paid_pursuant_to_collective_bargaining_agreement_between_employee_representatives_and_one_or_more_employers
+      : false
+      us:statutes/26/3402/o#input.collective_bargaining_agreement_specifies_paragraph_applies_and_determines_withholding_amount: false
+      us:statutes/26/3402/o#input.individual_social_security_number_furnished_to_payor: false
+      us:statutes/26/3402/o#input.payor_furnished_information_needed_for_collective_bargaining_sick_pay_withholding: false
+    - ? us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_employer_party_plan_because_of_qualifying_involuntary_separation
+      : false
+      us:statutes/26/3402/o#input.supplemental_unemployment_compensation_benefit_includible_in_employee_gross_income_amount: 0
+      us:statutes/26/3402/o#input.amount_paid_to_individual_as_pension_or_annuity: false
+      us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_plan_to_which_employer_is_party: true
+      us:statutes/26/3402/o#input.payment_is_remuneration_or_in_lieu_for_temporary_absence_due_to_sickness_or_personal_injuries: true
+      us:statutes/26/3402/o#input.sick_pay_does_not_constitute_wages_determined_without_regard_to_subsection: true
+      us:statutes/26/3402/o#input.request_made_by_payee_in_writing_to_person_making_payments: true
+      us:statutes/26/3402/o#input.request_contains_payee_social_security_number: true
+      us:statutes/26/3402/o#input.request_specifies_amount_to_deduct_from_each_full_payment: true
+      us:statutes/26/3402/o#input.days_after_sick_pay_request_furnished_to_payor: 8
+      us:statutes/26/3402/o#input.payor_elects_request_effective_earlier_than_default: false
+      us:statutes/26/3402/o#input.annuity_request_effective_time_prescribed_by_secretary_has_arrived: false
+      us:statutes/26/3402/o#input.specified_withholding_amount_in_request: 90
+      us:statutes/26/3402/o#input.minimum_withholding_amount_under_secretary_regulations: 10
+      us:statutes/26/3402/o#input.payment_is_greater_or_less_than_full_payment: true
+      us:statutes/26/3402/o#input.payment_amount: 500
+      us:statutes/26/3402/o#input.full_payment_amount: 1000
+      ? us:statutes/26/3402/o#input.sick_pay_paid_pursuant_to_collective_bargaining_agreement_between_employee_representatives_and_one_or_more_employers
+      : false
+      us:statutes/26/3402/o#input.collective_bargaining_agreement_specifies_paragraph_applies_and_determines_withholding_amount: false
+      us:statutes/26/3402/o#input.individual_social_security_number_furnished_to_payor: false
+      us:statutes/26/3402/o#input.payor_furnished_information_needed_for_collective_bargaining_sick_pay_withholding: false
+    - ? us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_employer_party_plan_because_of_qualifying_involuntary_separation
+      : false
+      us:statutes/26/3402/o#input.supplemental_unemployment_compensation_benefit_includible_in_employee_gross_income_amount: 0
+      us:statutes/26/3402/o#input.amount_paid_to_individual_as_pension_or_annuity: false
+      us:statutes/26/3402/o#input.amount_paid_to_employee_pursuant_to_plan_to_which_employer_is_party: true
+      us:statutes/26/3402/o#input.payment_is_remuneration_or_in_lieu_for_temporary_absence_due_to_sickness_or_personal_injuries: true
+      us:statutes/26/3402/o#input.sick_pay_does_not_constitute_wages_determined_without_regard_to_subsection: true
+      us:statutes/26/3402/o#input.request_made_by_payee_in_writing_to_person_making_payments: false
+      us:statutes/26/3402/o#input.request_contains_payee_social_security_number: false
+      us:statutes/26/3402/o#input.request_specifies_amount_to_deduct_from_each_full_payment: false
+      us:statutes/26/3402/o#input.days_after_sick_pay_request_furnished_to_payor: 0
+      us:statutes/26/3402/o#input.payor_elects_request_effective_earlier_than_default: false
+      us:statutes/26/3402/o#input.annuity_request_effective_time_prescribed_by_secretary_has_arrived: false
+      us:statutes/26/3402/o#input.specified_withholding_amount_in_request: 0
+      us:statutes/26/3402/o#input.minimum_withholding_amount_under_secretary_regulations: 10
+      us:statutes/26/3402/o#input.payment_is_greater_or_less_than_full_payment: false
+      us:statutes/26/3402/o#input.payment_amount: 1000
+      us:statutes/26/3402/o#input.full_payment_amount: 1000
+      ? us:statutes/26/3402/o#input.sick_pay_paid_pursuant_to_collective_bargaining_agreement_between_employee_representatives_and_one_or_more_employers
+      : true
+      us:statutes/26/3402/o#input.collective_bargaining_agreement_specifies_paragraph_applies_and_determines_withholding_amount: true
+      us:statutes/26/3402/o#input.individual_social_security_number_furnished_to_payor: true
+      us:statutes/26/3402/o#input.payor_furnished_information_needed_for_collective_bargaining_sick_pay_withholding: true

--- a/statutes/26/3402/o.yaml
+++ b/statutes/26/3402/o.yaml
@@ -1,0 +1,330 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: 26 USC 3402(o) extends withholding to "any supplemental unemployment compensation
+    benefit", requested annuity payments, and requested non-wage sick pay, treating
+    covered payments "as if it were a payment of wages by an employer to an employee
+    for a payroll period." It defines those payment categories, provides that requested
+    annuity or sick-pay withholding is the amount "specified by the payee", prorated
+    for payments greater or less than a full payment, sets written-request requirements
+    including sick-pay timing for "payments made more than 7 days after" furnishing,
+    creates a collective-bargaining sick-pay special rule, and states that the subsection
+    does not apply to a section 3405(e)(1) designated distribution.
+  deferred_outputs:
+  - output: us:statutes/26/3402/o#payment_treated_as_wages_by_employer_to_employee_for_payroll_period
+    reason: Paragraph (6) makes subsection (o) inapplicable to amounts that are designated
+      distributions within the meaning of 26 USC 3405(e)(1), but no copied RuleSpec
+      source provides that definition.
+  - output: us:statutes/26/3402/o#amount_to_deduct_and_withhold_under_subsection_o
+    reason: A final subsection-level withholding amount must apply the section 3405(e)(1)
+      designated-distribution exclusion in paragraph (6); that upstream definition
+      is not available in copied RuleSpec context.
+rules:
+- name: sick_pay_request_effective_wait_days
+  kind: parameter
+  dtype: Count
+  source: 26 USC 3402(o)(4)(C)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3402
+          excerpt: payments made more than 7 days after the date on which such request
+            is furnished to the payor
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '7'
+- name: supplemental_unemployment_compensation_benefit_amount
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Day
+  unit: USD
+  source: 26 USC 3402(o)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if amount_paid_to_employee_pursuant_to_employer_party_plan_because_of_qualifying_involuntary_separation:
+      supplemental_unemployment_compensation_benefit_includible_in_employee_gross_income_amount
+      else: 0'
+- name: supplemental_unemployment_compensation_benefit
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: supplemental_unemployment_compensation_benefit_amount > 0
+- name: annuity
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: amount_paid_to_individual_as_pension_or_annuity
+- name: sick_pay
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'amount_paid_to_employee_pursuant_to_plan_to_which_employer_is_party
+
+      and payment_is_remuneration_or_in_lieu_for_temporary_absence_due_to_sickness_or_personal_injuries'
+- name: sick_pay_not_constituting_wages
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(1)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'sick_pay
+
+      and sick_pay_does_not_constitute_wages_determined_without_regard_to_subsection'
+- name: withholding_request_form_requirements_satisfied
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(4)(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'request_made_by_payee_in_writing_to_person_making_payments
+
+      and request_contains_payee_social_security_number
+
+      and request_specifies_amount_to_deduct_from_each_full_payment'
+- name: sick_pay_request_timing_satisfied
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(4)(C)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3402/o#sick_pay_request_effective_wait_days
+          output: sick_pay_request_effective_wait_days
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'days_after_sick_pay_request_furnished_to_payor > sick_pay_request_effective_wait_days
+
+      or payor_elects_request_effective_earlier_than_default'
+- name: annuity_request_timing_satisfied
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(4)(C)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'annuity_request_effective_time_prescribed_by_secretary_has_arrived
+
+      or payor_elects_request_effective_earlier_than_default'
+- name: sick_pay_withholding_request_in_effect_for_payment
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(1)(C), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'sick_pay_not_constituting_wages
+
+      and withholding_request_form_requirements_satisfied
+
+      and sick_pay_request_timing_satisfied'
+- name: annuity_withholding_request_in_effect_for_payment
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(1)(B), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'annuity
+
+      and withholding_request_form_requirements_satisfied
+
+      and annuity_request_timing_satisfied'
+- name: annuity_or_sick_pay_withholding_request_applies_to_payment
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'annuity_withholding_request_in_effect_for_payment
+
+      or sick_pay_withholding_request_in_effect_for_payment'
+- name: request_specified_amount_satisfies_regulatory_minimum
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: specified_withholding_amount_in_request >= minimum_withholding_amount_under_secretary_regulations
+- name: request_specified_withholding_amount_for_payment
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Day
+  unit: USD
+  source: 26 USC 3402(o)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if annuity_or_sick_pay_withholding_request_applies_to_payment and request_specified_amount_satisfies_regulatory_minimum:\n\
+      \  if payment_is_greater_or_less_than_full_payment:\n    specified_withholding_amount_in_request\
+      \ * (payment_amount / full_payment_amount)\n  else:\n    specified_withholding_amount_in_request\n\
+      else:\n  0"
+- name: collective_bargaining_sick_pay_special_rule_applies
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'sick_pay_not_constituting_wages
+
+      and sick_pay_paid_pursuant_to_collective_bargaining_agreement_between_employee_representatives_and_one_or_more_employers
+
+      and collective_bargaining_agreement_specifies_paragraph_applies_and_determines_withholding_amount
+
+      and individual_social_security_number_furnished_to_payor
+
+      and payor_furnished_information_needed_for_collective_bargaining_sick_pay_withholding'
+- name: subsection_o_payment_category_before_designated_distribution_coordination
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Day
+  source: 26 USC 3402(o)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3402
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'supplemental_unemployment_compensation_benefit
+
+      or annuity_withholding_request_in_effect_for_payment
+
+      or sick_pay_withholding_request_in_effect_for_payment
+
+      or collective_bargaining_sick_pay_special_rule_applies'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3402(o)
- add generated companion test and signed encoding manifest
- defer final subsection-level outputs that require section 3405(e)(1) designated-distribution coordination not available in copied context

Generated by axiom-encode 0.2.350 from run 1a727dc0; signed apply repaired nested test-table structure. No direct RuleSpec hand edits.

## Tests
- uv run axiom-encode test /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/o.test.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode proof-validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/o.yaml
- uv run axiom-encode compile /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/o.yaml --axiom-rules-engine-path /private/tmp/axiom-payroll-night-20260527103157/axiom-rules-engine
- uv run axiom-encode validate /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3402/o.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json
- uv run axiom-encode guard-generated --repo /private/tmp/axiom-payroll-night-20260527103157/rulespec-us --base-ref origin/main --json
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20