### PR TITLE
Add generated section 3132(a) family leave credit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/a.yaml",
+      "sha256": "f249f97f60dad580a6e353f961a820960551254b821e267853fba2af34a1dfc2"
+    },
+    {
+      "path": "statutes/26/3132/a.test.yaml",
+      "sha256": "8d0e3125406e3bdd00afd2ab3fb836d8b1ca55e00ecdf5640ff64771b74573c9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "44a6f32a397c6bc046db923249ef551bd728250c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.369",
+    "version_commit": "44a6f32a397c6bc046db923249ef551bd728250c"
+  },
+  "axiom_encode_version": "0.2.369",
+  "backend": "openai",
+  "citation": "26 USC 3132(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3132a-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3132-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "05813f59a3333e84d849f31b4ba66f66392266f516c007f9e6cc26221883fab6",
+  "generated_at": "2026-05-28T09:20:55.571847+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132a-20260528-001/openai-gpt-5.5/statutes/26/3132/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132a-20260528-001",
+  "generated_output_sha256": "f249f97f60dad580a6e353f961a820960551254b821e267853fba2af34a1dfc2",
+  "generation_prompt_sha256": "2e8996ff28ba847a89dd497922780d42a37aa620b8db911098107cd8c4bc26d3",
+  "model": "gpt-5.5",
+  "run_id": "7d63a05f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dada50b82ac0f6d3056454afb76fe71b20962ade6fae9d516ec8c9f0de1c2efa"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132a-20260528-001/traces/openai-gpt-5.5/26-USC-3132-a.json",
+  "trace_sha256": "ce2278d06d319f36c93ca5aa55b368c98db8cbbf9c2832ae67be8bc5df2eb98b"
+}

--- a/statutes/26/3132/a.test.yaml
+++ b/statutes/26/3132/a.test.yaml
@@ -1,0 +1,21 @@
+- name: employer_credit_equals_qualified_family_leave_wages_paid
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+  output:
+    us:statutes/26/3132/a#qualified_family_leave_wages_credit_rate: 1
+    us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes: 5000
+- name: negative_wage_input_does_not_create_negative_credit
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: -100
+  output:
+    us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes: 0

--- a/statutes/26/3132/a.yaml
+++ b/statutes/26/3132/a.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    In the case of an employer, there shall be allowed as a credit against applicable employment taxes for each calendar quarter an amount equal to 100 percent of the qualified family leave wages paid by such employer with respect to such calendar quarter.
+rules:
+  - name: qualified_family_leave_wages_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3132(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "100 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1
+
+  - name: qualified_family_leave_wages_credit_against_applicable_employment_taxes
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/a#qualified_family_leave_wages_credit_rate
+              output: qualified_family_leave_wages_credit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualified_family_leave_wages_credit_rate
+          * max(0, qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter)


### PR DESCRIPTION
## Summary\n- add generated RuleSpec for 26 USC 3132(a), the qualified family leave wages credit amount\n- add generated companion tests for the 100% credit rate and nonnegative floor\n- include signed axiom-encode manifest/provenance\n\n## Generated provenance\n- axiom-encode 0.2.369\n- run id 7d63a05f\n- model gpt-5.5\n- manifest: .axiom/encoding-manifests/statutes/26/3132/a.json\n\n## Validation\n- uv run axiom-encode validate --skip-reviewers statutes/26/3132/a.yaml\n- uv run axiom-encode proof-validate statutes/26/3132/a.yaml --json\n- uv run axiom-encode test statutes/26/3132/a.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json\n- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50\n- uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json