### PR TITLE
Add generated section 3132(b)(2) employment tax limit

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/b/2.yaml",
+      "sha256": "c04e7f1804b139db1dcd2cd7131ae23e2cca236c07a4e21ecfa38835a8cd8f34"
+    },
+    {
+      "path": "statutes/26/3132/b/2.test.yaml",
+      "sha256": "522fc0f746aed9fa257f7d9d07d6203e54abbd5d72a742b9407ce9895fa99c19"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b52906608c76ebf1274dc217e95261e0f6afa866",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.370",
+    "version_commit": "b52906608c76ebf1274dc217e95261e0f6afa866"
+  },
+  "axiom_encode_version": "0.2.370",
+  "backend": "openai",
+  "citation": "26 USC 3132(b)(2)",
+  "context_manifest_file": "/tmp/axiom-encode-3132b2-20260528-002/_eval_workspaces/openai-gpt-5.5/26-USC-3132-b-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "2d105eb04e2c82eed19a0d7d959448cdf18cda64303882338f10982b4e1d17d0",
+  "generated_at": "2026-05-28T10:00:48.295336+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132b2-20260528-002/openai-gpt-5.5/statutes/26/3132/b/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132b2-20260528-002",
+  "generated_output_sha256": "c04e7f1804b139db1dcd2cd7131ae23e2cca236c07a4e21ecfa38835a8cd8f34",
+  "generation_prompt_sha256": "7dc02123a6b18e287fd2a05cda3dbe6d465ba5307547be3b3747acd8735982c6",
+  "model": "gpt-5.5",
+  "run_id": "b76536ce",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c43e99c859d97f589306135f9be574ed47a244ef31e0f6e1710887a7dca34ab9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132b2-20260528-002/traces/openai-gpt-5.5/26-USC-3132-b-2.json",
+  "trace_sha256": "32a10cb20804272874ed0e9bf58d5fb3493a2b9d955012a2c444c58bee82d331"
+}

--- a/statutes/26/3132/b/2.test.yaml
+++ b/statutes/26/3132/b/2.test.yaml
@@ -1,0 +1,42 @@
+- name: family_leave_credit_below_reduced_employment_taxes_is_not_capped
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 4000
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 1000
+    ? us:statutes/26/3132/b/2#input.applicable_employment_taxes_for_calendar_quarter_on_wages_paid_with_respect_to_employment_of_all_employees
+    : 10000
+  output:
+    us:statutes/26/3132/b/2#applicable_employment_taxes_after_section_3131_credits: 9000
+    us:statutes/26/3132/b/2#qualified_family_leave_wages_credit_after_employment_tax_limit: 4000
+- name: family_leave_credit_is_capped_by_employment_taxes_reduced_by_section_3131_credit
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 9000
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 2000
+    ? us:statutes/26/3132/b/2#input.applicable_employment_taxes_for_calendar_quarter_on_wages_paid_with_respect_to_employment_of_all_employees
+    : 7000
+  output:
+    us:statutes/26/3132/b/2#applicable_employment_taxes_after_section_3131_credits: 5000
+    us:statutes/26/3132/b/2#qualified_family_leave_wages_credit_after_employment_tax_limit: 5000
+- name: section_3131_credits_cannot_make_employment_tax_limit_negative
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 3000
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 8000
+    ? us:statutes/26/3132/b/2#input.applicable_employment_taxes_for_calendar_quarter_on_wages_paid_with_respect_to_employment_of_all_employees
+    : 5000
+  output:
+    us:statutes/26/3132/b/2#applicable_employment_taxes_after_section_3131_credits: 0
+    us:statutes/26/3132/b/2#qualified_family_leave_wages_credit_after_employment_tax_limit: 0

--- a/statutes/26/3132/b/2.yaml
+++ b/statutes/26/3132/b/2.yaml
@@ -1,0 +1,71 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    “The credit allowed by subsection (a) ... shall not exceed the applicable employment taxes ... (reduced by any credits allowed under section 3131)”
+imports:
+  - us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+  - us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+rules:
+  - name: applicable_employment_taxes_after_section_3131_credits
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "applicable employment taxes ... (reduced by any credits allowed under section 3131)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, applicable_employment_taxes_for_calendar_quarter_on_wages_paid_with_respect_to_employment_of_all_employees - qualified_sick_leave_wages_credit_against_applicable_employment_taxes)
+
+  - name: qualified_family_leave_wages_credit_after_employment_tax_limit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "The credit allowed by subsection (a) ... shall not exceed the applicable employment taxes"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:f249f97f60dad580a6e353f961a820960551254b821e267853fba2af34a1dfc2
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/b/2#applicable_employment_taxes_after_section_3131_credits
+              output: applicable_employment_taxes_after_section_3131_credits
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(max(0, qualified_family_leave_wages_credit_against_applicable_employment_taxes),
+            applicable_employment_taxes_after_section_3131_credits
+          )


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(b)(2) limiting the family leave credit by employment taxes reduced by section 3131 credits.
- Includes the generated companion tests and signed encode manifest from `axiom-encode encode --apply`.
- Generated with `axiom-encode` 0.2.370 after the multiline nonnegative-floor repair landed.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/b/2.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/b/2.yaml --json`
- `uv run axiom-encode test statutes/26/3132/b/2.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
