### PR TITLE
Add generated section 3134(f) governmental employer rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3134/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3134/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3134/f.yaml",
+      "sha256": "58d1f406098105b7327a56e32b2a74becb78e2e70693f67257378ba11e9cae89"
+    },
+    {
+      "path": "statutes/26/3134/f.test.yaml",
+      "sha256": "8281696a2462a2834f65faaa68a0780bf6031a093678f2543a7e999bc556e317"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "aec0844a6c20d500de4fce087b28be423781923f",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.376",
+    "version_commit": "aec0844a6c20d500de4fce087b28be423781923f"
+  },
+  "axiom_encode_version": "0.2.376",
+  "backend": "codex",
+  "citation": "26 USC 3134(f)",
+  "context_manifest_file": "/tmp/axiom-encode-3134f-20260528-001/_eval_workspaces/codex-gpt-5.5/26-USC-3134-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "36695f8390724d89001ea8034cbb5a5d19e912c76e7a991ce5377f3b153dc68f",
+  "generated_at": "2026-05-28T14:43:44.705340+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3134f-20260528-001/codex-gpt-5.5/statutes/26/3134/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3134f-20260528-001",
+  "generated_output_sha256": "58d1f406098105b7327a56e32b2a74becb78e2e70693f67257378ba11e9cae89",
+  "generation_prompt_sha256": "910b9158120abfdf1ab9e486cb82fcebf60cf1c26e6b1cca92d2276809552605",
+  "model": "gpt-5.5",
+  "run_id": "f71df497",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "85888a68109a9227ac6c8cdb98cbc073082defde02ff4c5e8db410273e25a1c1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3134f-20260528-001/traces/codex-gpt-5.5/26-USC-3134-f.json",
+  "trace_sha256": "15d97fbc09b3f2eb405bc1b25256a5d7ff9d5fa28a4801459d54510d4ef0355f"
+}

--- a/statutes/26/3134/f.test.yaml
+++ b/statutes/26/3134/f.test.yaml
@@ -1,0 +1,75 @@
+- name: non_governmental_employer_is_not_excluded_by_paragraph_1
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/f#input.employer_is_government_of_united_states: false
+    us:statutes/26/3134/f#input.employer_is_government_of_state_or_political_subdivision: false
+    us:statutes/26/3134/f#input.employer_is_agency_or_instrumentality_of_foregoing_government: false
+    us:statutes/26/3134/f#input.employer_is_college_or_university: false
+    us:statutes/26/3134/f#input.employer_principal_purpose_or_function_is_providing_medical_or_hospital_care: false
+  output:
+    us:statutes/26/3134/f#governmental_employer_described_in_paragraph_1: not_holds
+    us:statutes/26/3134/f#college_or_medical_care_entity_exception_to_governmental_employer_exclusion: not_holds
+    us:statutes/26/3134/f#subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement: not_holds
+- name: governmental_employer_without_exception_is_excluded
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/f#input.employer_is_government_of_united_states: true
+    us:statutes/26/3134/f#input.employer_is_government_of_state_or_political_subdivision: false
+    us:statutes/26/3134/f#input.employer_is_agency_or_instrumentality_of_foregoing_government: false
+    us:statutes/26/3134/f#input.employer_is_college_or_university: false
+    us:statutes/26/3134/f#input.employer_principal_purpose_or_function_is_providing_medical_or_hospital_care: false
+  output:
+    us:statutes/26/3134/f#governmental_employer_described_in_paragraph_1: holds
+    us:statutes/26/3134/f#college_or_medical_care_entity_exception_to_governmental_employer_exclusion: not_holds
+    us:statutes/26/3134/f#subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement: not_holds
+- name: section_501_organization_exception_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/f#input.employer_is_government_of_united_states: true
+    us:statutes/26/3134/f#input.employer_is_government_of_state_or_political_subdivision: false
+    us:statutes/26/3134/f#input.employer_is_agency_or_instrumentality_of_foregoing_government: false
+    us:statutes/26/3134/f#input.employer_is_college_or_university: false
+    us:statutes/26/3134/f#input.employer_principal_purpose_or_function_is_providing_medical_or_hospital_care: false
+  output:
+    us:statutes/26/3134/f#governmental_employer_described_in_paragraph_1: holds
+    us:statutes/26/3134/f#college_or_medical_care_entity_exception_to_governmental_employer_exclusion: not_holds
+    us:statutes/26/3134/f#subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement: not_holds
+- name: governmental_college_or_university_exception_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/f#input.employer_is_government_of_united_states: true
+    us:statutes/26/3134/f#input.employer_is_government_of_state_or_political_subdivision: false
+    us:statutes/26/3134/f#input.employer_is_agency_or_instrumentality_of_foregoing_government: false
+    us:statutes/26/3134/f#input.employer_is_college_or_university: true
+    us:statutes/26/3134/f#input.employer_principal_purpose_or_function_is_providing_medical_or_hospital_care: false
+  output:
+    us:statutes/26/3134/f#governmental_employer_described_in_paragraph_1: holds
+    us:statutes/26/3134/f#college_or_medical_care_entity_exception_to_governmental_employer_exclusion: holds
+    us:statutes/26/3134/f#subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement: holds
+- name: governmental_medical_or_hospital_care_exception_prevents_exclusion
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/f#input.employer_is_government_of_united_states: true
+    us:statutes/26/3134/f#input.employer_is_government_of_state_or_political_subdivision: false
+    us:statutes/26/3134/f#input.employer_is_agency_or_instrumentality_of_foregoing_government: false
+    us:statutes/26/3134/f#input.employer_is_college_or_university: false
+    us:statutes/26/3134/f#input.employer_principal_purpose_or_function_is_providing_medical_or_hospital_care: true
+  output:
+    us:statutes/26/3134/f#governmental_employer_described_in_paragraph_1: holds
+    us:statutes/26/3134/f#college_or_medical_care_entity_exception_to_governmental_employer_exclusion: holds
+    us:statutes/26/3134/f#subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement: holds

--- a/statutes/26/3134/f.yaml
+++ b/statutes/26/3134/f.yaml
@@ -1,0 +1,83 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3134
+  summary: (f)(1) "This credit shall not apply to the Government of the United States,
+    the government of any State or political subdivision thereof, or any agency or
+    instrumentality of any of the foregoing." (f)(2) "Paragraph (1) shall not apply
+    to" a section 501(c)(1)/501(a) organization or paragraph (1) entity that "is a
+    college or university" or whose principal purpose/function is "providing medical
+    or hospital care." Such subparagraph (B) entity "shall be treated as satisfying
+    the requirements of subsection (c)(2)(A)(i)."
+  deferred_outputs:
+  - output: us:statutes/26/3134/f#employee_retention_credit_not_applicable_to_governmental_employer
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/3134/f#section_501_organization_exception_to_governmental_employer_exclusion
+    reason: Generated rule kept a local fact for a cited legal section. This output
+      is deferred until the cited source can be encoded or imported without a local
+      cross-reference placeholder.
+rules:
+- name: governmental_employer_described_in_paragraph_1
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3134(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3134
+  versions:
+  - effective_from: '2021-01-01'
+    formula: 'employer_is_government_of_united_states
+
+      or employer_is_government_of_state_or_political_subdivision
+
+      or employer_is_agency_or_instrumentality_of_foregoing_government'
+- name: college_or_medical_care_entity_exception_to_governmental_employer_exclusion
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3134(f)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/3134
+  versions:
+  - effective_from: '2021-01-01'
+    formula: 'governmental_employer_described_in_paragraph_1
+
+      and (employer_is_college_or_university
+
+      or employer_principal_purpose_or_function_is_providing_medical_or_hospital_care)'
+- name: subparagraph_b_entity_treated_as_satisfying_subsection_c_requirement
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3134(f)(2), flush sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3134
+  versions:
+  - effective_from: '2021-01-01'
+    formula: 'governmental_employer_described_in_paragraph_1
+
+      and (employer_is_college_or_university
+
+      or employer_principal_purpose_or_function_is_providing_medical_or_hospital_care)'


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3134(f)'s governmental-employer exclusion and subparagraph (B) college/medical exception
- defer the final exclusion output and the 501(c)(1)/501(a) exception branch because they depend on cited rules not available as executable RuleSpec exports
- include signed axiom-encode apply manifest from encoder 0.2.376 at aec0844, run_id f71df497

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/f.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/f.yaml
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/f.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-untested-comparable
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD
- subagent read-only review: no actionable findings

Note: these outputs are classified as known-not-comparable to PolicyEngine, so there is no PE match rate.