### PR TITLE
Add generated section 3406(a) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/a.yaml",
+      "sha256": "9467807fb54c802544cac122686aa76c3787d9de7e3e8fb106b49bfeef1a9cad"
+    },
+    {
+      "path": "statutes/26/3406/a.test.yaml",
+      "sha256": "a9a76d97bdf92f30000259a39d3e7dfc61fa689e3e3495e0807bbd7847284f57"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3406(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3406-a-20260528-003/_eval_workspaces/openai-gpt-5.5/26-USC-3406-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "2ed4fa0fb11fb7c1960e7895623d9b2764a89d393010b21866ee30588404f5e7",
+  "generated_at": "2026-05-28T05:35:48.152286+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406-a-20260528-003/openai-gpt-5.5/statutes/26/3406/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406-a-20260528-003",
+  "generated_output_sha256": "9467807fb54c802544cac122686aa76c3787d9de7e3e8fb106b49bfeef1a9cad",
+  "generation_prompt_sha256": "a01b7809ed8618a7db7db22811eba4974636b4f3e85c45fe3fb5f9c2dff9f790",
+  "model": "gpt-5.5",
+  "run_id": "034d8b9c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "44611c1e15d15c6d54c0df984875238826b76ddc9a0ffd28de00477cfe7c2c2c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3406-a-20260528-003/traces/openai-gpt-5.5/26-USC-3406-a.json",
+  "trace_sha256": "32ff2f51b5f305db496e088227d55ff33c96ed76b2a0778dd5dc166fee61e2a8"
+}

--- a/statutes/26/3406/a.test.yaml
+++ b/statutes/26/3406/a.test.yaml
@@ -1,0 +1,60 @@
+- name: payee_fails_to_furnish_tin_triggers_backup_withholding_on_reportable_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/a#input.reportable_payment: true
+    us:statutes/26/3406/a#input.payee_fails_to_furnish_tin_to_payor_in_required_manner: true
+    us:statutes/26/3406/a#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/a#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/a#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/a#input.payee_certification_failure_described_in_subsection_d: false
+  output:
+    us:statutes/26/3406/a#underreporting_or_certification_failure_applies_to_payment: not_holds
+    us:statutes/26/3406/a#backup_withholding_requirement_applies: holds
+- name: incorrect_tin_notice_triggers_backup_withholding_on_reportable_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/a#input.reportable_payment: true
+    us:statutes/26/3406/a#input.payee_fails_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/a#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: true
+    us:statutes/26/3406/a#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/a#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/a#input.payee_certification_failure_described_in_subsection_d: false
+  output:
+    us:statutes/26/3406/a#underreporting_or_certification_failure_applies_to_payment: not_holds
+    us:statutes/26/3406/a#backup_withholding_requirement_applies: holds
+- name: notified_payee_underreporting_triggers_only_for_reportable_interest_or_dividend_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/a#input.reportable_payment: true
+    us:statutes/26/3406/a#input.payee_fails_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/a#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/a#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/a#input.notified_payee_underreporting_described_in_subsection_c: true
+    us:statutes/26/3406/a#input.payee_certification_failure_described_in_subsection_d: false
+  output:
+    us:statutes/26/3406/a#underreporting_or_certification_failure_applies_to_payment: holds
+    us:statutes/26/3406/a#backup_withholding_requirement_applies: holds
+- name: payee_certification_failure_does_not_trigger_for_non_interest_non_dividend_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/a#input.reportable_payment: true
+    us:statutes/26/3406/a#input.payee_fails_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/a#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/a#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/a#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/a#input.payee_certification_failure_described_in_subsection_d: true
+  output:
+    us:statutes/26/3406/a#underreporting_or_certification_failure_applies_to_payment: not_holds
+    us:statutes/26/3406/a#backup_withholding_requirement_applies: not_holds

--- a/statutes/26/3406/a.yaml
+++ b/statutes/26/3406/a.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  deferred_outputs:
+    - output: us:statutes/26/3406/a#backup_withholding_tax
+      reason: >-
+        Section 3406(a)(1) computes the withheld tax as the product of the
+        fourth lowest rate of tax applicable under section 1(c) and the
+        reportable payment. The source states the rate by cross-reference, and
+        no executable RuleSpec context for the section 1(c) fourth-lowest-rate
+        computation is available in the copied workspace.
+  summary: |-
+    In the case of any reportable payment, if the payee fails to furnish his TIN, the Secretary notifies the payor that the TIN furnished is incorrect, there has been notified payee underreporting, or there has been a payee certification failure, the payor shall deduct and withhold. Subparagraphs (C) and (D) apply only to reportable interest or dividend payments.
+rules:
+  - name: underreporting_or_certification_failure_applies_to_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(a)(1)(C)-(D), 3406(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "there has been a notified payee underreporting described in subsection (c), or (D) there has been a payee certification failure described in subsection (d)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Subparagraphs (C) and (D) of paragraph (1) shall apply only to reportable interest or dividend payments."
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and (
+              notified_payee_underreporting_described_in_subsection_c
+              or payee_certification_failure_described_in_subsection_d
+          )
+
+  - name: backup_withholding_requirement_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(a)(1), 3406(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "In the case of any reportable payment, if—"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee fails to furnish his TIN to the payor in the manner required"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies the payor that the TIN furnished by the payee is incorrect"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/a#underreporting_or_certification_failure_applies_to_payment
+              output: underreporting_or_certification_failure_applies_to_payment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_payment
+          and (
+              payee_fails_to_furnish_tin_to_payor_in_required_manner
+              or secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect
+              or underreporting_or_certification_failure_applies_to_payment
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3406(a) backup withholding trigger rules
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `034d8b9c`, encoder version `0.2.361`; PE coverage classifier merged in TheAxiomFoundation/axiom-encode#387

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/a.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/a.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/a.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`