### PR TITLE
Add generated section 3401(f) tip wage rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3401/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3401/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3401/f.yaml",
+      "sha256": "847f558f8a7aabe134ace8e6d8be678cc67447bd33e7bf7127dfb55bedf09822"
+    },
+    {
+      "path": "statutes/26/3401/f.test.yaml",
+      "sha256": "923d7b3295e040eb5ee6b83bc7e4bca00b37f3fdc7a01b94a30e0a02790f0f1f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "152dc9019cafacaa53a2bea5c4a31c3737cd21d2",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.385",
+    "version_commit": "152dc9019cafacaa53a2bea5c4a31c3737cd21d2"
+  },
+  "axiom_encode_version": "0.2.385",
+  "backend": "openai",
+  "citation": "26 USC 3401(f)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3401-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "b68cc3f956a039611870456c2dce71b8241148ec8d7083f7f3767910a1abffdb",
+  "generated_at": "2026-05-28T20:21:07.263096+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3401/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "847f558f8a7aabe134ace8e6d8be678cc67447bd33e7bf7127dfb55bedf09822",
+  "generation_prompt_sha256": "96b55878db9d258735455e4eaa59a08ea078056b1ccf3eb9c5f46612dd55ce03",
+  "model": "gpt-5.5",
+  "run_id": "717abc23",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a41c530b79fd50aa15a1b5f4aebf5db7df79b1fbad83d9772bf7cabc3eacca47"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3401-f.json",
+  "trace_sha256": "4d703b267cedec9dcea199f94c8e2bdc72110b1729fe9dde56360cd00070fd30"
+}

--- a/statutes/26/3401/f.test.yaml
+++ b/statutes/26/3401/f.test.yaml
@@ -1,0 +1,51 @@
+- name: employment_tips_with_written_statement_are_included_and_deemed_paid_on_statement
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/f#input.tips_received_by_employee_in_course_of_employment: true
+      us:statutes/26/3401/f#input.tips_received_amount: 100
+      us:statutes/26/3401/f#input.written_statement_including_tips_furnished_to_employer_under_section_6053_a: true
+  output:
+    us:statutes/26/3401/f#tips_included_in_wages_for_subsection_a:
+    - 100
+    us:statutes/26/3401/f#tips_deemed_paid_when_written_statement_furnished:
+    - holds
+    us:statutes/26/3401/f#tips_deemed_paid_when_received:
+    - not_holds
+- name: employment_tips_without_written_statement_are_deemed_paid_when_received
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/f#input.tips_received_by_employee_in_course_of_employment: true
+      us:statutes/26/3401/f#input.tips_received_amount: 75
+      us:statutes/26/3401/f#input.written_statement_including_tips_furnished_to_employer_under_section_6053_a: false
+  output:
+    us:statutes/26/3401/f#tips_included_in_wages_for_subsection_a:
+    - 75
+    us:statutes/26/3401/f#tips_deemed_paid_when_written_statement_furnished:
+    - not_holds
+    us:statutes/26/3401/f#tips_deemed_paid_when_received:
+    - holds
+- name: non_employment_tips_are_not_included_or_deemed_paid_under_this_subsection
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/f#input.tips_received_by_employee_in_course_of_employment: false
+      us:statutes/26/3401/f#input.tips_received_amount: 50
+      us:statutes/26/3401/f#input.written_statement_including_tips_furnished_to_employer_under_section_6053_a: false
+  output:
+    us:statutes/26/3401/f#tips_included_in_wages_for_subsection_a:
+    - 0
+    us:statutes/26/3401/f#tips_deemed_paid_when_written_statement_furnished:
+    - not_holds
+    us:statutes/26/3401/f#tips_deemed_paid_when_received:
+    - not_holds

--- a/statutes/26/3401/f.yaml
+++ b/statutes/26/3401/f.yaml
@@ -1,0 +1,63 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3401
+  summary: |-
+    26 USC 3401(f): For purposes of subsection (a), “wages” includes tips received by an employee in the course of employment; such wages are deemed paid when the section 6053(a) written statement is furnished, or if no such statement is furnished, when received.
+rules:
+  - name: tips_included_in_wages_for_subsection_a
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3401(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tips_received_by_employee_in_course_of_employment: tips_received_amount else: 0
+  - name: tips_deemed_paid_when_written_statement_furnished
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3401(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tips_received_by_employee_in_course_of_employment
+          and written_statement_including_tips_furnished_to_employer_under_section_6053_a
+  - name: tips_deemed_paid_when_received
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3401(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tips_received_by_employee_in_course_of_employment
+          and not written_statement_including_tips_furnished_to_employer_under_section_6053_a


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3401(f), covering tip inclusion in wages and deemed payment timing
- include companion tests for tips with and without a section 6053(a) statement
- include signed axiom-encode apply manifest from encoder 0.2.385

## Validation
- axiom-encode validate statutes/26/3401/f.yaml --skip-reviewers
- axiom-encode proof-validate statutes/26/3401/f.yaml
- axiom-encode test statutes/26/3401/f.test.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD
- axiom-encode oracle-coverage --root current --program tax --fail-on-untested-comparable