### PR TITLE
Add generated section 3503 refund rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3503.json
+++ b/.axiom/encoding-manifests/statutes/26/3503.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3503.yaml",
+      "sha256": "3ca6b549f672a9f37e8139a126ef38b8a4c5d4c10119433af09af2f5fd1f2005"
+    },
+    {
+      "path": "statutes/26/3503.test.yaml",
+      "sha256": "2d87fc0f895834099c8b84f1a467c31491d6460b8eb197b06c21e27763288b6a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4861a1b08f8c2022a808b6571192ce2b14c6cb56",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.384",
+    "version_commit": "4861a1b08f8c2022a808b6571192ce2b14c6cb56"
+  },
+  "axiom_encode_version": "0.2.384",
+  "backend": "openai",
+  "citation": "26 USC 3503",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3503/workspace/context-manifest.json",
+  "context_manifest_sha256": "3713f78b1f401f351e63b64cd17a93b13dd784efe2b13398763bf0b0036788ee",
+  "generated_at": "2026-05-28T19:37:31.877716+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3503.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "3ca6b549f672a9f37e8139a126ef38b8a4c5d4c10119433af09af2f5fd1f2005",
+  "generation_prompt_sha256": "935ae20a63c647c69cb54e3f7d8caa583a3f607d8a4a35ae10a86d271b653f2d",
+  "model": "gpt-5.5",
+  "run_id": "9ef7e033",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "add14231833e0615d02eb1df61b8ead6f2d8c1b0d0b275518c180c02fa7a8341"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3503.json",
+  "trace_sha256": "b5932a1dca3b10b8c264eec4e204ed8568929cfb85180188d9e9a8673f936e9c"
+}

--- a/statutes/26/3503.test.yaml
+++ b/statutes/26/3503.test.yaml
@@ -1,0 +1,52 @@
+- name: tax_paid_without_liability_fully_credited_when_other_chapter_tax_exceeds_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter: true
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period: 1000
+    us:statutes/26/3503#input.tax_imposed_by_other_chapter_on_taxpayer: 1500
+  output:
+    us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability: 1000
+    us:statutes/26/3503#credit_against_tax_imposed_by_other_chapter: 1000
+    us:statutes/26/3503#refund_balance_after_other_chapter_credit: 0
+- name: tax_paid_without_liability_partly_credited_and_balance_refunded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter: true
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period: 1000
+    us:statutes/26/3503#input.tax_imposed_by_other_chapter_on_taxpayer: 400
+  output:
+    us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability: 1000
+    us:statutes/26/3503#credit_against_tax_imposed_by_other_chapter: 400
+    us:statutes/26/3503#refund_balance_after_other_chapter_credit: 600
+- name: no_other_chapter_tax_all_eligible_payment_refunded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter: true
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period: 700
+    us:statutes/26/3503#input.tax_imposed_by_other_chapter_on_taxpayer: 0
+  output:
+    us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability: 700
+    us:statutes/26/3503#credit_against_tax_imposed_by_other_chapter: 0
+    us:statutes/26/3503#refund_balance_after_other_chapter_credit: 700
+- name: tax_paid_for_period_with_liability_not_credited_or_refunded_under_section_3503
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter: false
+    us:statutes/26/3503#input.tax_paid_under_chapter_21_or_22_for_period: 1000
+    us:statutes/26/3503#input.tax_imposed_by_other_chapter_on_taxpayer: 400
+  output:
+    us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability: 0
+    us:statutes/26/3503#credit_against_tax_imposed_by_other_chapter: 0
+    us:statutes/26/3503#refund_balance_after_other_chapter_credit: 0

--- a/statutes/26/3503.yaml
+++ b/statutes/26/3503.yaml
@@ -1,0 +1,97 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3503
+  summary: |-
+    Tax paid under chapter 21 or 22 for a period for which the taxpayer is not liable under that chapter is credited against tax imposed by the other chapter, and any balance is refunded.
+rules:
+  - name: chapter_21_or_22_tax_paid_for_period_without_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3503
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3503
+              excerpt: "Any tax paid under chapter 21 or 22 by a taxpayer with respect to any period with respect to which he is not liable to tax under such chapter"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3503
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter: max(0, tax_paid_under_chapter_21_or_22_for_period) else: 0
+
+  - name: credit_against_tax_imposed_by_other_chapter
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3503
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3503
+              excerpt: "shall be credited against the tax, if any, imposed by such other chapter upon the taxpayer"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability
+              output: chapter_21_or_22_tax_paid_for_period_without_liability
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+              chapter_21_or_22_tax_paid_for_period_without_liability,
+              max(0, tax_imposed_by_other_chapter_on_taxpayer)
+          )
+
+  - name: refund_balance_after_other_chapter_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3503
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3503
+              excerpt: "and the balance, if any, shall be refunded"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3503#chapter_21_or_22_tax_paid_for_period_without_liability
+              output: chapter_21_or_22_tax_paid_for_period_without_liability
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3503#credit_against_tax_imposed_by_other_chapter
+              output: credit_against_tax_imposed_by_other_chapter
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              chapter_21_or_22_tax_paid_for_period_without_liability
+              - credit_against_tax_imposed_by_other_chapter
+          )


### PR DESCRIPTION
Summary:
- add generated 26 USC 3503 cross-chapter payroll tax credit and refund rules
- include generated companion tests and signed axiom-encode apply manifest
- generated with axiom-encode 0.2.384 after classifying the outputs as PolicyEngine not-comparable

Local checks:
- axiom-encode validate statutes/26/3503.yaml --skip-reviewers
- axiom-encode proof-validate statutes/26/3503.yaml
- axiom-encode test statutes/26/3503.test.yaml
- axiom-encode guard-generated
- axiom-encode oracle-coverage --program tax --fail-on-untested-comparable