### PR TITLE
Add generated section 3510 domestic service rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3510.json
+++ b/.axiom/encoding-manifests/statutes/26/3510.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3510.yaml",
+      "sha256": "99c66932c0d26a67a785cfcf71bc5ef7aeec64c990a53ecaca3ea09f9845bbd2"
+    },
+    {
+      "path": "statutes/26/3510.test.yaml",
+      "sha256": "9c21ed00555363831f576d0f925588ed269289e5fb0e188641b75acd96f4d063"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0b319ff9114219771535407c8c7533e53a72b583",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.367",
+    "version_commit": "0b319ff9114219771535407c8c7533e53a72b583"
+  },
+  "axiom_encode_version": "0.2.367",
+  "backend": "openai",
+  "citation": "26 USC 3510",
+  "context_manifest_file": "/tmp/axiom-encode-3510-20260528-004/_eval_workspaces/openai-gpt-5.5/26-USC-3510/workspace/context-manifest.json",
+  "context_manifest_sha256": "92e7453c50de4d08f41886c3eadcf720c9fbcc8a65cf9311b5853eed532fcd9f",
+  "generated_at": "2026-05-28T08:24:19.425381+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3510-20260528-004/openai-gpt-5.5/statutes/26/3510.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3510-20260528-004",
+  "generated_output_sha256": "99c66932c0d26a67a785cfcf71bc5ef7aeec64c990a53ecaca3ea09f9845bbd2",
+  "generation_prompt_sha256": "55acc75e33d5a903c69984e07979cd2bd22cca28de917683e0d241aac154e42d",
+  "model": "gpt-5.5",
+  "run_id": "2fc04f9c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6ec80dfce958edd3858267bd6b5781ae1926f6167c1b5195744d8ee6291feb54"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3510-20260528-004/traces/openai-gpt-5.5/26-USC-3510.json",
+  "trace_sha256": "8898fe571a2169d9dcf6e9d2af737d0efb08b420a4c82a0d21412a407ff58a96"
+}

--- a/statutes/26/3510.test.yaml
+++ b/statutes/26/3510.test.yaml
@@ -1,0 +1,20 @@
+- name: section_3402_p_withholding_component_included
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3510#input.amount_withheld_from_remuneration_for_domestic_service_in_private_home_pursuant_to_section_3402_p_agreement
+    : 1200
+  output:
+    us:statutes/26/3510#amount_withheld_from_domestic_service_remuneration_under_section_3402_p_agreement: 1200
+- name: section_3402_p_withholding_component_floored_at_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3510#input.amount_withheld_from_remuneration_for_domestic_service_in_private_home_pursuant_to_section_3402_p_agreement
+    : -100
+  output:
+    us:statutes/26/3510#amount_withheld_from_domestic_service_remuneration_under_section_3402_p_agreement: 0

--- a/statutes/26/3510.yaml
+++ b/statutes/26/3510.yaml
@@ -1,0 +1,53 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3510
+  deferred_outputs:
+    - output: us:statutes/26/3510#domestic_service_employment_tax_return_calendar_year_basis
+      reason: The source-stated return rule is an administrative filing requirement, not a computable amount, legal eligibility predicate, or supported filing obligation output in the current RuleSpec ontology.
+    - output: us:statutes/26/3510#domestic_service_employment_tax_return_due_date
+      reason: The due date depends on calendar-year and employer-taxable-year date mechanics; RuleSpec formulas do not support date-valued outputs.
+    - output: us:statutes/26/3510#domestic_service_employment_tax_deposit_requirement
+      reason: The no-deposit/no-section-6157-installment rule depends on requirements under section 6157, for which no copied RuleSpec target is available.
+    - output: us:statutes/26/3510#domestic_service_employment_taxes_treated_as_chapter_2_tax_for_section_6654
+      reason: Treatment applies solely for purposes of section 6654, but no copied RuleSpec target provides section 6654 mechanics.
+    - output: us:statutes/26/3510#employer_excluded_from_section_6654_treatment
+      reason: The exception depends on wage-withholding credit under section 31 and additions to tax under section 6654(e); no copied RuleSpec targets provide those upstream legal concepts.
+    - output: us:statutes/26/3510#section_6654_annualization_adjustment_for_domestic_service_employment_taxes
+      reason: The annualization adjustment depends on section 6654(d)(2) and regulations prescribed by the Secretary, neither of which is provided as copied executable RuleSpec context.
+    - output: us:statutes/26/3510/c#domestic_service_employment_taxes
+      reason: The definition includes taxes imposed by chapters 21 and 23 and domestic service described in section 3121(g)(5); no copied RuleSpec target provides chapter 21, chapter 23, or section 3121(g)(5) mechanics. The independently source-stated voluntary-withholding component is encoded separately.
+      source_values:
+        - us:statutes/26/3510#amount_withheld_from_domestic_service_remuneration_under_section_3402_p_agreement
+    - output: us:statutes/26/3510#section_3510_nonapplication_for_employer_liable_for_other_employment_taxes
+      reason: The exception applies only to the extent provided in regulations prescribed by the Secretary, and those regulations are not included in the source text or copied context.
+    - output: us:statutes/26/3510#state_unemployment_taxes_collected_under_agreement_treated_as_domestic_service_employment_taxes
+      reason: The state-unemployment-tax collection agreement rule depends on State unemployment tax categories, collection agreements, and State as defined by section 3306(j)(1); no copied executable RuleSpec target provides those mechanics.
+    - output: us:statutes/26/3510#state_unemployment_tax_collections_transferred_to_state_account
+      reason: Transfer to the State account in the Unemployment Trust Fund is an administrative fund-transfer duty, not a supported computable taxpayer/employer output.
+    - output: us:statutes/26/3510#state_unemployment_tax_amount_treated_as_chapter_23_tax_for_subtitle_F
+      reason: Treatment applies for purposes of subtitle F and depends on amounts required to be collected under State agreements; the necessary subtitle F and State-agreement mechanics are not copied executable RuleSpec context.
+  summary: |-
+    Section 3510 provides calendar-year return and no-deposit rules for domestic service employment taxes; treats such taxes as chapter 2 taxes solely for section 6654 subject to exceptions and annualization regulations; defines “domestic service employment taxes” to include chapter 21 or 23 taxes on remuneration for domestic service in a private home and amounts withheld from such remuneration under a section 3402(p) agreement; and authorizes agreements to collect State unemployment taxes.
+rules:
+  - name: amount_withheld_from_domestic_service_remuneration_under_section_3402_p_agreement
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3510(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3510
+              excerpt: "any amount withheld from such remuneration pursuant to an agreement under section 3402(p)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, amount_withheld_from_remuneration_for_domestic_service_in_private_home_pursuant_to_section_3402_p_agreement)


### PR DESCRIPTION
## Summary
- add signed generated RuleSpec for 26 USC 3510 domestic service employment tax rules
- encode the independently source-stated section 3402(p) withholding component
- defer unsupported administrative filing, deposit, estimated-tax, chapter 21/23, and state unemployment agreement surfaces

## Generated provenance
- axiom-encode 0.2.367
- run id: 2fc04f9c
- model: gpt-5.5
- manifest: .axiom/encoding-manifests/statutes/26/3510.json

## Local checks
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3510.yaml`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3510.yaml --json`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3510.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD --json`