### PR TITLE
Add generated section 3402(t) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3402/t.json
+++ b/.axiom/encoding-manifests/statutes/26/3402/t.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3402/t.yaml",
+      "sha256": "30ef9b38e40ca9b4ccd297347e9374211f2ad62762f1776294bf4a83284e308f"
+    },
+    {
+      "path": "statutes/26/3402/t.test.yaml",
+      "sha256": "f6a361b4caec65963eaee73ffe2f307e2494f196ec60c84d85cc95799258bfaa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e21ce7432ec52f6418bbf87976aab541fcdb0c4c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.355",
+    "version_commit": "e21ce7432ec52f6418bbf87976aab541fcdb0c4c"
+  },
+  "axiom_encode_version": "0.2.355",
+  "backend": "openai",
+  "citation": "26 USC 3402(t)",
+  "context_manifest_file": "/tmp/axiom-encode-3402t-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3402-t/workspace/context-manifest.json",
+  "context_manifest_sha256": "40c943e5a07fd3417baa4375430c020cf0c568da75814957247a357388a99e6d",
+  "generated_at": "2026-05-28T03:24:37.514272+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3402t-20260528-001/openai-gpt-5.5/statutes/26/3402/t.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3402t-20260528-001",
+  "generated_output_sha256": "30ef9b38e40ca9b4ccd297347e9374211f2ad62762f1776294bf4a83284e308f",
+  "generation_prompt_sha256": "fec5da9a2f07d9f319e22b4b43ea7d745c420b6e51f96c19d986ae2a420f25f5",
+  "model": "gpt-5.5",
+  "run_id": "20915572",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f3de2f856aff76caa1df0d51aaa1eb610df2884ded6acd44e28ee1d5e8320c2a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3402t-20260528-001/traces/openai-gpt-5.5/26-USC-3402-t.json",
+  "trace_sha256": "6a9409125051c135a21fbe3327934e82742287524937e34453e44af7b0f568d5"
+}

--- a/statutes/26/3402/t.test.yaml
+++ b/statutes/26/3402/t.test.yaml
@@ -1,0 +1,36 @@
+- name: qualified_stock_with_section_83_i_election_triggers_rate_floor_and_fringe_benefit_treatment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/t#input.stock_is_qualified_stock_as_defined_in_section_83_i_2: true
+    us:statutes/26/3402/t#input.section_83_i_election_made_with_respect_to_stock: true
+  output:
+    us:statutes/26/3402/t#qualified_stock_with_section_83_i_election: holds
+    us:statutes/26/3402/t#section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election: holds
+    us:statutes/26/3402/t#qualified_stock_treated_as_noncash_fringe_benefit_for_section_3501_b: holds
+- name: nonqualified_stock_does_not_trigger_subsection_t_treatment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/t#input.stock_is_qualified_stock_as_defined_in_section_83_i_2: false
+    us:statutes/26/3402/t#input.section_83_i_election_made_with_respect_to_stock: true
+  output:
+    us:statutes/26/3402/t#qualified_stock_with_section_83_i_election: not_holds
+    us:statutes/26/3402/t#section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election: not_holds
+    us:statutes/26/3402/t#qualified_stock_treated_as_noncash_fringe_benefit_for_section_3501_b: not_holds
+- name: no_section_83_i_election_does_not_trigger_subsection_t_treatment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3402/t#input.stock_is_qualified_stock_as_defined_in_section_83_i_2: true
+    us:statutes/26/3402/t#input.section_83_i_election_made_with_respect_to_stock: false
+  output:
+    us:statutes/26/3402/t#qualified_stock_with_section_83_i_election: not_holds
+    us:statutes/26/3402/t#section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election: not_holds
+    us:statutes/26/3402/t#qualified_stock_treated_as_noncash_fringe_benefit_for_section_3501_b: not_holds

--- a/statutes/26/3402/t.yaml
+++ b/statutes/26/3402/t.yaml
@@ -1,0 +1,94 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3402
+  deferred_outputs:
+    - output: us:statutes/26/3402/t#minimum_withholding_rate_for_qualified_stock_with_section_83_i_election
+      reason: >-
+        Section 3402(t)(1) requires the withholding rate under subsection (a) not
+        to be less than the maximum rate of tax in effect under section 1. The
+        copied section 1 context does not export the maximum rate of tax in effect
+        under section 1 as a standalone rate, so the numeric rate floor is not
+        computable in this artifact.
+      source_values:
+        - us:statutes/26/3402/t#qualified_stock_with_section_83_i_election
+        - us:statutes/26/3402/t#section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election
+  summary: |-
+    26 USC 3402(t): in the case of qualified stock with respect to which an election is made under section 83(i), the subsection (a) withholding rate shall not be less than the maximum rate under section 1, and the stock is treated for section 3501(b) purposes like a non-cash fringe benefit.
+rules:
+  - name: qualified_stock_with_section_83_i_election
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(t)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "qualified stock (as defined in section 83(i)(2))"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "with respect to which an election is made under section 83(i)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          stock_is_qualified_stock_as_defined_in_section_83_i_2
+          and section_83_i_election_made_with_respect_to_stock
+
+  - name: section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(t)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/t#qualified_stock_with_section_83_i_election
+              output: qualified_stock_with_section_83_i_election
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "the rate of tax under subsection (a) shall not be less than the maximum rate of tax in effect under section 1"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          qualified_stock_with_section_83_i_election
+
+  - name: qualified_stock_treated_as_noncash_fringe_benefit_for_section_3501_b
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3402(t)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/t#qualified_stock_with_section_83_i_election
+              output: qualified_stock_with_section_83_i_election
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3402
+              excerpt: "such stock shall be treated for purposes of section 3501(b) in the same manner as a non-cash fringe benefit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          qualified_stock_with_section_83_i_election


### PR DESCRIPTION
## Summary
- Add signed generated RuleSpec for 26 USC 3402(t), qualified stock withholding-rate floor and section 3501(b) treatment.
- Add generated companion tests for qualified stock with a section 83(i) election and the two resulting treatment predicates.
- Include the signed axiom-encode apply manifest.

## Provenance
- Generated with axiom-encode encode "26 USC 3402(t)" using backend openai, model gpt-5.5, repo-augmented mode, and signed --apply.
- Run ID: 20915572.
- Encoder classifier support: TheAxiomFoundation/axiom-encode#381.

## Tests
- axiom-encode validate statutes/26/3402/t.yaml --skip-reviewers --require-oracle-classification --json
- axiom-encode test statutes/26/3402/t.test.yaml
- axiom-encode proof-validate statutes/26/3402/t.yaml --json
- axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json
- axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD --json