### PR TITLE
Add generated section 3502 deduction disallowance rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3502.json
+++ b/.axiom/encoding-manifests/statutes/26/3502.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3502.yaml",
+      "sha256": "068c4dc5b087895f268701d18a4771a3e3f1051dd9b14a31b95b25728587a314"
+    },
+    {
+      "path": "statutes/26/3502.test.yaml",
+      "sha256": "d1d09ac123de6d8601ce4f8c6545ca4ce54b805b40c235c641c119dbedbe4071"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "18f3363e70a9738ae9e446d4641c6ede26ba42bf",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.383",
+    "version_commit": "18f3363e70a9738ae9e446d4641c6ede26ba42bf"
+  },
+  "axiom_encode_version": "0.2.383",
+  "backend": "openai",
+  "citation": "26 USC 3502",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3502/workspace/context-manifest.json",
+  "context_manifest_sha256": "943a07b62af6a4781f10ad6c16ec3a5c48b413edd75a9c0f84ddb0dc4b8af074",
+  "generated_at": "2026-05-28T19:17:35.341564+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3502.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "068c4dc5b087895f268701d18a4771a3e3f1051dd9b14a31b95b25728587a314",
+  "generation_prompt_sha256": "159d333e3afadab5f77cdb35aded987ac77f90a6d027cf25c7b5cff12d8b7b73",
+  "model": "gpt-5.5",
+  "run_id": "1706b88c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "682246cdc99061551234602b6b0cac1317ae1cbbc976b1d85371c12910eab9f5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3502.json",
+  "trace_sha256": "104d0bdbf4d8782a70c0e1a36f4f4a9ba41a0655424e57bb668487e601298d96"
+}

--- a/statutes/26/3502.test.yaml
+++ b/statutes/26/3502.test.yaml
@@ -1,0 +1,24 @@
+- name: taxpayer_employment_taxes_not_allowed_as_subtitle_a_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3502#chapter_21_and_22_employment_taxes_allowed_as_subtitle_a_deduction: 0
+- name: employer_chapter_24_withheld_tax_not_allowed_as_subtitle_a_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3502#employer_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction: 0
+- name: income_recipient_chapter_24_withheld_tax_not_allowed_as_subtitle_a_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/3502#income_recipient_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction: 0

--- a/statutes/26/3502.yaml
+++ b/statutes/26/3502.yaml
@@ -1,0 +1,68 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3502
+  summary: |-
+    Taxes imposed by section 3101 of chapter 21 and by sections 3201 and 3211 of chapter 22 are not allowed as deductions to the taxpayer in computing taxable income under subtitle A. Tax deducted and withheld under chapter 24 is not allowed as a deduction to the employer or to the recipient of the income in computing taxable income under subtitle A.
+rules:
+  - name: chapter_21_and_22_employment_taxes_allowed_as_subtitle_a_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3502(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3502
+              excerpt: "shall not be allowed as a deduction to the taxpayer in computing taxable income under subtitle A"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0
+
+  - name: employer_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3502(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3502
+              excerpt: "shall not be allowed as a deduction either to the employer"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0
+
+  - name: income_recipient_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3502(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3502
+              excerpt: "shall not be allowed as a deduction either ... to the recipient of the income"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0


### PR DESCRIPTION
Summary:
- add generated 26 USC 3502 deduction-disallowance rules
- include generated companion tests and signed axiom-encode apply manifest
- generated with axiom-encode 0.2.383 after classifying the outputs as PolicyEngine not-comparable

Local checks:
- axiom-encode validate statutes/26/3502.yaml --skip-reviewers
- axiom-encode proof-validate statutes/26/3502.yaml
- axiom-encode test statutes/26/3502.test.yaml
- axiom-encode guard-generated
- axiom-encode oracle-coverage --program tax --fail-on-untested-comparable