### PR TITLE
Add generated section 3132(h) application period

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3132/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3132/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3132/h.yaml",
+      "sha256": "e76b0a43cbe67159e56d3df4b7cac4e50b1c39a425e55ca15f283a607f835129"
+    },
+    {
+      "path": "statutes/26/3132/h.test.yaml",
+      "sha256": "3001a0d197c4f017cab63d6fc8005ce5e7d13882679a5c59c3ed57267c110f84"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3132(h)",
+  "context_manifest_file": "/tmp/axiom-encode-3132h-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3132-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "c76ccc367b7608882a1e27c2ac982bdcf40076826e551c08fd46b4865dc0026c",
+  "generated_at": "2026-05-28T11:30:22.977384+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3132h-20260528-001/codex-gpt-5.5/statutes/26/3132/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3132h-20260528-001",
+  "generated_output_sha256": "e76b0a43cbe67159e56d3df4b7cac4e50b1c39a425e55ca15f283a607f835129",
+  "generation_prompt_sha256": "81b5d7e2e2fbb65964392d911e2a3c4efe155baa03a7199b5d6f474d32bb7216",
+  "model": "gpt-5.5",
+  "run_id": "105f660a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d88188fc65b8fb76239f22f035ee12cefbd1a37e6ffeef10f8b0139bca57b72e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3132h-20260528-001/traces/codex-gpt-5.5/26-USC-3132-h.json",
+  "trace_sha256": "2070e580d541ea767d0c1ae6a3673f9969d3a430483b73b94a84dc092a5ed047"
+}

--- a/statutes/26/3132/h.test.yaml
+++ b/statutes/26/3132/h.test.yaml
@@ -1,0 +1,33 @@
+- name: wage_payment_with_respect_to_application_period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-04-01'
+    end: '2021-04-01'
+  input:
+    us:statutes/26/3132/h#input.payment_is_wages: true
+    us:statutes/26/3132/h#input.payment_is_with_respect_to_section_application_period: true
+  output:
+    us:statutes/26/3132/h#section_applies_to_wage_payment: holds
+- name: non_wage_payment_with_respect_to_application_period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-06-15'
+    end: '2021-06-15'
+  input:
+    us:statutes/26/3132/h#input.payment_is_wages: false
+    us:statutes/26/3132/h#input.payment_is_with_respect_to_section_application_period: true
+  output:
+    us:statutes/26/3132/h#section_applies_to_wage_payment: not_holds
+- name: wage_payment_outside_application_period
+  period:
+    period_kind: custom
+    name: day
+    start: '2021-10-01'
+    end: '2021-10-01'
+  input:
+    us:statutes/26/3132/h#input.payment_is_wages: true
+    us:statutes/26/3132/h#input.payment_is_with_respect_to_section_application_period: false
+  output:
+    us:statutes/26/3132/h#section_applies_to_wage_payment: not_holds

--- a/statutes/26/3132/h.yaml
+++ b/statutes/26/3132/h.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3132
+  summary: |-
+    This section applies only to wages paid with respect to the period beginning on April 1, 2021, and ending on September 30, 2021.
+rules:
+  - name: section_applies_to_wage_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 26 USC 3132(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/26/3132
+              excerpt: "wages paid with respect to the period beginning on April 1, 2021, and ending on September 30, 2021"
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          payment_is_wages
+          and payment_is_with_respect_to_section_application_period


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3132(h), covering the April 1, 2021 through September 30, 2021 application period for wage payments.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3132/h.yaml`
- `uv run axiom-encode proof-validate statutes/26/3132/h.yaml --json`
- `uv run axiom-encode test statutes/26/3132/h.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
