### PR TITLE
Add generated section 3132(d) health plan expenses

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/d.yaml",
+      "sha256": "812889595597054b647ca55d0d176575d09735aa559cf34a3649c5ef80f3cf64"
+    },
+    {
+      "path": "statutes/26/3132/d.test.yaml",
+      "sha256": "deda5fd18ed5009dffa764a2e6013114acfe47d4ac8f7afcf2f23356981a29d4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3132(d)",
+  "context_manifest_file": "/tmp/axiom-encode-3132d-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3132-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "fd1942bccda3fe1186d38655e218aa71ad7ccf835526c888f13b6a8a05c45aad",
+  "generated_at": "2026-05-28T10:26:13.134135+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132d-20260528-001/openai-gpt-5.5/statutes/26/3132/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132d-20260528-001",
+  "generated_output_sha256": "812889595597054b647ca55d0d176575d09735aa559cf34a3649c5ef80f3cf64",
+  "generation_prompt_sha256": "48dd135616ae92e1e182bc40e254623d303a3d711f70483abc541912c8fc3578",
+  "model": "gpt-5.5",
+  "run_id": "a31cecbd",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1474e1977b07cff5b13b34f93a4910919fb185ee6ad5ba6e6746fdaa2e3c10dc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132d-20260528-001/traces/openai-gpt-5.5/26-USC-3132-d.json",
+  "trace_sha256": "8ab42a416a448604474241019eb5bccfdf2fd46a2a7f0be2b51365859137c9ef"
+}

--- a/statutes/26/3132/d.test.yaml
+++ b/statutes/26/3132/d.test.yaml
@@ -1,0 +1,53 @@
+- name: default_allocation_safe_harbor_and_credit_increase_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3132/d#input.secretary_otherwise_provides_health_plan_expense_allocation_method: false
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_among_covered_employees: true
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_on_basis_of_periods_of_coverage_relative_to_leave_periods: true
+    ? us:statutes/26/3132/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_family_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 800
+  output:
+    us:statutes/26/3132/d#default_health_plan_expense_allocation_properly_made: holds
+    us:statutes/26/3132/d#credit_increase_for_allocable_health_plan_expenses: 800
+- name: secretary_otherwise_provides_displaces_default_safe_harbor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3132/d#input.secretary_otherwise_provides_health_plan_expense_allocation_method: true
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_among_covered_employees: true
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_on_basis_of_periods_of_coverage_relative_to_leave_periods: true
+    ? us:statutes/26/3132/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_family_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 800
+  output:
+    us:statutes/26/3132/d#default_health_plan_expense_allocation_properly_made: not_holds
+- name: allocation_not_pro_rata_among_covered_employees_fails_default_safe_harbor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3132/d#input.secretary_otherwise_provides_health_plan_expense_allocation_method: false
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_among_covered_employees: false
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_on_basis_of_periods_of_coverage_relative_to_leave_periods: true
+    ? us:statutes/26/3132/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_family_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 800
+  output:
+    us:statutes/26/3132/d#default_health_plan_expense_allocation_properly_made: not_holds
+- name: allocation_not_pro_rata_by_coverage_periods_fails_default_safe_harbor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3132/d#input.secretary_otherwise_provides_health_plan_expense_allocation_method: false
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_among_covered_employees: true
+    us:statutes/26/3132/d#input.allocation_made_pro_rata_on_basis_of_periods_of_coverage_relative_to_leave_periods: false
+    ? us:statutes/26/3132/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_family_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 800
+  output:
+    us:statutes/26/3132/d#default_health_plan_expense_allocation_properly_made: not_holds

--- a/statutes/26/3132/d.yaml
+++ b/statutes/26/3132/d.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    The credit under subsection (a) is increased by the employer’s qualified health plan expenses properly allocable to qualified family leave wages; “qualified health plan expenses” are amounts paid or incurred to provide and maintain a group health plan, only to the extent excluded from employees’ gross income by reason of section 106(a); allocation is as the Secretary may prescribe, with a default pro rata safe harbor.
+  deferred_outputs:
+    - output: us:statutes/26/3132/d#qualified_health_plan_expenses
+      reason: The definition depends on the unavailable cross-referenced definition of a group health plan in section 5000(b)(1) and the unavailable section 106(a) exclusion from employees' gross income.
+rules:
+  - name: default_health_plan_expense_allocation_properly_made
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3132(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "Except as otherwise provided by the Secretary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "pro rata among covered employees and pro rata on the basis of periods of coverage"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          not secretary_otherwise_provides_health_plan_expense_allocation_method
+          and allocation_made_pro_rata_among_covered_employees
+          and allocation_made_pro_rata_on_basis_of_periods_of_coverage_relative_to_leave_periods
+
+  - name: credit_increase_for_allocable_health_plan_expenses
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+          - path: versions[0].formula
+            kind: unit
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "amount of the credit"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, employer_qualified_health_plan_expenses_properly_allocable_to_qualified_family_leave_wages_for_which_subsection_a_credit_is_allowed)


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(d), including the default allocation safe harbor and credit increase for allocable health plan expenses.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/d.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/d.yaml --json`
- `uv run axiom-encode test statutes/26/3132/d.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
