### PR TITLE
Add generated section 3405(f) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3405/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3405/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3405/f.yaml",
+      "sha256": "3191f551c12b70d38627f7bf0d9a33edcd0e595df631ec7e3ac31cc8a9824934"
+    },
+    {
+      "path": "statutes/26/3405/f.test.yaml",
+      "sha256": "8c3c9fe41cf804bbdba8aec23d933226441087ac16d080ab226cfcbefd69f6b9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e2b36927fcad66d48767b72853f7c4074d757769",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.359",
+    "version_commit": "e2b36927fcad66d48767b72853f7c4074d757769"
+  },
+  "axiom_encode_version": "0.2.359",
+  "backend": "openai",
+  "citation": "26 USC 3405(f)",
+  "context_manifest_file": "/tmp/axiom-encode-3405-f-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3405-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "c127fd55f9a69417b808df2018e99c6fa344b2e8e0abdbf7a051d7515e64f3c9",
+  "generated_at": "2026-05-28T05:05:08.498016+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3405-f-20260528-001/openai-gpt-5.5/statutes/26/3405/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3405-f-20260528-001",
+  "generated_output_sha256": "3191f551c12b70d38627f7bf0d9a33edcd0e595df631ec7e3ac31cc8a9824934",
+  "generation_prompt_sha256": "33d973456046787435b8cd05c1997367a7dd814820895dad108ece057ec82862",
+  "model": "gpt-5.5",
+  "run_id": "0dc91c76",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f7459226f149975946407d0d6323b347f3098caf073c75fb8b3e4f915d53326e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3405-f-20260528-001/traces/openai-gpt-5.5/26-USC-3405-f.json",
+  "trace_sha256": "e224a41df3e28197beee4992f87242e381268b56aa02ca83a88cb4cfb3b61d31"
+}

--- a/statutes/26/3405/f.test.yaml
+++ b/statutes/26/3405/f.test.yaml
@@ -1,0 +1,39 @@
+- name: designated_distribution_treated_as_wages_with_section_3402_withholding
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/f#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    ? us:statutes/26/3405/f#input.designated_distribution_not_subject_to_withholding_under_section_3405_by_reason_of_election_under_section_3405
+    : false
+    us:statutes/26/3405/f#input.actual_amount_withheld_from_designated_distribution_under_section_3405: 125
+  output:
+    us:statutes/26/3405/f#designated_distribution_treated_as_wages_with_section_3402_withholding: holds
+    us:statutes/26/3405/f#elected_no_withholding_designated_distribution_amount_withheld_treated_as_zero: 125
+- name: non_designated_distribution_not_treated_by_subsection_f
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/f#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: false
+    ? us:statutes/26/3405/f#input.designated_distribution_not_subject_to_withholding_under_section_3405_by_reason_of_election_under_section_3405
+    : false
+    us:statutes/26/3405/f#input.actual_amount_withheld_from_designated_distribution_under_section_3405: 0
+  output:
+    us:statutes/26/3405/f#designated_distribution_treated_as_wages_with_section_3402_withholding: not_holds
+    us:statutes/26/3405/f#elected_no_withholding_designated_distribution_amount_withheld_treated_as_zero: 0
+- name: election_under_section_3405_makes_amount_withheld_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3405/f#input.payment_is_designated_distribution_as_defined_in_section_3405_e_1: true
+    ? us:statutes/26/3405/f#input.designated_distribution_not_subject_to_withholding_under_section_3405_by_reason_of_election_under_section_3405
+    : true
+    us:statutes/26/3405/f#input.actual_amount_withheld_from_designated_distribution_under_section_3405: 125
+  output:
+    us:statutes/26/3405/f#designated_distribution_treated_as_wages_with_section_3402_withholding: holds
+    us:statutes/26/3405/f#elected_no_withholding_designated_distribution_amount_withheld_treated_as_zero: 0

--- a/statutes/26/3405/f.yaml
+++ b/statutes/26/3405/f.yaml
@@ -1,0 +1,52 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3405
+  summary: |-
+    For purposes of this chapter and related subtitle F provisions, any designated distribution is treated as wages paid by an employer to an employee with withholding under section 3402; if an election under section 3405 makes the designated distribution not subject to withholding, the amount withheld is treated as zero.
+rules:
+  - name: designated_distribution_treated_as_wages_with_section_3402_withholding
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3405(f)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "any designated distribution ... shall be treated as if it were wages paid by an employer to an employee with respect to which there has been withholding under section 3402"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_designated_distribution_as_defined_in_section_3405_e_1
+
+  - name: elected_no_withholding_designated_distribution_amount_withheld_treated_as_zero
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3405(f)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "in the case of any designated distribution not subject to withholding under this section by reason of an election under this section"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3405
+              excerpt: "the amount withheld shall be treated as zero"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_is_designated_distribution_as_defined_in_section_3405_e_1 and designated_distribution_not_subject_to_withholding_under_section_3405_by_reason_of_election_under_section_3405: 0 else: actual_amount_withheld_from_designated_distribution_under_section_3405


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3405(f) wage-withholding treatment for designated distributions
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `0dc91c76`, encoder version `0.2.359`

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/f.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/f.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3405/f.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`