### PR TITLE
Add generated section 3405(e) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/e.yaml",
+      "sha256": "0f680c84365a9db2da5228475970d56d8fe879ecbc9f8d146a50f10e302d1ca2"
+    },
+    {
+      "path": "statutes/26/3405/e.test.yaml",
+      "sha256": "a40adee152dc94f6341c67f3769d232bd0f6244ef0dce86855ce76d1615f2a54"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e2b36927fcad66d48767b72853f7c4074d757769",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.359",
+    "version_commit": "e2b36927fcad66d48767b72853f7c4074d757769"
+  },
+  "axiom_encode_version": "0.2.359",
+  "backend": "openai",
+  "citation": "26 USC 3405(e)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-e-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "bacc158b31fb282fda31f9a4671abd5ce8a2865d6be2b13ddf3270cfd4588165",
+  "generated_at": "2026-05-28T04:55:27.811251+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-e-20260528-001/openai-gpt-5.5/statutes/26/3405/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-e-20260528-001",
+  "generated_output_sha256": "0f680c84365a9db2da5228475970d56d8fe879ecbc9f8d146a50f10e302d1ca2",
+  "generation_prompt_sha256": "a3359792ab5d66f0f5840fe27a50d0d3990feb5b47dbd3f59a76415978a7bfae",
+  "model": "gpt-5.5",
+  "run_id": "b3b44c40",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "17cd6112dc6e3d24cb88b987aabce9ff53506b8abe34dd5cc8e068e101f61d81"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-e-20260528-001/traces/openai-gpt-5.5/26-USC-3405-e.json",
+  "trace_sha256": "2164344b407b91f934558640d507675cbfdd0a560802180351450daecd88ec5e"
+}

--- a/statutes/26/3405/e.test.yaml
+++ b/statutes/26/3405/e.test.yaml
@@ -1,0 +1,66 @@
+- name: periodic_and_nonperiodic_classification
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    us:statutes/26/3405/e#input.payment_is_annuity_or_similar_periodic_payment: true
+  output:
+    us:statutes/26/3405/e#periodic_payment: holds
+    us:statutes/26/3405/e#nonperiodic_distribution: not_holds
+- name: nonperiodic_distribution_when_not_periodic
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    us:statutes/26/3405/e#input.payment_is_annuity_or_similar_periodic_payment: false
+  output:
+    us:statutes/26/3405/e#periodic_payment: not_holds
+    us:statutes/26/3405/e#nonperiodic_distribution: holds
+- name: plan_annuity_notices_and_tin_failure
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_from_pension_annuity_profit_sharing_or_stock_bonus_plan: true
+    us:statutes/26/3405/e#input.payment_from_other_plan_deferring_receipt_of_compensation: false
+    us:statutes/26/3405/e#input.contract_is_annuity_endowment_or_life_insurance_contract: true
+    us:statutes/26/3405/e#input.contract_issued_by_insurance_company_licensed_under_state_law: true
+    ? us:statutes/26/3405/e#input.payor_transmits_periodic_payment_election_notice_not_earlier_than_six_months_before_first_payment
+    : true
+    us:statutes/26/3405/e#input.payor_transmits_periodic_payment_election_notice_not_later_than_first_payment: true
+    us:statutes/26/3405/e#input.periodic_payment_first_notice_not_transmitted_when_making_first_payment: true
+    us:statutes/26/3405/e#input.payor_transmits_periodic_payment_election_notice_when_making_first_payment: true
+    ? us:statutes/26/3405/e#input.payor_transmits_notice_of_periodic_payment_election_and_revocation_rights_at_least_once_each_calendar_year
+    : true
+    us:statutes/26/3405/e#input.payor_transmits_nonperiodic_distribution_election_notice_at_time_of_distribution: true
+    us:statutes/26/3405/e#input.payor_transmits_nonperiodic_distribution_election_notice_at_earlier_regulatory_time: false
+    us:statutes/26/3405/e#input.payment_action_is_withholding_withhold_or_withheld: true
+    us:statutes/26/3405/e#input.payment_action_is_deducting_deduct_or_deducted: false
+    us:statutes/26/3405/e#input.payee_fails_to_furnish_tin_to_payor_in_required_manner: true
+    us:statutes/26/3405/e#input.secretary_notifies_payor_before_payment_or_distribution_that_payee_tin_is_incorrect: false
+  output:
+    us:statutes/26/3405/e#employer_deferred_compensation_plan: holds
+    us:statutes/26/3405/e#commercial_annuity: holds
+    us:statutes/26/3405/e#periodic_payment_first_notice_timely: holds
+    us:statutes/26/3405/e#periodic_payment_first_payment_notice_required_when_not_previously_transmitted: holds
+    us:statutes/26/3405/e#annual_periodic_payment_election_and_revocation_notice: holds
+    us:statutes/26/3405/e#nonperiodic_distribution_election_notice: holds
+    us:statutes/26/3405/e#withholding_includes_deduction: holds
+    us:statutes/26/3405/e#withholding_election_not_in_effect_due_to_tin_failure: holds
+    us:statutes/26/3405/e#subsection_a_four_not_apply_due_to_tin_failure: holds
+- name: scalar_and_person_arrangement_rule
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3405/e#input.payor_has_more_than_one_arrangement_under_which_designated_distributions_may_be_made_to_individual
+    : true
+  output:
+    us:statutes/26/3405/e#cash_in_lieu_of_fractional_shares_threshold: 200
+    us:statutes/26/3405/e#separate_arrangements_treated_separately: holds

--- a/statutes/26/3405/e.yaml
+++ b/statutes/26/3405/e.yaml
@@ -1,0 +1,264 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: |-
+    For purposes of section 3405, subsection (e) defines designated distribution, periodic payment, nonperiodic distribution, employer deferred compensation plan, commercial annuity, plan administrator, maximum amount withheld, separate-arrangement treatment, election timing and notice rules, withholding terminology, TIN failure consequences, and limits on elections for certain payments delivered outside the United States or its possessions.
+  deferred_outputs:
+    - output: us:statutes/26/3405/e#designated_distribution
+      reason: The definition depends in part on missing upstream definitions and exclusions in section 7701(a)(37), section 404(k)(2), and subchapter A of chapter 3/tax-treaty withholding status; those cited mechanics are not available as copied RuleSpec sources.
+    - output: us:statutes/26/3405/e#plan_administrator
+      reason: The term has the meaning given by missing upstream section 414(g), which is not available as copied RuleSpec context.
+    - output: us:statutes/26/3405/e#maximum_amount_withheld
+      reason: The cap depends on identifying "securities of the employer corporation" as defined in missing upstream section 402(e)(4)(E), which is not available as copied RuleSpec context.
+      source_values:
+        - us:statutes/26/3405/e#cash_in_lieu_of_fractional_shares_threshold
+    - output: us:statutes/26/3405/e#election_may_be_made_for_outside_delivery_payment
+      reason: The outside-delivery election exception depends on whether the recipient is an individual to whom missing upstream section 877 applies, which is not available as copied RuleSpec context.
+rules:
+  - name: cash_in_lieu_of_fractional_shares_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3405(e)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: cash (not in excess of $200) in lieu of financial shares
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          200
+
+  - name: periodic_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_designated_distribution_as_defined_in_section_3405_e_1
+          and payment_is_annuity_or_similar_periodic_payment
+
+  - name: nonperiodic_distribution
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_designated_distribution_as_defined_in_section_3405_e_1
+          and not periodic_payment
+
+  - name: employer_deferred_compensation_plan
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_from_pension_annuity_profit_sharing_or_stock_bonus_plan
+          or payment_from_other_plan_deferring_receipt_of_compensation
+
+  - name: commercial_annuity
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          contract_is_annuity_endowment_or_life_insurance_contract
+          and contract_issued_by_insurance_company_licensed_under_state_law
+
+  - name: separate_arrangements_treated_separately
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payor_has_more_than_one_arrangement_under_which_designated_distributions_may_be_made_to_individual
+
+  - name: periodic_payment_first_notice_timely
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(10)(B)(i)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: not earlier than 6 months before the first of such payments and not later than when making the first of such payments
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payor_transmits_periodic_payment_election_notice_not_earlier_than_six_months_before_first_payment
+          and payor_transmits_periodic_payment_election_notice_not_later_than_first_payment
+
+  - name: periodic_payment_first_payment_notice_required_when_not_previously_transmitted
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(10)(B)(i)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          periodic_payment_first_notice_not_transmitted_when_making_first_payment
+          and payor_transmits_periodic_payment_election_notice_when_making_first_payment
+
+  - name: annual_periodic_payment_election_and_revocation_notice
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(10)(B)(i)(III)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: not less frequently than once each calendar year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payor_transmits_notice_of_periodic_payment_election_and_revocation_rights_at_least_once_each_calendar_year
+
+  - name: nonperiodic_distribution_election_notice
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(10)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payor_transmits_nonperiodic_distribution_election_notice_at_time_of_distribution
+          or payor_transmits_nonperiodic_distribution_election_notice_at_earlier_regulatory_time
+
+  - name: withholding_includes_deduction
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_action_is_withholding_withhold_or_withheld
+          or payment_action_is_deducting_deduct_or_deducted
+
+  - name: withholding_election_not_in_effect_due_to_tin_failure
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payee_fails_to_furnish_tin_to_payor_in_required_manner
+          or secretary_notifies_payor_before_payment_or_distribution_that_payee_tin_is_incorrect
+
+  - name: subsection_a_four_not_apply_due_to_tin_failure
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(e)(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          withholding_election_not_in_effect_due_to_tin_failure


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3405(e) withholding definitions and related notice/TIN rules
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `b3b44c40`, encoder version `0.2.359`

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/e.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/e.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/e.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`