### PR TITLE
Add generated section 3131(d) health plan expenses

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/d.yaml",
+      "sha256": "1330e0ddf7d458bc798bdfec6e40667ff7ce67ce3b487a583baac6f041b27fbc"
+    },
+    {
+      "path": "statutes/26/3131/d.test.yaml",
+      "sha256": "66dd3b72968e17534699a73a584499d144a570e0345ebafa8f052bdd4f92d973"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3131(d)",
+  "context_manifest_file": "/tmp/axiom-encode-3131d-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "5369338678d030fef228b5d479756b06805666fa7551d7b7a3129968d18c4395",
+  "generated_at": "2026-05-28T10:44:28.540138+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131d-20260528-001/openai-gpt-5.5/statutes/26/3131/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131d-20260528-001",
+  "generated_output_sha256": "1330e0ddf7d458bc798bdfec6e40667ff7ce67ce3b487a583baac6f041b27fbc",
+  "generation_prompt_sha256": "984d2978ae742ff28a1f0622412a7f2431ce9091d8c3b815aeadb1e88251c8ad",
+  "model": "gpt-5.5",
+  "run_id": "7d20fbb3",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9593dcc14bb24c5146d11e5cc180873c65b69b9addaa7570a576c19d4328c0bb"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131d-20260528-001/traces/openai-gpt-5.5/26-USC-3131-d.json",
+  "trace_sha256": "9a1f3238427ff0afbd12bfef7f18635420534843d30f6f7788fe4c6be89d270c"
+}

--- a/statutes/26/3131/d.test.yaml
+++ b/statutes/26/3131/d.test.yaml
@@ -1,0 +1,26 @@
+- name: qualified_sick_leave_credit_is_increased_by_allocable_health_plan_expenses
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+    ? us:statutes/26/3131/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_sick_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 1200
+  output:
+    us:statutes/26/3131/d#health_plan_expense_increase_to_qualified_sick_leave_wages_credit: 1200
+    us:statutes/26/3131/d#qualified_sick_leave_wages_credit_with_health_plan_expense_increase: 6200
+- name: health_plan_expense_increase_is_floored_at_zero
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+    ? us:statutes/26/3131/d#input.employer_qualified_health_plan_expenses_properly_allocable_to_qualified_sick_leave_wages_for_which_subsection_a_credit_is_allowed
+    : 0
+  output:
+    us:statutes/26/3131/d#health_plan_expense_increase_to_qualified_sick_leave_wages_credit: 0
+    us:statutes/26/3131/d#qualified_sick_leave_wages_credit_with_health_plan_expense_increase: 5000

--- a/statutes/26/3131/d.yaml
+++ b/statutes/26/3131/d.yaml
@@ -1,0 +1,68 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    The credit allowed under subsection (a) is increased by the employer's qualified health plan expenses properly allocable to the qualified sick leave wages for which that credit is allowed; allocation is as the Secretary may prescribe, with a pro rata default.
+  deferred_outputs:
+    - output: us:statutes/26/3131/d#qualified_health_plan_expenses
+      reason: The definition depends on the group health plan definition in section 5000(b)(1) and the section 106(a) gross-income exclusion, neither of which is available as copied RuleSpec context.
+    - output: us:statutes/26/3131/d#qualified_health_plan_expenses_properly_allocable_to_qualified_sick_leave_wages
+      reason: The allocation rule is prescribed by the Secretary and depends on covered-employee and coverage-period allocation mechanics not present in the source text as computable data relations.
+rules:
+  - name: health_plan_expense_increase_to_qualified_sick_leave_wages_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall be increased by so much of the employer’s qualified health plan expenses as are properly allocable"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, employer_qualified_health_plan_expenses_properly_allocable_to_qualified_sick_leave_wages_for_which_subsection_a_credit_is_allowed)
+
+  - name: qualified_sick_leave_wages_credit_with_health_plan_expense_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "The amount of the credit allowed under subsection (a) shall be increased"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/d#health_plan_expense_increase_to_qualified_sick_leave_wages_credit
+              output: health_plan_expense_increase_to_qualified_sick_leave_wages_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+          + health_plan_expense_increase_to_qualified_sick_leave_wages_credit


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3131(d), covering health plan expense increases to the qualified sick leave wages credit.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3131/d.yaml`
- `uv run axiom-encode proof-validate statutes/26/3131/d.yaml --json`
- `uv run axiom-encode test statutes/26/3131/d.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
