### PR TITLE
Add generated section 3131(a) paid sick leave credit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/a.yaml",
+      "sha256": "eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9"
+    },
+    {
+      "path": "statutes/26/3131/a.test.yaml",
+      "sha256": "4c15fee4d9627ed14784ca4726ab75736a26fe28ce05b0ef9ae099bb9cec6c36"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6131c2dbab777e9da567fa418768f4cb953ba2e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.368",
+    "version_commit": "6131c2dbab777e9da567fa418768f4cb953ba2e8"
+  },
+  "axiom_encode_version": "0.2.368",
+  "backend": "openai",
+  "citation": "26 USC 3131(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3131a-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "091d7ea498a2d3777afafaf2598bb7fa795390158e607eaf5aa675112c282e74",
+  "generated_at": "2026-05-28T09:01:41.843048+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131a-20260528-001/openai-gpt-5.5/statutes/26/3131/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131a-20260528-001",
+  "generated_output_sha256": "eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9",
+  "generation_prompt_sha256": "e8bab781c8901aae455d4581b513715c6f7248860624bda410ba81708407c9d0",
+  "model": "gpt-5.5",
+  "run_id": "e1a635ef",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "60fb599923a7dbcab565f470b96e5bf08bce700befa7f70f3c0663813560182a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131a-20260528-001/traces/openai-gpt-5.5/26-USC-3131-a.json",
+  "trace_sha256": "2386321f6248b3de6eddfa4274226b85677dbf2699136fc822352dd3644f6a8b"
+}

--- a/statutes/26/3131/a.test.yaml
+++ b/statutes/26/3131/a.test.yaml
@@ -1,0 +1,21 @@
+- name: employer_credit_equals_qualified_sick_leave_wages_paid_for_quarter
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+  output:
+    us:statutes/26/3131/a#qualified_sick_leave_wages_credit_rate: 1
+    us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes: 5000
+- name: employer_credit_floored_at_zero_when_no_qualified_sick_leave_wages_paid
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 0
+  output:
+    us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes: 0

--- a/statutes/26/3131/a.yaml
+++ b/statutes/26/3131/a.yaml
@@ -1,0 +1,52 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    In the case of an employer, a credit against applicable employment taxes for each calendar quarter equals 100 percent of the qualified sick leave wages paid by such employer with respect to such calendar quarter.
+rules:
+  - name: qualified_sick_leave_wages_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3131(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "100 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1
+
+  - name: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "an amount equal to 100 percent of the qualified sick leave wages paid by such employer with respect to such calendar quarter"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_rate
+              output: qualified_sick_leave_wages_credit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualified_sick_leave_wages_credit_rate
+          * max(0, qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter)


### PR DESCRIPTION
## Summary\n- add generated RuleSpec for 26 USC 3131(a), the qualified sick leave wages credit amount\n- add generated companion tests for the 100% credit rate and zero wage floor\n- include signed axiom-encode manifest/provenance\n\n## Generated provenance\n- axiom-encode 0.2.368\n- run id e1a635ef\n- model gpt-5.5\n- manifest: .axiom/encoding-manifests/statutes/26/3131/a.json\n\n## Validation\n- uv run axiom-encode validate --skip-reviewers statutes/26/3131/a.yaml\n- uv run axiom-encode proof-validate statutes/26/3131/a.yaml --json\n- uv run axiom-encode test statutes/26/3131/a.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json\n- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50\n- uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json\n\nDepends on axiom-encode #396, now merged, for PolicyEngine oracle classification of the 3131 paid-leave credit outputs.