### PR TITLE
Add generated section 3406(e) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/e.yaml",
+      "sha256": "9b895cded32074b474986c9e3f4389ae5727a824d684f6a789c0b39a871ec2b3"
+    },
+    {
+      "path": "statutes/26/3406/e.test.yaml",
+      "sha256": "a8a83e3fde3b1c0b7df5563505f4e386a7f1f7d737c12c153b631e6aaeba21ad"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3406(e)",
+  "context_manifest_file": "/tmp/axiom-encode-3406-e-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3406-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "cbc9aca0d4a4f80a4e08c2fa69cee4525b4fec7ecdcbafc6c0527da9e0ba309d",
+  "generated_at": "2026-05-28T05:57:54.946420+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406-e-20260528-001/openai-gpt-5.5/statutes/26/3406/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406-e-20260528-001",
+  "generated_output_sha256": "9b895cded32074b474986c9e3f4389ae5727a824d684f6a789c0b39a871ec2b3",
+  "generation_prompt_sha256": "9f2a4b924bf44450df3798a7e6a0bb360d38e388769a8e0892a82b7580f8d3e6",
+  "model": "gpt-5.5",
+  "run_id": "e993e6d1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c671bc465df50243dc83fdf529ea20f6ffaa7b6b86abc6ffd391bd241467112e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3406-e-20260528-001/traces/openai-gpt-5.5/26-USC-3406-e.json",
+  "trace_sha256": "e35e593d4c9cc886c169ce062b7cb1621b5f6ce2fd00926a8cfc90d394b88c75"
+}

--- a/statutes/26/3406/e.test.yaml
+++ b/statutes/26/3406/e.test.yaml
@@ -1,0 +1,160 @@
+- name: failure_to_furnish_tin_period_triggers_subsection_a
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.reportable_payment: true
+    us:statutes/26/3406/e#input.payee_failed_to_furnish_tin_to_payor_in_required_manner: true
+    us:statutes/26/3406/e#input.tin_has_not_been_furnished_in_required_manner_when_payment_is_made: true
+    us:statutes/26/3406/e#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/e#input.days_after_payor_received_incorrect_tin_notification: 0
+    us:statutes/26/3406/e#input.payee_has_furnished_another_tin_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/e#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/e#input.days_after_payor_received_underreporting_notification: 0
+    us:statutes/26/3406/e#input.payment_is_before_stop_date: false
+    us:statutes/26/3406/e#input.payee_certification_failure_described_in_subsection_d_1: false
+    us:statutes/26/3406/e#input.certification_described_in_subsection_d_1_has_not_been_furnished_to_payor: false
+    us:statutes/26/3406/e#input.readily_tradable_instrument_acquired_by_payee_through_broker: false
+    us:statutes/26/3406/e#input.days_after_payor_received_broker_notification_under_subsection_d_2_B: 0
+    us:statutes/26/3406/e#input.payor_elects_start_up_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_during_start_up_grace_period_described_in_paragraph_2_A_3_A_or_4_B: false
+    us:statutes/26/3406/e#input.days_into_start_up_grace_period: 0
+    us:statutes/26/3406/e#input.payor_elects_out_of_stopping_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: false
+    us:statutes/26/3406/e#input.days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: 0
+  output:
+    us:statutes/26/3406/e#failure_to_furnish_tin_withholding_period_applies: holds
+    us:statutes/26/3406/e#incorrect_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#notified_underreporting_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#payee_certification_failure_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#start_up_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#stopping_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#subsection_a_applies_to_payment_during_subsection_e_period: holds
+- name: incorrect_tin_period_after_waiting_period_triggers_until_new_tin
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.reportable_payment: true
+    us:statutes/26/3406/e#input.payee_failed_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/e#input.tin_has_not_been_furnished_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: true
+    us:statutes/26/3406/e#input.days_after_payor_received_incorrect_tin_notification: 31
+    us:statutes/26/3406/e#input.payee_has_furnished_another_tin_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/e#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/e#input.days_after_payor_received_underreporting_notification: 0
+    us:statutes/26/3406/e#input.payment_is_before_stop_date: false
+    us:statutes/26/3406/e#input.payee_certification_failure_described_in_subsection_d_1: false
+    us:statutes/26/3406/e#input.certification_described_in_subsection_d_1_has_not_been_furnished_to_payor: false
+    us:statutes/26/3406/e#input.readily_tradable_instrument_acquired_by_payee_through_broker: false
+    us:statutes/26/3406/e#input.days_after_payor_received_broker_notification_under_subsection_d_2_B: 0
+    us:statutes/26/3406/e#input.payor_elects_start_up_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_during_start_up_grace_period_described_in_paragraph_2_A_3_A_or_4_B: false
+    us:statutes/26/3406/e#input.days_into_start_up_grace_period: 0
+    us:statutes/26/3406/e#input.payor_elects_out_of_stopping_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: false
+    us:statutes/26/3406/e#input.days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: 0
+  output:
+    us:statutes/26/3406/e#failure_to_furnish_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#incorrect_tin_withholding_period_applies: holds
+    us:statutes/26/3406/e#notified_underreporting_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#payee_certification_failure_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#start_up_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#stopping_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#subsection_a_applies_to_payment_during_subsection_e_period: holds
+- name: broker_acquired_instrument_certification_failure_waits_thirty_days
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.reportable_payment: true
+    us:statutes/26/3406/e#input.payee_failed_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/e#input.tin_has_not_been_furnished_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/e#input.days_after_payor_received_incorrect_tin_notification: 0
+    us:statutes/26/3406/e#input.payee_has_furnished_another_tin_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/e#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/e#input.days_after_payor_received_underreporting_notification: 0
+    us:statutes/26/3406/e#input.payment_is_before_stop_date: false
+    us:statutes/26/3406/e#input.payee_certification_failure_described_in_subsection_d_1: true
+    us:statutes/26/3406/e#input.certification_described_in_subsection_d_1_has_not_been_furnished_to_payor: true
+    us:statutes/26/3406/e#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
+    us:statutes/26/3406/e#input.days_after_payor_received_broker_notification_under_subsection_d_2_B: 31
+    us:statutes/26/3406/e#input.payor_elects_start_up_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_during_start_up_grace_period_described_in_paragraph_2_A_3_A_or_4_B: false
+    us:statutes/26/3406/e#input.days_into_start_up_grace_period: 0
+    us:statutes/26/3406/e#input.payor_elects_out_of_stopping_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: false
+    us:statutes/26/3406/e#input.days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: 0
+  output:
+    us:statutes/26/3406/e#failure_to_furnish_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#incorrect_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#notified_underreporting_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#payee_certification_failure_withholding_period_applies: holds
+    us:statutes/26/3406/e#start_up_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#stopping_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#subsection_a_applies_to_payment_during_subsection_e_period: holds
+- name: grace_period_elections_control_starting_and_stopping_extensions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.reportable_payment: true
+    us:statutes/26/3406/e#input.payee_failed_to_furnish_tin_to_payor_in_required_manner: false
+    us:statutes/26/3406/e#input.tin_has_not_been_furnished_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect: false
+    us:statutes/26/3406/e#input.days_after_payor_received_incorrect_tin_notification: 0
+    us:statutes/26/3406/e#input.payee_has_furnished_another_tin_in_required_manner_when_payment_is_made: false
+    us:statutes/26/3406/e#input.reportable_interest_or_dividend_payment: false
+    us:statutes/26/3406/e#input.notified_payee_underreporting_described_in_subsection_c: false
+    us:statutes/26/3406/e#input.days_after_payor_received_underreporting_notification: 0
+    us:statutes/26/3406/e#input.payment_is_before_stop_date: false
+    us:statutes/26/3406/e#input.payee_certification_failure_described_in_subsection_d_1: false
+    us:statutes/26/3406/e#input.certification_described_in_subsection_d_1_has_not_been_furnished_to_payor: false
+    us:statutes/26/3406/e#input.readily_tradable_instrument_acquired_by_payee_through_broker: false
+    us:statutes/26/3406/e#input.days_after_payor_received_broker_notification_under_subsection_d_2_B: 0
+    us:statutes/26/3406/e#input.payor_elects_start_up_grace_period_with_respect_to_payee: true
+    us:statutes/26/3406/e#input.payment_made_during_start_up_grace_period_described_in_paragraph_2_A_3_A_or_4_B: true
+    us:statutes/26/3406/e#input.days_into_start_up_grace_period: 30
+    us:statutes/26/3406/e#input.payor_elects_out_of_stopping_grace_period_with_respect_to_payee: true
+    us:statutes/26/3406/e#input.payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: true
+    us:statutes/26/3406/e#input.days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: 29
+  output:
+    us:statutes/26/3406/e#failure_to_furnish_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#incorrect_tin_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#notified_underreporting_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#payee_certification_failure_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#start_up_grace_withholding_period_applies: holds
+    us:statutes/26/3406/e#stopping_grace_withholding_period_applies: not_holds
+    us:statutes/26/3406/e#subsection_a_applies_to_payment_during_subsection_e_period: holds
+- name: auto_positive_notified_underreporting_withholding_period_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.days_after_payor_received_underreporting_notification: 999999
+    us:statutes/26/3406/e#input.notified_payee_underreporting_described_in_subsection_c: true
+    us:statutes/26/3406/e#input.payment_is_before_stop_date: true
+    us:statutes/26/3406/e#input.reportable_interest_or_dividend_payment: true
+  output:
+    us:statutes/26/3406/e#notified_underreporting_withholding_period_applies: holds
+- name: auto_positive_stopping_grace_withholding_period_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/e#input.days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: 0
+    us:statutes/26/3406/e#input.payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A: true
+    us:statutes/26/3406/e#input.payor_elects_out_of_stopping_grace_period_with_respect_to_payee: false
+    us:statutes/26/3406/e#input.reportable_payment: true
+  output:
+    us:statutes/26/3406/e#stopping_grace_withholding_period_applies: holds

--- a/statutes/26/3406/e.yaml
+++ b/statutes/26/3406/e.yaml
@@ -1,0 +1,352 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  summary: |-
+    Section 3406(e) specifies the periods for which subsection (a) withholding is in effect for failure to furnish a TIN, notification of an incorrect TIN, notified payee underreporting, payee certification failure, and elective 30-day start-up or stopping grace periods.
+rules:
+  - name: incorrect_tin_notice_waiting_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(e)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "after the close of the 30th day after the day on which the payor received such notification"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: underreporting_notice_waiting_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(e)(3)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "after the close of the 30th day after the day on which the payor received notification from the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: broker_notification_waiting_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(e)(4)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "after the close of the 30th day after the payor receives notification from a broker"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: start_up_grace_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(e)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "during the 30-day period described in paragraph (2)(A), (3)(A), or (4)(B)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: stopping_grace_period_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(e)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "before the 30th day after the close of such period"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          30
+
+  - name: failure_to_furnish_tin_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any failure by a payee to furnish his TIN to a payor in the manner required"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any reportable payment made by such payor during the period during which the TIN has not been furnished"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_payment
+          and payee_failed_to_furnish_tin_to_payor_in_required_manner
+          and tin_has_not_been_furnished_in_required_manner_when_payment_is_made
+
+  - name: incorrect_tin_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies the payor that the TIN furnished by the payee is incorrect"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "before the payee furnishes another TIN in the manner required"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#incorrect_tin_notice_waiting_period_days
+              output: incorrect_tin_notice_waiting_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_payment
+          and secretary_notifies_payor_that_tin_furnished_by_payee_is_incorrect
+          and days_after_payor_received_incorrect_tin_notification > incorrect_tin_notice_waiting_period_days
+          and not payee_has_furnished_another_tin_in_required_manner_when_payment_is_made
+
+  - name: notified_underreporting_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "notified payee underreporting described in subsection (c)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any reportable interest or dividend payment made ... before the stop date"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#underreporting_notice_waiting_period_days
+              output: underreporting_notice_waiting_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and notified_payee_underreporting_described_in_subsection_c
+          and days_after_payor_received_underreporting_notification > underreporting_notice_waiting_period_days
+          and payment_is_before_stop_date
+
+  - name: payee_certification_failure_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "payee certification failure described in subsection (d)(1)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "during the period during which the certification described in subsection (d)(1) has not been furnished"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "readily tradable instrument acquired by the payee through a broker"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#broker_notification_waiting_period_days
+              output: broker_notification_waiting_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and payee_certification_failure_described_in_subsection_d_1
+          and certification_described_in_subsection_d_1_has_not_been_furnished_to_payor
+          and (
+              not readily_tradable_instrument_acquired_by_payee_through_broker
+              or days_after_payor_received_broker_notification_under_subsection_d_2_B > broker_notification_waiting_period_days
+          )
+
+  - name: start_up_grace_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "If the payor elects the application of this subparagraph with respect to the payee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "during the 30-day period described in paragraph (2)(A), (3)(A), or (4)(B)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#start_up_grace_period_days
+              output: start_up_grace_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_payment
+          and payor_elects_start_up_grace_period_with_respect_to_payee
+          and payment_made_during_start_up_grace_period_described_in_paragraph_2_A_3_A_or_4_B
+          and days_into_start_up_grace_period <= start_up_grace_period_days
+
+  - name: stopping_grace_withholding_period_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Unless the payor elects not to have this subparagraph apply with respect to the payee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "after the close of the period described in paragraph (1), (2), or (4)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "A similar rule shall also apply with respect to the period described in paragraph (3)(A)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#stopping_grace_period_days
+              output: stopping_grace_period_days
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_payment
+          and not payor_elects_out_of_stopping_grace_period_with_respect_to_payee
+          and payment_made_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A
+          and days_after_close_of_period_described_in_paragraph_1_2_4_or_applicable_paragraph_3_A < stopping_grace_period_days
+
+  - name: subsection_a_applies_to_payment_during_subsection_e_period
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#failure_to_furnish_tin_withholding_period_applies
+              output: failure_to_furnish_tin_withholding_period_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#incorrect_tin_withholding_period_applies
+              output: incorrect_tin_withholding_period_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#notified_underreporting_withholding_period_applies
+              output: notified_underreporting_withholding_period_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#payee_certification_failure_withholding_period_applies
+              output: payee_certification_failure_withholding_period_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#start_up_grace_withholding_period_applies
+              output: start_up_grace_withholding_period_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/e#stopping_grace_withholding_period_applies
+              output: stopping_grace_withholding_period_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          failure_to_furnish_tin_withholding_period_applies
+          or incorrect_tin_withholding_period_applies
+          or notified_underreporting_withholding_period_applies
+          or payee_certification_failure_withholding_period_applies
+          or start_up_grace_withholding_period_applies
+          or stopping_grace_withholding_period_applies


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3406(e) withholding-period rules
- add generated companion tests and signed apply manifest
- provenance: generated by `axiom-encode encode --apply`, model `gpt-5.5`, run id `e993e6d1`, encoder version `0.2.361`; deterministic positive-test auto-repairs ran before signed apply

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/e.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/e.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/e.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`