### PR TITLE
Add generated section 3509 misclassification liability rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3509.json
+++ b/.axiom/encoding-manifests/statutes/26/3509.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3509.yaml",
+      "sha256": "c0ada2bdac091c20730035055b187a8661fd0bacde824a8158d7ed043006692e"
+    },
+    {
+      "path": "statutes/26/3509.test.yaml",
+      "sha256": "3772f3e06cd06c4d27277ed3a256563b70a19c21040c1b0361f6c7b177c851a3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1676055841a004ad3108b0796925a0417f8b05da",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.364",
+    "version_commit": "1676055841a004ad3108b0796925a0417f8b05da"
+  },
+  "axiom_encode_version": "0.2.364",
+  "backend": "openai",
+  "citation": "26 USC 3509",
+  "context_manifest_file": "/tmp/axiom-encode-3509-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3509/workspace/context-manifest.json",
+  "context_manifest_sha256": "80975455464be29ef4d9653fe203815c2ca8fd096334e9571d59e8eb7a09bb8b",
+  "generated_at": "2026-05-28T07:25:42.247349+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3509-20260528-001/openai-gpt-5.5/statutes/26/3509.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3509-20260528-001",
+  "generated_output_sha256": "c0ada2bdac091c20730035055b187a8661fd0bacde824a8158d7ed043006692e",
+  "generation_prompt_sha256": "ccb11c3dfffb9d2179deed11913d3c107bc48b1e935f70774060441adc8d8027",
+  "model": "gpt-5.5",
+  "run_id": "281b6855",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c823b84be6ddbb5fe0165e2b9c4a501de1bdbad08855a2ab82f511a0c91c26ce"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3509-20260528-001/traces/openai-gpt-5.5/26-USC-3509.json",
+  "trace_sha256": "27f32f28de61e7386e6ea0dd1d671fc7c4105be8b9547048b67f667ff430f370"
+}

--- a/statutes/26/3509.test.yaml
+++ b/statutes/26/3509.test.yaml
@@ -1,0 +1,77 @@
+- name: scalar_rates_under_default_and_increased_subsections
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
+    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
+    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
+    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+    : false
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
+  output:
+    us:statutes/26/3509#default_withholding_liability_rate: 0.015
+    us:statutes/26/3509#default_employee_social_security_tax_liability_percentage: 0.2
+    us:statutes/26/3509#increased_withholding_liability_rate: 0.03
+    us:statutes/26/3509#increased_employee_social_security_tax_liability_percentage: 0.4
+    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: holds
+    us:statutes/26/3509#section_applies_to_employee_social_security_tax: holds
+    us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: holds
+    us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: holds
+    us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: holds
+- name: intentional_disregard_blocks_section_application
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
+    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
+    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: true
+    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+    : false
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: false
+  output:
+    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: not_holds
+    us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds
+    us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: not_holds
+    us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: not_holds
+    us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: not_holds
+- name: wage_withholding_but_no_social_security_withholding_blocks_section_application_for_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
+    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
+    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
+    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+    : true
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
+  output:
+    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: not_holds
+    us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds
+    us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: holds
+    us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: holds
+    us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: holds
+- name: statutory_employee_described_in_section_3121_d_3_blocks_social_security_tax_application_only
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
+    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
+    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
+    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+    : false
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: true
+    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
+  output:
+    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: holds
+    us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds

--- a/statutes/26/3509.yaml
+++ b/statutes/26/3509.yaml
@@ -1,0 +1,230 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3509
+  summary: |-
+    26 USC 3509 sets reduced employer liability rates when an employer fails to deduct and withhold chapter 24 or subchapter A of chapter 21 tax because the employer treated an employee as not an employee. It substitutes 1.5 percent of section 3401 wages for chapter 24 withholding and 20 percent of the otherwise imposed subchapter A chapter 21 employee tax; increases those rates to 3 percent and 40 percent where specified reporting requirements are disregarded without reasonable cause; excludes intentional disregard cases; and states special nonapplication and recovery/collection rules.
+  deferred_outputs:
+    - output: us:statutes/26/3509#employer_chapter_24_withholding_tax_liability
+      reason: >-
+        The chapter 24 liability amount depends on wages as defined in section
+        3401. The copied section 3401(a) context is deferred and has no
+        executable wages export, so a faithful wage-based amount cannot be
+        computed here.
+    - output: us:statutes/26/3509#employer_employee_social_security_tax_liability
+      reason: >-
+        The subchapter A of chapter 21 liability amount is computed as a
+        percentage of the tax imposed under that subchapter without regard to the
+        section 3509 substitution. No executable copied context provides that
+        otherwise-imposed employee tax amount for this computation.
+    - output: us:statutes/26/3509/b#employer_liability_increased_for_reporting_requirement_disregard
+      reason: >-
+        Subsection (b) applies the increased 3 percent and 40 percent rates when
+        the employer fails to meet applicable requirements of sections 6041(a),
+        6041A, or 6051, unless due to reasonable cause and not willful neglect.
+        No copied RuleSpec context provides executable targets for those
+        reporting requirements, so the reporting-disregard condition and final
+        increased-liability surface are deferred.
+      source_values:
+        - us:statutes/26/3509#increased_withholding_liability_rate
+        - us:statutes/26/3509#increased_employee_social_security_tax_liability_percentage
+rules:
+  - name: default_withholding_liability_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3509(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "equal to 1.5 percent of the wages"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.015
+
+  - name: default_employee_social_security_tax_liability_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3509(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "20 percent of the amount imposed"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20
+
+  - name: increased_withholding_liability_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3509(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "by substituting “3 percent” for “1.5 percent”"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.03
+
+  - name: increased_employee_social_security_tax_liability_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3509(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "by substituting “40 percent” for “20 percent”"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.40
+
+  - name: section_applies_to_misclassified_employee_withholding_failure
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(a), 3509(c), 3509(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "fails to deduct and withhold any tax ... by reason of treating such employee as not being an employee"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "shall not apply ... if such liability is due to the employer’s intentional disregard"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "shall not apply to any employer with respect to any wages if ... deducted and withheld any amount of the tax imposed by chapter 24 ... but ... failed to deduct and withhold ... subchapter A of chapter 21"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax
+          and failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter
+          and not liability_due_to_employer_intentional_disregard_of_withholding_requirement
+          and not employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+
+  - name: section_applies_to_employee_social_security_tax
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(a), 3509(c), 3509(d)(2), 3509(d)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure
+              output: section_applies_to_misclassified_employee_withholding_failure
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "shall not apply to any tax under subchapter A of chapter 21 with respect to an individual described in subsection (d)(3) of section 3121"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          section_applies_to_misclassified_employee_withholding_failure
+          and not individual_described_in_section_3121_d_3
+
+  - name: employee_tax_liability_unaffected_by_section_assessment_or_collection
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(d)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "If the amount of any liability for tax is determined under this section"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "the employee’s liability for tax shall not be affected by the assessment or collection of the tax so determined"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_of_liability_for_tax_determined_under_this_section
+
+  - name: employer_not_entitled_to_recover_section_tax_from_employee
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(d)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "If the amount of any liability for tax is determined under this section"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "the employer shall not be entitled to recover from the employee any tax so determined"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_of_liability_for_tax_determined_under_this_section
+
+  - name: section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(d)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "If the amount of any liability for tax is determined under this section"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "section 3402(d) and section 6521 shall not apply"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_of_liability_for_tax_determined_under_this_section


### PR DESCRIPTION
## Summary
- Add generated 26 USC 3509 misclassification withholding/FICA liability rates, predicates, and companion tests.
- Include signed axiom-encode apply manifest for run `281b6855` using `gpt-5.5` and encoder `0.2.364`.
- Depends on merged encoder oracle classification support in TheAxiomFoundation/axiom-encode#391.

## Validation
- `uv run axiom-encode validate statutes/26/3509.yaml --skip-reviewers --require-oracle-classification --json`
- `uv run axiom-encode proof-validate statutes/26/3509.yaml --json`
- `uv run axiom-encode test statutes/26/3509.test.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main`