### PR TITLE
Add generated section 3131(h) application period

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3131/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3131/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3131/h.yaml",
+      "sha256": "398db4f4510837d988e00ed61fa36a16c775ac3a846bc5d5b29343e9e609922c"
+    },
+    {
+      "path": "statutes/26/3131/h.test.yaml",
+      "sha256": "b3531be7193f01c2c859690e0b1d4468b62d0a350ea9c743c883d2e7af82f493"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3131(h)",
+  "context_manifest_file": "/tmp/axiom-encode-3131h-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3131-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "4e9426b679fd75d0de1b45c8dc1ffdc2c3137412bfdee2fdda792c25d5342564",
+  "generated_at": "2026-05-28T11:12:11.325739+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3131h-20260528-001/codex-gpt-5.5/statutes/26/3131/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3131h-20260528-001",
+  "generated_output_sha256": "398db4f4510837d988e00ed61fa36a16c775ac3a846bc5d5b29343e9e609922c",
+  "generation_prompt_sha256": "5724f410b90485ffbd0cc3123eb4541b1aaa3e9da6c3ac297021856ffe3ad2a3",
+  "model": "gpt-5.5",
+  "run_id": "45dbd772",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "adcdc06a36904c6cf9d01d4789d7b5b139c1430dfff4a902f6ca65058401287d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3131h-20260528-001/traces/codex-gpt-5.5/26-USC-3131-h.json",
+  "trace_sha256": "a422429fb60b17382efb2e10932eee62f0157d46e8c74ac96d1180168746ccaf"
+}

--- a/statutes/26/3131/h.test.yaml
+++ b/statutes/26/3131/h.test.yaml
@@ -1,0 +1,33 @@
+- name: wages within section application period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-04-01'
+    end: '2021-04-01'
+  input:
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_beginning_not_before_section_application_period: true
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_ending_not_after_section_application_period: true
+  output:
+    us:statutes/26/3131/h#wages_within_section_application_period: holds
+- name: wages before section application period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-03-31'
+    end: '2021-03-31'
+  input:
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_beginning_not_before_section_application_period: false
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_ending_not_after_section_application_period: true
+  output:
+    us:statutes/26/3131/h#wages_within_section_application_period: not_holds
+- name: wages after section application period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-10-01'
+    end: '2021-10-01'
+  input:
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_beginning_not_before_section_application_period: true
+    us:statutes/26/3131/h#input.wages_paid_with_respect_to_period_ending_not_after_section_application_period: false
+  output:
+    us:statutes/26/3131/h#wages_within_section_application_period: not_holds

--- a/statutes/26/3131/h.yaml
+++ b/statutes/26/3131/h.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3131
+  summary: |-
+    This section applies only to wages paid with respect to the period beginning on April 1, 2021, and ending on September 30, 2021.
+rules:
+  - name: wages_within_section_application_period
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3131(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/3131
+              excerpt: "period beginning on April 1, 2021, and ending on September 30, 2021"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          wages_paid_with_respect_to_period_beginning_not_before_section_application_period
+          and wages_paid_with_respect_to_period_ending_not_after_section_application_period


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3131(h), covering the April 1, 2021 through September 30, 2021 application period for wages.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3131/h.yaml`
- `uv run axiom-encode proof-validate statutes/26/3131/h.yaml --json`
- `uv run axiom-encode test statutes/26/3131/h.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
