### PR TITLE
Add generated section 3134(a) retention credit rate

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3134/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3134/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3134/a.yaml",
+      "sha256": "be3abd3878cb9b84ecba29b9279f5a9fa3e952bbaa572400e4fce7d0873cc9c8"
+    },
+    {
+      "path": "statutes/26/3134/a.test.yaml",
+      "sha256": "b66fa53cfc7f130fe47c12982f9cc9def2ea175a2200afbf4e385dd1a69f5cd7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3134(a)",
+  "context_manifest_file": "/tmp/axiom-encode-3134a-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3134-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "5201aa20f719ef8e34fab2b46365d2e54b25716460311cff4031fb0b98fa3001",
+  "generated_at": "2026-05-28T12:00:37.188221+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3134a-20260528-001/codex-gpt-5.5/statutes/26/3134/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3134a-20260528-001",
+  "generated_output_sha256": "be3abd3878cb9b84ecba29b9279f5a9fa3e952bbaa572400e4fce7d0873cc9c8",
+  "generation_prompt_sha256": "9908cef04c3d56de942a5a956475e77229186b4196a0b498a3b870d223cbb404",
+  "model": "gpt-5.5",
+  "run_id": "7cad43be",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "db02d9efb6718429c19a88a684863338cbff86d80b22390ef3c68477114ed58a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3134a-20260528-001/traces/codex-gpt-5.5/26-USC-3134-a.json",
+  "trace_sha256": "97764732cf87b40e16bcb5b3e8d2b318754f55858912ad7e7c9e8e1a183e0b3d"
+}

--- a/statutes/26/3134/a.test.yaml
+++ b/statutes/26/3134/a.test.yaml
@@ -1,0 +1,8 @@
+- name: employee_retention_credit_rate_is_seventy_percent
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input: {}
+  output:
+    us:statutes/26/3134/a#employee_retention_credit_rate: 0.7

--- a/statutes/26/3134/a.yaml
+++ b/statutes/26/3134/a.yaml
@@ -1,0 +1,30 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3134
+  summary: |-
+    In the case of an eligible employer, a credit is allowed for each calendar quarter in an amount equal to 70 percent of qualified wages with respect to each employee.
+  deferred_outputs:
+    - output: us:statutes/26/3134/a#employee_retention_credit_against_applicable_employment_taxes_for_calendar_quarter
+      reason: The final credit is expressly computed for each calendar quarter, but the supported RuleSpec period enum has no Quarter period; the final amount also requires an employer-employee wage base for qualified wages with respect to each employee for that quarter.
+      source_values:
+        - us:statutes/26/3134/a#employee_retention_credit_rate
+rules:
+  - name: employee_retention_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3134(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: 70 percent
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.70


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3134(a), the employee retention credit amount rule.
- Encodes the statutory 70 percent credit rate as an executable parameter.
- Defers the full quarterly credit output because the generated source requires per-calendar-quarter computation and employee-level qualified wage bases that are not currently represented in RuleSpec context.
- Includes the generated companion test and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3134/a.yaml`
- `uv run axiom-encode proof-validate statutes/26/3134/a.yaml --json`
- `uv run axiom-encode test statutes/26/3134/a.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`
