### PR TITLE
Add generated section 3406(c) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/c.yaml",
+      "sha256": "760007bec2116b336f03d22d52cc5a341ab884cb99fbdb83828c159a31e82a2f"
+    },
+    {
+      "path": "statutes/26/3406/c.test.yaml",
+      "sha256": "ccb19bd778781c4bb9589a8e62c02dc26971df4bd03261bbebc56834ce89b779"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3406(c)",
+  "context_manifest_file": "/tmp/axiom-encode-3406-c-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3406-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "81b3bdfd1fa447b1c03402a0c8ae1a516d915ed6b5683ffd503b2c6114af8295",
+  "generated_at": "2026-05-28T05:46:27.888279+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406-c-20260528-001/openai-gpt-5.5/statutes/26/3406/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406-c-20260528-001",
+  "generated_output_sha256": "760007bec2116b336f03d22d52cc5a341ab884cb99fbdb83828c159a31e82a2f",
+  "generation_prompt_sha256": "fb8f5972a924402b7a85aa2db28692b189a576a8980d6fc3f4f2233634aaf8a5",
+  "model": "gpt-5.5",
+  "run_id": "0e949ca1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f9ecc28c1e0ca4ca2cfd2a511ea5994d5faa11ca0d805e98b3f1c921d9ad1958"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3406-c-20260528-001/traces/openai-gpt-5.5/26-USC-3406-c.json",
+  "trace_sha256": "3dc07debb823555f16d5196edc905212d61e8fdc9c425b0cc4f07faaa969fd6a"
+}

--- a/statutes/26/3406/c.test.yaml
+++ b/statutes/26/3406/c.test.yaml
@@ -1,0 +1,112 @@
+- name: filed_return_omission_with_required_notices_allows_secretary_notice_and_no_underreporting_determination_stops
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/c#input.payee_failed_to_include_reportable_interest_or_dividend_payment_on_chapter_1_return: true
+    us:statutes/26/3406/c#input.payee_may_be_required_to_file_return_including_reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/c#input.payee_failed_to_file_return: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting: true
+    us:statutes/26/3406/c#input.underreporting_notices_mailed_count: 4
+    us:statutes/26/3406/c#input.underreporting_notice_period_days: 120
+    us:statutes/26/3406/c#input.payee_filed_return_for_taxable_year: true
+    us:statutes/26/3406/c#input.deficiency_of_tax_attributable_to_underreporting_failure_has_been_assessed: true
+    us:statutes/26/3406/c#input.secretary_determines_no_payee_underreporting: true
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting_corrected: false
+    us:statutes/26/3406/c#input.tax_penalty_or_interest_with_respect_to_underreporting_has_been_paid: false
+    us:statutes/26/3406/c#input.secretary_determines_withholding_causes_or_would_cause_undue_hardship: false
+    us:statutes/26/3406/c#input.secretary_determines_underreporting_unlikely_to_occur_again: false
+    us:statutes/26/3406/c#input.secretary_determines_bona_fide_dispute_as_to_underreporting: false
+    us:statutes/26/3406/c#input.payee_receives_reportable_interest_or_dividend_payments: true
+    us:statutes/26/3406/c#input.payee_is_subject_to_withholding_under_subsection_a_1_C: true
+    us:statutes/26/3406/c#input.secretary_requires_payee_to_notify_secretary_of_payors_and_brokers: true
+  output:
+    us:statutes/26/3406/c#payee_underreporting: holds
+    us:statutes/26/3406/c#secretary_may_notify_payors_of_underreporting_withholding: holds
+    us:statutes/26/3406/c#secretary_shall_take_action_to_stop_or_not_start_withholding: holds
+    us:statutes/26/3406/c#payee_must_identify_payors_and_brokers_to_secretary: holds
+- name: failure_to_file_route_is_underreporting_but_insufficient_notice_count_blocks_secretary_notice
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/c#input.payee_failed_to_include_reportable_interest_or_dividend_payment_on_chapter_1_return: false
+    us:statutes/26/3406/c#input.payee_may_be_required_to_file_return_including_reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/c#input.payee_failed_to_file_return: true
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting: true
+    us:statutes/26/3406/c#input.underreporting_notices_mailed_count: 3
+    us:statutes/26/3406/c#input.underreporting_notice_period_days: 120
+    us:statutes/26/3406/c#input.payee_filed_return_for_taxable_year: false
+    us:statutes/26/3406/c#input.deficiency_of_tax_attributable_to_underreporting_failure_has_been_assessed: false
+    us:statutes/26/3406/c#input.secretary_determines_no_payee_underreporting: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting_corrected: true
+    us:statutes/26/3406/c#input.tax_penalty_or_interest_with_respect_to_underreporting_has_been_paid: true
+    us:statutes/26/3406/c#input.secretary_determines_withholding_causes_or_would_cause_undue_hardship: false
+    us:statutes/26/3406/c#input.secretary_determines_underreporting_unlikely_to_occur_again: false
+    us:statutes/26/3406/c#input.secretary_determines_bona_fide_dispute_as_to_underreporting: false
+    us:statutes/26/3406/c#input.payee_receives_reportable_interest_or_dividend_payments: true
+    us:statutes/26/3406/c#input.payee_is_subject_to_withholding_under_subsection_a_1_C: true
+    us:statutes/26/3406/c#input.secretary_requires_payee_to_notify_secretary_of_payors_and_brokers: false
+  output:
+    us:statutes/26/3406/c#payee_underreporting: holds
+    us:statutes/26/3406/c#secretary_may_notify_payors_of_underreporting_withholding: not_holds
+    us:statutes/26/3406/c#secretary_shall_take_action_to_stop_or_not_start_withholding: holds
+    us:statutes/26/3406/c#payee_must_identify_payors_and_brokers_to_secretary: not_holds
+- name: filed_return_without_assessed_deficiency_blocks_secretary_notice_but_hardship_determination_stops
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/c#input.payee_failed_to_include_reportable_interest_or_dividend_payment_on_chapter_1_return: true
+    us:statutes/26/3406/c#input.payee_may_be_required_to_file_return_including_reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/c#input.payee_failed_to_file_return: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting: true
+    us:statutes/26/3406/c#input.underreporting_notices_mailed_count: 4
+    us:statutes/26/3406/c#input.underreporting_notice_period_days: 120
+    us:statutes/26/3406/c#input.payee_filed_return_for_taxable_year: true
+    us:statutes/26/3406/c#input.deficiency_of_tax_attributable_to_underreporting_failure_has_been_assessed: false
+    us:statutes/26/3406/c#input.secretary_determines_no_payee_underreporting: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting_corrected: false
+    us:statutes/26/3406/c#input.tax_penalty_or_interest_with_respect_to_underreporting_has_been_paid: false
+    us:statutes/26/3406/c#input.secretary_determines_withholding_causes_or_would_cause_undue_hardship: true
+    us:statutes/26/3406/c#input.secretary_determines_underreporting_unlikely_to_occur_again: true
+    us:statutes/26/3406/c#input.secretary_determines_bona_fide_dispute_as_to_underreporting: false
+    us:statutes/26/3406/c#input.payee_receives_reportable_interest_or_dividend_payments: true
+    us:statutes/26/3406/c#input.payee_is_subject_to_withholding_under_subsection_a_1_C: false
+    us:statutes/26/3406/c#input.secretary_requires_payee_to_notify_secretary_of_payors_and_brokers: true
+  output:
+    us:statutes/26/3406/c#payee_underreporting: holds
+    us:statutes/26/3406/c#secretary_may_notify_payors_of_underreporting_withholding: not_holds
+    us:statutes/26/3406/c#secretary_shall_take_action_to_stop_or_not_start_withholding: holds
+    us:statutes/26/3406/c#payee_must_identify_payors_and_brokers_to_secretary: not_holds
+- name: no_underreporting_when_neither_omission_nor_required_return_failure_and_bona_fide_dispute_stops
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/c#input.payee_failed_to_include_reportable_interest_or_dividend_payment_on_chapter_1_return: false
+    us:statutes/26/3406/c#input.payee_may_be_required_to_file_return_including_reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/c#input.payee_failed_to_file_return: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting: true
+    us:statutes/26/3406/c#input.underreporting_notices_mailed_count: 4
+    us:statutes/26/3406/c#input.underreporting_notice_period_days: 119
+    us:statutes/26/3406/c#input.payee_filed_return_for_taxable_year: false
+    us:statutes/26/3406/c#input.deficiency_of_tax_attributable_to_underreporting_failure_has_been_assessed: false
+    us:statutes/26/3406/c#input.secretary_determines_no_payee_underreporting: false
+    us:statutes/26/3406/c#input.secretary_determines_payee_underreporting_corrected: false
+    us:statutes/26/3406/c#input.tax_penalty_or_interest_with_respect_to_underreporting_has_been_paid: false
+    us:statutes/26/3406/c#input.secretary_determines_withholding_causes_or_would_cause_undue_hardship: false
+    us:statutes/26/3406/c#input.secretary_determines_underreporting_unlikely_to_occur_again: false
+    us:statutes/26/3406/c#input.secretary_determines_bona_fide_dispute_as_to_underreporting: true
+    us:statutes/26/3406/c#input.payee_receives_reportable_interest_or_dividend_payments: false
+    us:statutes/26/3406/c#input.payee_is_subject_to_withholding_under_subsection_a_1_C: true
+    us:statutes/26/3406/c#input.secretary_requires_payee_to_notify_secretary_of_payors_and_brokers: true
+  output:
+    us:statutes/26/3406/c#payee_underreporting: not_holds
+    us:statutes/26/3406/c#secretary_may_notify_payors_of_underreporting_withholding: not_holds
+    us:statutes/26/3406/c#secretary_shall_take_action_to_stop_or_not_start_withholding: holds
+    us:statutes/26/3406/c#payee_must_identify_payors_and_brokers_to_secretary: not_holds

--- a/statutes/26/3406/c.yaml
+++ b/statutes/26/3406/c.yaml
@@ -1,0 +1,188 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  summary: |-
+    If the Secretary determines payee underreporting, at least 4 notices have been mailed over at least 120 days, and any return-filer deficiency attributable to the failure has been assessed, the Secretary may notify payors of reportable interest or dividend payments of withholding under subsection (a)(1)(C). Payee underreporting includes omitted reportable interest or dividend payments on a filed chapter 1 return, or failure to file a return that may be required to include such payments. The Secretary shall act to stop or not start withholding after specified determinations, and may require a payee subject to subsection (a)(1)(C) withholding to identify payors and brokers.
+rules:
+  - name: minimum_underreporting_notice_count
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(c)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "at least 4 notices"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4
+
+  - name: minimum_underreporting_notice_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(c)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "over a period of at least 120 days"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          120
+
+  - name: payee_underreporting
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee failed to include in his return of tax under chapter 1 ... any portion of a reportable interest or dividend payment"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee may be required to file a return ... and to include a reportable interest or dividend payment ... but failed to file such return"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payee_failed_to_include_reportable_interest_or_dividend_payment_on_chapter_1_return
+          or (
+              payee_may_be_required_to_file_return_including_reportable_interest_or_dividend_payment
+              and payee_failed_to_file_return
+          )
+
+  - name: secretary_may_notify_payors_of_underreporting_withholding
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary determines with respect to any payee that there has been payee underreporting"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "at least 4 notices have been mailed ... over a period of at least 120 days"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "in the case of any payee who has filed a return ... any deficiency ... has been assessed"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/c#payee_underreporting
+              output: payee_underreporting
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/c#minimum_underreporting_notice_count
+              output: minimum_underreporting_notice_count
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/c#minimum_underreporting_notice_period_days
+              output: minimum_underreporting_notice_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          secretary_determines_payee_underreporting
+          and payee_underreporting
+          and underreporting_notices_mailed_count >= minimum_underreporting_notice_count
+          and underreporting_notice_period_days >= minimum_underreporting_notice_period_days
+          and (
+              not payee_filed_return_for_taxable_year
+              or deficiency_of_tax_attributable_to_underreporting_failure_has_been_assessed
+          )
+
+  - name: secretary_shall_take_action_to_stop_or_not_start_withholding
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(c)(3)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "there was no payee underreporting"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any payee underreporting has been corrected ... and any tax, penalty, or interest ... has been paid"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "withholding ... has caused (or would cause) undue hardship ... and it is unlikely that any payee underreporting ... will occur again"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "there is a bona fide dispute as to whether there has been any payee underreporting"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          secretary_determines_no_payee_underreporting
+          or (
+              secretary_determines_payee_underreporting_corrected
+              and tax_penalty_or_interest_with_respect_to_underreporting_has_been_paid
+          )
+          or (
+              secretary_determines_withholding_causes_or_would_cause_undue_hardship
+              and secretary_determines_underreporting_unlikely_to_occur_again
+          )
+          or secretary_determines_bona_fide_dispute_as_to_underreporting
+
+  - name: payee_must_identify_payors_and_brokers_to_secretary
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "The Secretary may require any payee of reportable interest or dividend payments who is subject to withholding under subsection (a)(1)(C) to notify the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payee_receives_reportable_interest_or_dividend_payments
+          and payee_is_subject_to_withholding_under_subsection_a_1_C
+          and secretary_requires_payee_to_notify_secretary_of_payors_and_brokers


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3406(c) notified-payee-underreporting backup withholding rules
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `0e949ca1`, encoder version `0.2.361`

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/c.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/c.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/c.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`