### PR TITLE
Repair 26 USC 3101(b)(2) surviving-spouse threshold

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3101/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3101/b/2.json
@@ -2,27 +2,29 @@
   "applied_files": [
     {
       "path": "statutes/26/3101/b/2.yaml",
-      "sha256": "c79e593747b22cf54f34573eb8108d55e422adc1387497c14f0bbc0f04a40bb5"
+      "sha256": "f06b93b281a9f04e380d545bbc6f6484b0ae591237831b84051b57d05aa661fa"
     },
     {
       "path": "statutes/26/3101/b/2.test.yaml",
-      "sha256": "6b8c12394662de4c21056d0b4b2ad84fcd6d7481518baed0eb3e5b18f74b438d"
+      "sha256": "1057e79fc0ba24340ffaecd3a057cf79ed67b4b738e8b9a7d08135b0ad89343c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d6916fadcfb0d28326345a2c8a3b0b4fe730c4b4",
+    "commit": "262bb659d9d9443369301d537d48bb2d5bc1f4ff",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.382",
+    "version_commit": "262bb659d9d9443369301d537d48bb2d5bc1f4ff"
   },
-  "axiom_encode_version": "0.2.68",
+  "axiom_encode_version": "0.2.382",
   "backend": "deterministic",
   "citation": "us:statutes/26/3101/b/2",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-12T17:30:44.133726+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4y2hjm2c/deterministic-repair/statutes/26/3101/b/2.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4y2hjm2c",
-  "generated_output_sha256": "c79e593747b22cf54f34573eb8108d55e422adc1387497c14f0bbc0f04a40bb5",
+  "generated_at": "2026-05-28T18:40:50.920770+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpr5s5cka3/deterministic-repair/statutes/26/3101/b/2.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpr5s5cka3",
+  "generated_output_sha256": "f06b93b281a9f04e380d545bbc6f6484b0ae591237831b84051b57d05aa661fa",
   "generation_prompt_sha256": null,
   "model": "tax-filing-status-branch-v1",
   "run_id": "deterministic-repair",
@@ -31,9 +33,9 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "4bad434ade251e93e2d51ae2d76ba7ba02d5b11b455fb94e6a56ffcd79b1fe7f"
+    "value": "fd56c7c7c1d0a11d7d1faf6a0f6b362b7d51221583fd37f9efe522cf1fd0e4e4"
   },
-  "tool": "axiom-encode encode --apply",
+  "tool": "axiom-encode repair-tax-filing-status-branches",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/statutes/26/3101/b/2.test.yaml
+++ b/statutes/26/3101/b/2.test.yaml
@@ -22,7 +22,6 @@
     us:statutes/26/3101/b/2#input.filing_status: 0
     us:statutes/26/3101/b/2#input.wages: 260000
   output:
-    # (260000 - 200000) * 0.009 = 540
     us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 200000
     us:statutes/26/3101/b/2#additional_medicare_excess_wages: 60000
     us:statutes/26/3101/b/2#additional_medicare_tax: 540
@@ -47,7 +46,6 @@
     us:statutes/26/3101/b/2#input.filing_status: 1
     us:statutes/26/3101/b/2#input.wages: 300000
   output:
-    # (300000 - 250000) * 0.009 = 450
     us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 250000
     us:statutes/26/3101/b/2#additional_medicare_excess_wages: 50000
     us:statutes/26/3101/b/2#additional_medicare_tax: 450
@@ -60,7 +58,6 @@
     us:statutes/26/3101/b/2#input.filing_status: 2
     us:statutes/26/3101/b/2#input.wages: 200000
   output:
-    # (200000 - 125000) * 0.009 = 675
     us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 125000
     us:statutes/26/3101/b/2#additional_medicare_excess_wages: 75000
     us:statutes/26/3101/b/2#additional_medicare_tax: 675
@@ -73,11 +70,10 @@
     us:statutes/26/3101/b/2#input.filing_status: 3
     us:statutes/26/3101/b/2#input.wages: 250000
   output:
-    # (250000 - 200000) * 0.009 = 450
     us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 200000
     us:statutes/26/3101/b/2#additional_medicare_excess_wages: 50000
     us:statutes/26/3101/b/2#additional_medicare_tax: 450
-- name: surviving_spouse_uses_joint_threshold
+- name: surviving_spouse_uses_other_threshold
   period:
     period_kind: tax_year
     start: 2026-01-01
@@ -86,6 +82,6 @@
     us:statutes/26/3101/b/2#input.filing_status: 4
     us:statutes/26/3101/b/2#input.wages: 300000
   output:
-    us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 250000
-    us:statutes/26/3101/b/2#additional_medicare_excess_wages: 50000
-    us:statutes/26/3101/b/2#additional_medicare_tax: 450
+    us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 200000
+    us:statutes/26/3101/b/2#additional_medicare_excess_wages: 100000
+    us:statutes/26/3101/b/2#additional_medicare_tax: 900

--- a/statutes/26/3101/b/2.yaml
+++ b/statutes/26/3101/b/2.yaml
@@ -8,14 +8,14 @@ module:
 
     Filing-status encoding convention (matches PolicyEngine US):
         0 = single
-        1 = joint / surviving spouse
+        1 = joint
         2 = married filing separately
         3 = head of household
+        4 = surviving spouse / qualifying widow(er)
 
     0.9% rate applied to wages above the threshold; thresholds set by
-    26 USC §3101(b)(2)(A)-(C): $250,000 for a joint return or surviving
-    spouse, one-half of that amount for a married individual filing
-    separately, and $200,000 in any other case.
+    26 USC §3101(b)(2)(A)-(C): $250,000 for a joint return, one-half of that amount for a married
+    individual filing separately, and $200,000 in any other case.
   source_verification:
     corpus_citation_path: us/statute/26/3101
 rules:
@@ -86,7 +86,7 @@ rules:
         formula: |-
           match filing_status:
               1 => additional_medicare_wage_tax_joint_threshold
-              4 => additional_medicare_wage_tax_joint_threshold
+              4 => additional_medicare_wage_tax_other_threshold
               2 => additional_medicare_wage_tax_joint_threshold / 2
               0 => additional_medicare_wage_tax_other_threshold
               3 => additional_medicare_wage_tax_other_threshold


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3101(b)(2) so surviving spouse filing status uses the statutory ,000 other-case additional Medicare wage threshold
- update the companion test expectation/name for status 4
- refresh the signed apply manifest from axiom-encode 0.2.382 (encoder PR TheAxiomFoundation/axiom-encode#414)

## Provenance
Generated via signed deterministic encoder repair; no manual RuleSpec edits.

## Tests
- axiom-encode validate statutes/26/3101/b/2.yaml --skip-reviewers
- axiom-encode proof-validate statutes/26/3101/b/2.yaml
- axiom-encode test statutes/26/3101/b/2.test.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD
- axiom-encode oracle-coverage --root current --program tax --fail-on-untested-comparable