### PR TITLE
Add generated section 3134(c) definitions

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3134/c.json
+++ b/.axiom/encoding-manifests/statutes/26/3134/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3134/c.yaml",
+      "sha256": "570450edc19afd3b4f251f1a4f9faa2599e0be406607f4c04ffb117f1e1858d5"
+    },
+    {
+      "path": "statutes/26/3134/c.test.yaml",
+      "sha256": "9dc3962da5842aa728b9cd2d1d9973949485d825b193b8a8e719c6048ecb7d2d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.371",
+    "version_commit": "d7b4b91cfa5157aeba92d5ec8c4fbdabe64054e8"
+  },
+  "axiom_encode_version": "0.2.371",
+  "backend": "codex",
+  "citation": "26 USC 3134(c)",
+  "context_manifest_file": "/tmp/axiom-encode-3134c-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3134-c/workspace/context-manifest.json",
+  "context_manifest_sha256": "a1157354790b42f7a660bdbf248544d082d72801e67d20f001143124cfa8332f",
+  "generated_at": "2026-05-28T12:16:51.038131+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3134c-20260528-001/codex-gpt-5.5/statutes/26/3134/c.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3134c-20260528-001",
+  "generated_output_sha256": "570450edc19afd3b4f251f1a4f9faa2599e0be406607f4c04ffb117f1e1858d5",
+  "generation_prompt_sha256": "07cc0be2ac2d6c6d250f0370c59066ae1d848a42219f856c28278b1df2d1f711",
+  "model": "gpt-5.5",
+  "run_id": "2d72d1c7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "24b22f1e0070a5f7042c3165c90ada4aead801bd5fa9471d545b178cd11b8b6c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3134c-20260528-001/traces/codex-gpt-5.5/26-USC-3134-c.json",
+  "trace_sha256": "adfc7b615eca6c7962727bda649dce89d523486ccf6785f8fa06723b37a9c6d2"
+}

--- a/statutes/26/3134/c.test.yaml
+++ b/statutes/26/3134/c.test.yaml
@@ -1,0 +1,39 @@
+- name: section_3111_b_component_parameters_and_default_health_plan_allocation
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3111/b#input.wages: 100000
+    us:statutes/26/3134/c#input.secretary_otherwise_provides_health_plan_expense_allocation_method: false
+    us:statutes/26/3134/c#input.health_plan_expense_allocation_made_pro_rata_among_periods_of_coverage: true
+  output:
+    us:statutes/26/3134/c#section_3111_b_applicable_employment_tax_component: 1450
+    us:statutes/26/3134/c#gross_receipts_decline_threshold: 0.8
+    us:statutes/26/3134/c#severely_financially_distressed_gross_receipts_threshold: 0.1
+    us:statutes/26/3134/c#qualified_wages_large_employer_full_time_employee_threshold: 500
+    us:statutes/26/3134/c#recovery_startup_business_average_annual_gross_receipts_limit: 1000000
+    us:statutes/26/3134/c#recovery_startup_business_gross_receipts_period_taxable_years: 3
+    us:statutes/26/3134/c#default_health_plan_expense_allocation_properly_made: holds
+- name: secretary_override_prevents_default_health_plan_allocation_safe_harbor
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3111/b#input.wages: 100000
+    us:statutes/26/3134/c#input.secretary_otherwise_provides_health_plan_expense_allocation_method: true
+    us:statutes/26/3134/c#input.health_plan_expense_allocation_made_pro_rata_among_periods_of_coverage: true
+  output:
+    us:statutes/26/3134/c#section_3111_b_applicable_employment_tax_component: 1450
+    us:statutes/26/3134/c#default_health_plan_expense_allocation_properly_made: not_holds
+- name: non_pro_rata_allocation_fails_default_health_plan_allocation_safe_harbor
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/c#input.secretary_otherwise_provides_health_plan_expense_allocation_method: false
+    us:statutes/26/3134/c#input.health_plan_expense_allocation_made_pro_rata_among_periods_of_coverage: false
+  output:
+    us:statutes/26/3134/c#default_health_plan_expense_allocation_properly_made: not_holds

--- a/statutes/26/3134/c.yaml
+++ b/statutes/26/3134/c.yaml
@@ -1,0 +1,176 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3111/b#hospital_insurance_employer_tax
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3134
+  summary: |-
+    (c) Definitions For purposes of this section— "applicable employment taxes" include "The taxes imposed under section 3111(b)" and the section 3221(a) portion attributable to the section 3111(b) rate. "Eligible employer" requires carrying on a trade or business and a suspension, gross-receipts decline, or recovery-startup-business condition. "Qualified wages" depends on eligible-employer status, full-time employee counts, service status, severe financial distress, and listed wage exclusions. "Wages" include section 3121(a) wages, section 3231(e) compensation, and certain allocable health plan expenses. "Recovery startup business" includes the February 15, 2020 start date and the $1,000,000 average annual gross receipts limit.
+  deferred_outputs:
+    - output: us:statutes/26/3134/c#applicable_employment_taxes
+      reason: The complete definition includes taxes imposed under section 3221(a) attributable to the rate in effect under section 3111(b), but no copied RuleSpec context provides an executable section 3221(a) target.
+      source_values:
+        - us:statutes/26/3134/c#section_3111_b_applicable_employment_tax_component
+    - output: us:statutes/26/3134/c#eligible_employer
+      reason: The complete definition is calendar-quarter based and depends on gross receipts within the meaning of section 448(c), tax-exempt organization rules under sections 501(c), 501(a), and 6033, and recovery-startup-business status; the quarter period and several cited definitions are unavailable here.
+      source_values:
+        - us:statutes/26/3134/c#gross_receipts_decline_threshold
+        - us:statutes/26/3134/c#recovery_startup_business_average_annual_gross_receipts_limit
+        - us:statutes/26/3134/c#recovery_startup_business_gross_receipts_period_taxable_years
+    - output: us:statutes/26/3134/c#qualified_wages
+      reason: The complete definition depends on eligible-employer status, full-time employee counts within the meaning of section 4980H, wages as defined in this subsection, calendar-quarter wage periods, severe financial distress, and wage exclusions for sections 41, 45A, 45P, 45S, 51, 1396, 3131, and 3132; several cited sources or period mechanics are unavailable as executable RuleSpec dependencies.
+      source_values:
+        - us:statutes/26/3134/c#qualified_wages_large_employer_full_time_employee_threshold
+        - us:statutes/26/3134/c#severely_financially_distressed_gross_receipts_threshold
+    - output: us:statutes/26/3134/c#severely_financially_distressed_employer
+      reason: The definition is an eligible-employer determination with the gross-receipts threshold substituted from 80 percent to 10 percent; it cannot be completed until the eligible-employer definition and section 448(c) gross receipts mechanics are executable.
+      source_values:
+        - us:statutes/26/3134/c#severely_financially_distressed_gross_receipts_threshold
+    - output: us:statutes/26/3134/c#wages
+      reason: The complete definition depends on wages as defined in section 3121(a), compensation as defined in section 3231(e), purpose-specific section 3121(b) modifications for organizations or entities described in subsection (f)(2), and health plan amounts under sections 5000(b)(1) and 106(a). Several cited targets are missing or deferred.
+    - output: us:statutes/26/3134/c#recovery_startup_business
+      reason: The definition depends on whether the employer began carrying on a trade or business after February 15, 2020 and on average annual gross receipts determined under rules similar to section 448(c)(3), which is not available as executable context.
+      source_values:
+        - us:statutes/26/3134/c#recovery_startup_business_average_annual_gross_receipts_limit
+        - us:statutes/26/3134/c#recovery_startup_business_gross_receipts_period_taxable_years
+    - output: us:statutes/26/3134/c#other_terms_same_meaning
+      reason: Paragraph (6) assigns same meanings to terms used in this chapter or chapter 22; the complete set of same-meaning dependencies is outside the executable context copied for this source.
+rules:
+  - name: section_3111_b_applicable_employment_tax_component
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(c)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: The taxes imposed under section 3111(b).
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3111/b#hospital_insurance_employer_tax
+              output: hospital_insurance_employer_tax
+              hash: sha256:342eabb01340bdb2a8b4785a3948f2c51c59657045662fb4f668b4b7422ee906
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          max(0, hospital_insurance_employer_tax)
+
+  - name: gross_receipts_decline_threshold
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3134(c)(2)(A)(ii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: less than 80 percent
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.80
+
+  - name: severely_financially_distressed_gross_receipts_threshold
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3134(c)(3)(C)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: substituting "less than 10 percent" for "less than 80 percent"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.10
+
+  - name: qualified_wages_large_employer_full_time_employee_threshold
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3134(c)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: greater than 500
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          500
+
+  - name: recovery_startup_business_average_annual_gross_receipts_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3134(c)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: does not exceed $1,000,000
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          1000000
+
+  - name: recovery_startup_business_gross_receipts_period_taxable_years
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3134(c)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: for the 3-taxable-year period
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          3
+
+  - name: default_health_plan_expense_allocation_properly_made
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3134(c)(4)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: Except as otherwise provided by the Secretary
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: pro rata among periods of coverage
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          not secretary_otherwise_provides_health_plan_expense_allocation_method
+          and health_plan_expense_allocation_made_pro_rata_among_periods_of_coverage


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec artifacts for 26 USC 3134(c), the employee retention credit definitions subsection.
- Encodes clear executable source values for the section 3111(b) applicable employment tax component, gross receipts thresholds, large-employer threshold, recovery startup gross receipts limit/period, and the default health-plan expense allocation safe harbor.
- Defers complete outputs for applicable employment taxes, eligible employer, qualified wages, wages, severe financial distress, recovery startup business, and same-meaning terms where quarter support or cited cross-section mechanics are not yet executable.
- Includes generated tests and signed encode manifest from `axiom-encode encode --apply`.

## Validation
- `uv run axiom-encode validate --skip-reviewers statutes/26/3134/c.yaml`
- `uv run axiom-encode proof-validate statutes/26/3134/c.yaml --json`
- `uv run axiom-encode test statutes/26/3134/c.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine --json`
- `uv run axiom-encode oracle-coverage --root current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD --json`

## Note
- I generated 3134(c) before retrying 3134(b) because an earlier generated 3134(b) draft incorrectly reached for an unrelated same-named 45A qualified-wages output. This PR provides local 3134 definitions for the next retry.
