### PR TITLE
Add generated section 3131(f) coordination rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/f.yaml",
+      "sha256": "19f87556bc561407643ea6440ab1f1996f4e1c2626c672cdcbd61fe653234493"
+    },
+    {
+      "path": "statutes/26/3131/f.test.yaml",
+      "sha256": "ea1c08fd9ee305e5d2ea0b2de2ce1761a4583e8aeb1a5e00f3aeffcf30c85491"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "openai",
+  "citation": "26 USC 3131(f)",
+  "context_manifest_file": "/tmp/axiom-encode-3131f-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3131-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "ac52e602dcfe37b5f3aa19ea3d1cea86d925541546ca8df9dc112190a1c4d3fd",
+  "generated_at": "2026-05-28T10:57:38.099053+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131f-20260528-001/openai-gpt-5.5/statutes/26/3131/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131f-20260528-001",
+  "generated_output_sha256": "19f87556bc561407643ea6440ab1f1996f4e1c2626c672cdcbd61fe653234493",
+  "generation_prompt_sha256": "23e1c90aeb45b8843119edb35549e30c2804beaa21364649c692f7d4fb9de4a4",
+  "model": "gpt-5.5",
+  "run_id": "a38e051e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dd3069cef4a009ebf76108b331ef354d5af131aad2bcec0c64856780a6a49166"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131f-20260528-001/traces/openai-gpt-5.5/26-USC-3131-f.json",
+  "trace_sha256": "094ba7a249d76c34c5c0bf8845657be764d2d52c20af603a29b15f9dcdb2e55b"
+}

--- a/statutes/26/3131/f.test.yaml
+++ b/statutes/26/3131/f.test.yaml
@@ -1,0 +1,42 @@
+- name: section_3111_b_component_and_credit_adjustment_amounts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/b#input.wages: 100000
+    us:statutes/26/3131/f#input.credit_allowed_under_section_3131_for_calendar_quarter_in_taxable_year: 5000
+    us:statutes/26/3131/f#input.wages_taken_into_account_in_determining_section_3131_credit: 5000
+    ? us:statutes/26/3131/f#input.portion_of_cares_act_section_2301_or_section_41_credit_attributable_to_wages_taken_into_account_under_section_3131
+    : 1200
+  output:
+    us:statutes/26/3131/f#section_3111_b_applicable_employment_tax_component: 1450
+    us:statutes/26/3131/f#employer_gross_income_increase_for_section_3131_credit: 5000
+    us:statutes/26/3131/f#wages_taken_into_account_for_section_3131_credit_excluded_from_listed_credits: 5000
+    us:statutes/26/3131/f#section_3131_credit_reduction_for_cares_act_or_section_41_credit: 1200
+    us:statutes/26/3131/f#assessment_limitation_minimum_years_after_later_return_date: 5
+- name: employer_election_removes_only_elected_qualified_sick_leave_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3131/f#input.qualified_sick_leave_wages_paid_by_eligible_employer: 5000
+    us:statutes/26/3131/f#input.qualified_sick_leave_wages_employer_elects_not_to_take_into_account: 1500
+  output:
+    us:statutes/26/3131/f#elected_out_qualified_sick_leave_wages: 1500
+    us:statutes/26/3131/f#qualified_sick_leave_wages_after_employer_election: 3500
+- name: program_coordination_disallows_source_stated_payroll_cost_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3131/f#input.qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan
+    : 1000
+    ? us:statutes/26/3131/f#input.qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_hard_hit_small_businesses_nonprofits_and_venues_grant
+    : 600
+    ? us:statutes/26/3131/f#input.qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_restaurant_revitalization_grant
+    : 400
+  output:
+    us:statutes/26/3131/f#qualified_sick_leave_wages_disallowed_by_program_coordination: 2000

--- a/statutes/26/3131/f.yaml
+++ b/statutes/26/3131/f.yaml
@@ -1,0 +1,205 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3111/b#hospital_insurance_employer_tax
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: 26 USC 3131(f) defines applicable employment taxes and wages for section
+    3131, denies double benefits, permits an election not to take certain qualified
+    sick leave wages into account, denies the credit to the United States and its
+    agencies or instrumentalities except section 501(c)(1) organizations exempt under
+    section 501(a), extends assessment limitations to 5 years, and coordinates qualified
+    sick leave wages with PPP, venue, and restaurant revitalization programs.
+  deferred_outputs:
+  - output: us:statutes/26/3131/f#applicable_employment_taxes
+    reason: The complete definition includes taxes imposed under section 3221(a) attributable
+      to the rate in effect under section 3111(b), but no copied RuleSpec context
+      provides an executable section 3221(a) target.
+  - output: us:statutes/26/3131/f#wages
+    reason: The complete section-specific definition depends on wages as defined in
+      section 3121(a) determined without regard to paragraphs (1) through (22) of
+      section 3121(b), and compensation as defined in section 3231(e) determined without
+      regard to a sentence in paragraph (1). The copied section 3121(a) and section
+      3231(e) final definition targets are deferred.
+  - output: us:statutes/26/3131/f#credit_after_all_double_benefit_reductions
+    reason: Full double-benefit coordination depends on credits allowed under sections
+      45A, 45P, 45S, 51, 3132, 3134, CARES Act section 2301, and section 41; several
+      cited credit sources are unavailable or deferred as complete executable targets.
+  - output: us:statutes/26/3131/f#assessment_limitation_expiration_date_for_section_3131_credit
+    reason: The rule requires computing a date 5 years after the later of the original-return
+      filing date or the date the return is treated as filed under section 6501(b)(2);
+      RuleSpec has no date-valued output type here and no copied executable section
+      6501(b)(2) target.
+  - output: us:statutes/26/3131/f#governmental_employer_not_denied_section_3131_credit
+    reason: Generated rule kept a local fact for a cited legal section. This output
+      is deferred until the cited source can be encoded or imported without a local
+      cross-reference placeholder.
+rules:
+- name: section_3111_b_applicable_employment_tax_component
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(1)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: The taxes imposed under section 3111(b).
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/b#hospital_insurance_employer_tax
+          output: hospital_insurance_employer_tax
+          hash: sha256:342eabb01340bdb2a8b4785a3948f2c51c59657045662fb4f668b4b7422ee906
+  versions:
+  - effective_from: '1990-01-01'
+    formula: max(0, hospital_insurance_employer_tax)
+- name: elected_out_qualified_sick_leave_wages
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: so much of the qualified sick leave wages paid by an eligible employer
+            as such employer elects ... to not take into account
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "min(\n  max(0, qualified_sick_leave_wages_paid_by_eligible_employer),\n\
+      \  max(0, qualified_sick_leave_wages_employer_elects_not_to_take_into_account)\n\
+      )"
+- name: qualified_sick_leave_wages_after_employer_election
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: This section shall not apply to so much of the qualified sick leave
+            wages ... as such employer elects
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3131/f#elected_out_qualified_sick_leave_wages
+          output: elected_out_qualified_sick_leave_wages
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n  0,\n  max(0, qualified_sick_leave_wages_paid_by_eligible_employer)\n\
+      \  - elected_out_qualified_sick_leave_wages\n)"
+- name: employer_gross_income_increase_for_section_3131_credit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(3), first sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: the gross income of the employer ... shall be increased by the
+            amount of such credit
+  versions:
+  - effective_from: '1990-01-01'
+    formula: max(0, credit_allowed_under_section_3131_for_calendar_quarter_in_taxable_year)
+- name: wages_taken_into_account_for_section_3131_credit_excluded_from_listed_credits
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(3), second sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: Any wages taken into account ... shall not be taken into account
+            for purposes of determining the credit allowed under sections 45A, 45P,
+            45S, 51, 3132, and 3134.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: max(0, wages_taken_into_account_in_determining_section_3131_credit)
+- name: section_3131_credit_reduction_for_cares_act_or_section_41_credit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(3), third sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: shall be reduced by the portion of the credit allowed under such
+            section 2301 or section 41 which is attributable to such wages
+  versions:
+  - effective_from: '1990-01-01'
+    formula: max(0, portion_of_cares_act_section_2301_or_section_41_credit_attributable_to_wages_taken_into_account_under_section_3131)
+- name: qualified_sick_leave_wages_disallowed_by_program_coordination
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3131(f)(7)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: shall not apply to so much of the qualified sick leave wages ...
+            as are taken into account as payroll costs
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "max(\n  0,\n  qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan\n\
+      \  + qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_hard_hit_small_businesses_nonprofits_and_venues_grant\n\
+      \  + qualified_sick_leave_wages_taken_into_account_as_payroll_costs_for_restaurant_revitalization_grant\n\
+      )"
+- name: assessment_limitation_minimum_years_after_later_return_date
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3131(f)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3131
+          excerpt: 5 years after the later of
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '5'


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3131(f), covering applicable employment tax component, employer election, gross-income and double-benefit coordination, assessment-limit years, and program coordination outputs.
- Defers unresolved outputs that require unavailable upstream sections or date-valued assessment computations.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3131/f.yaml`
- `uv run axiom-encode proof-validate statutes/26/3131/f.yaml --json`
- `uv run axiom-encode test statutes/26/3131/f.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
