### PR TITLE
Add generated section 3404 withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3404.json
+++ b/.axiom/encoding-manifests/statutes/26/3404.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3404.yaml",
+      "sha256": "d5fc7cf878c60cf1bb5ab5445d2ac4fa441254c9260dd0a48985f085d0abc278"
+    },
+    {
+      "path": "statutes/26/3404.test.yaml",
+      "sha256": "a1e7d9873081adb14d6fa40e66913817a557d01ce878e0a3af40405a146db015"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c21739087c481634380eaca279420c25b79358be",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.356",
+    "version_commit": "c21739087c481634380eaca279420c25b79358be"
+  },
+  "axiom_encode_version": "0.2.356",
+  "backend": "openai",
+  "citation": "26 USC 3404",
+  "context_manifest_file": "/tmp/axiom-encode-3404-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3404/workspace/context-manifest.json",
+  "context_manifest_sha256": "4ef2c4671dc71576e4f79b9c352cd93119efb1f725948584943b38e4d5c0f0c8",
+  "generated_at": "2026-05-28T03:41:18.637965+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3404-20260528-001/openai-gpt-5.5/statutes/26/3404.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3404-20260528-001",
+  "generated_output_sha256": "d5fc7cf878c60cf1bb5ab5445d2ac4fa441254c9260dd0a48985f085d0abc278",
+  "generation_prompt_sha256": "6f33b00cf07ab79006b4e6f6b7257c08d057428e7cfd65446cb0ad0721bd5ad6",
+  "model": "gpt-5.5",
+  "run_id": "8a76e69d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5ea1f68b7f6663f34c326e765b209b4249ad410d43d4f916056d6446f1c332df"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3404-20260528-001/traces/openai-gpt-5.5/26-USC-3404.json",
+  "trace_sha256": "33f18288dffb857c1248a4bef3ff81d16fa559efe67ebb1c3ebd96acd8dcb2da"
+}

--- a/statutes/26/3404.test.yaml
+++ b/statutes/26/3404.test.yaml
@@ -1,0 +1,65 @@
+- name: officer_with_control_authorized_to_make_return
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3404#input.employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+    : true
+    us:statutes/26/3404#input.person_is_officer_or_employee_of_that_government_employer: true
+    us:statutes/26/3404#input.person_has_control_of_payment_of_wages: true
+    us:statutes/26/3404#input.person_is_appropriately_designated_to_make_withholding_return: false
+  output:
+    us:statutes/26/3404#government_employer_withholding_return_maker_authorized: holds
+- name: designated_employee_authorized_to_make_return
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3404#input.employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+    : true
+    us:statutes/26/3404#input.person_is_officer_or_employee_of_that_government_employer: true
+    us:statutes/26/3404#input.person_has_control_of_payment_of_wages: false
+    us:statutes/26/3404#input.person_is_appropriately_designated_to_make_withholding_return: true
+  output:
+    us:statutes/26/3404#government_employer_withholding_return_maker_authorized: holds
+- name: non_government_employer_not_authorized_under_section_3404
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3404#input.employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+    : false
+    us:statutes/26/3404#input.person_is_officer_or_employee_of_that_government_employer: true
+    us:statutes/26/3404#input.person_has_control_of_payment_of_wages: true
+    us:statutes/26/3404#input.person_is_appropriately_designated_to_make_withholding_return: false
+  output:
+    us:statutes/26/3404#government_employer_withholding_return_maker_authorized: not_holds
+- name: non_officer_or_employee_not_authorized_under_section_3404
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3404#input.employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+    : true
+    us:statutes/26/3404#input.person_is_officer_or_employee_of_that_government_employer: false
+    us:statutes/26/3404#input.person_has_control_of_payment_of_wages: true
+    us:statutes/26/3404#input.person_is_appropriately_designated_to_make_withholding_return: false
+  output:
+    us:statutes/26/3404#government_employer_withholding_return_maker_authorized: not_holds
+- name: officer_or_employee_without_control_or_designation_not_authorized
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3404#input.employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+    : true
+    us:statutes/26/3404#input.person_is_officer_or_employee_of_that_government_employer: true
+    us:statutes/26/3404#input.person_has_control_of_payment_of_wages: false
+    us:statutes/26/3404#input.person_is_appropriately_designated_to_make_withholding_return: false
+  output:
+    us:statutes/26/3404#government_employer_withholding_return_maker_authorized: not_holds

--- a/statutes/26/3404.yaml
+++ b/statutes/26/3404.yaml
@@ -1,0 +1,35 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3404
+  summary: |-
+    If the employer is the United States, a State, a political subdivision, the District of Columbia, or an agency or instrumentality of the foregoing, the return of the amount deducted and withheld upon wages may be made by an officer or employee of that government employer having control of wage payment or appropriately designated for that purpose.
+rules:
+  - name: government_employer_withholding_return_maker_authorized
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3404
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3404
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3404
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_united_states_state_political_subdivision_district_of_columbia_or_agency_or_instrumentality
+          and person_is_officer_or_employee_of_that_government_employer
+          and (
+              person_has_control_of_payment_of_wages
+              or person_is_appropriately_designated_to_make_withholding_return
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3404
- add generated companion tests for the government-employer withholding return-maker authorization
- add the signed axiom-encode apply manifest

## Provenance
- generated by axiom-encode encode --apply
- model: gpt-5.5
- run id: 8a76e69d
- encoder version in manifest: 0.2.356
- coverage classifier merged in TheAxiomFoundation/axiom-encode#382

## Validation
- axiom-encode validate statutes/26/3404.yaml --skip-reviewers --require-oracle-classification --json
- axiom-encode proof-validate statutes/26/3404.yaml --json
- axiom-encode test statutes/26/3404.test.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json
- axiom-encode oracle-coverage --root current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json