### PR TITLE
Add generated section 3131(b)(1) sick leave wage caps

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/b/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/b/1.yaml",
+      "sha256": "90783d4414cc88840de318f1ae40496a391b6d43aaa40579928d8ac667322818"
+    },
+    {
+      "path": "statutes/26/3131/b/1.test.yaml",
+      "sha256": "4a152103bd8b1c134362e0e43df1771f15733187438f9ff40372c2b9c9a2b174"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "44a6f32a397c6bc046db923249ef551bd728250c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.369",
+    "version_commit": "44a6f32a397c6bc046db923249ef551bd728250c"
+  },
+  "axiom_encode_version": "0.2.369",
+  "backend": "openai",
+  "citation": "26 USC 3131(b)(1)",
+  "context_manifest_file": "/tmp/axiom-encode-3131b1-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "cdf1a9d4ce41fb23b159845896709607c4166f3d01fd70267045d4eb7e470193",
+  "generated_at": "2026-05-28T09:25:15.692021+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131b1-20260528-001/openai-gpt-5.5/statutes/26/3131/b/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131b1-20260528-001",
+  "generated_output_sha256": "90783d4414cc88840de318f1ae40496a391b6d43aaa40579928d8ac667322818",
+  "generation_prompt_sha256": "77d64d8dd6e6d6de69ed423eb1d318d2dd1fcd527639f04c02740d131a769ac5",
+  "model": "gpt-5.5",
+  "run_id": "87df8a7f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "40dc86c8749f03ed11903668e251389d2a6a18043d76d3ac4431f7ab85bbc5d6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131b1-20260528-001/traces/openai-gpt-5.5/26-USC-3131-b-1.json",
+  "trace_sha256": "4f0f3c9e1f86a3b7545c0ff9931e1be9c32456b2f029392da1c0aeec14ff675d"
+}

--- a/statutes/26/3131/b/1.test.yaml
+++ b/statutes/26/3131/b/1.test.yaml
@@ -1,0 +1,44 @@
+- name: standard_daily_limit_caps_non_described_paid_sick_time
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    ? us:statutes/26/3131/b/1#input.any_portion_of_day_is_paid_sick_time_described_in_section_5102_a_1_2_or_3_with_subsection_c_2_A_i_modification
+    : false
+    us:statutes/26/3131/b/1#input.qualified_sick_leave_wages_paid_to_individual_for_day: 250
+    us:statutes/26/3131/b/1#input.increases_under_subsection_e_for_individual_day: 0
+  output:
+    us:statutes/26/3131/b/1#standard_daily_wage_limit: 200
+    us:statutes/26/3131/b/1#described_paid_sick_time_daily_wage_limit: 511
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_daily_limit: 200
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_for_day: 200
+- name: described_paid_sick_time_daily_limit_caps_at_higher_amount
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-02-10'
+    end: '2026-02-10'
+  input:
+    ? us:statutes/26/3131/b/1#input.any_portion_of_day_is_paid_sick_time_described_in_section_5102_a_1_2_or_3_with_subsection_c_2_A_i_modification
+    : true
+    us:statutes/26/3131/b/1#input.qualified_sick_leave_wages_paid_to_individual_for_day: 600
+    us:statutes/26/3131/b/1#input.increases_under_subsection_e_for_individual_day: 0
+  output:
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_daily_limit: 511
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_for_day: 511
+- name: subsection_e_increases_are_included_before_applying_daily_limit
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-03-05'
+    end: '2026-03-05'
+  input:
+    ? us:statutes/26/3131/b/1#input.any_portion_of_day_is_paid_sick_time_described_in_section_5102_a_1_2_or_3_with_subsection_c_2_A_i_modification
+    : false
+    us:statutes/26/3131/b/1#input.qualified_sick_leave_wages_paid_to_individual_for_day: 150
+    us:statutes/26/3131/b/1#input.increases_under_subsection_e_for_individual_day: 25
+  output:
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_daily_limit: 200
+    us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_for_day: 175

--- a/statutes/26/3131/b/1.yaml
+++ b/statutes/26/3131/b/1.yaml
@@ -1,0 +1,105 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    Amount of qualified sick leave wages taken into account, plus subsection (e) increases, shall not exceed $200, or $511 for days with paid sick time described in section 5102(a)(1), (2), or (3), for any day or portion thereof.
+rules:
+  - name: standard_daily_wage_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3131(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall not exceed $200"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          200
+
+  - name: described_paid_sick_time_daily_wage_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3131(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "$511 in the case of any day any portion of which is paid sick time described in paragraph (1), (2), or (3) of section 5102(a)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          511
+
+  - name: qualified_sick_leave_wages_taken_into_account_daily_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Day
+    unit: USD
+    source: 26 USC 3131(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall not exceed $200 ($511 in the case of any day any portion of which is paid sick time described in paragraph (1), (2), or (3) of section 5102(a))"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/b/1#standard_daily_wage_limit
+              output: standard_daily_wage_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/b/1#described_paid_sick_time_daily_wage_limit
+              output: described_paid_sick_time_daily_wage_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if any_portion_of_day_is_paid_sick_time_described_in_section_5102_a_1_2_or_3_with_subsection_c_2_A_i_modification: described_paid_sick_time_daily_wage_limit else: standard_daily_wage_limit
+
+  - name: qualified_sick_leave_wages_taken_into_account_for_day
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Day
+    unit: USD
+    source: 26 USC 3131(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "The amount of qualified sick leave wages taken into account under subsection (a), plus any increases under subsection (e), with respect to any individual shall not exceed"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/b/1#qualified_sick_leave_wages_taken_into_account_daily_limit
+              output: qualified_sick_leave_wages_taken_into_account_daily_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+            max(0, qualified_sick_leave_wages_paid_to_individual_for_day + increases_under_subsection_e_for_individual_day),
+            qualified_sick_leave_wages_taken_into_account_daily_limit
+          )


### PR DESCRIPTION
## Summary\n- add generated RuleSpec for 26 USC 3131(b)(1), the qualified sick leave wage daily caps\n- add generated companion tests for the  standard cap,  described paid-sick-time cap, and subsection (e) increase inclusion\n- include signed axiom-encode manifest/provenance\n\n## Generated provenance\n- axiom-encode 0.2.369\n- run id 87df8a7f\n- model gpt-5.5\n- manifest: .axiom/encoding-manifests/statutes/26/3131/b/1.json\n\n## Validation\n- uv run axiom-encode validate --skip-reviewers statutes/26/3131/b/1.yaml\n- uv run axiom-encode proof-validate statutes/26/3131/b/1.yaml --json\n- uv run axiom-encode test statutes/26/3131/b/1.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json\n- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50\n- uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json