### PR TITLE
Add generated section 3405(c) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/c.yaml",
+      "sha256": "1b499dee5ab48251a5d64e0ecfeab460a6f1b19dc9b4f815be9b330b624c2475"
+    },
+    {
+      "path": "statutes/26/3405/c.test.yaml",
+      "sha256": "a991b5ad0124ba1b6ad5cebbf95642c1fc9d7122326427a851f4632287fad36b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5521cb5028b7c8d9505cb8e553cd222cbada7069",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.358",
+    "version_commit": "5521cb5028b7c8d9505cb8e553cd222cbada7069"
+  },
+  "axiom_encode_version": "0.2.358",
+  "backend": "openai",
+  "citation": "26 USC 3405(c)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-c-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "4299d7801f52b5a70d162da458e78f28e7deaa96d18f7cb13f6213f52c563422",
+  "generated_at": "2026-05-28T04:27:54.454329+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-c-20260528-001/openai-gpt-5.5/statutes/26/3405/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-c-20260528-001",
+  "generated_output_sha256": "1b499dee5ab48251a5d64e0ecfeab460a6f1b19dc9b4f815be9b330b624c2475",
+  "generation_prompt_sha256": "2051d8e77d8444cc5fcbcd6157c0c7109cb989d4fd63ef8171ec1f6ef0d74a64",
+  "model": "gpt-5.5",
+  "run_id": "3f34c9eb",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "528c67c1de17f76f7bf123fa0e3423c7d00971a2c15cfa69115030d52f9a7c13"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-c-20260528-001/traces/openai-gpt-5.5/26-USC-3405-c.json",
+  "trace_sha256": "6c80489092401c66473055cde79fad76c37857c74643fa68f598bcdc441d6712"
+}

--- a/statutes/26/3405/c.test.yaml
+++ b/statutes/26/3405/c.test.yaml
@@ -1,0 +1,8 @@
+- name: eligible_rollover_distribution_withholding_rate_parameter
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3405/c#eligible_rollover_distribution_withholding_rate: 0.2

--- a/statutes/26/3405/c.yaml
+++ b/statutes/26/3405/c.yaml
@@ -1,0 +1,32 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: |-
+    In the case of a designated distribution which is an eligible rollover distribution, subsections (a) and (b) shall not apply, and the payor shall withhold 20 percent; paragraph (1)(B) does not apply if the distributee elects under section 401(a)(31)(A) direct payment to an eligible retirement plan; "eligible rollover distribution" has the meaning given by section 402(f)(2)(A).
+  deferred_outputs:
+    - output: us:statutes/26/3405/c#eligible_rollover_distribution_withholding
+      reason: Computing final withholding requires the missing upstream definition of "eligible rollover distribution" in section 402(f)(2)(A) and the missing direct-payment election exception under section 401(a)(31)(A).
+      source_values:
+        - us:statutes/26/3405/c#eligible_rollover_distribution_withholding_rate
+    - output: us:statutes/26/3405/c#subsections_a_and_b_do_not_apply_to_eligible_rollover_distribution
+      reason: Applicability of the override depends on the missing upstream definition of "eligible rollover distribution" in section 402(f)(2)(A).
+rules:
+  - name: eligible_rollover_distribution_withholding_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3405(c)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: an amount equal to 20 percent of such distribution
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3405(c) eligible rollover distribution withholding rate
- add generated companion test and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `3f34c9eb`, encoder manifest version `0.2.358`; PE coverage classifier merged in TheAxiomFoundation/axiom-encode#385

## Validation
- `uv run axiom-encode validate statutes/26/3405/c.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate statutes/26/3405/c.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --json`
- `uv run axiom-encode test statutes/26/3405/c.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current`
- `uv run axiom-encode guard-generated --policy-repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`