### PR TITLE
Add generated section 3405(a) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/a.yaml",
+      "sha256": "d31bded0631afd9ccfc1bf41b1e4372547dd9d4d8cd6c09740030fff01309a7e"
+    },
+    {
+      "path": "statutes/26/3405/a.test.yaml",
+      "sha256": "5b652ce5ce08315995cd93381227355ceb8e7c47f3e175a92cddef0db5ea93ab"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e2b36927fcad66d48767b72853f7c4074d757769",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.359",
+    "version_commit": "e2b36927fcad66d48767b72853f7c4074d757769"
+  },
+  "axiom_encode_version": "0.2.359",
+  "backend": "openai",
+  "citation": "26 USC 3405(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-a-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "80240545127d3151a0c4b356e2745ec22c869ea347594d5594a3390b9d483365",
+  "generated_at": "2026-05-28T05:00:07.806407+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-a-20260528-001/openai-gpt-5.5/statutes/26/3405/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-a-20260528-001",
+  "generated_output_sha256": "d31bded0631afd9ccfc1bf41b1e4372547dd9d4d8cd6c09740030fff01309a7e",
+  "generation_prompt_sha256": "acae2168f38671b82584c41c3c0ad62b0f81d252b420a2b30722f144bb1cd0ff",
+  "model": "gpt-5.5",
+  "run_id": "5ca597ec",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "780103352702e1691aacf78d2e92fa58a5ad6ea2acff8a98b0b831a9967f8fe6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-a-20260528-001/traces/openai-gpt-5.5/26-USC-3405-a.json",
+  "trace_sha256": "7cc54efc3149bcdb80829824aea5190ce2b97f5620c1e1fade3a6fbfeae15e0f"
+}

--- a/statutes/26/3405/a.test.yaml
+++ b/statutes/26/3405/a.test.yaml
@@ -1,0 +1,82 @@
+- name: periodic_payment_withholding_applies_without_no_withholding_election
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    us:statutes/26/3405/e#input.payment_is_annuity_or_similar_periodic_payment: true
+    us:statutes/26/3405/a#input.periodic_payment_amount: 1200
+    us:statutes/26/3405/a#input.individual_elects_no_withholding_for_periodic_payments: false
+    us:statutes/26/3405/a#input.individual_revokes_no_withholding_election_for_periodic_payments: false
+    us:statutes/26/3405/a#input.periodic_payment_withholding_allowance_certificate_not_in_effect: false
+  output:
+    us:statutes/26/3405/a#periodic_payment_amount_treated_as_wages_for_withholding: 1200
+    us:statutes/26/3405/a#periodic_payment_no_withholding_election_in_effect: not_holds
+    us:statutes/26/3405/a#periodic_payment_withholding_under_paragraph_one_applies: holds
+    us:statutes/26/3405/a#no_certificate_periodic_payment_secretary_rules_apply: not_holds
+- name: no_withholding_election_blocks_paragraph_one_until_revoked
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    us:statutes/26/3405/e#input.payment_is_annuity_or_similar_periodic_payment: true
+    us:statutes/26/3405/a#input.periodic_payment_amount: 1200
+    us:statutes/26/3405/a#input.individual_elects_no_withholding_for_periodic_payments: true
+    us:statutes/26/3405/a#input.individual_revokes_no_withholding_election_for_periodic_payments: false
+    us:statutes/26/3405/a#input.periodic_payment_withholding_allowance_certificate_not_in_effect: false
+  output:
+    us:statutes/26/3405/a#periodic_payment_amount_treated_as_wages_for_withholding: 1200
+    us:statutes/26/3405/a#periodic_payment_no_withholding_election_in_effect: holds
+    us:statutes/26/3405/a#periodic_payment_withholding_under_paragraph_one_applies: not_holds
+- name: revoked_no_withholding_election_no_longer_blocks_paragraph_one
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    us:statutes/26/3405/e#input.payment_is_annuity_or_similar_periodic_payment: true
+    us:statutes/26/3405/a#input.periodic_payment_amount: 1200
+    us:statutes/26/3405/a#input.individual_elects_no_withholding_for_periodic_payments: true
+    us:statutes/26/3405/a#input.individual_revokes_no_withholding_election_for_periodic_payments: true
+    us:statutes/26/3405/a#input.periodic_payment_withholding_allowance_certificate_not_in_effect: false
+  output:
+    us:statutes/26/3405/a#periodic_payment_no_withholding_election_in_effect: not_holds
+    us:statutes/26/3405/a#periodic_payment_withholding_under_paragraph_one_applies: holds
+- name: election_effective_under_section_3402_f_three_and_no_certificate_rules_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: false
+    us:statutes/26/3402/f#input.withholding_allowance_certificate_furnished_to_employer: true
+    us:statutes/26/3402/f#input.no_previous_withholding_allowance_certificate_in_effect: true
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_certificate_furnished_or_first_wage_payment_without_payroll_period_on_or_after_certificate_furnished
+    : true
+    us:statutes/26/3402/f#input.previous_withholding_allowance_certificate_in_effect: false
+    us:statutes/26/3402/f#input.certificate_furnished_pursuant_to_next_taxable_year_change_rule: false
+    ? us:statutes/26/3402/f#input.payment_is_in_first_payroll_period_ending_on_or_after_default_wait_day_or_first_wage_payment_without_payroll_period_on_or_after_default_wait_day
+    : false
+    us:statutes/26/3402/f#input.employer_elects_earlier_effective_date_for_replacement_certificate: false
+    us:statutes/26/3402/f#input.payment_of_wages_made_on_or_after_certificate_furnished_and_before_default_wait_day: false
+    us:statutes/26/3405/a#input.periodic_payment_withholding_allowance_certificate_not_in_effect: true
+  output:
+    us:statutes/26/3405/a#periodic_payment_election_or_revocation_effective_for_payment: holds
+    us:statutes/26/3405/a#no_certificate_periodic_payment_secretary_rules_apply: holds
+- name: auto_zero_periodic_payment_amount_treated_as_wages_for_withholding
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/e#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: false
+    us:statutes/26/3405/a#input.individual_elects_no_withholding_for_periodic_payments: false
+    us:statutes/26/3405/a#input.individual_revokes_no_withholding_election_for_periodic_payments: false
+    us:statutes/26/3405/a#input.periodic_payment_amount: 0
+    us:statutes/26/3405/a#input.periodic_payment_withholding_allowance_certificate_not_in_effect: false
+  output:
+    us:statutes/26/3405/a#periodic_payment_amount_treated_as_wages_for_withholding: 0

--- a/statutes/26/3405/a.yaml
+++ b/statutes/26/3405/a.yaml
@@ -1,0 +1,167 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: |-
+    26 USC 3405(a): the payor of any periodic payment withholds as if the payment were wages for the appropriate payroll period; an individual may elect no withholding until revoked; elections and revocations take effect as provided by section 3402(f)(3); where no withholding allowance certificate is in effect, withholding is determined under Secretary rules.
+  deferred_outputs:
+    - output: us:statutes/26/3405/a#periodic_payment_withholding_amount
+      reason: Section 3405(a)(1) requires the amount that would be required if the periodic payment were wages for the appropriate payroll period, but the Secretary-prescribed wage withholding tables or procedures used under section 3402 are not provided in copied executable context; section 3405(a)(4) also defers no-certificate cases to Secretary-prescribed rules.
+      source_values:
+        - us:statutes/26/3405/a#periodic_payment_amount_treated_as_wages_for_withholding
+imports:
+  - us:statutes/26/3405/e#periodic_payment
+  - us:statutes/26/3402/f#first_certificate_effective_for_payment
+  - us:statutes/26/3402/f#replacement_certificate_default_effective_for_payment
+  - us:statutes/26/3402/f#replacement_certificate_employer_election_earlier_effective_for_payment
+rules:
+  - name: periodic_payment_amount_treated_as_wages_for_withholding
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3405(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3405/e#periodic_payment
+              output: periodic_payment
+              hash: sha256:0f680c84365a9db2da5228475970d56d8fe879ecbc9f8d146a50f10e302d1ca2
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "if such payment were a payment of wages"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if periodic_payment: max(0, periodic_payment_amount) else: 0
+
+  - name: periodic_payment_no_withholding_election_in_effect
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "An individual may elect to have paragraph (1) not apply"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "Such an election shall remain in effect until revoked"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_elects_no_withholding_for_periodic_payments
+          and not individual_revokes_no_withholding_election_for_periodic_payments
+
+  - name: periodic_payment_withholding_under_paragraph_one_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(a)(1), 3405(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3405/e#periodic_payment
+              output: periodic_payment
+              hash: sha256:0f680c84365a9db2da5228475970d56d8fe879ecbc9f8d146a50f10e302d1ca2
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3405/a#periodic_payment_no_withholding_election_in_effect
+              output: periodic_payment_no_withholding_election_in_effect
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/statute/26/3405
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3405
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          periodic_payment
+          and not periodic_payment_no_withholding_election_in_effect
+
+  - name: periodic_payment_election_or_revocation_effective_for_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "shall take effect as provided by subsection (f)(3) of section 3402"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/f#first_certificate_effective_for_payment
+              output: first_certificate_effective_for_payment
+              hash: sha256:54413492205efa896b755bf3a814ad0fc88bad7b3dc76e0d22bf537e1f6bb4cd
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/f#replacement_certificate_default_effective_for_payment
+              output: replacement_certificate_default_effective_for_payment
+              hash: sha256:54413492205efa896b755bf3a814ad0fc88bad7b3dc76e0d22bf537e1f6bb4cd
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3402/f#replacement_certificate_employer_election_earlier_effective_for_payment
+              output: replacement_certificate_employer_election_earlier_effective_for_payment
+              hash: sha256:54413492205efa896b755bf3a814ad0fc88bad7b3dc76e0d22bf537e1f6bb4cd
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          first_certificate_effective_for_payment
+          or replacement_certificate_default_effective_for_payment
+          or replacement_certificate_employer_election_earlier_effective_for_payment
+
+  - name: no_certificate_periodic_payment_secretary_rules_apply
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "with respect to which a withholding allowance certificate is not in effect"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "shall be determined under rules prescribed by the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          periodic_payment_withholding_allowance_certificate_not_in_effect


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3405(a) periodic-payment withholding rules
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `5ca597ec`, encoder version `0.2.359`; deterministic zero-branch test auto-repair ran before signed apply

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/a.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/a.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/a.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`