### PR TITLE
Add generated section 3402(q) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/q.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/q.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/q.yaml",
+      "sha256": "5b92f4ec6cad2eee94dfe332b27e0cf4291c456530ca6992060251aecb7ae999"
+    },
+    {
+      "path": "statutes/26/3402/q.test.yaml",
+      "sha256": "db51ea56d2f8bdb35d252c1baa0b26156e296ff2abb8230e4ab0f07c5c930569"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21115ddf6792f49fe418a9d441b51a781ba9f5eb",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.352",
+    "version_commit": "21115ddf6792f49fe418a9d441b51a781ba9f5eb"
+  },
+  "axiom_encode_version": "0.2.352",
+  "backend": "codex",
+  "citation": "26 USC 3402(q)",
+  "context_manifest_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-q/_eval_workspaces/codex-gpt-5.5/26-USC-3402-q/workspace/context-manifest.json",
+  "context_manifest_sha256": "52dd6abc00013af79fecdaba2d3013443f3b81bb9fcbeb30d9c205cb3ab8cb1c",
+  "generated_at": "2026-05-28T02:11:46.058078+00:00",
+  "generated_output_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-q/codex-gpt-5.5/statutes/26/3402/q.yaml",
+  "generated_output_root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-q",
+  "generated_output_sha256": "5b92f4ec6cad2eee94dfe332b27e0cf4291c456530ca6992060251aecb7ae999",
+  "generation_prompt_sha256": "4b5d01f4ca261d97c590f6cfc9c64b87d4a243d83e29607f04fc07491c8d1d3a",
+  "model": "gpt-5.5",
+  "run_id": "39941617",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "61d4415842341d0b6884b2dba877458bdf6ef3dd00ff53185fed14d765487a3b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402-q/traces/codex-gpt-5.5/26-USC-3402-q.json",
+  "trace_sha256": "cceffed110a64be2d98d142c0783d4c162c5705af9a4881571c9c36630507b59"
+}

--- a/statutes/26/3402/q.test.yaml
+++ b/statutes/26/3402/q.test.yaml
@@ -1,0 +1,130 @@
+- name: general wagering transaction at 300 to 1 threshold
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/q#input.amount_received_from_wager: 6020
+      us:statutes/26/3402/q#input.fair_market_value_of_nonmoney_amount_received_from_wager: 0
+      us:statutes/26/3402/q#input.proceeds_are_not_money: false
+      us:statutes/26/3402/q#input.amount_wagered: 20
+      us:statutes/26/3402/q#input.wager_placed_in_state_conducted_lottery_with_state_agency_or_authorized_employee_or_agent: false
+      us:statutes/26/3402/q#input.wager_placed_in_sweepstakes: false
+      us:statutes/26/3402/q#input.wager_placed_in_wagering_pool: false
+      us:statutes/26/3402/q#input.wager_placed_in_lottery_other_than_state_conducted_lottery: false
+      us:statutes/26/3402/q#input.wagering_transaction_in_parimutuel_pool_for_horse_races_dog_races_or_jai_alai: false
+      ? us:statutes/26/3402/q#input.other_wagering_transaction_not_described_by_state_lottery_sweepstakes_wagering_pool_lottery_or_parimutuel_pool
+      : true
+      us:statutes/26/3402/q#input.payment_is_winnings_from_slot_machine: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_keno: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_bingo: false
+  output:
+    us:statutes/26/3402/q#withholding_winnings_proceeds_threshold: 5000
+    us:statutes/26/3402/q#wager_proceeds_to_wager_ratio_threshold: 300
+    us:statutes/26/3402/q#wager_proceeds:
+    - 6000
+    us:statutes/26/3402/q#winnings_subject_to_withholding:
+    - holds
+    us:statutes/26/3402/q#slot_keno_bingo_tax_exemption_applies:
+    - not_holds
+    us:statutes/26/3402/q#payment_of_winnings_treated_as_wages_for_section_3403:
+    - holds
+- name: state lottery nonmoney proceeds without 300 to 1 ratio
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/q#input.amount_received_from_wager: 0
+      us:statutes/26/3402/q#input.fair_market_value_of_nonmoney_amount_received_from_wager: 6100
+      us:statutes/26/3402/q#input.proceeds_are_not_money: true
+      us:statutes/26/3402/q#input.amount_wagered: 100
+      us:statutes/26/3402/q#input.wager_placed_in_state_conducted_lottery_with_state_agency_or_authorized_employee_or_agent: true
+      us:statutes/26/3402/q#input.wager_placed_in_sweepstakes: false
+      us:statutes/26/3402/q#input.wager_placed_in_wagering_pool: false
+      us:statutes/26/3402/q#input.wager_placed_in_lottery_other_than_state_conducted_lottery: false
+      us:statutes/26/3402/q#input.wagering_transaction_in_parimutuel_pool_for_horse_races_dog_races_or_jai_alai: false
+      ? us:statutes/26/3402/q#input.other_wagering_transaction_not_described_by_state_lottery_sweepstakes_wagering_pool_lottery_or_parimutuel_pool
+      : false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_slot_machine: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_keno: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_bingo: false
+  output:
+    us:statutes/26/3402/q#wager_proceeds:
+    - 6000
+    us:statutes/26/3402/q#winnings_subject_to_withholding:
+    - holds
+    us:statutes/26/3402/q#slot_keno_bingo_tax_exemption_applies:
+    - not_holds
+    us:statutes/26/3402/q#payment_of_winnings_treated_as_wages_for_section_3403:
+    - holds
+- name: parimutuel pool below 300 to 1 ratio
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/q#input.amount_received_from_wager: 6100
+      us:statutes/26/3402/q#input.fair_market_value_of_nonmoney_amount_received_from_wager: 0
+      us:statutes/26/3402/q#input.proceeds_are_not_money: false
+      us:statutes/26/3402/q#input.amount_wagered: 100
+      us:statutes/26/3402/q#input.wager_placed_in_state_conducted_lottery_with_state_agency_or_authorized_employee_or_agent: false
+      us:statutes/26/3402/q#input.wager_placed_in_sweepstakes: false
+      us:statutes/26/3402/q#input.wager_placed_in_wagering_pool: false
+      us:statutes/26/3402/q#input.wager_placed_in_lottery_other_than_state_conducted_lottery: false
+      us:statutes/26/3402/q#input.wagering_transaction_in_parimutuel_pool_for_horse_races_dog_races_or_jai_alai: true
+      ? us:statutes/26/3402/q#input.other_wagering_transaction_not_described_by_state_lottery_sweepstakes_wagering_pool_lottery_or_parimutuel_pool
+      : false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_slot_machine: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_keno: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_bingo: false
+  output:
+    us:statutes/26/3402/q#wager_proceeds:
+    - 6000
+    us:statutes/26/3402/q#winnings_subject_to_withholding:
+    - not_holds
+    us:statutes/26/3402/q#slot_keno_bingo_tax_exemption_applies:
+    - not_holds
+    us:statutes/26/3402/q#payment_of_winnings_treated_as_wages_for_section_3403:
+    - not_holds
+- name: slot machine winnings separately exempt from paragraph 1 tax
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3402/q#input.amount_received_from_wager: 6020
+      us:statutes/26/3402/q#input.fair_market_value_of_nonmoney_amount_received_from_wager: 0
+      us:statutes/26/3402/q#input.proceeds_are_not_money: false
+      us:statutes/26/3402/q#input.amount_wagered: 20
+      us:statutes/26/3402/q#input.wager_placed_in_state_conducted_lottery_with_state_agency_or_authorized_employee_or_agent: false
+      us:statutes/26/3402/q#input.wager_placed_in_sweepstakes: false
+      us:statutes/26/3402/q#input.wager_placed_in_wagering_pool: false
+      us:statutes/26/3402/q#input.wager_placed_in_lottery_other_than_state_conducted_lottery: false
+      us:statutes/26/3402/q#input.wagering_transaction_in_parimutuel_pool_for_horse_races_dog_races_or_jai_alai: false
+      ? us:statutes/26/3402/q#input.other_wagering_transaction_not_described_by_state_lottery_sweepstakes_wagering_pool_lottery_or_parimutuel_pool
+      : true
+      us:statutes/26/3402/q#input.payment_is_winnings_from_slot_machine: true
+      us:statutes/26/3402/q#input.payment_is_winnings_from_keno: false
+      us:statutes/26/3402/q#input.payment_is_winnings_from_bingo: false
+  output:
+    us:statutes/26/3402/q#wager_proceeds:
+    - 6000
+    us:statutes/26/3402/q#winnings_subject_to_withholding:
+    - holds
+    us:statutes/26/3402/q#slot_keno_bingo_tax_exemption_applies:
+    - holds
+    us:statutes/26/3402/q#payment_of_winnings_treated_as_wages_for_section_3403:
+    - holds

--- a/statutes/26/3402/q.yaml
+++ b/statutes/26/3402/q.yaml
@@ -1,0 +1,167 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  summary: |-
+    "(q) Extension of withholding to certain gambling winnings" defines "winnings which are subject to withholding" as certain proceeds from a wager.
+  deferred_outputs:
+    - output: us:statutes/26/3402/q#gambling_winnings_withholding_tax
+      reason: Requires the third lowest rate of tax applicable under section 1(c), and no copied RuleSpec source provides that upstream rate computation.
+    - output: us:statutes/26/3402/q#nonresident_alien_or_foreign_corporation_other_withholding_exemption_applies
+      reason: Requires determining whether the payment is subject to tax under section 1441(a) or section 1442(a), and no copied RuleSpec source provides those upstream withholding computations.
+    - output: us:statutes/26/3402/q#payment_of_winnings_treated_as_wages_for_section_3404_and_subtitle_f
+      reason: Section 3404 and subtitle F except section 7205 are cited purposes for the treated-as-wages rule, but no copied RuleSpec source provides those purpose-specific downstream computations.
+rules:
+  - name: withholding_winnings_proceeds_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3402(q)(3)(A)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "more than $5,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          5000
+
+  - name: wager_proceeds_to_wager_ratio_threshold
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3402(q)(3)(A), (C)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "at least 300 times"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          300
+
+  - name: wager_proceeds
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Day
+    unit: USD
+    source: 26 USC 3402(q)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3402
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (if proceeds_are_not_money: fair_market_value_of_nonmoney_amount_received_from_wager else: amount_received_from_wager) - amount_wagered
+
+  - name: winnings_subject_to_withholding
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(q)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3402
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/q#wager_proceeds
+              output: wager_proceeds
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/q#withholding_winnings_proceeds_threshold
+              output: withholding_winnings_proceeds_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/q#wager_proceeds_to_wager_ratio_threshold
+              output: wager_proceeds_to_wager_ratio_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          wager_proceeds > withholding_winnings_proceeds_threshold
+          and (
+            wager_placed_in_state_conducted_lottery_with_state_agency_or_authorized_employee_or_agent
+            or wager_placed_in_sweepstakes
+            or wager_placed_in_wagering_pool
+            or wager_placed_in_lottery_other_than_state_conducted_lottery
+            or (
+              wagering_transaction_in_parimutuel_pool_for_horse_races_dog_races_or_jai_alai
+              and wager_proceeds >= wager_proceeds_to_wager_ratio_threshold * amount_wagered
+            )
+            or (
+              other_wagering_transaction_not_described_by_state_lottery_sweepstakes_wagering_pool_lottery_or_parimutuel_pool
+              and wager_proceeds >= wager_proceeds_to_wager_ratio_threshold * amount_wagered
+            )
+          )
+
+  - name: slot_keno_bingo_tax_exemption_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(q)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3402
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payment_is_winnings_from_slot_machine
+          or payment_is_winnings_from_keno
+          or payment_is_winnings_from_bingo
+
+  - name: payment_of_winnings_treated_as_wages_for_section_3403
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3402(q)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/q#winnings_subject_to_withholding
+              output: winnings_subject_to_withholding
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          winnings_subject_to_withholding


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 3402(q) gambling winnings withholding surfaces
- Add generated companion tests and signed apply manifest

## Provenance
- Generated by axiom-encode 0.2.352 from encoder commit 21115ddf6792f49fe418a9d441b51a781ba9f5eb
- PolicyEngine oracle classification validated with axiom-encode 0.2.353 after TheAxiomFoundation/axiom-encode#378
- Model: gpt-5.5
- Run id: 39941617
- Applied via signed `axiom-encode encode --apply`; no direct RuleSpec hand edits

## Validation
- `uv run axiom-encode test --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/q.test.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/q.yaml`
- `uv run axiom-encode compile /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/q.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/q.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p --base-ref origin/main --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`