### PR TITLE
Add generated section 3134(b) limitations

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3134/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3134/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3134/b.yaml",
+      "sha256": "840aaa44745e11c1a840a1ec0c11ce48b5137144faf1629d289d79fc00b2ee2a"
+    },
+    {
+      "path": "statutes/26/3134/b.test.yaml",
+      "sha256": "f6013da66c9f7b1be7c76279330ccf54050d5fc8fa00a0ee296985f596b4ef2d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "01cae2aed8babb9f370beaee50425ee8ee4cf684",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.374",
+    "version_commit": "01cae2aed8babb9f370beaee50425ee8ee4cf684"
+  },
+  "axiom_encode_version": "0.2.374",
+  "backend": "codex",
+  "citation": "26 USC 3134(b)",
+  "context_manifest_file": "/tmp/axiom-encode-3134b-repaired-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3134-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "75ff0bb046a4bf7b0e91d50605e214d9b30e3130f9dc9b51511dc1117df87055",
+  "generated_at": "2026-05-28T13:44:44.720423+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3134b-repaired-20260528-001/codex-gpt-5.5/statutes/26/3134/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3134b-repaired-20260528-001",
+  "generated_output_sha256": "840aaa44745e11c1a840a1ec0c11ce48b5137144faf1629d289d79fc00b2ee2a",
+  "generation_prompt_sha256": "74e3251fd0e506348ac00f797ccaae5e2cc461d3890fce46e4c5a78bc84d79f6",
+  "model": "gpt-5.5",
+  "run_id": "af90def7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "53de44a5078eea8616efd4f4a8bf54bc35500c500eba3838eafe714f240dbd71"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3134b-repaired-20260528-001/traces/codex-gpt-5.5/26-USC-3134-b.json",
+  "trace_sha256": "5392b0185c9aefa3d22d835d15450cbd1faaa2cb7cf5b1152cc78c7bb8def755"
+}

--- a/statutes/26/3134/b.test.yaml
+++ b/statutes/26/3134/b.test.yaml
@@ -1,0 +1,56 @@
+- name: employee_qualified_wages_below_calendar_quarter_cap
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2021-04-01'
+    end: '2021-06-30'
+  input:
+    us:statutes/26/3134/b#input.qualified_wages_with_respect_to_employee_for_calendar_quarter: 8000
+  output:
+    us:statutes/26/3134/b#qualified_wages_employee_calendar_quarter_cap: 10000
+    us:statutes/26/3134/b#qualified_wages_taken_into_account_for_employee_for_calendar_quarter: 8000
+- name: employee_qualified_wages_capped_for_calendar_quarter
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2021-04-01'
+    end: '2021-06-30'
+  input:
+    us:statutes/26/3134/b#input.qualified_wages_with_respect_to_employee_for_calendar_quarter: 15000
+  output:
+    us:statutes/26/3134/b#qualified_wages_taken_into_account_for_employee_for_calendar_quarter: 10000
+- name: non_recovery_startup_business_credit_not_subject_to_fifty_thousand_cap
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2021-04-01'
+    end: '2021-06-30'
+  input:
+    us:statutes/26/3134/b#input.employer_is_recovery_startup_business: false
+    us:statutes/26/3134/b#input.employee_retention_credit_under_subsection_a_after_employee_wage_cap_for_calendar_quarter: 70000
+    us:statutes/26/3134/b#input.applicable_employment_taxes_on_wages_paid_to_all_employees_for_calendar_quarter: 80000
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 0
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 0
+  output:
+    us:statutes/26/3134/b#recovery_startup_business_credit_calendar_quarter_cap: 50000
+    us:statutes/26/3134/b#employee_retention_credit_after_recovery_startup_business_cap: 70000
+    us:statutes/26/3134/b#employment_tax_limitation_for_employee_retention_credit: 80000
+    us:statutes/26/3134/b#employee_retention_credit_after_employment_tax_limitation: 70000
+    us:statutes/26/3134/b#employee_retention_credit_refundable_excess: 0
+- name: recovery_startup_business_credit_limited_and_excess_refundable
+  period:
+    period_kind: custom
+    name: calendar_quarter
+    start: '2021-04-01'
+    end: '2021-06-30'
+  input:
+    us:statutes/26/3134/b#input.employer_is_recovery_startup_business: true
+    us:statutes/26/3134/b#input.employee_retention_credit_under_subsection_a_after_employee_wage_cap_for_calendar_quarter: 70000
+    us:statutes/26/3134/b#input.applicable_employment_taxes_on_wages_paid_to_all_employees_for_calendar_quarter: 30000
+    us:statutes/26/3131/a#input.qualified_sick_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+    us:statutes/26/3132/a#input.qualified_family_leave_wages_paid_by_employer_with_respect_to_calendar_quarter: 5000
+  output:
+    us:statutes/26/3134/b#employee_retention_credit_after_recovery_startup_business_cap: 50000
+    us:statutes/26/3134/b#employment_tax_limitation_for_employee_retention_credit: 20000
+    us:statutes/26/3134/b#employee_retention_credit_after_employment_tax_limitation: 20000
+    us:statutes/26/3134/b#employee_retention_credit_refundable_excess: 30000

--- a/statutes/26/3134/b.yaml
+++ b/statutes/26/3134/b.yaml
@@ -1,0 +1,223 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+  - us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3134
+  summary: |-
+    Qualified wages with respect to any employee taken into account under subsection (a) "shall not exceed $10,000." For a recovery startup business, the credit after that wage cap "shall not exceed $50,000." The credit "shall not exceed the applicable employment taxes (reduced by any credits allowed under sections 3131 and 3132)," and any excess "shall be treated as an overpayment."
+rules:
+  - name: qualified_wages_employee_calendar_quarter_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3134(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: shall not exceed $10,000
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          10000
+
+  - name: qualified_wages_taken_into_account_for_employee_for_calendar_quarter
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: The amount of qualified wages with respect to any employee which may be taken into account
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#qualified_wages_employee_calendar_quarter_cap
+              output: qualified_wages_employee_calendar_quarter_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          min(
+              max(0, qualified_wages_with_respect_to_employee_for_calendar_quarter),
+              qualified_wages_employee_calendar_quarter_cap
+          )
+
+  - name: recovery_startup_business_credit_calendar_quarter_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 3134(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: shall not exceed $50,000
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          50000
+
+  - name: employee_retention_credit_after_recovery_startup_business_cap
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: eligible employer which is a recovery startup business
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: the amount of the credit allowed under subsection (a) (after application of subparagraph (A))
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#recovery_startup_business_credit_calendar_quarter_cap
+              output: recovery_startup_business_credit_calendar_quarter_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          if employer_is_recovery_startup_business: min(
+              max(0, employee_retention_credit_under_subsection_a_after_employee_wage_cap_for_calendar_quarter),
+              recovery_startup_business_credit_calendar_quarter_cap
+          ) else: max(0, employee_retention_credit_under_subsection_a_after_employee_wage_cap_for_calendar_quarter)
+
+  - name: employment_tax_limitation_for_employee_retention_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: applicable employment taxes (reduced by any credits allowed under sections 3131 and 3132)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3131/a#qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:eb18d4a79c2902f4018ec4acfa89e326b6b86646355ace8ae4a89ab37c4f8aa9
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3132/a#qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              output: qualified_family_leave_wages_credit_against_applicable_employment_taxes
+              hash: sha256:f249f97f60dad580a6e353f961a820960551254b821e267853fba2af34a1dfc2
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          max(
+              0,
+              applicable_employment_taxes_on_wages_paid_to_all_employees_for_calendar_quarter
+              - qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+              - qualified_family_leave_wages_credit_against_applicable_employment_taxes
+          )
+
+  - name: employee_retention_credit_after_employment_tax_limitation
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: The credit allowed by subsection (a) with respect to any calendar quarter shall not exceed the applicable employment taxes
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#employee_retention_credit_after_recovery_startup_business_cap
+              output: employee_retention_credit_after_recovery_startup_business_cap
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#employment_tax_limitation_for_employee_retention_credit
+              output: employment_tax_limitation_for_employee_retention_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          min(
+              employee_retention_credit_after_recovery_startup_business_cap,
+              employment_tax_limitation_for_employee_retention_credit
+          )
+
+  - name: employee_retention_credit_refundable_excess
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3134(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: If the amount of the credit under subsection (a) exceeds the limitation of paragraph (2)
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: such excess shall be treated as an overpayment
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#employee_retention_credit_after_recovery_startup_business_cap
+              output: employee_retention_credit_after_recovery_startup_business_cap
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3134/b#employment_tax_limitation_for_employee_retention_credit
+              output: employment_tax_limitation_for_employee_retention_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          max(
+              0,
+              employee_retention_credit_after_recovery_startup_business_cap
+              - employment_tax_limitation_for_employee_retention_credit
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3134(b) employee wage cap, recovery startup cap, employment tax limitation, and refundable excess
- add companion tests for the wage cap, recovery startup cap, employment tax limit, and excess treatment
- include signed axiom-encode apply manifest from encoder 0.2.374 at 01cae2a, run_id af90def7

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/b.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/b.yaml
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/b.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-untested-comparable
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD
- subagent read-only review: no actionable findings

Note: these COVID employee-retention-credit outputs are classified as not PE-comparable, so this PR has structural/proof/test coverage but no PE match rate.