### PR TITLE
Add generated section 3402(p) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/p.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/p.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/p.yaml",
+      "sha256": "753c02277e844e31d5037a17a721e513d070eb88fb8065a24f2b92eeff464aa7"
+    },
+    {
+      "path": "statutes/26/3402/p.test.yaml",
+      "sha256": "9372134983bd925af81b3599900ed6aba0994af1d1a48903467478563a4653ac"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21115ddf6792f49fe418a9d441b51a781ba9f5eb",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.352",
+    "version_commit": "21115ddf6792f49fe418a9d441b51a781ba9f5eb"
+  },
+  "axiom_encode_version": "0.2.352",
+  "backend": "codex",
+  "citation": "26 USC 3402(p)",
+  "context_manifest_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-p-rerun/_eval_workspaces/codex-gpt-5.5/26-USC-3402-p/workspace/context-manifest.json",
+  "context_manifest_sha256": "c0253332296fd070110af37eeff85d2dcf7a0285a10d8064359d11b6ee513834",
+  "generated_at": "2026-05-28T01:59:02.541766+00:00",
+  "generated_output_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-p-rerun/codex-gpt-5.5/statutes/26/3402/p.yaml",
+  "generated_output_root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-p-rerun",
+  "generated_output_sha256": "753c02277e844e31d5037a17a721e513d070eb88fb8065a24f2b92eeff464aa7",
+  "generation_prompt_sha256": "51f614881779b13a9056b469109354ecb3a015e6514deae3775e5e6a1d758d98",
+  "model": "gpt-5.5",
+  "run_id": "5ff50ca1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b5cba61236625451e33ebec3ab2424b44b9edf8f044a30eaedff04a2841e3224"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-p-rerun/traces/codex-gpt-5.5/26-USC-3402-p.json",
+  "trace_sha256": "4b4fd9f55de1ca22033b6ba0fbb273e420731b34b421545c0398041020d79f98"
+}

--- a/statutes/26/3402/p.test.yaml
+++ b/statutes/26/3402/p.test.yaml
@@ -1,0 +1,10 @@
+- name: source_stated_voluntary_withholding_parameters
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us:statutes/26/3402/p#specified_federal_payment_request_seven_percent_rate: 0.07
+    us:statutes/26/3402/p#specified_federal_payment_lowest_income_brackets_count_for_request_percentages: 3
+    us:statutes/26/3402/p#unemployment_compensation_voluntary_withholding_rate: 0.1

--- a/statutes/26/3402/p.yaml
+++ b/statutes/26/3402/p.yaml
@@ -1,0 +1,73 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    "(p) Voluntary withholding agreements" provides wage-payment treatment when a request for withholding is in effect. For specified Federal payments, a request applies only if the percentage is "7 percent, any percentage applicable to any of the 3 lowest income brackets in the table under section 1(c), or such other percentage as is permitted under regulations"; for unemployment compensation, the amount withheld is "10 percent of such payment."
+  deferred_outputs:
+    - output: us:statutes/26/3402/p#specified_federal_payment_voluntary_withholding_amount
+      reason: The amount depends on specified Federal payment status and valid requested percentage choices involving section 1(c), section 451(d), section 77(a), Secretary-specified payments, regulations, and request rules similar to subsection (o)(4), which are not fully copied as executable RuleSpec dependencies.
+      source_values:
+        - us:statutes/26/3402/p#specified_federal_payment_request_seven_percent_rate
+        - us:statutes/26/3402/p#specified_federal_payment_lowest_income_brackets_count_for_request_percentages
+    - output: us:statutes/26/3402/p#specified_federal_payment_treated_as_wages_under_voluntary_withholding_request
+      reason: The wage-treatment consequence depends on specified Federal payment status and request rules involving section 86(d), section 451(d), section 77(a), Secretary-specified payments, and rules similar to subsection (o)(4), which are not fully copied as executable RuleSpec dependencies.
+    - output: us:statutes/26/3402/p#unemployment_compensation_voluntary_withholding_amount
+      reason: The amount depends on unemployment compensation as defined in section 85(b) and request rules similar to subsection (o)(4), which are not copied as executable RuleSpec dependencies.
+      source_values:
+        - us:statutes/26/3402/p#unemployment_compensation_voluntary_withholding_rate
+    - output: us:statutes/26/3402/p#unemployment_compensation_treated_as_wages_under_voluntary_withholding_request
+      reason: The wage-treatment consequence depends on unemployment compensation as defined in section 85(b) and request rules similar to subsection (o)(4), which are not copied as executable RuleSpec dependencies.
+    - output: us:statutes/26/3402/p#other_voluntary_withholding_treated_as_wages_during_agreement_period
+      reason: The consequence depends on Secretary regulations specifying eligible payment types and agreement form and manner; those regulations are not provided in the source text or copied context.
+rules:
+  - name: specified_federal_payment_request_seven_percent_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3402(p)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "percentage specified is 7 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.07
+  - name: specified_federal_payment_lowest_income_brackets_count_for_request_percentages
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3402(p)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "any percentage applicable to any of the 3 lowest income brackets"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+  - name: unemployment_compensation_voluntary_withholding_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3402(p)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "10 percent of such payment"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.10


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(p) voluntary withholding parameters
- Add generated companion test and signed apply manifest

## Provenance
- Generated by axiom-encode 0.2.352 from encoder commit 21115ddf6792f49fe418a9d441b51a781ba9f5eb
- Model: gpt-5.5
- Run id: 5ff50ca1
- Applied via signed `axiom-encode encode --apply`; no direct RuleSpec hand edits

## Validation
- `uv run axiom-encode test --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/p.test.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/p.yaml`
- `uv run axiom-encode compile /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/p.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/p.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`