### PR TITLE
Add generated section 3508 worker classification rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3508.json
+++ b/.axiom/encoding-manifests/statutes/26/3508.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3508.yaml",
+      "sha256": "27cf6193095ef4392bff83a98438ca352f4a323a93af26d520738eb0c0f072bf"
+    },
+    {
+      "path": "statutes/26/3508.test.yaml",
+      "sha256": "f4d857fd380351d0594dba742fdd61d43c115141e7a9667f23a68a8c8c186c34"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "88d8f37a29fe5c940bf6eeb2c17e0eef0f3cd9be",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.363",
+    "version_commit": "88d8f37a29fe5c940bf6eeb2c17e0eef0f3cd9be"
+  },
+  "axiom_encode_version": "0.2.363",
+  "backend": "openai",
+  "citation": "26 USC 3508",
+  "context_manifest_file": "/tmp/axiom-encode-3508-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3508/workspace/context-manifest.json",
+  "context_manifest_sha256": "4172f56a930324afd91e1cbfbc37df7544631256306ff30e64949537492baec4",
+  "generated_at": "2026-05-28T07:08:42.439443+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3508-20260528-001/openai-gpt-5.5/statutes/26/3508.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3508-20260528-001",
+  "generated_output_sha256": "27cf6193095ef4392bff83a98438ca352f4a323a93af26d520738eb0c0f072bf",
+  "generation_prompt_sha256": "102ad00bced030df913b56cef37716c0e258e2abfa9961befe46cc41ed80c004",
+  "model": "gpt-5.5",
+  "run_id": "af1bc871",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1b02809432c1f7aa4e63ebb8637c064c6fb68b68f71070475e642a91b165125f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3508-20260528-001/traces/openai-gpt-5.5/26-USC-3508.json",
+  "trace_sha256": "d6dca813c7210b8d39e2f4938a6fe979d26be4b5c1273938c85f56b77bacbb41"
+}

--- a/statutes/26/3508.test.yaml
+++ b/statutes/26/3508.test.yaml
@@ -1,0 +1,100 @@
+- name: qualified_real_estate_agent_and_direct_seller_resale_path_hold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3508#input.individual_is_sales_person: true
+    us:statutes/26/3508#input.individual_is_licensed_real_estate_agent: true
+    ? us:statutes/26/3508#input.real_estate_agent_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.real_estate_agent_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+    ? us:statutes/26/3508#input.engaged_in_consumer_products_resale_trade_or_business_on_buy_sell_deposit_commission_or_secretary_prescribed_similar_basis_for_home_or_nonpermanent_retail_resale
+    : true
+    us:statutes/26/3508#input.engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business: false
+    us:statutes/26/3508#input.engaged_in_newspaper_or_shopping_news_delivery_or_distribution_trade_or_business: false
+    ? us:statutes/26/3508#input.direct_seller_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.direct_seller_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+  output:
+    us:statutes/26/3508#qualified_real_estate_agent: holds
+    us:statutes/26/3508#direct_seller_engaged_trade_or_business: holds
+    us:statutes/26/3508#direct_seller: holds
+    us:statutes/26/3508#services_performed_as_qualified_real_estate_agent_or_direct_seller: holds
+- name: real_estate_license_missing_and_no_direct_seller_trade_or_business
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3508#input.individual_is_sales_person: true
+    us:statutes/26/3508#input.individual_is_licensed_real_estate_agent: false
+    ? us:statutes/26/3508#input.real_estate_agent_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.real_estate_agent_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+    ? us:statutes/26/3508#input.engaged_in_consumer_products_resale_trade_or_business_on_buy_sell_deposit_commission_or_secretary_prescribed_similar_basis_for_home_or_nonpermanent_retail_resale
+    : false
+    us:statutes/26/3508#input.engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business: false
+    us:statutes/26/3508#input.engaged_in_newspaper_or_shopping_news_delivery_or_distribution_trade_or_business: false
+    ? us:statutes/26/3508#input.direct_seller_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.direct_seller_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+  output:
+    us:statutes/26/3508#qualified_real_estate_agent: not_holds
+    us:statutes/26/3508#direct_seller_engaged_trade_or_business: not_holds
+    us:statutes/26/3508#direct_seller: not_holds
+    us:statutes/26/3508#services_performed_as_qualified_real_estate_agent_or_direct_seller: not_holds
+- name: remuneration_not_output_based_blocks_both_definitions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3508#input.individual_is_sales_person: true
+    us:statutes/26/3508#input.individual_is_licensed_real_estate_agent: true
+    ? us:statutes/26/3508#input.real_estate_agent_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : false
+    ? us:statutes/26/3508#input.real_estate_agent_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+    ? us:statutes/26/3508#input.engaged_in_consumer_products_resale_trade_or_business_on_buy_sell_deposit_commission_or_secretary_prescribed_similar_basis_for_home_or_nonpermanent_retail_resale
+    : false
+    us:statutes/26/3508#input.engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business: true
+    us:statutes/26/3508#input.engaged_in_newspaper_or_shopping_news_delivery_or_distribution_trade_or_business: false
+    ? us:statutes/26/3508#input.direct_seller_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : false
+    ? us:statutes/26/3508#input.direct_seller_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : true
+  output:
+    us:statutes/26/3508#qualified_real_estate_agent: not_holds
+    us:statutes/26/3508#direct_seller_engaged_trade_or_business: holds
+    us:statutes/26/3508#direct_seller: not_holds
+    us:statutes/26/3508#services_performed_as_qualified_real_estate_agent_or_direct_seller: not_holds
+- name: written_contract_missing_blocks_both_definitions_even_with_newspaper_path
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3508#input.individual_is_sales_person: true
+    us:statutes/26/3508#input.individual_is_licensed_real_estate_agent: true
+    ? us:statutes/26/3508#input.real_estate_agent_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.real_estate_agent_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : false
+    ? us:statutes/26/3508#input.engaged_in_consumer_products_resale_trade_or_business_on_buy_sell_deposit_commission_or_secretary_prescribed_similar_basis_for_home_or_nonpermanent_retail_resale
+    : false
+    us:statutes/26/3508#input.engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business: false
+    us:statutes/26/3508#input.engaged_in_newspaper_or_shopping_news_delivery_or_distribution_trade_or_business: true
+    ? us:statutes/26/3508#input.direct_seller_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+    : true
+    ? us:statutes/26/3508#input.direct_seller_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+    : false
+  output:
+    us:statutes/26/3508#qualified_real_estate_agent: not_holds
+    us:statutes/26/3508#direct_seller_engaged_trade_or_business: holds
+    us:statutes/26/3508#direct_seller: not_holds
+    us:statutes/26/3508#services_performed_as_qualified_real_estate_agent_or_direct_seller: not_holds

--- a/statutes/26/3508.yaml
+++ b/statutes/26/3508.yaml
@@ -1,0 +1,184 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3508
+  deferred_outputs:
+    - output: us:statutes/26/3508/a#individual_performing_services_not_treated_as_employee
+      reason: >-
+        The general non-employee treatment in subsection (a) is limited by
+        subsection (b)(3) for purposes of subtitle A to the extent the individual
+        is treated as an employee under section 401(c)(1); no copied RuleSpec
+        source provides the section 401(c)(1) treatment needed to encode that
+        coordination faithfully.
+      source_values:
+        - us:statutes/26/3508#qualified_real_estate_agent
+        - us:statutes/26/3508#direct_seller
+    - output: us:statutes/26/3508/a#service_recipient_not_treated_as_employer
+      reason: >-
+        The general non-employer treatment in subsection (a) is limited by
+        subsection (b)(3) for purposes of subtitle A to the extent the individual
+        is treated as an employee under section 401(c)(1); no copied RuleSpec
+        source provides the section 401(c)(1) treatment needed to encode that
+        coordination faithfully.
+      source_values:
+        - us:statutes/26/3508#qualified_real_estate_agent
+        - us:statutes/26/3508#direct_seller
+    - output: us:statutes/26/3508/b/3#section_3508_applies_for_subtitle_a
+      reason: >-
+        Subsection (b)(3) makes section 3508 inapplicable for subtitle A to the
+        extent the individual is treated as an employee under section 401(c)(1),
+        but the section 401(c)(1) employee-treatment dependency is not available
+        as copied RuleSpec context.
+      source_values:
+        - us:statutes/26/3508#qualified_real_estate_agent
+        - us:statutes/26/3508#direct_seller
+  summary: |-
+    For purposes of this title, services performed as a qualified real estate
+    agent or direct seller are not treated as employment by an employee/employer.
+    For purposes of this section, “qualified real estate agent” and “direct
+    seller” are defined by licensing or trade/business categories, remuneration
+    directly related to sales or other output rather than hours worked, and a
+    written Federal-tax contract stating non-employee treatment. Section 3508
+    does not apply for subtitle A to the extent the individual is treated as an
+    employee under section 401(c)(1).
+rules:
+  - name: qualified_real_estate_agent
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3508(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3508
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "licensed real estate agent"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "substantially all of the remuneration ... is directly related to sales or other output ... rather than to the number of hours worked"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "written contract ... provides that the individual will not be treated as an employee ... for Federal tax purposes"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_is_sales_person
+          and individual_is_licensed_real_estate_agent
+          and real_estate_agent_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+          and real_estate_agent_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+
+  - name: direct_seller_engaged_trade_or_business
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3508(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3508
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "selling (or soliciting the sale of) consumer products ... for resale ... in the home or otherwise than in a permanent retail establishment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "selling (or soliciting the sale of) consumer products in the home or otherwise than in a permanent retail establishment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "delivering or distribution of newspapers or shopping news"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          engaged_in_consumer_products_resale_trade_or_business_on_buy_sell_deposit_commission_or_secretary_prescribed_similar_basis_for_home_or_nonpermanent_retail_resale
+          or engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business
+          or engaged_in_newspaper_or_shopping_news_delivery_or_distribution_trade_or_business
+
+  - name: direct_seller
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3508(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3508
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3508#direct_seller_engaged_trade_or_business
+              output: direct_seller_engaged_trade_or_business
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "substantially all the remuneration ... is directly related to sales or other output ... rather than to the number of hours worked"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "written contract ... provides that the person will not be treated as an employee ... for Federal tax purposes"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          direct_seller_engaged_trade_or_business
+          and direct_seller_remuneration_substantially_all_directly_related_to_sales_or_other_output_rather_than_hours
+          and direct_seller_services_performed_under_written_contract_providing_federal_tax_nonemployee_treatment
+
+  - name: services_performed_as_qualified_real_estate_agent_or_direct_seller
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3508(a), 26 USC 3508(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3508#qualified_real_estate_agent
+              output: qualified_real_estate_agent
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3508#direct_seller
+              output: direct_seller
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "services performed as a qualified real estate agent or as a direct seller"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualified_real_estate_agent
+          or direct_seller


### PR DESCRIPTION
## Summary
- Add generated 26 USC 3508 qualified real estate agent/direct seller worker-classification rules and companion tests.
- Include signed axiom-encode apply manifest for run `af1bc871` using `gpt-5.5`.
- Depends on merged encoder oracle classification support in TheAxiomFoundation/axiom-encode#390.

## Validation
- `uv run axiom-encode validate statutes/26/3508.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate statutes/26/3508.yaml --json`
- `uv run axiom-encode test statutes/26/3508.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`