### PR TITLE
Add generated section 3405(d) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/d.yaml",
+      "sha256": "5e0934865b4f48fdf991472911108f67e47c14ad66db0f6301622499716a25a1"
+    },
+    {
+      "path": "statutes/26/3405/d.test.yaml",
+      "sha256": "fb7870ab56f8c73e1079f2fb789ea54dd4a69c62e1f4aa7e57ef23f1ef9d5fb9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e2b36927fcad66d48767b72853f7c4074d757769",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.359",
+    "version_commit": "e2b36927fcad66d48767b72853f7c4074d757769"
+  },
+  "axiom_encode_version": "0.2.359",
+  "backend": "openai",
+  "citation": "26 USC 3405(d)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-d-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "ccbb3fe55108af47ce71c59a117a745d381b9e786c2785ea5b73bed192d032d7",
+  "generated_at": "2026-05-28T04:50:07.940418+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-d-20260528-001/openai-gpt-5.5/statutes/26/3405/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-d-20260528-001",
+  "generated_output_sha256": "5e0934865b4f48fdf991472911108f67e47c14ad66db0f6301622499716a25a1",
+  "generation_prompt_sha256": "5fa2c5e03fcdd1b61c0c436b34a27d49e92fcefaa9a24bcc684d1bb0e1153836",
+  "model": "gpt-5.5",
+  "run_id": "c3ac4d8d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "261088d8eb20eb51b7594c1d25967a7622e57b4dcaeae27c6cb653643113b615"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-d-20260528-001/traces/openai-gpt-5.5/26-USC-3405-d.json",
+  "trace_sha256": "dcc84c4669e29e5f2e06ec4823644fd306c65ea8ef1c2a8a122e0d2f6b10937d"
+}

--- a/statutes/26/3405/d.test.yaml
+++ b/statutes/26/3405/d.test.yaml
@@ -1,0 +1,72 @@
+- name: ordinary_designated_distribution_payor_liable
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/d#input.payment_is_designated_distribution_as_defined_in_subsection_e_1: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_401_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_403_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_301_d_tax_reduction_act_1975: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_457_b: false
+    us:statutes/26/3405/d#input.plan_is_maintained_by_eligible_employer_described_in_section_457_e_1_A: false
+    us:statutes/26/3405/d#input.plan_administrator_directs_payor_to_withhold_tax: false
+    us:statutes/26/3405/d#input.plan_administrator_provides_payor_information_required_by_secretary_regulations: false
+  output:
+    us:statutes/26/3405/d#paragraph_two_plan_applies: not_holds
+    us:statutes/26/3405/d#payor_withholding_liability: holds
+    us:statutes/26/3405/d#plan_administrator_withholding_liability: not_holds
+- name: section_401_a_plan_administrator_liable_without_unless_conditions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/d#input.payment_is_designated_distribution_as_defined_in_subsection_e_1: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_401_a: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_403_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_301_d_tax_reduction_act_1975: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_457_b: false
+    us:statutes/26/3405/d#input.plan_is_maintained_by_eligible_employer_described_in_section_457_e_1_A: false
+    us:statutes/26/3405/d#input.plan_administrator_directs_payor_to_withhold_tax: false
+    us:statutes/26/3405/d#input.plan_administrator_provides_payor_information_required_by_secretary_regulations: false
+  output:
+    us:statutes/26/3405/d#paragraph_two_plan_applies: holds
+    us:statutes/26/3405/d#payor_withholding_liability: not_holds
+    us:statutes/26/3405/d#plan_administrator_withholding_liability: holds
+- name: plan_administrator_direction_and_information_shift_liability_to_payor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/d#input.payment_is_designated_distribution_as_defined_in_subsection_e_1: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_401_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_403_a: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_301_d_tax_reduction_act_1975: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_457_b: false
+    us:statutes/26/3405/d#input.plan_is_maintained_by_eligible_employer_described_in_section_457_e_1_A: false
+    us:statutes/26/3405/d#input.plan_administrator_directs_payor_to_withhold_tax: true
+    us:statutes/26/3405/d#input.plan_administrator_provides_payor_information_required_by_secretary_regulations: true
+  output:
+    us:statutes/26/3405/d#paragraph_two_plan_applies: holds
+    us:statutes/26/3405/d#payor_withholding_liability: holds
+    us:statutes/26/3405/d#plan_administrator_withholding_liability: not_holds
+- name: section_457_b_plan_requires_eligible_employer_maintenance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/d#input.payment_is_designated_distribution_as_defined_in_subsection_e_1: true
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_401_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_403_a: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_301_d_tax_reduction_act_1975: false
+    us:statutes/26/3405/d#input.plan_is_described_in_or_determined_described_in_section_457_b: true
+    us:statutes/26/3405/d#input.plan_is_maintained_by_eligible_employer_described_in_section_457_e_1_A: false
+    us:statutes/26/3405/d#input.plan_administrator_directs_payor_to_withhold_tax: false
+    us:statutes/26/3405/d#input.plan_administrator_provides_payor_information_required_by_secretary_regulations: false
+  output:
+    us:statutes/26/3405/d#paragraph_two_plan_applies: not_holds
+    us:statutes/26/3405/d#payor_withholding_liability: holds
+    us:statutes/26/3405/d#plan_administrator_withholding_liability: not_holds

--- a/statutes/26/3405/d.yaml
+++ b/statutes/26/3405/d.yaml
@@ -1,0 +1,99 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: |-
+    The payor of a designated distribution shall withhold and be liable for the tax required under section 3405, except that for specified plans the plan administrator is liable unless the administrator directs the payor to withhold and provides required information. The specified plans are those described in or determined to be described in section 401(a), section 403(a), section 301(d) of the Tax Reduction Act of 1975, or section 457(b) maintained by an eligible employer described in section 457(e)(1)(A).
+rules:
+  - name: paragraph_two_plan_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(d)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          plan_is_described_in_or_determined_described_in_section_401_a
+          or plan_is_described_in_or_determined_described_in_section_403_a
+          or plan_is_described_in_or_determined_described_in_section_301_d_tax_reduction_act_1975
+          or (
+            plan_is_described_in_or_determined_described_in_section_457_b
+            and plan_is_maintained_by_eligible_employer_described_in_section_457_e_1_A
+          )
+  - name: plan_administrator_withholding_liability
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(d)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3405
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3405
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3405/d#paragraph_two_plan_applies
+              output: paragraph_two_plan_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_designated_distribution_as_defined_in_subsection_e_1
+          and paragraph_two_plan_applies
+          and not (
+            plan_administrator_directs_payor_to_withhold_tax
+            and plan_administrator_provides_payor_information_required_by_secretary_regulations
+          )
+  - name: payor_withholding_liability
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(d)(1), 3405(d)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/statute/26/3405
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3405
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3405/d#paragraph_two_plan_applies
+              output: paragraph_two_plan_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_designated_distribution_as_defined_in_subsection_e_1
+          and (
+            not paragraph_two_plan_applies
+            or (
+              paragraph_two_plan_applies
+              and plan_administrator_directs_payor_to_withhold_tax
+              and plan_administrator_provides_payor_information_required_by_secretary_regulations
+            )
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3405(d) payor and plan-administrator withholding liability
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `c3ac4d8d`, encoder version `0.2.359`

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/d.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/d.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/d.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`