### PR TITLE
Add generated section 3405(b) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/b.yaml",
+      "sha256": "a5cc3d11303fea5319af6aa869eb6933bafbd833e1993487c263759435d5d457"
+    },
+    {
+      "path": "statutes/26/3405/b.test.yaml",
+      "sha256": "d85b6e93960ddeb2315a763b176c563e065c3ea00d5179de0b98ac0de991d64a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1a0aca26da0bc38d85e545d67e43a93d14be29b4",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.357",
+    "version_commit": "1a0aca26da0bc38d85e545d67e43a93d14be29b4"
+  },
+  "axiom_encode_version": "0.2.357",
+  "backend": "openai",
+  "citation": "26 USC 3405(b)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-b-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "6172f0279437b02b83a466a67ad1dd8788b018ebb998255a453d0a5853d6b90f",
+  "generated_at": "2026-05-28T04:09:39.981705+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-b-20260528-001/openai-gpt-5.5/statutes/26/3405/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-b-20260528-001",
+  "generated_output_sha256": "a5cc3d11303fea5319af6aa869eb6933bafbd833e1993487c263759435d5d457",
+  "generation_prompt_sha256": "e2c94f85c397514ccdc15843b01edc824e54c0b0535cee912bd9e0c31a31b105",
+  "model": "gpt-5.5",
+  "run_id": "31912525",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4e648c063b0c7eaa4937eacd6cc757c4910160fe16a922d258d75c0585c32669"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-b-20260528-001/traces/openai-gpt-5.5/26-USC-3405-b.json",
+  "trace_sha256": "ce829accbd2de9b6be430f58f636db927bec4b9c749abe93c01131759f4a4fb6"
+}

--- a/statutes/26/3405/b.test.yaml
+++ b/statutes/26/3405/b.test.yaml
@@ -1,0 +1,52 @@
+- name: nonperiodic_distribution_withholding_without_election
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/b#input.nonperiodic_distribution_amount: 1000
+    us:statutes/26/3405/b#input.individual_elects_no_withholding_for_nonperiodic_distribution: false
+    us:statutes/26/3405/b#input.regulations_provide_election_may_apply_to_subsequent_nonperiodic_distributions: false
+    us:statutes/26/3405/b#input.subsequent_nonperiodic_distribution_made_by_same_payor_to_payee_under_same_arrangement: false
+  output:
+    us:statutes/26/3405/b#nonperiodic_distribution_withholding: 100
+    us:statutes/26/3405/b#election_scope_for_current_nonperiodic_distribution: not_holds
+    us:statutes/26/3405/b#election_scope_for_subsequent_nonperiodic_distributions: not_holds
+- name: election_of_no_withholding_zeroes_current_distribution_withholding
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/b#input.nonperiodic_distribution_amount: 1000
+    us:statutes/26/3405/b#input.individual_elects_no_withholding_for_nonperiodic_distribution: true
+    us:statutes/26/3405/b#input.regulations_provide_election_may_apply_to_subsequent_nonperiodic_distributions: false
+    us:statutes/26/3405/b#input.subsequent_nonperiodic_distribution_made_by_same_payor_to_payee_under_same_arrangement: false
+  output:
+    us:statutes/26/3405/b#nonperiodic_distribution_withholding: 0
+    us:statutes/26/3405/b#election_scope_for_current_nonperiodic_distribution: holds
+    us:statutes/26/3405/b#election_scope_for_subsequent_nonperiodic_distributions: not_holds
+- name: election_may_apply_to_subsequent_distribution_under_regulations_same_arrangement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/b#input.nonperiodic_distribution_amount: 500
+    us:statutes/26/3405/b#input.individual_elects_no_withholding_for_nonperiodic_distribution: true
+    us:statutes/26/3405/b#input.regulations_provide_election_may_apply_to_subsequent_nonperiodic_distributions: true
+    us:statutes/26/3405/b#input.subsequent_nonperiodic_distribution_made_by_same_payor_to_payee_under_same_arrangement: true
+  output:
+    us:statutes/26/3405/b#election_scope_for_subsequent_nonperiodic_distributions: holds
+- name: subsequent_election_scope_requires_same_arrangement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/b#input.nonperiodic_distribution_amount: 500
+    us:statutes/26/3405/b#input.individual_elects_no_withholding_for_nonperiodic_distribution: true
+    us:statutes/26/3405/b#input.regulations_provide_election_may_apply_to_subsequent_nonperiodic_distributions: true
+    us:statutes/26/3405/b#input.subsequent_nonperiodic_distribution_made_by_same_payor_to_payee_under_same_arrangement: false
+  output:
+    us:statutes/26/3405/b#election_scope_for_subsequent_nonperiodic_distributions: not_holds

--- a/statutes/26/3405/b.yaml
+++ b/statutes/26/3405/b.yaml
@@ -1,0 +1,99 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: The payor of any nonperiodic distribution shall withhold an amount equal
+    to 10 percent of such distribution. An individual may elect not to have that withholding
+    apply with respect to any nonperiodic distribution; the election is distribution-by-distribution
+    except as regulations allow it to apply to subsequent nonperiodic distributions
+    under the same arrangement.
+rules:
+- name: nonperiodic_distribution_withholding_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3405(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3405
+          excerpt: an amount equal to 10 percent of such distribution
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.10'
+- name: nonperiodic_distribution_withholding
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3405(b)(1), 3405(b)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3405
+          excerpt: The payor of any nonperiodic distribution ... shall withhold from
+            such distribution an amount equal to 10 percent of such distribution.
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3405
+          excerpt: An individual may elect not to have paragraph (1) apply with respect
+            to any nonperiodic distribution.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3405/b#nonperiodic_distribution_withholding_rate
+          output: nonperiodic_distribution_withholding_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if individual_elects_no_withholding_for_nonperiodic_distribution: 0
+      else: nonperiodic_distribution_withholding_rate * max(0, nonperiodic_distribution_amount)'
+- name: election_scope_for_current_nonperiodic_distribution
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3405(b)(2)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3405
+          excerpt: shall be on a distribution-by-distribution basis
+  versions:
+  - effective_from: '1990-01-01'
+    formula: individual_elects_no_withholding_for_nonperiodic_distribution
+- name: election_scope_for_subsequent_nonperiodic_distributions
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3405(b)(2)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3405
+          excerpt: to the extent provided in regulations, may apply to subsequent
+            nonperiodic distributions made by the payor to the payee under the same
+            arrangement
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'regulations_provide_election_may_apply_to_subsequent_nonperiodic_distributions
+
+      and subsequent_nonperiodic_distribution_made_by_same_payor_to_payee_under_same_arrangement
+
+      and individual_elects_no_withholding_for_nonperiodic_distribution'


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3405(b) nonperiodic distribution withholding
- add generated companion tests for the 10 percent withholding rule and no-withholding election scope
- add the signed axiom-encode apply manifest

## Provenance
- generated by axiom-encode encode --apply
- model: gpt-5.5
- run id: 31912525
- encoder version in manifest: 0.2.357
- coverage classifier merged in TheAxiomFoundation/axiom-encode#384

## Validation
- axiom-encode validate statutes/26/3405/b.yaml --skip-reviewers --require-oracle-classification --json
- axiom-encode proof-validate statutes/26/3405/b.yaml --json
- axiom-encode test statutes/26/3405/b.test.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json
- axiom-encode oracle-coverage --root current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json