### PR TITLE
Encode 7 USC 2014(d) and (g) — SNAP income exclusions and resource limits

### DIFF
--- a/.axiom/encoding-manifests/statutes/7/2014/a.json
+++ b/.axiom/encoding-manifests/statutes/7/2014/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7/2014/a.yaml",
+      "sha256": "6053fc8fb0b0ced2f36e02f107ce96dbcd7c51c05a6bfdd44bf8a9982e54de8f"
+    },
+    {
+      "path": "statutes/7/2014/a.test.yaml",
+      "sha256": "02960a1508759ef0d9fdf13c8f5126e702add2317c52bcf618dc41b657f0f64d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "codex",
+  "citation": "us/statute/7/2014/a",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.4/us-statute-7-2014-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "3f29bc1446f58039f8ad908ae761e33ab8965e9e4272bafa5a0cacaf3bbc0d24",
+  "generated_at": "2026-05-28T03:50:22.595297+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.4/statutes/7/2014/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6053fc8fb0b0ced2f36e02f107ce96dbcd7c51c05a6bfdd44bf8a9982e54de8f",
+  "generation_prompt_sha256": "39d714f5bf7df63d8781efc56a09c8b1fba85bcf0696e7c96e08829329e12dac",
+  "model": "gpt-5.4",
+  "run_id": "525922c8",
+  "runner": "codex-gpt-5.4",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d16dc54fe5cfd3398ff93779c839ec734d80c5b0e451841d93d521fb507051be"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.4/us-statute-7-2014-a.json",
+  "trace_sha256": "c831bab8853c18e0f6bba98d80a72b08155cba973ee406c45046c1273e083697"
+}

--- a/.axiom/encoding-manifests/statutes/7/2014/d.json
+++ b/.axiom/encoding-manifests/statutes/7/2014/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7/2014/d.yaml",
+      "sha256": "6bceb7c220fdfd8b6d91e27d62238009906927573520322a302c9493afc1ed8b"
+    },
+    {
+      "path": "statutes/7/2014/d.test.yaml",
+      "sha256": "735c39c7a28976422492c4daa748f10b26a0e23ff584be883a118cf87aef4b62"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "codex",
+  "citation": "us/statute/7/2014/d",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.4/us-statute-7-2014-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "8415cc89a44d0e3774019cb12de961a30bcda93a4ed487163657d79d110f99fc",
+  "generated_at": "2026-05-28T03:36:51.410516+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.4/statutes/7/2014/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6bceb7c220fdfd8b6d91e27d62238009906927573520322a302c9493afc1ed8b",
+  "generation_prompt_sha256": "9ec85d7002c38ca491e79fac5c2c911503a0cd189be533d54db3524b13c5e399",
+  "model": "gpt-5.4",
+  "run_id": "4399b488",
+  "runner": "codex-gpt-5.4",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b42961bf028cd27d84d908e125342b7466bfe8d32ffa7f05cd3ec3d642f986cc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.4/us-statute-7-2014-d.json",
+  "trace_sha256": "bc379e51db3389a1b835d21e5424d8008e0a8f93b805f449c9492fa61035efbe"
+}

--- a/.axiom/encoding-manifests/statutes/7/2014/e/2/B.json
+++ b/.axiom/encoding-manifests/statutes/7/2014/e/2/B.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7/2014/e/2/B.yaml",
+      "sha256": "f6df3554f1b7dfc588d313652f77c9331ae2272e3086a537fd72bbdebd7cfe66"
+    },
+    {
+      "path": "statutes/7/2014/e/2/B.test.yaml",
+      "sha256": "ed992813d755eb9ecadbb1c713ad6610458a5543fb38b8b94d9311e8270f66c9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "codex",
+  "citation": "us/statute/7/2014/e/2/B",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.4/us-statute-7-2014-e-2-B/workspace/context-manifest.json",
+  "context_manifest_sha256": "b8d6e7b7e87856dd291b54527012927d34e3c35b079065c3d5bac17e34e6c95a",
+  "generated_at": "2026-05-27T19:09:36.317187+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.4/statutes/7/2014/e/2/B.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f6df3554f1b7dfc588d313652f77c9331ae2272e3086a537fd72bbdebd7cfe66",
+  "generation_prompt_sha256": "9de75d6992551253bfad143b52e3e1cee6112708cbefeea0fa0a74e1f9fc6b58",
+  "model": "gpt-5.4",
+  "run_id": "abd3925c",
+  "runner": "codex-gpt-5.4",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9f48451d667f4cb11b44011247857f8d952d78d0bab577b1c43134a1c99bef64"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.4/us-statute-7-2014-e-2-B.json",
+  "trace_sha256": "34c62e81ed374b342211e1eccd4d4a4d1bb6777a73726340d6580089a28ea297"
+}

--- a/.axiom/encoding-manifests/statutes/7/2014/g.json
+++ b/.axiom/encoding-manifests/statutes/7/2014/g.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7/2014/g.yaml",
+      "sha256": "792bb680f0848ea7edbd8b21b746e34433ad6cf96b1a97e0b2a473afca2ea082"
+    },
+    {
+      "path": "statutes/7/2014/g.test.yaml",
+      "sha256": "8ca8aea75e9b4ef95910ccc382835db5f27cacdecd72b2a68b0600085173daa6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "89652fa32ecfa9f496c76d5a3821796c79540380",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.336",
+    "version_commit": "89652fa32ecfa9f496c76d5a3821796c79540380"
+  },
+  "axiom_encode_version": "0.2.336",
+  "backend": "codex",
+  "citation": "us/statute/7/2014/g",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.4/us-statute-7-2014-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "98b2f941343291e84571f23a93dd5a7ed4614b4bd5a9bbb10d0a88d890517d59",
+  "generated_at": "2026-05-28T03:38:38.965304+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.4/statutes/7/2014/g.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "792bb680f0848ea7edbd8b21b746e34433ad6cf96b1a97e0b2a473afca2ea082",
+  "generation_prompt_sha256": "e05da642d99f8a86ac3ebd18b4371ea1fb04c2bac36c6ce1504cf76a15e5c833",
+  "model": "gpt-5.4",
+  "run_id": "01ba350c",
+  "runner": "codex-gpt-5.4",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c35ad87ddbaf81e31cf4620a31aee624f9018478b857d68c6305e0ff5665e007"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.4/us-statute-7-2014-g.json",
+  "trace_sha256": "6d115b1be608185838f878f4f56312f697033f916947d2e6a3cbf0aacd3216b1"
+}

--- a/statutes/7/2014/a.test.yaml
+++ b/statutes/7/2014/a.test.yaml
@@ -1,0 +1,80 @@
+- name: no_income_or_categorical_basis
+  period: 2008-10
+  input:
+    ? us:statutes/7/2014/a#input.household_income_and_other_financial_resources_are_substantial_limiting_factor_in_permitting_more_nutritious_diet
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_program_funded_under_part_a_title_iv_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_supplemental_security_income_benefits_under_title_xvi_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_aid_to_aged_blind_or_disabled_under_title_i_x_xiv_or_xvi_social_security_act
+    : false
+    us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_or_local_general_assistance_program: false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_uses_income_criteria_comparable_to_or_more_restrictive_than_subsection_c_2
+    : false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_is_not_limited_to_one_time_emergency_payments_unavailable_for_more_than_one_consecutive_month
+    : false
+  output:
+    us:statutes/7/2014/a#household_meets_social_security_act_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_meets_qualifying_general_assistance_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_has_snap_participation_basis_from_income_or_categorical_benefits: not_holds
+- name: substantial_limiting_factor_basis
+  period: 2008-10
+  input:
+    ? us:statutes/7/2014/a#input.household_income_and_other_financial_resources_are_substantial_limiting_factor_in_permitting_more_nutritious_diet
+    : true
+    ? us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_program_funded_under_part_a_title_iv_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_supplemental_security_income_benefits_under_title_xvi_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_aid_to_aged_blind_or_disabled_under_title_i_x_xiv_or_xvi_social_security_act
+    : false
+    us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_or_local_general_assistance_program: false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_uses_income_criteria_comparable_to_or_more_restrictive_than_subsection_c_2
+    : false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_is_not_limited_to_one_time_emergency_payments_unavailable_for_more_than_one_consecutive_month
+    : false
+  output:
+    us:statutes/7/2014/a#household_meets_social_security_act_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_meets_qualifying_general_assistance_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_has_snap_participation_basis_from_income_or_categorical_benefits: holds
+- name: supplemental_security_income_categorical_basis
+  period: 2008-10
+  input:
+    ? us:statutes/7/2014/a#input.household_income_and_other_financial_resources_are_substantial_limiting_factor_in_permitting_more_nutritious_diet
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_program_funded_under_part_a_title_iv_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_supplemental_security_income_benefits_under_title_xvi_social_security_act
+    : true
+    ? us:statutes/7/2014/a#input.each_household_member_receives_aid_to_aged_blind_or_disabled_under_title_i_x_xiv_or_xvi_social_security_act
+    : false
+    us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_or_local_general_assistance_program: false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_uses_income_criteria_comparable_to_or_more_restrictive_than_subsection_c_2
+    : false
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_is_not_limited_to_one_time_emergency_payments_unavailable_for_more_than_one_consecutive_month
+    : false
+  output:
+    us:statutes/7/2014/a#household_meets_social_security_act_benefit_criterion: holds
+    us:statutes/7/2014/a#household_meets_qualifying_general_assistance_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_has_snap_participation_basis_from_income_or_categorical_benefits: holds
+- name: qualifying_general_assistance_categorical_basis
+  period: 2008-10
+  input:
+    ? us:statutes/7/2014/a#input.household_income_and_other_financial_resources_are_substantial_limiting_factor_in_permitting_more_nutritious_diet
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_program_funded_under_part_a_title_iv_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_supplemental_security_income_benefits_under_title_xvi_social_security_act
+    : false
+    ? us:statutes/7/2014/a#input.each_household_member_receives_aid_to_aged_blind_or_disabled_under_title_i_x_xiv_or_xvi_social_security_act
+    : false
+    us:statutes/7/2014/a#input.each_household_member_receives_benefits_under_state_or_local_general_assistance_program: true
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_uses_income_criteria_comparable_to_or_more_restrictive_than_subsection_c_2
+    : true
+    ? us:statutes/7/2014/a#input.state_or_local_general_assistance_program_is_not_limited_to_one_time_emergency_payments_unavailable_for_more_than_one_consecutive_month
+    : true
+  output:
+    us:statutes/7/2014/a#household_meets_social_security_act_benefit_criterion: not_holds
+    us:statutes/7/2014/a#household_meets_qualifying_general_assistance_benefit_criterion: holds
+    us:statutes/7/2014/a#household_has_snap_participation_basis_from_income_or_categorical_benefits: holds

--- a/statutes/7/2014/a.yaml
+++ b/statutes/7/2014/a.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: Participation in SNAP is limited to households whose incomes and other
+    financial resources are a substantial limiting factor in obtaining a more nutritious
+    diet. Households in which each member receives specified title IV-A, SSI, or aged,
+    blind, or disabled assistance benefits, or qualifying State or local general assistance,
+    shall be eligible subject to the cited exceptions.
+  deferred_outputs:
+  - output: us:statutes/7/2014/a#household_eligible_for_snap_participation
+    reason: Final SNAP participation eligibility under 7 U.S.C. 2014(a) remains subject
+      to cited exceptions and cross-references, including 7 U.S.C. 2015(b), 2015(d)(2),
+      2015(g), 2015(r), 2025(e)(1), and 2012(m)(4). Copied context does not provide
+      complete executable coverage for all of those dependencies, and the available
+      7 U.S.C. 2014(g) resource computation is itself deferred.
+    blocked_by:
+    - us:statutes/7/2014/g#countable_household_financial_resources
+rules:
+- name: household_meets_social_security_act_benefit_criterion
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2014(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2014
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'each_household_member_receives_benefits_under_state_program_funded_under_part_a_title_iv_social_security_act
+
+      or each_household_member_receives_supplemental_security_income_benefits_under_title_xvi_social_security_act
+
+      or each_household_member_receives_aid_to_aged_blind_or_disabled_under_title_i_x_xiv_or_xvi_social_security_act'
+- name: household_meets_qualifying_general_assistance_benefit_criterion
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2014(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2014
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'each_household_member_receives_benefits_under_state_or_local_general_assistance_program
+
+      and state_or_local_general_assistance_program_uses_income_criteria_comparable_to_or_more_restrictive_than_subsection_c_2
+
+      and state_or_local_general_assistance_program_is_not_limited_to_one_time_emergency_payments_unavailable_for_more_than_one_consecutive_month'
+- name: household_has_snap_participation_basis_from_income_or_categorical_benefits
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2014(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2014
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'household_income_and_other_financial_resources_are_substantial_limiting_factor_in_permitting_more_nutritious_diet
+
+      or household_meets_social_security_act_benefit_criterion
+
+      or household_meets_qualifying_general_assistance_benefit_criterion'

--- a/statutes/7/2014/d.test.yaml
+++ b/statutes/7/2014/d.test.yaml
@@ -1,0 +1,52 @@
+- name: irregular_income_exclusion_caps_at_quarter_limit
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.income_received_too_infrequently_or_irregularly_to_be_reasonably_anticipated: true
+    us:statutes/7/2014/d#input.irregular_income_amount_in_certification_period: 45
+  output:
+    us:statutes/7/2014/d#irregular_income_quarter_cap: 30
+    us:statutes/7/2014/d#irregular_income_excluded_from_snap_income: 30
+- name: irregular_income_not_excluded_without_irregularity_condition
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.income_received_too_infrequently_or_irregularly_to_be_reasonably_anticipated: false
+    us:statutes/7/2014/d#input.irregular_income_amount_in_certification_period: 20
+  output:
+    us:statutes/7/2014/d#irregular_income_excluded_from_snap_income: 0
+- name: student_child_earned_income_excluded_at_age_limit
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.person_is_child_member_of_household: true
+    us:statutes/7/2014/d#input.person_is_elementary_or_secondary_school_student: true
+    us:statutes/7/2014/d#input.person_age: 17
+    us:statutes/7/2014/d#input.child_earned_income_amount: 240
+  output:
+    us:statutes/7/2014/d#student_child_income_age_limit: 17
+    us:statutes/7/2014/d#student_child_earned_income_excluded_from_snap_income: 240
+- name: student_child_earned_income_not_excluded_over_age_limit
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.person_is_child_member_of_household: true
+    us:statutes/7/2014/d#input.person_is_elementary_or_secondary_school_student: true
+    us:statutes/7/2014/d#input.person_age: 18
+    us:statutes/7/2014/d#input.child_earned_income_amount: 240
+  output:
+    us:statutes/7/2014/d#student_child_earned_income_excluded_from_snap_income: 0
+- name: student_income_not_excluded_if_not_household_child
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.person_is_child_member_of_household: false
+    us:statutes/7/2014/d#input.person_is_elementary_or_secondary_school_student: true
+    us:statutes/7/2014/d#input.person_age: 16
+    us:statutes/7/2014/d#input.child_earned_income_amount: 200
+  output:
+    us:statutes/7/2014/d#student_child_earned_income_excluded_from_snap_income: 0
+- name: student_income_not_excluded_if_not_student
+  period: 2026-01
+  input:
+    us:statutes/7/2014/d#input.person_is_child_member_of_household: true
+    us:statutes/7/2014/d#input.person_is_elementary_or_secondary_school_student: false
+    us:statutes/7/2014/d#input.person_age: 16
+    us:statutes/7/2014/d#input.child_earned_income_amount: 200
+  output:
+    us:statutes/7/2014/d#student_child_earned_income_excluded_from_snap_income: 0

--- a/statutes/7/2014/d.yaml
+++ b/statutes/7/2014/d.yaml
@@ -1,0 +1,110 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: |-
+    Household income for purposes of the supplemental nutrition assistance program shall include all income from whatever source excluding only income in the certification period which is received too infrequently or irregularly to be reasonably anticipated, but not in excess of $30 in a quarter, and income earned by a child who is a member of the household, who is an elementary or secondary school student, and who is 17 years of age or younger.
+  deferred_outputs:
+    - output: us:statutes/7/2014/d#snap_excluded_income_under_subsection_d
+      reason: Subsection (d) excludes many income categories; this file encodes selected source-backed leaves only, while the full aggregate requires additional branch encodings and upstream classifications.
+    - output: us:statutes/7/2014/d#other_federal_law_exclusions_from_snap_income
+      reason: Paragraph (10) excludes income categories identified by other Federal laws, but those upstream Federal-law exclusion rules are not enumerated in this source slice.
+    - output: us:statutes/7/2014/d#advance_earned_income_credit_payments_excluded_from_snap_income
+      reason: Paragraph (13) excludes payments made under 26 USC 3507, but no copied RuleSpec source provides that upstream classification.
+    - output: us:statutes/7/2014/d#section_2015_or_section_2025_work_related_or_dependent_care_payments_excluded_from_snap_income
+      reason: Paragraph (14) depends on 7 USC 2015(d)(4)(I) and 7 USC 2025(h)(1)(F), which are not copied into the workspace.
+    - output: us:statutes/7/2014/d#state_optional_medicaid_and_tanf_aligned_exclusions_from_snap_income
+      reason: Paragraphs (16) through (18) depend on State-option treatment aligned to title XIX or section 1931 medical assistance and part A of title IV cash assistance classifications that are not encoded here.
+rules:
+  - name: irregular_income_quarter_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 USC 2014(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "but not in excess of $30 in a quarter"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          30
+
+  - name: irregular_income_excluded_from_snap_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 USC 2014(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "any income in the certification period which is received too infrequently or irregularly to be reasonably anticipated, but not in excess of $30 in a quarter"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/7/2014/d#irregular_income_quarter_cap
+              output: irregular_income_quarter_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if income_received_too_infrequently_or_irregularly_to_be_reasonably_anticipated:
+            min(irregular_income_amount_in_certification_period, irregular_income_quarter_cap)
+          else: 0
+
+  - name: student_child_income_age_limit
+    kind: parameter
+    dtype: Integer
+    source: 7 USC 2014(d)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "17 years of age or younger"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          17
+
+  - name: student_child_earned_income_excluded_from_snap_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 USC 2014(d)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "income earned by a child who is a member of the household, who is an elementary or secondary school student, and who is 17 years of age or younger"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/7/2014/d#student_child_income_age_limit
+              output: student_child_income_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if person_is_child_member_of_household and person_is_elementary_or_secondary_school_student and person_age <= student_child_income_age_limit:
+            child_earned_income_amount
+          else: 0

--- a/statutes/7/2014/e/2/B.test.yaml
+++ b/statutes/7/2014/e/2/B.test.yaml
@@ -1,0 +1,5 @@
+- name: earned_income_deduction_rate_is_twenty_percent
+  period: 2026-01
+  input: {}
+  output:
+    us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate: 0.2

--- a/statutes/7/2014/e/2/B.yaml
+++ b/statutes/7/2014/e/2/B.yaml
@@ -1,0 +1,30 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: |-
+    Except as provided in subparagraph (C), a household with earned income shall be allowed a deduction of 20 percent of all earned income.
+  deferred_outputs:
+    - output: us:statutes/7/2014/e/2/B#snap_earned_income_deduction
+      reason: Subparagraph (B) makes the deduction amount subject to the same-section exception in subparagraph (C), but no copied RuleSpec source for 7 USC 2014(e)(2)(C) is available in this workspace to compute the adjusted earned-income base faithfully.
+      source_values:
+        - us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 USC 2014(e)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "20 percent of all earned income"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          0.20

--- a/statutes/7/2014/g.test.yaml
+++ b/statutes/7/2014/g.test.yaml
@@ -1,0 +1,55 @@
+- name: household_resource_limit_with_elderly_member_and_annual_adjustment
+  period: 2026-10
+  input:
+    us:statutes/7/2014/g#input.household_includes_elderly_or_disabled_member: true
+    us:statutes/7/2014/g#input.prior_unrounded_household_resource_limit_amount: 3000
+    us:statutes/7/2014/g#input.consumer_price_index_change_for_12_month_period_ending_preceding_june: 0.1
+  output:
+    us:statutes/7/2014/g#snap_household_resource_limit_base_amount: 2000
+    us:statutes/7/2014/g#snap_household_resource_limit_base_amount_with_elderly_or_disabled_member: 3000
+    us:statutes/7/2014/g#allowable_financial_resources_rounding_increment: 250
+    us:statutes/7/2014/g#statutory_household_resource_limit_base_amount: 3000
+    us:statutes/7/2014/g#next_annual_household_resource_limit_amount: 3250
+- name: licensed_vehicle_default_countable_amount
+  period: 2026-10
+  input:
+    us:statutes/7/2014/g#input.asset_is_licensed_vehicle: true
+    us:statutes/7/2014/g#input.asset_is_used_for_household_transportation_or_to_obtain_or_continue_employment: true
+    us:statutes/7/2014/g#input.vehicle_used_to_produce_earned_income: false
+    us:statutes/7/2014/g#input.vehicle_necessary_for_transport_of_physically_disabled_household_member: false
+    us:statutes/7/2014/g#input.vehicle_depended_on_to_carry_household_fuel_or_water: false
+    us:statutes/7/2014/g#input.vehicle_provides_household_primary_source_of_fuel_or_water: false
+    us:statutes/7/2014/g#input.state_vehicle_allowance_standards_apply_in_lieu_of_default_vehicle_rule: false
+    us:statutes/7/2014/g#input.asset_fair_market_value: 5000
+  output:
+    us:statutes/7/2014/g#licensed_vehicle_resource_fair_market_value_threshold: 4650
+    us:statutes/7/2014/g#vehicle_excluded_from_financial_resources_under_vehicle_exceptions: not_holds
+    us:statutes/7/2014/g#licensed_vehicle_countable_resource_amount_under_default_rule: 350
+- name: licensed_vehicle_state_alternative_displaces_default_rule
+  period: 2026-10
+  input:
+    us:statutes/7/2014/g#input.asset_is_licensed_vehicle: true
+    us:statutes/7/2014/g#input.asset_is_used_for_household_transportation_or_to_obtain_or_continue_employment: true
+    us:statutes/7/2014/g#input.vehicle_used_to_produce_earned_income: false
+    us:statutes/7/2014/g#input.vehicle_necessary_for_transport_of_physically_disabled_household_member: false
+    us:statutes/7/2014/g#input.vehicle_depended_on_to_carry_household_fuel_or_water: false
+    us:statutes/7/2014/g#input.vehicle_provides_household_primary_source_of_fuel_or_water: false
+    us:statutes/7/2014/g#input.state_vehicle_allowance_standards_apply_in_lieu_of_default_vehicle_rule: true
+    us:statutes/7/2014/g#input.asset_fair_market_value: 5000
+  output:
+    us:statutes/7/2014/g#vehicle_excluded_from_financial_resources_under_vehicle_exceptions: not_holds
+    us:statutes/7/2014/g#licensed_vehicle_countable_resource_amount_under_default_rule: 0
+- name: licensed_vehicle_earned_income_use_exclusion
+  period: 2026-10
+  input:
+    us:statutes/7/2014/g#input.asset_is_licensed_vehicle: true
+    us:statutes/7/2014/g#input.asset_is_used_for_household_transportation_or_to_obtain_or_continue_employment: true
+    us:statutes/7/2014/g#input.vehicle_used_to_produce_earned_income: true
+    us:statutes/7/2014/g#input.vehicle_necessary_for_transport_of_physically_disabled_household_member: false
+    us:statutes/7/2014/g#input.vehicle_depended_on_to_carry_household_fuel_or_water: false
+    us:statutes/7/2014/g#input.vehicle_provides_household_primary_source_of_fuel_or_water: false
+    us:statutes/7/2014/g#input.state_vehicle_allowance_standards_apply_in_lieu_of_default_vehicle_rule: false
+    us:statutes/7/2014/g#input.asset_fair_market_value: 5000
+  output:
+    us:statutes/7/2014/g#vehicle_excluded_from_financial_resources_under_vehicle_exceptions: holds
+    us:statutes/7/2014/g#licensed_vehicle_countable_resource_amount_under_default_rule: 0

--- a/statutes/7/2014/g.yaml
+++ b/statutes/7/2014/g.yaml
@@ -1,0 +1,199 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: |-
+    Households otherwise eligible for SNAP are ineligible if resources exceed "$2,000" or, for a household that consists of or includes an elderly or disabled member, "$3,000"; beginning on October 1, 2008, those amounts are adjusted and rounded down to the nearest "$250 increment." Financial resources include certain licensed vehicles above "$4,650" subject to vehicle exclusions and State alternative vehicle allowance standards, and paragraphs (3) through (8) exclude specified burial, self-sufficiency, farm, inaccessible, retirement, and education resources.
+  deferred_outputs:
+    - output: us:statutes/7/2014/g#countable_household_financial_resources
+      reason: Full household countable financial resources under 7 USC 2014(g) depend on Secretary-prescribed inclusions and exclusions across paragraphs (2) through (8), including optional State exclusions and category classifications for retirement and education accounts that this module does not model.
+    - output: us:statutes/7/2014/g#excluded_self_sufficiency_resources
+      reason: Paragraph (3) partly depends on participation in a pilot project under 7 USC 2025(h)(1)(F), and no copied RuleSpec target encodes that cited provision.
+rules:
+  - name: snap_household_resource_limit_base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 USC 2014(g)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'resources exceed $2,000'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          2000
+
+  - name: snap_household_resource_limit_base_amount_with_elderly_or_disabled_member
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 USC 2014(g)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'includes an elderly or disabled member, if its resources exceed $3,000'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          3000
+
+  - name: allowable_financial_resources_rounding_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 USC 2014(g)(1)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'rounded down to the nearest $250 increment'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          250
+
+  - name: statutory_household_resource_limit_base_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 USC 2014(g)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'resources exceed $2,000 ... includes an elderly or disabled member ... exceed $3,000'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if household_includes_elderly_or_disabled_member: snap_household_resource_limit_base_amount_with_elderly_or_disabled_member else: snap_household_resource_limit_base_amount
+
+  - name: next_annual_household_resource_limit_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 USC 2014(g)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'Beginning on October 1, 2008'
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'shall be adjusted and rounded down to the nearest $250 increment'
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'Each adjustment ... shall be based on the unrounded amount for the prior 12-month period'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          floor((prior_unrounded_household_resource_limit_amount * (1 + consumer_price_index_change_for_12_month_period_ending_preceding_june)) / allowable_financial_resources_rounding_increment) * allowable_financial_resources_rounding_increment
+
+  - name: licensed_vehicle_resource_fair_market_value_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 USC 2014(g)(2)(B)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'fair market value of the vehicle exceeds $4,650'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          4650
+
+  - name: vehicle_excluded_from_financial_resources_under_vehicle_exceptions
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Month
+    source: 7 USC 2014(g)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'used to produce earned income'
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'necessary for the transportation of a physically disabled household member'
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'carry fuel for heating or water for home use and provides the primary source of fuel or water'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          vehicle_used_to_produce_earned_income
+          or vehicle_necessary_for_transport_of_physically_disabled_household_member
+          or (
+            vehicle_depended_on_to_carry_household_fuel_or_water
+            and vehicle_provides_household_primary_source_of_fuel_or_water
+          )
+
+  - name: licensed_vehicle_countable_resource_amount_under_default_rule
+    kind: derived
+    entity: Asset
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 USC 2014(g)(2)(B)(iv); 7 USC 2014(g)(2)(C); 7 USC 2014(g)(2)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'any licensed vehicle that is used for household transportation or to obtain or continue employment to the extent that the fair market value of the vehicle exceeds $4,650'
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'shall not be included in financial resources under this paragraph if the vehicle is'
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: 'in lieu of applying subparagraph (B)(iv), the State agency may elect to apply the State vehicle allowance standards'
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if asset_is_licensed_vehicle and asset_is_used_for_household_transportation_or_to_obtain_or_continue_employment and not vehicle_excluded_from_financial_resources_under_vehicle_exceptions and not state_vehicle_allowance_standards_apply_in_lieu_of_default_vehicle_rule and asset_fair_market_value > licensed_vehicle_resource_fair_market_value_threshold: asset_fair_market_value - licensed_vehicle_resource_fair_market_value_threshold else: 0


### PR DESCRIPTION
Two more federal SNAP subsections via axiom-encode 0.2.336 encode --apply.

- 7 USC 2014(d) Exclusions from income — source-backed leaves with deferred_outputs for upstream-dependent paragraphs
- 7 USC 2014(g) Allowable financial resources — $2,000 / $3,000 / $4,650 thresholds with deferred outputs for paragraphs (2)-(8) inclusions/exclusions

Both pass compile, CI, generalist 8.5/10, zero ungrounded. Signed apply manifests included.

Continues the Tier 1 chain from rulespec-us#241 ((e)(2)(B) rate).

Subsections (a) and (c) attempted in the same batch but blocked on encoder validator issues — scope mismatch for (a), concept-registry violations for (c). Filed for encoder iteration.