### PR TITLE
Add generated section 3132(c) family leave wages

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/c.yaml",
+      "sha256": "b82c4c11b811ce6aa08533624caada517c92636f3f25f60f67628eb6551f432c"
+    },
+    {
+      "path": "statutes/26/3132/c.test.yaml",
+      "sha256": "966ccfea6bc3e92eaa0cf750e3c2b48b1a4db26e4705cdc50b56b07469a3da9d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3132(c)",
+  "context_manifest_file": "/tmp/axiom-encode-3132c-20260528-002/_eval_workspaces/openai-gpt-5.5/26-USC-3132-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "dc302263347459b364e24635f415f2269b5006dce4802b4eaf454457e0b67bc3",
+  "generated_at": "2026-05-28T10:20:11.621681+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132c-20260528-002/openai-gpt-5.5/statutes/26/3132/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132c-20260528-002",
+  "generated_output_sha256": "b82c4c11b811ce6aa08533624caada517c92636f3f25f60f67628eb6551f432c",
+  "generation_prompt_sha256": "a8997d3dfd50e738dfc8398ff96ed6aa0ffb3bc76c62493e67c384fa9a62644e",
+  "model": "gpt-5.5",
+  "run_id": "9ae54229",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "364034a220a512794c2ee353b60fe1a7451aa35e7b27577940f43c7e3886f233"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132c-20260528-002/traces/openai-gpt-5.5/26-USC-3132-c.json",
+  "trace_sha256": "e85402a871bbc83b793db45999e2edefb66e534d651c5c167486cd4b276379eb"
+}

--- a/statutes/26/3132/c.test.yaml
+++ b/statutes/26/3132/c.test.yaml
@@ -1,0 +1,57 @@
+- name: qualifying_family_leave_wages_count_up_to_substituted_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 5000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : false
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: false
+  output:
+    us:statutes/26/3132/c#substituted_family_leave_wage_cap: 12000
+    us:statutes/26/3132/c#family_leave_wages_meet_leave_requirements: holds
+    us:statutes/26/3132/c#qualified_family_leave_wages: 5000
+- name: qualifying_family_leave_wages_are_limited_by_substituted_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 15000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : false
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: false
+  output:
+    us:statutes/26/3132/c#family_leave_wages_meet_leave_requirements: holds
+    us:statutes/26/3132/c#qualified_family_leave_wages: 12000
+- name: employer_noncompliance_prevents_family_leave_wages_from_being_taken_into_account
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 5000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : true
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: false
+  output:
+    us:statutes/26/3132/c#family_leave_wages_meet_leave_requirements: not_holds
+    us:statutes/26/3132/c#qualified_family_leave_wages: 0
+- name: section_105_action_is_treated_as_failure_to_meet_requirement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 5000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : false
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: true
+  output:
+    us:statutes/26/3132/c#family_leave_wages_meet_leave_requirements: not_holds
+    us:statutes/26/3132/c#qualified_family_leave_wages: 0

--- a/statutes/26/3132/c.yaml
+++ b/statutes/26/3132/c.yaml
@@ -1,0 +1,88 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: "\u201Cqualified family leave wages\u201D means wages paid by an employer\
+    \ which would be required to be paid by reason of the Emergency Family and Medical\
+    \ Leave Expansion Act as if such Act applied after March 31, 2021; section 110(b)\
+    \ is applied by substituting \u201C$12,000\u201D for \u201C$10,000\u201D; noncompliant\
+    \ leave amounts are not taken into account."
+rules:
+- name: substituted_family_leave_wage_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 3132(c)(2)(A)(ii)(III)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: "by substituting \u201C$12,000\u201D for \u201C$10,000\u201D"
+  versions:
+  - effective_from: '2021-04-01'
+    formula: '12000'
+- name: family_leave_wages_meet_leave_requirements
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3132(c)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3132
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: an employer which takes an action described in section 105 of the
+            Family and Medical Leave Act of 1993 shall be treated as failing to meet
+            a requirement
+  versions:
+  - effective_from: '2021-04-01'
+    formula: 'not employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+
+      and not employer_takes_action_described_in_section_105_of_family_and_medical_leave_act'
+- name: qualified_family_leave_wages
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3132
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: "by substituting \u201C$12,000\u201D for \u201C$10,000\u201D"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/c#substituted_family_leave_wage_cap
+          output: substituted_family_leave_wage_cap
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/c#family_leave_wages_meet_leave_requirements
+          output: family_leave_wages_meet_leave_requirements
+          hash: sha256:local
+  versions:
+  - effective_from: '2021-04-01'
+    formula: 'if family_leave_wages_meet_leave_requirements: min(max(0, wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified),
+      substituted_family_leave_wage_cap) else: 0'


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(c), including the $12,000 substituted family leave wage cap, compliance judgment, and qualified family leave wage definition.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.
- Generated with `axiom-encode` 0.2.371 after the deferred source-value target repair landed.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/c.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/c.yaml --json`
- `uv run axiom-encode test statutes/26/3132/c.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`

## Notes
- The standalone reviewer score was 7.5/10, while the CI-style validation gates all pass.
