### PR TITLE
Add generated section 3406(g) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/g.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/g.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/g.yaml",
+      "sha256": "8b6779d786f8599c758e19261a4795372465a2a1f0924b1f4735dba4cf86deb9"
+    },
+    {
+      "path": "statutes/26/3406/g.test.yaml",
+      "sha256": "f65f5ab5ca08d04e251c2309e35b266538a7f9185bb54e4587e0a164802a5cf7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3406(g)",
+  "context_manifest_file": "/tmp/axiom-encode-3406-g-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3406-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "315120c2b340216a1cba7381caf39dac030a61a97a69c24c6b74ef88e2abe51b",
+  "generated_at": "2026-05-28T06:12:02.839622+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406-g-20260528-001/openai-gpt-5.5/statutes/26/3406/g.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406-g-20260528-001",
+  "generated_output_sha256": "8b6779d786f8599c758e19261a4795372465a2a1f0924b1f4735dba4cf86deb9",
+  "generation_prompt_sha256": "c65b8ac0570c356e8f1ae34008a1f69056c915d87fb5da8abfc044adf2b5d187",
+  "model": "gpt-5.5",
+  "run_id": "c7591055",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "258a8a2a1a057da717ae9f02daeec9b4ecb620a051a1e97d74b941b47f1d97ef"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3406-g-20260528-001/traces/openai-gpt-5.5/26-USC-3406-g.json",
+  "trace_sha256": "09ac57709bd0178795227630575c7de683abefed14942c5bc733a7cc199637a1"
+}

--- a/statutes/26/3406/g.test.yaml
+++ b/statutes/26/3406/g.test.yaml
@@ -1,0 +1,52 @@
+- name: organization_or_governmental_unit_payee_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/g#input.payment_made_to_organization_or_governmental_unit_described_in_section_6049_b_4_B_C_D_E_or_F: true
+    us:statutes/26/3406/g#input.payment_made_to_other_person_specified_in_regulations: false
+    us:statutes/26/3406/g#input.withholding_on_amount_is_otherwise_required_by_this_title: false
+  output:
+    us:statutes/26/3406/g#exempt_payee_payment_exception_applies: holds
+    us:statutes/26/3406/g#otherwise_required_withholding_exception_applies: not_holds
+    us:statutes/26/3406/g#subsection_a_payment_exception_applies: holds
+- name: regulation_specified_payee_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/g#input.payment_made_to_organization_or_governmental_unit_described_in_section_6049_b_4_B_C_D_E_or_F: false
+    us:statutes/26/3406/g#input.payment_made_to_other_person_specified_in_regulations: true
+    us:statutes/26/3406/g#input.withholding_on_amount_is_otherwise_required_by_this_title: false
+  output:
+    us:statutes/26/3406/g#exempt_payee_payment_exception_applies: holds
+    us:statutes/26/3406/g#otherwise_required_withholding_exception_applies: not_holds
+    us:statutes/26/3406/g#subsection_a_payment_exception_applies: holds
+- name: otherwise_required_withholding_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/g#input.payment_made_to_organization_or_governmental_unit_described_in_section_6049_b_4_B_C_D_E_or_F: false
+    us:statutes/26/3406/g#input.payment_made_to_other_person_specified_in_regulations: false
+    us:statutes/26/3406/g#input.withholding_on_amount_is_otherwise_required_by_this_title: true
+  output:
+    us:statutes/26/3406/g#exempt_payee_payment_exception_applies: not_holds
+    us:statutes/26/3406/g#otherwise_required_withholding_exception_applies: holds
+    us:statutes/26/3406/g#subsection_a_payment_exception_applies: holds
+- name: no_subsection_a_payment_exception_without_exempt_payee_or_other_required_withholding
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/g#input.payment_made_to_organization_or_governmental_unit_described_in_section_6049_b_4_B_C_D_E_or_F: false
+    us:statutes/26/3406/g#input.payment_made_to_other_person_specified_in_regulations: false
+    us:statutes/26/3406/g#input.withholding_on_amount_is_otherwise_required_by_this_title: false
+  output:
+    us:statutes/26/3406/g#exempt_payee_payment_exception_applies: not_holds
+    us:statutes/26/3406/g#otherwise_required_withholding_exception_applies: not_holds
+    us:statutes/26/3406/g#subsection_a_payment_exception_applies: not_holds

--- a/statutes/26/3406/g.yaml
+++ b/statutes/26/3406/g.yaml
@@ -1,0 +1,91 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  deferred_outputs:
+    - output: us:statutes/26/3406/g#waiting_for_tin_regulatory_exemption_from_subsection_a_tax
+      reason: >-
+        Section 3406(g)(3) directs the Secretary to prescribe regulations for
+        exemptions from the tax imposed by subsection (a) during the period a
+        person is waiting for receipt of a TIN, but the source text does not
+        state the operative regulatory exemption conditions.
+  summary: |-
+    Subsection (a) shall not apply to payments made to specified exempt payees, or to amounts for which withholding is otherwise required by this title. The Secretary shall prescribe regulations for exemptions while a person is waiting for receipt of a TIN.
+rules:
+  - name: exempt_payee_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(g)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Subsection (a) shall not apply to any payment made to"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any organization or governmental unit described in subparagraph (B), (C), (D), (E), or (F) of section 6049(b)(4)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any other person specified in regulations"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_organization_or_governmental_unit_described_in_section_6049_b_4_B_C_D_E_or_F
+          or payment_made_to_other_person_specified_in_regulations
+
+  - name: otherwise_required_withholding_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(g)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Subsection (a) shall not apply to any amount for which withholding is otherwise required by this title."
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          withholding_on_amount_is_otherwise_required_by_this_title
+
+  - name: subsection_a_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(g)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/g#exempt_payee_payment_exception_applies
+              output: exempt_payee_payment_exception_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/g#otherwise_required_withholding_exception_applies
+              output: otherwise_required_withholding_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          exempt_payee_payment_exception_applies
+          or otherwise_required_withholding_exception_applies


### PR DESCRIPTION
Generated by axiom-encode apply for `26 USC 3406(g)` using gpt-5.5.\n\nRun id: `c7591055`\n\nLocal checks:\n- `uv run axiom-encode validate .../statutes/26/3406/g.yaml --skip-reviewers --require-oracle-classification --json`\n- `uv run axiom-encode proof-validate .../statutes/26/3406/g.yaml --json`\n- `uv run axiom-encode test .../statutes/26/3406/g.test.yaml`\n- `uv run axiom-encode oracle-coverage --root .../current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`\n- `uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main`