### PR TITLE
Add generated section 3406(h) withholding rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/h.yaml",
+      "sha256": "42f86f3aeba1aeb33a50686ed8abb235b0ab173c9816f341882c361f4558d244"
+    },
+    {
+      "path": "statutes/26/3406/h.test.yaml",
+      "sha256": "90245c033fa78e83a2ce6c0d374f439c30aeb4b620ae1dc71f4c0dea1be13ee0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3406(h)",
+  "context_manifest_file": "/tmp/axiom-encode-3406-h-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3406-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "6b4533a209c0fdd1e5d6dfccaebe94327dbc61ed00dae81e22aafece6db2bc20",
+  "generated_at": "2026-05-28T06:17:17.578289+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406-h-20260528-001/openai-gpt-5.5/statutes/26/3406/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406-h-20260528-001",
+  "generated_output_sha256": "42f86f3aeba1aeb33a50686ed8abb235b0ab173c9816f341882c361f4558d244",
+  "generation_prompt_sha256": "c629bddfc654f21dc567012c2a287d585931fa755781258b67b174f02504d963",
+  "model": "gpt-5.5",
+  "run_id": "93fe36cf",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ddfa582e7e1de4edf2c80396a9e3f67b269a548b806707919e144fc33b8c3dea"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3406-h-20260528-001/traces/openai-gpt-5.5/26-USC-3406-h.json",
+  "trace_sha256": "12c29debea793f7d74ac7ea2a1d2a477e006b77b6b45a04749b02858058c2d16"
+}

--- a/statutes/26/3406/h.test.yaml
+++ b/statutes/26/3406/h.test.yaml
@@ -1,0 +1,114 @@
+- name: person_tin_lockout_and_payor_rules_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.tin_furnished_does_not_contain_proper_number_of_digits: true
+    us:statutes/26/3406/h#input.incorrect_tins_furnished_to_payor_count_in_period: 2
+    us:statutes/26/3406/h#input.incorrect_tin_count_period_years: 3
+    us:statutes/26/3406/h#input.payor_received_notice_of_second_incorrect_tin: true
+    us:statutes/26/3406/h#input.payor_has_received_secretary_notification_that_correct_tin_has_been_furnished: false
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_2_with_respect_to_payment: true
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_3_with_respect_to_payment: false
+  output:
+    us:statutes/26/3406/h#improper_digit_tin_treated_as_failure_to_furnish: holds
+    us:statutes/26/3406/h#second_incorrect_tin_lockout_applies: holds
+    us:statutes/26/3406/h#payor: holds
+- name: person_tin_lockout_and_payor_rules_apply_scalar_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.tin_furnished_does_not_contain_proper_number_of_digits: true
+    us:statutes/26/3406/h#input.incorrect_tins_furnished_to_payor_count_in_period: 2
+    us:statutes/26/3406/h#input.incorrect_tin_count_period_years: 3
+    us:statutes/26/3406/h#input.payor_received_notice_of_second_incorrect_tin: true
+    us:statutes/26/3406/h#input.payor_has_received_secretary_notification_that_correct_tin_has_been_furnished: false
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_2_with_respect_to_payment: true
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_3_with_respect_to_payment: false
+  output:
+    us:statutes/26/3406/h#incorrect_tin_count_threshold_for_lockout: 2
+    us:statutes/26/3406/h#incorrect_tin_lockout_period_years: 3
+- name: secretary_correct_tin_notice_ends_lockout_and_no_return_requirement_means_not_payor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.tin_furnished_does_not_contain_proper_number_of_digits: false
+    us:statutes/26/3406/h#input.incorrect_tins_furnished_to_payor_count_in_period: 2
+    us:statutes/26/3406/h#input.incorrect_tin_count_period_years: 3
+    us:statutes/26/3406/h#input.payor_received_notice_of_second_incorrect_tin: true
+    us:statutes/26/3406/h#input.payor_has_received_secretary_notification_that_correct_tin_has_been_furnished: true
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_2_with_respect_to_payment: false
+    us:statutes/26/3406/h#input.person_required_to_file_return_described_in_subsection_b_3_with_respect_to_payment: false
+  output:
+    us:statutes/26/3406/h#improper_digit_tin_treated_as_failure_to_furnish: not_holds
+    us:statutes/26/3406/h#second_incorrect_tin_lockout_applies: not_holds
+    us:statutes/26/3406/h#payor: not_holds
+- name: payment_joint_notice_and_coordination_rules_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.payment_made_to_joint_payees: true
+    us:statutes/26/3406/h#input.regulations_provide_otherwise_for_joint_payee_payment: false
+    us:statutes/26/3406/h#input.secretary_notifies_payor_under_subsection_a_1_B_that_payee_tin_is_incorrect: true
+    us:statutes/26/3406/h#input.payee_subsequently_furnishes_another_tin_to_payor: true
+    us:statutes/26/3406/h#input.payment_subject_to_withholding_under_section_3406: true
+    us:statutes/26/3406/h#input.amount_deducted_and_withheld_under_section_3406: true
+    ? us:statutes/26/3406/h#input.coordination_purpose_is_section_31_or_this_chapter_other_than_section_3402_n_or_subtitle_F_related_to_this_chapter_other_than_section_7205
+    : true
+  output:
+    us:statutes/26/3406/h#joint_payee_payment_attributed_to_first_listed_payee: holds
+    us:statutes/26/3406/h#payor_must_promptly_furnish_incorrect_tin_notice_copy_to_payee: holds
+    us:statutes/26/3406/h#payor_must_promptly_notify_secretary_of_other_tin: holds
+    us:statutes/26/3406/h#backup_withheld_payments_treated_as_wages_for_coordination: holds
+    us:statutes/26/3406/h#backup_withheld_amounts_treated_as_withheld_under_section_3402: holds
+- name: regulatory_exceptions_and_missing_subsequent_tin_block_payment_rules_but_asset_market_rule_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.payment_made_to_joint_payees: true
+    us:statutes/26/3406/h#input.regulations_provide_otherwise_for_joint_payee_payment: true
+    us:statutes/26/3406/h#input.secretary_notifies_payor_under_subsection_a_1_B_that_payee_tin_is_incorrect: true
+    us:statutes/26/3406/h#input.payee_subsequently_furnishes_another_tin_to_payor: false
+    us:statutes/26/3406/h#input.payment_subject_to_withholding_under_section_3406: false
+    us:statutes/26/3406/h#input.amount_deducted_and_withheld_under_section_3406: false
+    ? us:statutes/26/3406/h#input.coordination_purpose_is_section_31_or_this_chapter_other_than_section_3402_n_or_subtitle_F_related_to_this_chapter_other_than_section_7205
+    : true
+    ? us:statutes/26/3406/h#input.instrument_is_part_of_issue_with_portion_traded_on_established_securities_market_within_section_453_f_5
+    : true
+    us:statutes/26/3406/h#input.instrument_is_regularly_quoted_by_brokers_or_dealers_making_a_market: false
+    us:statutes/26/3406/h#input.secretary_regulations_provide_otherwise_for_regularly_quoted_instruments: true
+  output:
+    us:statutes/26/3406/h#joint_payee_payment_attributed_to_first_listed_payee: not_holds
+    us:statutes/26/3406/h#payor_must_promptly_furnish_incorrect_tin_notice_copy_to_payee: holds
+    us:statutes/26/3406/h#payor_must_promptly_notify_secretary_of_other_tin: not_holds
+    us:statutes/26/3406/h#backup_withheld_payments_treated_as_wages_for_coordination: not_holds
+    us:statutes/26/3406/h#backup_withheld_amounts_treated_as_withheld_under_section_3402: not_holds
+- name: regulatory_exceptions_and_missing_subsequent_tin_block_payment_rules_but_asset_market_rule_applies_asset_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/h#input.payment_made_to_joint_payees: true
+    us:statutes/26/3406/h#input.regulations_provide_otherwise_for_joint_payee_payment: true
+    us:statutes/26/3406/h#input.secretary_notifies_payor_under_subsection_a_1_B_that_payee_tin_is_incorrect: true
+    us:statutes/26/3406/h#input.payee_subsequently_furnishes_another_tin_to_payor: false
+    us:statutes/26/3406/h#input.payment_subject_to_withholding_under_section_3406: false
+    us:statutes/26/3406/h#input.amount_deducted_and_withheld_under_section_3406: false
+    ? us:statutes/26/3406/h#input.coordination_purpose_is_section_31_or_this_chapter_other_than_section_3402_n_or_subtitle_F_related_to_this_chapter_other_than_section_7205
+    : true
+    ? us:statutes/26/3406/h#input.instrument_is_part_of_issue_with_portion_traded_on_established_securities_market_within_section_453_f_5
+    : true
+    us:statutes/26/3406/h#input.instrument_is_regularly_quoted_by_brokers_or_dealers_making_a_market: false
+    us:statutes/26/3406/h#input.secretary_regulations_provide_otherwise_for_regularly_quoted_instruments: true
+  output:
+    us:statutes/26/3406/h#readily_tradable_instrument: holds

--- a/statutes/26/3406/h.yaml
+++ b/statutes/26/3406/h.yaml
@@ -1,0 +1,291 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  deferred_outputs:
+    - output: us:statutes/26/3406/h#broker
+      reason: >-
+        Section 3406(h)(5)(A) gives "broker" the meaning given by section
+        6045(c)(1), and no copied RuleSpec context provides that definition.
+        The closest-contact, payor-exclusion, and real-estate-broker-exclusion
+        special rules cannot produce a final broker definition without the
+        upstream section 6045(c)(1) baseline and section 6045(e)(2) real estate
+        broker definition or regulations.
+    - output: us:statutes/26/3406/h#original_issue_discount_rules
+      reason: >-
+        Section 3406(h)(7) applies rules similar to section 6049(d)(6) only to
+        the extent provided in regulations. No copied RuleSpec context provides
+        section 6049(d)(6) or the operative regulations.
+  summary: |-
+    For purposes of section 3406: a TIN with an improper number of digits is treated as failure to furnish a TIN; two incorrect TINs in any 3-year period trigger treatment as not furnishing another TIN until Secretary notification of a correct TIN; joint payee payments are attributed to the first listed payee except as regulations provide; payor, broker, readily tradable instrument, original issue discount, notice, and coordination rules are stated.
+rules:
+  - name: incorrect_tin_count_threshold_for_lockout
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(h)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "2 incorrect TINs"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2
+
+  - name: incorrect_tin_lockout_period_years
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(h)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "in any 3-year period"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          3
+
+  - name: improper_digit_tin_treated_as_failure_to_furnish
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "treated as failing to furnish his TIN if the TIN furnished does not contain the proper number of digits"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          tin_furnished_does_not_contain_proper_number_of_digits
+
+  - name: second_incorrect_tin_lockout_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "If the payee furnishes the payor 2 incorrect TINs in any 3-year period"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "after receiving notice of the second incorrect TIN"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "until the day on which the payor receives notification from the Secretary that a correct TIN has been furnished"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/h#incorrect_tin_count_threshold_for_lockout
+              output: incorrect_tin_count_threshold_for_lockout
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/h#incorrect_tin_lockout_period_years
+              output: incorrect_tin_lockout_period_years
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          incorrect_tins_furnished_to_payor_count_in_period >= incorrect_tin_count_threshold_for_lockout
+          and incorrect_tin_count_period_years <= incorrect_tin_lockout_period_years
+          and payor_received_notice_of_second_incorrect_tin
+          and not payor_has_received_secretary_notification_that_correct_tin_has_been_furnished
+
+  - name: joint_payee_payment_attributed_to_first_listed_payee
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any payment to joint payees shall be treated as if all the payment were made to the first person listed"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Except to the extent otherwise provided in regulations"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_joint_payees
+          and not regulations_provide_otherwise_for_joint_payee_payment
+
+  - name: payor
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "a person required to file a return described in paragraph (2) or (3) of subsection (b) with respect to such payment"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_required_to_file_return_described_in_subsection_b_2_with_respect_to_payment
+          or person_required_to_file_return_described_in_subsection_b_3_with_respect_to_payment
+
+  - name: readily_tradable_instrument
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any instrument which is part of an issue any portion of which is traded on an established securities market"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any instrument which is regularly quoted by brokers or dealers making a market"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "except as otherwise provided in regulations prescribed by the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          instrument_is_part_of_issue_with_portion_traded_on_established_securities_market_within_section_453_f_5
+          or (
+              instrument_is_regularly_quoted_by_brokers_or_dealers_making_a_market
+              and not secretary_regulations_provide_otherwise_for_regularly_quoted_instruments
+          )
+
+  - name: payor_must_promptly_furnish_incorrect_tin_notice_copy_to_payee
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Whenever the Secretary notifies a payor under paragraph (1)(B) of subsection (a) that the TIN furnished by any payee is incorrect"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payor shall promptly furnish such copy to the payee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          secretary_notifies_payor_under_subsection_a_1_B_that_payee_tin_is_incorrect
+
+  - name: payor_must_promptly_notify_secretary_of_other_tin
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "If the Secretary notifies a payor under paragraph (1)(B) of subsection (a) that the TIN furnished by any payee is incorrect"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "such payee subsequently furnishes another TIN to the payor"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payor shall promptly notify the Secretary of the other TIN so furnished"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          secretary_notifies_payor_under_subsection_a_1_B_that_payee_tin_is_incorrect
+          and payee_subsequently_furnishes_another_tin_to_payor
+
+  - name: backup_withheld_payments_treated_as_wages_for_coordination
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "payments which are subject to withholding under this section shall be treated as if they were wages paid by an employer to an employee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_subject_to_withholding_under_section_3406
+          and coordination_purpose_is_section_31_or_this_chapter_other_than_section_3402_n_or_subtitle_F_related_to_this_chapter_other_than_section_7205
+
+  - name: backup_withheld_amounts_treated_as_withheld_under_section_3402
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(h)(10)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "amounts deducted and withheld under this section shall be treated as if deducted and withheld under section 3402"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_deducted_and_withheld_under_section_3406
+          and coordination_purpose_is_section_31_or_this_chapter_other_than_section_3402_n_or_subtitle_F_related_to_this_chapter_other_than_section_7205


### PR DESCRIPTION
Generated by axiom-encode apply for `26 USC 3406(h)` using gpt-5.5.\n\nRun id: `93fe36cf`\n\nLocal checks:\n- `uv run axiom-encode validate .../statutes/26/3406/h.yaml --skip-reviewers --require-oracle-classification --json`\n- `uv run axiom-encode proof-validate .../statutes/26/3406/h.yaml --json`\n- `uv run axiom-encode test .../statutes/26/3406/h.test.yaml`\n- `uv run axiom-encode oracle-coverage --root .../current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`\n- `uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main`