### PR TITLE
Add generated section 3505 liability rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3505.json
+++ b/.axiom/encoding-manifests/statutes/26/3505.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3505.yaml",
+      "sha256": "4a4c292bfc38ba96454a32e707f75b7c825be241471a9e32d7014e0b5578f6f9"
+    },
+    {
+      "path": "statutes/26/3505.test.yaml",
+      "sha256": "d2287ba21a7f154fcc1d061ec7e6709c2b8a7dc099d08fd408ddca652e16a3d0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6abf7a1f844f4d9523375321d01857c11a2d830c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.361",
+    "version_commit": "6abf7a1f844f4d9523375321d01857c11a2d830c"
+  },
+  "axiom_encode_version": "0.2.361",
+  "backend": "openai",
+  "citation": "26 USC 3505",
+  "context_manifest_file": "/tmp/axiom-encode-3505-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3505/workspace/context-manifest.json",
+  "context_manifest_sha256": "cec5a48a792629fd09affaf7ded3dc0a3a0e28d1ed6c8482a4e28736fed64c2f",
+  "generated_at": "2026-05-28T06:25:21.490222+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3505-20260528-001/openai-gpt-5.5/statutes/26/3505.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3505-20260528-001",
+  "generated_output_sha256": "4a4c292bfc38ba96454a32e707f75b7c825be241471a9e32d7014e0b5578f6f9",
+  "generation_prompt_sha256": "b85cc8128dece7140b76c0669a978bc7cd084eab2ac7051855a79a81a5643be5",
+  "model": "gpt-5.5",
+  "run_id": "80c43ac3",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3ad8df2446ec53e6bf2f1ec2085ddb81f83986da7a9845671ff4c704c7000a3d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3505-20260528-001/traces/openai-gpt-5.5/26-USC-3505.json",
+  "trace_sha256": "89056665b8991562fd195f3cddd998b5191fd5c680ea82784371b4feaa054c5c"
+}

--- a/statutes/26/3505.test.yaml
+++ b/statutes/26/3505.test.yaml
@@ -1,0 +1,166 @@
+- name: direct_wage_payment_liability_applies_when_nonemployer_lender_directly_pays_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_is_not_employer_under_sections_3102_3202_3402_and_3403_with_respect_to_employees: true
+      us:statutes/26/3505#input.third_party_pays_wages_directly_to_employee_group_or_agent: true
+      us:statutes/26/3505#input.taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages: 1200
+      us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: false
+      us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 0
+      us:statutes/26/3402/a#input.wages: 0
+      us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 0
+      us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 0
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: false
+      us:statutes/26/3505#input.third_party_is_not_employer_under_sections_3102_3202_3402_and_3403_with_respect_to_employees: true
+      us:statutes/26/3505#input.third_party_pays_wages_directly_to_employee_group_or_agent: true
+      us:statutes/26/3505#input.taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages: 1200
+      us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: false
+      us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 0
+      us:statutes/26/3402/a#input.wages: 0
+      us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 0
+      us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 0
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_is_not_employer_under_sections_3102_3202_3402_and_3403_with_respect_to_employees: false
+      us:statutes/26/3505#input.third_party_pays_wages_directly_to_employee_group_or_agent: true
+      us:statutes/26/3505#input.taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages: 1200
+      us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: false
+      us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 0
+      us:statutes/26/3402/a#input.wages: 0
+      us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 0
+      us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 0
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_is_not_employer_under_sections_3102_3202_3402_and_3403_with_respect_to_employees: true
+      us:statutes/26/3505#input.third_party_pays_wages_directly_to_employee_group_or_agent: false
+      us:statutes/26/3505#input.taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages: 1200
+      us:statutes/26/3102/a#input.employer_is_employer_of_taxpayer: true
+      us:statutes/26/3102/a#input.wages_are_paid: true
+      us:statutes/26/3202#input.employer_required_under_subsection_a_to_deduct_tax: false
+      us:statutes/26/3202#input.tax_required_to_deduct_from_employee_compensation: 0
+      us:statutes/26/3402/a#input.wages: 0
+      us:statutes/26/3402/a#input.taxpayer_withholding_allowance_prorated_to_payroll_period: 0
+      us:statutes/26/3403#input.tax_required_to_be_deducted_and_withheld_under_this_chapter: 0
+  output:
+    us:statutes/26/3505#direct_wage_payment_third_party_liability_applies:
+    - holds
+    - not_holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3505#direct_wage_payment_third_party_liability:
+    - 1200
+    - 0
+    - 0
+    - 0
+- name: supplied_funds_liability_limited_to_twenty_five_percent_of_amount_supplied
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: true
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: true
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : true
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 4000
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: true
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: true
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : true
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 1200
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+  output:
+    us:statutes/26/3505#supplied_funds_liability_limit_rate: 0.25
+    us:statutes/26/3505#supplied_funds_third_party_liability_applies:
+    - holds
+    - holds
+    us:statutes/26/3505#supplied_funds_third_party_liability_before_limit:
+    - 4000
+    - 1200
+    us:statutes/26/3505#supplied_funds_third_party_liability_limit:
+    - 2500
+    - 2500
+    us:statutes/26/3505#supplied_funds_third_party_liability:
+    - 2500
+    - 1200
+- name: supplied_funds_liability_requires_each_statutory_gate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: false
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: true
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: true
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : true
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 1200
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: false
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: true
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : true
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 1200
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: true
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: false
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : true
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 1200
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+    - us:statutes/26/3505#input.third_party_is_lender_surety_or_other_person: true
+      us:statutes/26/3505#input.third_party_supplies_funds_to_or_for_account_of_employer: true
+      us:statutes/26/3505#input.funds_supplied_for_specific_purpose_of_paying_employer_wages: true
+      ? us:statutes/26/3505#input.third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure
+      : false
+      ? us:statutes/26/3505#input.taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds
+      : 1200
+      us:statutes/26/3505#input.amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose: 10000
+  output:
+    us:statutes/26/3505#supplied_funds_third_party_liability_applies:
+    - not_holds
+    - not_holds
+    - not_holds
+    - not_holds
+    us:statutes/26/3505#supplied_funds_third_party_liability_before_limit:
+    - 0
+    - 0
+    - 0
+    - 0
+    us:statutes/26/3505#supplied_funds_third_party_liability:
+    - 0
+    - 0
+    - 0
+    - 0
+- name: section_3505_payment_credit_against_employer_liability
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3505#input.amounts_paid_to_united_states_pursuant_to_section_3505: 1800
+  output:
+    us:statutes/26/3505#employer_liability_credit_for_section_3505_payments: 1800

--- a/statutes/26/3505.yaml
+++ b/statutes/26/3505.yaml
@@ -1,0 +1,231 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3505
+  summary: Section 3505 makes a lender, surety, or other non-employer person personally
+    liable to the United States for withholding taxes and interest when it directly
+    pays wages for purposes of sections 3102, 3202, 3402, and 3403, or when it supplies
+    funds for the specific purpose of paying wages with actual notice or knowledge
+    that the employer will not make timely withholding-tax payment or deposit. The
+    supplied-funds liability is limited to 25 percent of the amount supplied. Amounts
+    paid under this section are credited against the employer's liability.
+imports:
+- us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+- us:statutes/26/3202#employer_section_3201_tax_payment_liability
+- us:statutes/26/3402/a#amount_of_wages_for_withholding_tables
+- us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
+rules:
+- name: supplied_funds_liability_limit_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3505(b), second sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: limited to an amount equal to 25 percent of the amount so supplied
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.25'
+- name: direct_wage_payment_third_party_liability_applies
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3505(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: if a lender, surety, or other person, who is not an employer under
+            such sections with respect to an employee or group of employees, pays
+            wages directly
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3102/a#employer_required_to_collect_section_3101_tax_by_wage_deduction
+          output: employer_required_to_collect_section_3101_tax_by_wage_deduction
+          hash: sha256:311604c9cc85d575f5115a34f1e664533465f2daea2626cae3518d3b593003e9
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3202#employer_section_3201_tax_payment_liability
+          output: employer_section_3201_tax_payment_liability
+          hash: sha256:37979be14574c0f3619fdd88b95c6c753fe279ba96427eeddc45e47c5a995a18
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3402/a#amount_of_wages_for_withholding_tables
+          output: amount_of_wages_for_withholding_tables
+          hash: sha256:f9facf3737b27df1ceb4af84b1f3212a61107e70b029bc13a68b5880832386e4
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
+          output: employer_liability_for_chapter_withholding_tax_payment
+          hash: sha256:8c8164eb226ffa31e3b381d0513429823d8507fd9b230fbd8c0f200028054382
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "third_party_is_lender_surety_or_other_person\nand third_party_is_not_employer_under_sections_3102_3202_3402_and_3403_with_respect_to_employees\n\
+      and third_party_pays_wages_directly_to_employee_group_or_agent\nand (\n    employer_required_to_collect_section_3101_tax_by_wage_deduction\n\
+      \    or employer_section_3201_tax_payment_liability > 0\n    or amount_of_wages_for_withholding_tables\
+      \ > 0\n    or employer_liability_for_chapter_withholding_tax_payment > 0\n)"
+- name: direct_wage_payment_third_party_liability
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3505(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: shall be liable ... in a sum equal to the taxes (together with
+            interest) required to be deducted and withheld from such wages
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3505#direct_wage_payment_third_party_liability_applies
+          output: direct_wage_payment_third_party_liability_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if direct_wage_payment_third_party_liability_applies: max(0, taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages)
+      else: 0'
+- name: supplied_funds_third_party_liability_applies
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3505(b), first sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: supplies funds to or for the account of an employer for the specific
+            purpose of paying wages
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: with actual notice or knowledge ... that such employer does not
+            intend to or will not be able to make timely payment or deposit
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'third_party_is_lender_surety_or_other_person
+
+      and third_party_supplies_funds_to_or_for_account_of_employer
+
+      and funds_supplied_for_specific_purpose_of_paying_employer_wages
+
+      and third_party_has_actual_notice_or_knowledge_under_section_6323_i_1_of_employer_withholding_payment_failure'
+- name: supplied_funds_third_party_liability_before_limit
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3505(b), first sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: liable ... in a sum equal to the taxes (together with interest)
+            which are not paid over to the United States by such employer
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3505#supplied_funds_third_party_liability_applies
+          output: supplied_funds_third_party_liability_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if supplied_funds_third_party_liability_applies: max(0, taxes_together_with_interest_not_paid_over_by_employer_with_respect_to_wages_paid_from_supplied_funds)
+      else: 0'
+- name: supplied_funds_third_party_liability_limit
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3505(b), second sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: limited to an amount equal to 25 percent of the amount so supplied
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3505#supplied_funds_liability_limit_rate
+          output: supplied_funds_liability_limit_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: supplied_funds_liability_limit_rate * max(0, amount_supplied_to_or_for_account_of_employer_for_wage_payment_purpose)
+- name: supplied_funds_third_party_liability
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3505(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3505#supplied_funds_third_party_liability_before_limit
+          output: supplied_funds_third_party_liability_before_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3505#supplied_funds_third_party_liability_limit
+          output: supplied_funds_third_party_liability_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "min(\n    supplied_funds_third_party_liability_before_limit,\n    supplied_funds_third_party_liability_limit\n\
+      )"
+- name: employer_liability_credit_for_section_3505_payments
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3505(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3505
+          excerpt: Any amounts paid to the United States pursuant to this section
+            shall be credited against the liability of the employer.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: max(0, amounts_paid_to_united_states_pursuant_to_section_3505)


### PR DESCRIPTION
Generated by axiom-encode apply for `26 USC 3505` using gpt-5.5.\n\nRun id: `80c43ac3`\n\nEncoder coverage support merged in TheAxiomFoundation/axiom-encode#388.\n\nLocal checks:\n- `uv run axiom-encode validate .../statutes/26/3505.yaml --skip-reviewers --require-oracle-classification --json`\n- `uv run axiom-encode proof-validate .../statutes/26/3505.yaml --json`\n- `uv run axiom-encode test .../statutes/26/3505.test.yaml`\n- `uv run axiom-encode oracle-coverage --root .../current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`\n- `uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main`