### PR TITLE
Add generated section 3134(i) third-party payor rule

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3134/i.json
+++ b/.axiom/encoding-manifests/statutes/26/3134/i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3134/i.yaml",
+      "sha256": "1b5419867c5cb336e1fb68a1dca8bbc3eb33e5e045e6dc19113cfa7b7c4d4551"
+    },
+    {
+      "path": "statutes/26/3134/i.test.yaml",
+      "sha256": "28378a630a336f604fcc147fb7545eb04df77b4e50361e221209afb9284c7d6a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "82b999eb22b1a2cb25ef418cc14e1f8133223f78",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.377",
+    "version_commit": "82b999eb22b1a2cb25ef418cc14e1f8133223f78"
+  },
+  "axiom_encode_version": "0.2.377",
+  "backend": "codex",
+  "citation": "26 USC 3134(i)",
+  "context_manifest_file": "/tmp/axiom-encode-3134i-20260528-003/_eval_workspaces/codex-gpt-5.5/26-USC-3134-i/workspace/context-manifest.json",
+  "context_manifest_sha256": "d6b5dc1c823801ece4f921470c21b578c2a50a6d1414abadae26a63f7b1d5e30",
+  "generated_at": "2026-05-28T16:22:56.318848+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3134i-20260528-003/codex-gpt-5.5/statutes/26/3134/i.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3134i-20260528-003",
+  "generated_output_sha256": "1b5419867c5cb336e1fb68a1dca8bbc3eb33e5e045e6dc19113cfa7b7c4d4551",
+  "generation_prompt_sha256": "37c77a20812ea95f71cacec77d662a9b100bf67ada38830c4a56be62855f80ad",
+  "model": "gpt-5.5",
+  "run_id": "d6d58003",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d253fc60ac4442b59538ac8f955892aa566b30c9f4900ea02b135eb76de7a0ac"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-3134i-20260528-003/traces/codex-gpt-5.5/26-USC-3134-i.json",
+  "trace_sha256": "a19e857c4e0a8697b0c3d3e1f3fc79b62bcaf44b82cc9bbbd4a08fb0eb6d25be"
+}

--- a/statutes/26/3134/i.test.yaml
+++ b/statutes/26/3134/i.test.yaml
@@ -1,0 +1,18 @@
+- name: credit_allowed_is_treated_as_specified_credit_for_third_party_payors
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/i#input.employee_retention_credit_allowed_under_this_section: true
+  output:
+    us:statutes/26/3134/i#employee_retention_credit_treated_as_specified_credit_for_third_party_payors: holds
+- name: no_allowed_credit_has_no_third_party_payor_specified_credit_treatment
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/3134/i#input.employee_retention_credit_allowed_under_this_section: false
+  output:
+    us:statutes/26/3134/i#employee_retention_credit_treated_as_specified_credit_for_third_party_payors: not_holds

--- a/statutes/26/3134/i.yaml
+++ b/statutes/26/3134/i.yaml
@@ -1,0 +1,27 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3134
+  summary: |-
+    Any credit allowed under this section shall be treated as a credit described in section 3511(d)(2).
+rules:
+  - name: employee_retention_credit_treated_as_specified_credit_for_third_party_payors
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3134(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3134
+              excerpt: Any credit allowed under this section shall be treated as a credit described in section 3511(d)(2).
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          employee_retention_credit_allowed_under_this_section


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 26 USC 3134(i)
- add companion tests for the third-party payor specified-credit treatment
- include signed encoder apply manifest from axiom-encode 0.2.377

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/i.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/i.yaml
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3134/i.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-untested-comparable
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD

Subagent review found no blocking issues.