### PR TITLE
Add generated section 3132(e) bargained contributions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/e.yaml",
+      "sha256": "997149ff7d7cb90fe58595602aa5d1df63b955b96137e8ecbb31f0af9fa42bce"
+    },
+    {
+      "path": "statutes/26/3132/e.test.yaml",
+      "sha256": "e4d9873940af8057e93ec37d8c4ab44fb694ad3b3dcd36cb204c787e001c989a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3132(e)",
+  "context_manifest_file": "/tmp/axiom-encode-3132e-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3132-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "1bdc87b24ef09eaddc09daa10d73e8b9ddc05fca7923f33870bc845af9628b54",
+  "generated_at": "2026-05-28T10:32:09.456315+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132e-20260528-001/openai-gpt-5.5/statutes/26/3132/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132e-20260528-001",
+  "generated_output_sha256": "997149ff7d7cb90fe58595602aa5d1df63b955b96137e8ecbb31f0af9fa42bce",
+  "generation_prompt_sha256": "82dffe33de5637c1929d5d33d557e24f1fd3eedd85f3313440bc0af3e8bc890f",
+  "model": "gpt-5.5",
+  "run_id": "8034b7f1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ffd13560bfe6b8e5995b957bf60ed6d4f7caea3f554c050cfcbbe1966fd26314"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132e-20260528-001/traces/openai-gpt-5.5/26-USC-3132-e.json",
+  "trace_sha256": "a0d8a484c010154a608dc1ceb000eda2359be63c66a872c82b4e51d91379dad2"
+}

--- a/statutes/26/3132/e.test.yaml
+++ b/statutes/26/3132/e.test.yaml
@@ -1,0 +1,34 @@
+- name: allocable_pension_and_apprenticeship_contributions_increase_credit
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3132/e#input.pension_contribution_rate_as_hourly_rate_defined_in_section_3131_e_2: 5
+    ? us:statutes/26/3132/e#input.hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_2_A_iii_during_calendar_quarter
+    : 40
+    us:statutes/26/3132/e#input.apprenticeship_contribution_rate_as_hourly_rate_defined_in_section_3131_e_3: 2
+    ? us:statutes/26/3132/e#input.hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_3_A_iii_during_calendar_quarter
+    : 40
+  output:
+    us:statutes/26/3132/e#pension_plan_contributions_allocated_to_qualified_family_leave_wages: 200
+    us:statutes/26/3132/e#apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages: 80
+    us:statutes/26/3132/e#credit_increase_for_collectively_bargained_contributions: 280
+- name: no_covered_hours_produces_no_collectively_bargained_credit_increase
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3132/e#input.pension_contribution_rate_as_hourly_rate_defined_in_section_3131_e_2: 5
+    ? us:statutes/26/3132/e#input.hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_2_A_iii_during_calendar_quarter
+    : 0
+    us:statutes/26/3132/e#input.apprenticeship_contribution_rate_as_hourly_rate_defined_in_section_3131_e_3: 2
+    ? us:statutes/26/3132/e#input.hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_3_A_iii_during_calendar_quarter
+    : 0
+  output:
+    us:statutes/26/3132/e#pension_plan_contributions_allocated_to_qualified_family_leave_wages: 0
+    us:statutes/26/3132/e#apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages: 0
+    us:statutes/26/3132/e#credit_increase_for_collectively_bargained_contributions: 0

--- a/statutes/26/3132/e.yaml
+++ b/statutes/26/3132/e.yaml
@@ -1,0 +1,103 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    The amount of the credit allowed under subsection (a) shall be increased by allocable collectively bargained defined benefit pension plan contributions and allocable collectively bargained apprenticeship program contributions; each allocation is the applicable hourly contribution rate multiplied by the hours for which qualified family leave wages were provided to covered employees during the calendar quarter.
+rules:
+  - name: pension_plan_contributions_allocated_to_qualified_family_leave_wages
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(e)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "shall be the product of"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "pension contribution rate (as defined in section 3131(e)(2)), expressed as an hourly rate"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "number of hours for which qualified family leave wages were provided to employees covered under the collective bargaining agreement"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, pension_contribution_rate_as_hourly_rate_defined_in_section_3131_e_2)
+          * max(0, hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_2_A_iii_during_calendar_quarter)
+
+  - name: apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(e)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "shall be the product of"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "apprenticeship contribution rate (as defined in section 3131(e)(3)), expressed as an hourly rate"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "number of hours for which qualified family leave wages were provided to employees covered under the collective bargaining agreement"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, apprenticeship_contribution_rate_as_hourly_rate_defined_in_section_3131_e_3)
+          * max(0, hours_for_qualified_family_leave_wages_provided_to_employees_covered_under_collective_bargaining_agreement_described_in_section_3131_e_3_A_iii_during_calendar_quarter)
+
+  - name: credit_increase_for_collectively_bargained_contributions
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3132(e)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "shall be increased by so much of the sum of"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/e#pension_plan_contributions_allocated_to_qualified_family_leave_wages
+              output: pension_plan_contributions_allocated_to_qualified_family_leave_wages
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/e#apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages
+              output: apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          pension_plan_contributions_allocated_to_qualified_family_leave_wages
+          + apprenticeship_program_contributions_allocated_to_qualified_family_leave_wages


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(e), covering allocable collectively bargained pension and apprenticeship contributions that increase the family leave credit.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/e.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/e.yaml --json`
- `uv run axiom-encode test statutes/26/3132/e.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
