### PR TITLE
Add generated section 3131(b)(2) sick leave day limit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/b/2.yaml",
+      "sha256": "d23650d376644b6106033860b31b1aca47c1eea0bb8504afe520027b4e57b62c"
+    },
+    {
+      "path": "statutes/26/3131/b/2.test.yaml",
+      "sha256": "07480d418a394db10f0daa3d512ac15ebbee4daaf3af048407d656f0b9afc112"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "44a6f32a397c6bc046db923249ef551bd728250c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.369",
+    "version_commit": "44a6f32a397c6bc046db923249ef551bd728250c"
+  },
+  "axiom_encode_version": "0.2.369",
+  "backend": "openai",
+  "citation": "26 USC 3131(b)(2)",
+  "context_manifest_file": "/tmp/axiom-encode-3131b2-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-b-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "63c9ce5bc6689c338783763be5d05474ab1b3e2b95377908647bf0815e2cb7e0",
+  "generated_at": "2026-05-28T09:29:55.226605+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131b2-20260528-001/openai-gpt-5.5/statutes/26/3131/b/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131b2-20260528-001",
+  "generated_output_sha256": "d23650d376644b6106033860b31b1aca47c1eea0bb8504afe520027b4e57b62c",
+  "generation_prompt_sha256": "648cfac810c01a1c93e0ee3317fc55a6c912326bd83171d1b14cf49ce8d7ea5a",
+  "model": "gpt-5.5",
+  "run_id": "5b783e9b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "64600659e4166b53728837b7e476b8965bf33d6e5f9f2b6222acd5243c2f6cec"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131b2-20260528-001/traces/openai-gpt-5.5/26-USC-3131-b-2.json",
+  "trace_sha256": "07115db3bbfb81b05be7521d0d8bef29177f5e94410fa59af455fffb9a5ff2ea"
+}

--- a/statutes/26/3131/b/2.test.yaml
+++ b/statutes/26/3131/b/2.test.yaml
@@ -1,0 +1,43 @@
+- name: no_prior_days_allows_up_to_ten_days_for_quarter
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_during_preceding_calendar_quarters_in_calendar_year_other_than_first_quarter_of_calendar_year_2021
+    : 0
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_under_paragraph_1_for_calendar_quarter_before_overall_limitation
+    : 8
+  output:
+    us:statutes/26/3131/b/2#overall_calendar_year_days_limit: 10
+    us:statutes/26/3131/b/2#remaining_days_limit_for_calendar_quarter: 10
+    us:statutes/26/3131/b/2#aggregate_days_taken_into_account_for_calendar_quarter: 8
+- name: prior_days_reduce_quarter_days_limit
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_during_preceding_calendar_quarters_in_calendar_year_other_than_first_quarter_of_calendar_year_2021
+    : 6
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_under_paragraph_1_for_calendar_quarter_before_overall_limitation
+    : 7
+  output:
+    us:statutes/26/3131/b/2#remaining_days_limit_for_calendar_quarter: 4
+    us:statutes/26/3131/b/2#aggregate_days_taken_into_account_for_calendar_quarter: 4
+- name: excess_if_any_prevents_negative_remaining_limit
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_during_preceding_calendar_quarters_in_calendar_year_other_than_first_quarter_of_calendar_year_2021
+    : 12
+    ? us:statutes/26/3131/b/2#input.aggregate_number_of_days_taken_into_account_under_paragraph_1_for_calendar_quarter_before_overall_limitation
+    : 3
+  output:
+    us:statutes/26/3131/b/2#remaining_days_limit_for_calendar_quarter: 0
+    us:statutes/26/3131/b/2#aggregate_days_taken_into_account_for_calendar_quarter: 0

--- a/statutes/26/3131/b/2.yaml
+++ b/statutes/26/3131/b/2.yaml
@@ -1,0 +1,78 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    "The aggregate number of days taken into account under paragraph (1) for any calendar quarter shall not exceed" 10 reduced by days so taken into account in preceding calendar quarters in the calendar year, excluding the first quarter of calendar year 2021.
+rules:
+  - name: overall_calendar_year_days_limit
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3131(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "(A) 10"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          10
+
+  - name: remaining_days_limit_for_calendar_quarter
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: 26 USC 3131(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "the excess (if any) of— (A) 10, over (B) the aggregate number of days so taken into account during preceding calendar quarters in such calendar year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/b/2#overall_calendar_year_days_limit
+              output: overall_calendar_year_days_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, overall_calendar_year_days_limit - aggregate_number_of_days_taken_into_account_during_preceding_calendar_quarters_in_calendar_year_other_than_first_quarter_of_calendar_year_2021)
+
+  - name: aggregate_days_taken_into_account_for_calendar_quarter
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: 26 USC 3131(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "The aggregate number of days taken into account under paragraph (1) for any calendar quarter shall not exceed the excess (if any)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/b/2#remaining_days_limit_for_calendar_quarter
+              output: remaining_days_limit_for_calendar_quarter
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+            max(0, aggregate_number_of_days_taken_into_account_under_paragraph_1_for_calendar_quarter_before_overall_limitation),
+            remaining_days_limit_for_calendar_quarter
+          )


### PR DESCRIPTION
## Summary\n- add generated RuleSpec for 26 USC 3131(b)(2), the overall quarterly sick-leave day limit\n- add generated companion tests for no prior days, prior-quarter reduction, and excess-if-any flooring\n- include signed axiom-encode manifest/provenance\n\n## Generated provenance\n- axiom-encode 0.2.369\n- run id 5b783e9b\n- model gpt-5.5\n- manifest: .axiom/encoding-manifests/statutes/26/3131/b/2.json\n\n## Validation\n- uv run axiom-encode validate --skip-reviewers statutes/26/3131/b/2.yaml\n- uv run axiom-encode proof-validate statutes/26/3131/b/2.yaml --json\n- uv run axiom-encode test statutes/26/3131/b/2.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json\n- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50\n- uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json