### PR TITLE
Add generated section 3506 sitter placement rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3506.json
+++ b/.axiom/encoding-manifests/statutes/26/3506.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3506.yaml",
+      "sha256": "5f3d32a5f336197aa054ffa0509095f2f80de031cbd3f612c06bcc8f48fd69e1"
+    },
+    {
+      "path": "statutes/26/3506.test.yaml",
+      "sha256": "b923402fd38e871ec1522cbe9ca57ed9331baa934b716dd90cf05fb668f6e699"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0cab53a60dd1b054ee9e5f69d21fdff456224140",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.362",
+    "version_commit": "0cab53a60dd1b054ee9e5f69d21fdff456224140"
+  },
+  "axiom_encode_version": "0.2.362",
+  "backend": "openai",
+  "citation": "26 USC 3506",
+  "context_manifest_file": "/tmp/axiom-encode-3506-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3506/workspace/context-manifest.json",
+  "context_manifest_sha256": "729b006355476d565ef2b93e5665076a72fb7bb327582666f86aae7ba4dbc37f",
+  "generated_at": "2026-05-28T06:47:04.833545+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3506-20260528-001/openai-gpt-5.5/statutes/26/3506.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3506-20260528-001",
+  "generated_output_sha256": "5f3d32a5f336197aa054ffa0509095f2f80de031cbd3f612c06bcc8f48fd69e1",
+  "generation_prompt_sha256": "7e6aac4792a66c5221e5b4e9cdf743253ef558de478614aafb9e4ff76f9b956a",
+  "model": "gpt-5.5",
+  "run_id": "856f88a1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f36c4273c64dde4187f8952102d4adfcc97be2a15cc329b3a84652214d9c5d8a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3506-20260528-001/traces/openai-gpt-5.5/26-USC-3506.json",
+  "trace_sha256": "f54384e381a2b6cb5b05c1e7e64bc8fdaea05d6e7e8f022ba35f314926fb8724"
+}

--- a/statutes/26/3506.test.yaml
+++ b/statutes/26/3506.test.yaml
@@ -1,0 +1,53 @@
+- name: sitter_definition_personal_attendance_to_child
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3506#input.individual_furnishes_personal_attendance_companionship_or_household_care_services: true
+    us:statutes/26/3506#input.services_are_furnished_to_children: true
+    us:statutes/26/3506#input.services_are_furnished_to_elderly_individuals: false
+    us:statutes/26/3506#input.services_are_furnished_to_disabled_individuals: false
+  output:
+    us:statutes/26/3506#sitters: holds
+- name: sitter_definition_no_qualifying_recipient
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3506#input.individual_furnishes_personal_attendance_companionship_or_household_care_services: true
+    us:statutes/26/3506#input.services_are_furnished_to_children: false
+    us:statutes/26/3506#input.services_are_furnished_to_elderly_individuals: false
+    us:statutes/26/3506#input.services_are_furnished_to_disabled_individuals: false
+  output:
+    us:statutes/26/3506#sitters: not_holds
+- name: placement_business_not_treated_as_employer_when_conditions_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3506#input.person_engaged_in_trade_or_business_of_putting_sitters_in_touch_with_individuals_who_wish_to_employ_them
+    : true
+    us:statutes/26/3506#input.worker_is_sitter: true
+    us:statutes/26/3506#input.person_pays_or_receives_salary_or_wages_of_sitters: false
+    us:statutes/26/3506#input.person_is_compensated_by_sitters_or_employing_individuals_on_fee_basis: true
+  output:
+    us:statutes/26/3506#sitter_placement_person_not_treated_as_employer: holds
+- name: sitter_not_treated_as_employee_when_conditions_met
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3506#input.person_engaged_in_trade_or_business_of_putting_sitters_in_touch_with_individuals_who_wish_to_employ_them
+    : true
+    us:statutes/26/3506#input.individual_furnishes_personal_attendance_companionship_or_household_care_services: true
+    us:statutes/26/3506#input.services_are_furnished_to_children: false
+    us:statutes/26/3506#input.services_are_furnished_to_elderly_individuals: true
+    us:statutes/26/3506#input.services_are_furnished_to_disabled_individuals: false
+    us:statutes/26/3506#input.placement_person_pays_or_receives_salary_or_wages_of_sitters: false
+    us:statutes/26/3506#input.placement_person_is_compensated_by_sitters_or_employing_individuals_on_fee_basis: true
+  output:
+    us:statutes/26/3506#sitter_not_treated_as_employee_of_placement_person: holds

--- a/statutes/26/3506.yaml
+++ b/statutes/26/3506.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3506
+  summary: |-
+    For purposes of this subtitle, a person engaged in the trade or business of putting sitters in touch with individuals who wish to employ them shall not be treated as the employer of such sitters if the person does not pay or receive the salary or wages of the sitters and is compensated on a fee basis. “Sitters” means individuals who furnish personal attendance, companionship, or household care services to children or to individuals who are elderly or disabled.
+rules:
+  - name: sitters
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3506(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3506
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_furnishes_personal_attendance_companionship_or_household_care_services
+          and (
+              services_are_furnished_to_children
+              or services_are_furnished_to_elderly_individuals
+              or services_are_furnished_to_disabled_individuals
+          )
+
+  - name: sitter_placement_person_not_treated_as_employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3506(a), 26 USC 3506(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3506
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3506
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_engaged_in_trade_or_business_of_putting_sitters_in_touch_with_individuals_who_wish_to_employ_them
+          and worker_is_sitter
+          and not person_pays_or_receives_salary_or_wages_of_sitters
+          and person_is_compensated_by_sitters_or_employing_individuals_on_fee_basis
+
+  - name: sitter_not_treated_as_employee_of_placement_person
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3506(a), 26 USC 3506(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3506
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3506
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_engaged_in_trade_or_business_of_putting_sitters_in_touch_with_individuals_who_wish_to_employ_them
+          and sitters
+          and not placement_person_pays_or_receives_salary_or_wages_of_sitters
+          and placement_person_is_compensated_by_sitters_or_employing_individuals_on_fee_basis


### PR DESCRIPTION
## Summary
- Add generated 26 USC 3506 sitter-placement rules and companion tests.
- Include signed axiom-encode apply manifest for run `856f88a1` using `gpt-5.5`.
- Depends on merged encoder oracle classification support in TheAxiomFoundation/axiom-encode#389.

## Validation
- `uv run axiom-encode validate statutes/26/3506.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate statutes/26/3506.yaml --json`
- `uv run axiom-encode test statutes/26/3506.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`