### PR TITLE
Add generated section 3133(a) credit increases

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3133/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3133/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3133/a.yaml",
+      "sha256": "44f6de44d0464565a25a2a7194cee371a3376947da37806e40347b166a1b1027"
+    },
+    {
+      "path": "statutes/26/3133/a.test.yaml",
+      "sha256": "cd62f528213a7b2bbf9c9dd8507924720097e129260f212c1a4c6d028f53e94f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3133(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3133a-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3133-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "40f81676237976a9dad93a5fa9fb778ad11b1bf21faa133b09078b35aa416062",
+  "generated_at": "2026-05-28T11:44:06.420485+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3133a-20260528-001/codex-gpt-5.5/statutes/26/3133/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3133a-20260528-001",
+  "generated_output_sha256": "44f6de44d0464565a25a2a7194cee371a3376947da37806e40347b166a1b1027",
+  "generation_prompt_sha256": "d03e003049dfb4c44e572d7b13df10850064113dff5c1da0abea77cd0026b1fd",
+  "model": "gpt-5.5",
+  "run_id": "f84d1b09",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "70edec5edd623ece3af9c21ce02ff096fedea6852e5e094256ebe41e856dc143"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3133a-20260528-001/traces/codex-gpt-5.5/26-USC-3133-a.json",
+  "trace_sha256": "c1cdf696dcc4f877b1f6af4054215a652e92f30c4c046b9cb537ef3cebc9b316"
+}

--- a/statutes/26/3133/a.test.yaml
+++ b/statutes/26/3133/a.test.yaml
@@ -1,0 +1,29 @@
+- name: sick_and_family_leave_credits_increase_by_employment_tax_amounts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 10000
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 20000
+    ? us:statutes/26/3133/a#input.qualified_sick_leave_wages_subject_to_section_3111_a_tax_for_which_section_3131_credit_is_allowed
+    : 10000
+    ? us:statutes/26/3133/a#input.qualified_sick_leave_wages_subject_to_section_3111_b_tax_for_which_section_3131_credit_is_allowed
+    : 10000
+    ? us:statutes/26/3133/a#input.tax_imposed_by_section_3221_a_on_qualified_sick_leave_wages_for_which_section_3131_credit_is_allowed
+    : 35
+    ? us:statutes/26/3133/a#input.qualified_family_leave_wages_subject_to_section_3111_a_tax_for_which_section_3132_credit_is_allowed
+    : 20000
+    ? us:statutes/26/3133/a#input.qualified_family_leave_wages_subject_to_section_3111_b_tax_for_which_section_3132_credit_is_allowed
+    : 20000
+    ? us:statutes/26/3133/a#input.tax_imposed_by_section_3221_a_on_qualified_family_leave_wages_for_which_section_3132_credit_is_allowed
+    : 70
+  output:
+    us:statutes/26/3133/a#employer_oasdi_tax_on_qualified_sick_leave_wages_for_section_3131_credit: 620
+    us:statutes/26/3133/a#employer_hospital_insurance_tax_on_qualified_sick_leave_wages_for_section_3131_credit: 145
+    us:statutes/26/3133/a#qualified_sick_leave_wages_credit_employment_tax_increase: 800
+    us:statutes/26/3133/a#qualified_sick_leave_wages_credit_with_employment_tax_increase: 10800
+    us:statutes/26/3133/a#employer_oasdi_tax_on_qualified_family_leave_wages_for_section_3132_credit: 1240
+    us:statutes/26/3133/a#employer_hospital_insurance_tax_on_qualified_family_leave_wages_for_section_3132_credit: 290
+    us:statutes/26/3133/a#qualified_family_leave_wages_credit_employment_tax_increase: 1600
+    us:statutes/26/3133/a#qualified_family_leave_wages_credit_with_employment_tax_increase: 21600

--- a/statutes/26/3133/a.yaml
+++ b/statutes/26/3133/a.yaml
@@ -1,0 +1,247 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+  - us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+  - us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
+  - us:statutes/26/3111/b#hospital_insurance_employer_tax_rate
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3133
+  summary: |-
+    Section 3133(a): "shall each be increased" by specified employment taxes on creditable sick or family leave wages.
+rules:
+  - name: employer_oasdi_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
+              output: employer_oasdi_excise_tax_rate
+              hash: sha256:efb33150d9a178e184a16c1d9fd99bd56e789343f781eedb42228d1359df25ca
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, qualified_sick_leave_wages_subject_to_section_3111_a_tax_for_which_section_3131_credit_is_allowed)
+          * employer_oasdi_excise_tax_rate
+
+  - name: employer_hospital_insurance_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3111/b#hospital_insurance_employer_tax_rate
+              output: hospital_insurance_employer_tax_rate
+              hash: sha256:342eabb01340bdb2a8b4785a3948f2c51c59657045662fb4f668b4b7422ee906
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, qualified_sick_leave_wages_subject_to_section_3111_b_tax_for_which_section_3131_credit_is_allowed)
+          * hospital_insurance_employer_tax_rate
+
+  - name: qualified_sick_leave_wages_credit_employment_tax_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#employer_oasdi_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+              output: employer_oasdi_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#employer_hospital_insurance_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+              output: employer_hospital_insurance_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          employer_oasdi_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+          + employer_hospital_insurance_tax_on_qualified_sick_leave_wages_for_section_3131_credit
+          + max(0, tax_imposed_by_section_3221_a_on_qualified_sick_leave_wages_for_which_section_3131_credit_is_allowed)
+
+  - name: qualified_sick_leave_wages_credit_with_employment_tax_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#qualified_sick_leave_wages_credit_employment_tax_increase
+              output: qualified_sick_leave_wages_credit_employment_tax_increase
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+          + qualified_sick_leave_wages_credit_employment_tax_increase
+
+  - name: employer_oasdi_tax_on_qualified_family_leave_wages_for_section_3132_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
+              output: employer_oasdi_excise_tax_rate
+              hash: sha256:efb33150d9a178e184a16c1d9fd99bd56e789343f781eedb42228d1359df25ca
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, qualified_family_leave_wages_subject_to_section_3111_a_tax_for_which_section_3132_credit_is_allowed)
+          * employer_oasdi_excise_tax_rate
+
+  - name: employer_hospital_insurance_tax_on_qualified_family_leave_wages_for_section_3132_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3111/b#hospital_insurance_employer_tax_rate
+              output: hospital_insurance_employer_tax_rate
+              hash: sha256:342eabb01340bdb2a8b4785a3948f2c51c59657045662fb4f668b4b7422ee906
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          max(0, qualified_family_leave_wages_subject_to_section_3111_b_tax_for_which_section_3132_credit_is_allowed)
+          * hospital_insurance_employer_tax_rate
+
+  - name: qualified_family_leave_wages_credit_employment_tax_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#employer_oasdi_tax_on_qualified_family_leave_wages_for_section_3132_credit
+              output: employer_oasdi_tax_on_qualified_family_leave_wages_for_section_3132_credit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#employer_hospital_insurance_tax_on_qualified_family_leave_wages_for_section_3132_credit
+              output: employer_hospital_insurance_tax_on_qualified_family_leave_wages_for_section_3132_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          employer_oasdi_tax_on_qualified_family_leave_wages_for_section_3132_credit
+          + employer_hospital_insurance_tax_on_qualified_family_leave_wages_for_section_3132_credit
+          + max(0, tax_imposed_by_section_3221_a_on_qualified_family_leave_wages_for_which_section_3132_credit_is_allowed)
+
+  - name: qualified_family_leave_wages_credit_with_employment_tax_increase
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3133(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3133
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:f249f97f60dad580a6e353f961a820960551254b821e267853fba2af34a1dfc2
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3133/a#qualified_family_leave_wages_credit_employment_tax_increase
+              output: qualified_family_leave_wages_credit_employment_tax_increase
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-04-01'
+        formula: |-
+          qualified_family_leave_wages_credit_against_applicable_employment_taxes
+          + qualified_family_leave_wages_credit_employment_tax_increase


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3133(a), increasing the section 3131 and 3132 leave credits by employer OASDI, Medicare, and section 3221(a) taxes on creditable sick or family leave wages.
- Imports generated section 3131(a), 3132(a), 3111(a), and 3111(b) outputs where available.
- Includes generated companion tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3133/a.yaml`
- `uv run axiom-encode proof-validate statutes/26/3133/a.yaml --json`
- `uv run axiom-encode test statutes/26/3133/a.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
