### PR TITLE
Add generated section 3131(e) bargained contributions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/e.yaml",
+      "sha256": "1d4ce5ac1c513d27211c667100173a916707af1294d580180f0c73840c2a17b2"
+    },
+    {
+      "path": "statutes/26/3131/e.test.yaml",
+      "sha256": "a859f5bdc19fd83ad7dd4a7707847125b8957a9960f7dcecad7ca18a207d1c1c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3131(e)",
+  "context_manifest_file": "/tmp/axiom-encode-3131e-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "f00c07079437ac55d11b58eefb5a714d55d9fc2d07b086924cc0bb83de045a2f",
+  "generated_at": "2026-05-28T10:50:18.348898+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131e-20260528-001/openai-gpt-5.5/statutes/26/3131/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131e-20260528-001",
+  "generated_output_sha256": "1d4ce5ac1c513d27211c667100173a916707af1294d580180f0c73840c2a17b2",
+  "generation_prompt_sha256": "07603ca5723573ba38940b2ffd7f251fffd6ff32ca84938567aaa04bd3e1aa02",
+  "model": "gpt-5.5",
+  "run_id": "6d6ad504",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e39230e6ba883b2b6d0fe73a191ad3a978efc36a2e9dc212693de4699a5461e4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131e-20260528-001/traces/openai-gpt-5.5/26-USC-3131-e.json",
+  "trace_sha256": "f3f90bf2d9bd2e4af5c15a877aafec236e05113cae7891c4634e15addde72f3a"
+}

--- a/statutes/26/3131/e.test.yaml
+++ b/statutes/26/3131/e.test.yaml
@@ -1,0 +1,38 @@
+- name: qualified_sick_leave_credit_is_increased_by_allocable_collectively_bargained_contributions
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-01-01'
+    end: '2026-03-31'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+    us:statutes/26/3131/e#input.pension_contribution_rate_expressed_as_hourly_rate: 4
+    ? us:statutes/26/3131/e#input.hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_pension_contributions
+    : 100
+    us:statutes/26/3131/e#input.apprenticeship_program_contribution_rate_expressed_as_hourly_rate: 2
+    ? us:statutes/26/3131/e#input.hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_apprenticeship_contributions
+    : 100
+  output:
+    us:statutes/26/3131/e#defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages: 400
+    us:statutes/26/3131/e#apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages: 200
+    us:statutes/26/3131/e#collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit: 600
+    us:statutes/26/3131/e#qualified_sick_leave_wages_credit_with_collectively_bargained_contributions_increase: 5600
+- name: collectively_bargained_contribution_increase_is_zero_when_no_allocable_hours_or_rates
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2026-04-01'
+    end: '2026-06-30'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+    us:statutes/26/3131/e#input.pension_contribution_rate_expressed_as_hourly_rate: 0
+    ? us:statutes/26/3131/e#input.hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_pension_contributions
+    : 100
+    us:statutes/26/3131/e#input.apprenticeship_program_contribution_rate_expressed_as_hourly_rate: 2
+    ? us:statutes/26/3131/e#input.hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_apprenticeship_contributions
+    : 0
+  output:
+    us:statutes/26/3131/e#defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages: 0
+    us:statutes/26/3131/e#apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages: 0
+    us:statutes/26/3131/e#collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit: 0
+    us:statutes/26/3131/e#qualified_sick_leave_wages_credit_with_collectively_bargained_contributions_increase: 5000

--- a/statutes/26/3131/e.yaml
+++ b/statutes/26/3131/e.yaml
@@ -1,0 +1,118 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    The amount of the credit allowed under subsection (a) shall be increased by collectively bargained defined benefit pension plan contributions and collectively bargained apprenticeship program contributions properly allocable to the qualified sick leave wages for which such credit is allowed.
+rules:
+  - name: defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(e)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall be the product of— (i) the pension contribution rate (expressed as an hourly rate), and (ii) the number of hours"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, pension_contribution_rate_expressed_as_hourly_rate)
+          * max(0, hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_pension_contributions)
+
+  - name: apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(e)(3)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall be the product of— (i) the apprenticeship program contribution rate (expressed as an hourly rate), and (ii) the number of hours"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, apprenticeship_program_contribution_rate_expressed_as_hourly_rate)
+          * max(0, hours_for_which_qualified_sick_leave_wages_were_provided_to_employees_covered_under_collective_bargaining_agreement_for_apprenticeship_contributions)
+
+  - name: collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(e)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "shall be increased by the sum of"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/e#defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages
+              output: defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/e#apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages
+              output: apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          defined_benefit_pension_plan_contributions_allocated_to_qualified_sick_leave_wages
+          + apprenticeship_program_contributions_allocated_to_qualified_sick_leave_wages
+
+  - name: qualified_sick_leave_wages_credit_with_collectively_bargained_contributions_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3131(e)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "The amount of the credit allowed under subsection (a) shall be increased"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/e#collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit
+              output: collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+          + collectively_bargained_contributions_increase_to_qualified_sick_leave_wages_credit


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3131(e), covering collectively bargained pension and apprenticeship contribution increases to the qualified sick leave wages credit.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3131/e.yaml`
- `uv run axiom-encode proof-validate statutes/26/3131/e.yaml --json`
- `uv run axiom-encode test statutes/26/3131/e.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
