### PR TITLE
Add generated section 3132(b)(1) family leave wage limits

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/b/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/b/1.yaml",
+      "sha256": "83e4d157defb7d6dfac9b4dc044b36a1b605475885fe21386e216670bb4d3555"
+    },
+    {
+      "path": "statutes/26/3132/b/1.test.yaml",
+      "sha256": "d94b61370216e5f206c219cf839072b2e30750593c9ce72624cf935e70ffe898"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "44a6f32a397c6bc046db923249ef551bd728250c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.369",
+    "version_commit": "44a6f32a397c6bc046db923249ef551bd728250c"
+  },
+  "axiom_encode_version": "0.2.369",
+  "backend": "openai",
+  "citation": "26 USC 3132(b)(1)",
+  "context_manifest_file": "/tmp/axiom-encode-3132b1-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3132-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "65b35267e21debd2f7ef96b0b8182565d2184a9e66e42f21cbbbb75c6fe8bd8d",
+  "generated_at": "2026-05-28T09:34:53.967100+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132b1-20260528-001/openai-gpt-5.5/statutes/26/3132/b/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132b1-20260528-001",
+  "generated_output_sha256": "83e4d157defb7d6dfac9b4dc044b36a1b605475885fe21386e216670bb4d3555",
+  "generation_prompt_sha256": "1de74928070389ee7a68466dada44ba50dd5f6abaeed07e0b52575844ad61a38",
+  "model": "gpt-5.5",
+  "run_id": "fef355ff",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4e7d0a63f17356d652318acf428425e8ddf5e4bd7d7553e26f56d62dd90c1f5a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132b1-20260528-001/traces/openai-gpt-5.5/26-USC-3132-b-1.json",
+  "trace_sha256": "d06058b7e144e786c95955a995e177c7dc37dab148a7c5c0f8d3cf9c719e729f"
+}

--- a/statutes/26/3132/b/1.test.yaml
+++ b/statutes/26/3132/b/1.test.yaml
@@ -1,0 +1,32 @@
+- name: daily_wages_below_daily_limit_taken_into_account
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us:statutes/26/3132/b/1#input.qualified_family_leave_wages_plus_increases_paid_for_day: 150
+  output:
+    us:statutes/26/3132/b/1#qualified_family_leave_wages_daily_limit_per_individual: 200
+    us:statutes/26/3132/b/1#qualified_family_leave_wages_taken_into_account_for_day: 150
+- name: daily_wages_above_daily_limit_capped
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-16'
+    end: '2026-01-16'
+  input:
+    us:statutes/26/3132/b/1#input.qualified_family_leave_wages_plus_increases_paid_for_day: 250
+  output:
+    us:statutes/26/3132/b/1#qualified_family_leave_wages_taken_into_account_for_day: 200
+- name: aggregate_wages_above_all_calendar_quarters_limit_capped
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3132/b/1#input.aggregate_qualified_family_leave_wages_plus_increases_with_respect_to_all_calendar_quarters: 15000
+  output:
+    us:statutes/26/3132/b/1#qualified_family_leave_wages_aggregate_limit_per_individual: 12000
+    us:statutes/26/3132/b/1#aggregate_qualified_family_leave_wages_taken_into_account: 12000

--- a/statutes/26/3132/b/1.yaml
+++ b/statutes/26/3132/b/1.yaml
@@ -1,0 +1,100 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    “The amount of qualified family leave wages taken into account under subsection (a), plus any increases under subsection (e), with respect to any individual shall not exceed” $200 for any day and $12,000 in the aggregate for all calendar quarters.
+rules:
+  - name: qualified_family_leave_wages_daily_limit_per_individual
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3132(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "$200"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          200
+
+  - name: qualified_family_leave_wages_aggregate_limit_per_individual
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3132(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "$12,000"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          12000
+
+  - name: qualified_family_leave_wages_taken_into_account_for_day
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Day
+    unit: USD
+    source: 26 USC 3132(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/b/1#qualified_family_leave_wages_daily_limit_per_individual
+              output: qualified_family_leave_wages_daily_limit_per_individual
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+            max(0, qualified_family_leave_wages_plus_increases_paid_for_day),
+            qualified_family_leave_wages_daily_limit_per_individual
+          )
+
+  - name: aggregate_qualified_family_leave_wages_taken_into_account
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/b/1#qualified_family_leave_wages_aggregate_limit_per_individual
+              output: qualified_family_leave_wages_aggregate_limit_per_individual
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+            max(0, aggregate_qualified_family_leave_wages_plus_increases_with_respect_to_all_calendar_quarters),
+            qualified_family_leave_wages_aggregate_limit_per_individual
+          )


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(b)(1) family leave wage limits.
- Includes the generated test file and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/b/1.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/b/1.yaml --json`
- `uv run axiom-encode test statutes/26/3132/b/1.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
