### PR TITLE
Add generated section 3132(f) coordination rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/f.yaml",
+      "sha256": "f7e90459f6243247996f116e86b93b73d400acca5e4eb310e987fbe92ccf143c"
+    },
+    {
+      "path": "statutes/26/3132/f.test.yaml",
+      "sha256": "b84f77b5e8ab1f02050e7a687d706a0538e33658d28e305e36c8900afb2467f7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3132(f)",
+  "context_manifest_file": "/tmp/axiom-encode-3132f-20260528-002/_eval_workspaces/codex-gpt-5.5/26-USC-3132-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "535b21bbae1a382f3372abe4912c6f16023dd17c1d27aec647f3d6190f95be1d",
+  "generated_at": "2026-05-28T11:21:23.677853+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132f-20260528-002/codex-gpt-5.5/statutes/26/3132/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132f-20260528-002",
+  "generated_output_sha256": "f7e90459f6243247996f116e86b93b73d400acca5e4eb310e987fbe92ccf143c",
+  "generation_prompt_sha256": "5ba8fce0bb1509740c6f082febf7c7b7ca6a04bb35a7e3028d141f8827f1c358",
+  "model": "gpt-5.5",
+  "run_id": "1b3acb46",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6c6f6ec0483788b26a71fcc598cd454efbc138a55326db38a47026ab3128e496"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132f-20260528-002/traces/codex-gpt-5.5/26-USC-3132-f.json",
+  "trace_sha256": "a4a5cda8f5ad42ae28fba87cfbd1b31e792eeabcfb30282716977b09ac3254e4"
+}

--- a/statutes/26/3132/f.test.yaml
+++ b/statutes/26/3132/f.test.yaml
@@ -1,0 +1,78 @@
+- name: section_3111_b_component_credit_adjustments_and_program_coordination
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3111/b#input.wages: 100000
+    us:statutes/26/3132/f#input.credit_allowed_under_section_3132_for_calendar_quarter_in_taxable_year: 5000
+    us:statutes/26/3132/f#input.wages_taken_into_account_in_determining_section_3132_credit: 5000
+    ? us:statutes/26/3132/f#input.portion_of_cares_act_section_2301_or_section_41_credit_attributable_to_wages_taken_into_account_under_section_3132
+    : 1200
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan
+    : 1000
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_hard_hit_small_businesses_nonprofits_and_venues_grant
+    : 600
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_restaurant_revitalization_grant
+    : 400
+    ? us:statutes/26/3132/f#input.payroll_costs_paid_during_covered_period_for_covered_small_business_act_7_a_37_loan_not_forgiven_by_decision
+    : 0
+    ? us:statutes/26/3132/f#input.payroll_costs_paid_during_covered_period_for_covered_small_business_act_7a_loan_not_forgiven_by_decision
+    : 0
+  output:
+    us:statutes/26/3132/f#section_3111_b_applicable_employment_tax_component: 1450
+    us:statutes/26/3132/f#employer_gross_income_increase_for_section_3132_credit: 5000
+    us:statutes/26/3132/f#wages_taken_into_account_for_section_3132_credit_excluded_from_listed_credits: 5000
+    us:statutes/26/3132/f#section_3132_credit_reduction_for_cares_act_or_section_41_credit: 1200
+    us:statutes/26/3132/f#assessment_limitation_minimum_years_after_later_return_date: 5
+    us:statutes/26/3132/f#qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule: 0
+    us:statutes/26/3132/f#qualified_family_leave_wages_disallowed_by_program_coordination: 2000
+- name: employer_election_and_governmental_denial_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 5000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : false
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: false
+    us:statutes/26/3132/f#input.qualified_family_leave_wages_employer_elects_not_to_take_into_account: 1500
+  output:
+    us:statutes/26/3132/f#elected_out_qualified_family_leave_wages: 1500
+    us:statutes/26/3132/f#qualified_family_leave_wages_after_employer_election: 3500
+- name: section_501_organization_carveout_prevents_governmental_denial
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/c#input.wages_paid_by_employer_that_would_be_required_under_emergency_family_and_medical_leave_expansion_act_as_modified
+    : 5000
+    ? us:statutes/26/3132/c#input.employer_fails_to_comply_with_family_and_medical_leave_requirements_for_public_health_emergency_leave
+    : false
+    us:statutes/26/3132/c#input.employer_takes_action_described_in_section_105_of_family_and_medical_leave_act: false
+    us:statutes/26/3132/f#input.qualified_family_leave_wages_employer_elects_not_to_take_into_account: 1500
+  output:
+    us:statutes/26/3132/f#elected_out_qualified_family_leave_wages: 1500
+    us:statutes/26/3132/f#qualified_family_leave_wages_after_employer_election: 3500
+- name: ppp_nonforgiveness_preserves_covered_loan_payroll_cost_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan
+    : 1000
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_hard_hit_small_businesses_nonprofits_and_venues_grant
+    : 600
+    ? us:statutes/26/3132/f#input.qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_restaurant_revitalization_grant
+    : 400
+    ? us:statutes/26/3132/f#input.payroll_costs_paid_during_covered_period_for_covered_small_business_act_7_a_37_loan_not_forgiven_by_decision
+    : 700
+    ? us:statutes/26/3132/f#input.payroll_costs_paid_during_covered_period_for_covered_small_business_act_7a_loan_not_forgiven_by_decision
+    : 500
+  output:
+    us:statutes/26/3132/f#qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule: 1000
+    us:statutes/26/3132/f#qualified_family_leave_wages_disallowed_by_program_coordination: 1000

--- a/statutes/26/3132/f.yaml
+++ b/statutes/26/3132/f.yaml
@@ -1,0 +1,248 @@
+format: rulespec/v1
+imports:
+- us:statutes/26/3111/b#hospital_insurance_employer_tax
+- us:statutes/26/3132/c#qualified_family_leave_wages
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: '"Applicable employment taxes" include taxes imposed under section 3111(b)
+    and the section 3221(a) portion attributable to the section 3111(b) rate. The
+    employer''s gross income "shall be increased by the amount of such credit"; elected
+    qualified family leave wages are not taken into account; no credit is allowed
+    to the United States government except specified section 501 organizations; the
+    assessment period shall not expire before "5 years after the later of" the return
+    dates; and qualified family leave wages counted as specified payroll costs are
+    excluded, subject to PPP nonforgiveness guidance.'
+  deferred_outputs:
+  - output: us:statutes/26/3132/f#applicable_employment_taxes
+    reason: The complete definition includes taxes imposed under section 3221(a) attributable
+      to the section 3111(b) rate, but no copied RuleSpec context provides an executable
+      section 3221(a) target.
+  - output: us:statutes/26/3132/f#wages
+    reason: The complete section-specific definition depends on wages as defined in
+      section 3121(a) determined without regard to paragraphs (1) through (22) of
+      section 3121(b), and compensation as defined in section 3231(e) determined without
+      regard to a sentence in paragraph (1); the copied section 3121(a) target is
+      deferred and the needed purpose-specific compensation modification is not available.
+  - output: us:statutes/26/3132/f#credit_after_all_double_benefit_reductions
+    reason: Full double-benefit coordination depends on credits allowed under sections
+      45A, 45P, 45S, 51, 3131, 3134, CARES Act section 2301, and section 41; several
+      cited credit sources are unavailable or deferred as complete executable targets.
+  - output: us:statutes/26/3132/f#assessment_limitation_expiration_date_for_section_3132_credit
+    reason: The rule requires computing a date 5 years after the later of the original-return
+      filing date or the date the return is treated as filed under section 6501(b)(2);
+      RuleSpec has no date-valued output type here and no copied executable section
+      6501(b)(2) target.
+  - output: us:statutes/26/3132/f#governmental_employer_denied_section_3132_credit
+    reason: Generated rule kept a local fact for a cited legal section. This output
+      is deferred until the cited source can be encoded or imported without a local
+      cross-reference placeholder.
+rules:
+- name: section_3111_b_applicable_employment_tax_component
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(1)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: The taxes imposed under section 3111(b).
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3111/b#hospital_insurance_employer_tax
+          output: hospital_insurance_employer_tax
+          hash: sha256:342eabb01340bdb2a8b4785a3948f2c51c59657045662fb4f668b4b7422ee906
+  versions:
+  - effective_from: '2021-04-01'
+    formula: max(0, hospital_insurance_employer_tax)
+- name: elected_out_qualified_family_leave_wages
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: so much of the qualified family leave wages paid by an eligible
+            employer as such employer elects ... to not take into account
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/c#qualified_family_leave_wages
+          output: qualified_family_leave_wages
+          hash: sha256:b82c4c11b811ce6aa08533624caada517c92636f3f25f60f67628eb6551f432c
+  versions:
+  - effective_from: '2021-04-01'
+    formula: "min(\n  max(0, qualified_family_leave_wages),\n  max(0, qualified_family_leave_wages_employer_elects_not_to_take_into_account)\n\
+      )"
+- name: qualified_family_leave_wages_after_employer_election
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: This section shall not apply to so much of the qualified family
+            leave wages ... as such employer elects
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/c#qualified_family_leave_wages
+          output: qualified_family_leave_wages
+          hash: sha256:b82c4c11b811ce6aa08533624caada517c92636f3f25f60f67628eb6551f432c
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/f#elected_out_qualified_family_leave_wages
+          output: elected_out_qualified_family_leave_wages
+          hash: sha256:local
+  versions:
+  - effective_from: '2021-04-01'
+    formula: "max(\n  0,\n  qualified_family_leave_wages\n  - elected_out_qualified_family_leave_wages\n\
+      )"
+- name: employer_gross_income_increase_for_section_3132_credit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(3), first sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: the gross income of the employer ... shall be increased by the
+            amount of such credit
+  versions:
+  - effective_from: '2021-04-01'
+    formula: max(0, credit_allowed_under_section_3132_for_calendar_quarter_in_taxable_year)
+- name: wages_taken_into_account_for_section_3132_credit_excluded_from_listed_credits
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(3), second sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: Any wages taken into account ... shall not be taken into account
+            for purposes of determining the credit allowed under sections 45A, 45P,
+            45S, 51, 3131, and 3134.
+  versions:
+  - effective_from: '2021-04-01'
+    formula: max(0, wages_taken_into_account_in_determining_section_3132_credit)
+- name: section_3132_credit_reduction_for_cares_act_or_section_41_credit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(3), third sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: shall be reduced by the portion of the credit allowed under such
+            section 2301 or section 41 which is attributable to such wages
+  versions:
+  - effective_from: '2021-04-01'
+    formula: max(0, portion_of_cares_act_section_2301_or_section_41_credit_attributable_to_wages_taken_into_account_under_section_3132)
+- name: assessment_limitation_minimum_years_after_later_return_date
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 3132(f)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: 5 years after the later of
+  versions:
+  - effective_from: '2021-04-01'
+    formula: '5'
+- name: qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(7)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: payroll costs paid during the covered period shall not fail to
+            be treated as qualified family leave wages ... to the extent that
+  versions:
+  - effective_from: '2021-04-01'
+    formula: "min(\n  max(0, qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan),\n\
+      \  max(\n    0,\n    payroll_costs_paid_during_covered_period_for_covered_small_business_act_7_a_37_loan_not_forgiven_by_decision\n\
+      \    + payroll_costs_paid_during_covered_period_for_covered_small_business_act_7a_loan_not_forgiven_by_decision\n\
+      \  )\n)"
+- name: qualified_family_leave_wages_disallowed_by_program_coordination
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3132(f)(7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3132
+          excerpt: This section shall not apply to so much of the qualified family
+            leave wages ... as are taken into account as payroll costs
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3132/f#qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule
+          output: qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule
+          hash: sha256:local
+  versions:
+  - effective_from: '2021-04-01'
+    formula: "max(\n  0,\n  max(0, qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_covered_small_business_act_loan)\n\
+      \  - qualified_family_leave_wages_preserved_by_unforgiven_ppp_loan_rule\n  +\
+      \ max(0, qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_hard_hit_small_businesses_nonprofits_and_venues_grant)\n\
+      \  + max(0, qualified_family_leave_wages_taken_into_account_as_payroll_costs_for_restaurant_revitalization_grant)\n\
+      )"


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(f), covering family-leave credit applicable employment tax component, employer election, gross-income and double-benefit coordination, assessment-limit years, PPP nonforgiveness preservation, and program coordination outputs.
- Defers unresolved outputs that require unavailable section 3221(a), purpose-specific wage/compensation definitions, date-valued assessment computations, full credit coordination, or section 501 cross-reference handling.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/f.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/f.yaml --json`
- `uv run axiom-encode test statutes/26/3132/f.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`

## Notes
- The signed apply path auto-deferred the unsafe section 501 governmental-employer local cross-reference output and repaired invalid test inputs before installation.
