### PR TITLE
Add generated section 3401(h) differential wage rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3401/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3401/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3401/h.yaml",
+      "sha256": "b4f5e9b06aea75def524b234511310c523282acd690161ec95168e569b817ff2"
+    },
+    {
+      "path": "statutes/26/3401/h.test.yaml",
+      "sha256": "0ca13679636ec1349e09bfa6d03679401c133aa376c6e4f430b99faa8cf61540"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "19affca8a5f9e2ef25da4710822a76cc9d056045",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.386",
+    "version_commit": "19affca8a5f9e2ef25da4710822a76cc9d056045"
+  },
+  "axiom_encode_version": "0.2.386",
+  "backend": "openai",
+  "citation": "26 USC 3401(h)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3401-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "6f69a1bc08d087f811cfefa6ce9fd804da973442c67f352f37cb17100f26c7b2",
+  "generated_at": "2026-05-28T20:46:20.436653+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3401/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b4f5e9b06aea75def524b234511310c523282acd690161ec95168e569b817ff2",
+  "generation_prompt_sha256": "10382f675d7e91d98607f576295473d4fc4532b13f1cce4f39196f24d7c1ca8b",
+  "model": "gpt-5.5",
+  "run_id": "2a0077f2",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "01242cf25e0a0b2d2d5f3721d339d1eec257dee6e1a7d0d465ed70308642c627"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3401-h.json",
+  "trace_sha256": "409cdbe5250e340e5dc6edae9f35b8fdbedc60a23c1332380ac4fc3ef42cfeb5"
+}

--- a/statutes/26/3401/h.test.yaml
+++ b/statutes/26/3401/h.test.yaml
@@ -1,0 +1,77 @@
+- name: qualifying_differential_wage_payment_is_treated_as_wages
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/h#input.payment_is_made_by_employer_to_individual_with_respect_to_service_period: true
+      ? us:statutes/26/3401/h#input.individual_is_performing_service_in_uniformed_services_as_defined_in_chapter_43_of_title_38_while_on_active_duty
+      : true
+      us:statutes/26/3401/h#input.active_duty_period_days: 31
+      ? us:statutes/26/3401/h#input.payment_represents_all_or_portion_of_wages_individual_would_have_received_from_employer_if_performing_service_for_employer
+      : true
+      us:statutes/26/3401/h#input.differential_wage_payment_amount: 1000
+  output:
+    us:statutes/26/3401/h#active_duty_period_minimum_days_for_differential_wage_payment: 30
+    us:statutes/26/3401/h#differential_wage_payment:
+    - holds
+    us:statutes/26/3401/h#differential_wage_payment_treated_as_wages_for_subsection_a:
+    - 1000
+- name: payment_not_made_by_employer_for_service_period_is_not_differential_wage_payment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/h#input.payment_is_made_by_employer_to_individual_with_respect_to_service_period: false
+      ? us:statutes/26/3401/h#input.individual_is_performing_service_in_uniformed_services_as_defined_in_chapter_43_of_title_38_while_on_active_duty
+      : true
+      us:statutes/26/3401/h#input.active_duty_period_days: 31
+      ? us:statutes/26/3401/h#input.payment_represents_all_or_portion_of_wages_individual_would_have_received_from_employer_if_performing_service_for_employer
+      : true
+      us:statutes/26/3401/h#input.differential_wage_payment_amount: 1000
+  output:
+    us:statutes/26/3401/h#differential_wage_payment:
+    - not_holds
+    us:statutes/26/3401/h#differential_wage_payment_treated_as_wages_for_subsection_a:
+    - 0
+- name: active_duty_period_not_more_than_thirty_days_is_not_differential_wage_payment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/h#input.payment_is_made_by_employer_to_individual_with_respect_to_service_period: true
+      ? us:statutes/26/3401/h#input.individual_is_performing_service_in_uniformed_services_as_defined_in_chapter_43_of_title_38_while_on_active_duty
+      : true
+      us:statutes/26/3401/h#input.active_duty_period_days: 30
+      ? us:statutes/26/3401/h#input.payment_represents_all_or_portion_of_wages_individual_would_have_received_from_employer_if_performing_service_for_employer
+      : true
+      us:statutes/26/3401/h#input.differential_wage_payment_amount: 1000
+  output:
+    us:statutes/26/3401/h#differential_wage_payment:
+    - not_holds
+    us:statutes/26/3401/h#differential_wage_payment_treated_as_wages_for_subsection_a:
+    - 0
+- name: payment_not_representing_would_have_received_wages_is_not_differential_wage_payment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  tables:
+    Payment:
+    - us:statutes/26/3401/h#input.payment_is_made_by_employer_to_individual_with_respect_to_service_period: true
+      ? us:statutes/26/3401/h#input.individual_is_performing_service_in_uniformed_services_as_defined_in_chapter_43_of_title_38_while_on_active_duty
+      : true
+      us:statutes/26/3401/h#input.active_duty_period_days: 31
+      ? us:statutes/26/3401/h#input.payment_represents_all_or_portion_of_wages_individual_would_have_received_from_employer_if_performing_service_for_employer
+      : false
+      us:statutes/26/3401/h#input.differential_wage_payment_amount: 1000
+  output:
+    us:statutes/26/3401/h#differential_wage_payment:
+    - not_holds
+    us:statutes/26/3401/h#differential_wage_payment_treated_as_wages_for_subsection_a:
+    - 0

--- a/statutes/26/3401/h.yaml
+++ b/statutes/26/3401/h.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3401
+  summary: |-
+    26 USC 3401(h): For purposes of subsection (a), any differential wage payment is treated as wages by the employer to the employee. “Differential wage payment” means an employer payment for a period during which the individual performs uniformed-services active duty for more than 30 days and that represents all or part of wages the individual would have received from the employer.
+rules:
+  - name: active_duty_period_minimum_days_for_differential_wage_payment
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3401(h)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3401
+              excerpt: "active duty for a period of more than 30 days"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: differential_wage_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3401(h)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payment_is_made_by_employer_to_individual_with_respect_to_service_period
+          and individual_is_performing_service_in_uniformed_services_as_defined_in_chapter_43_of_title_38_while_on_active_duty
+          and active_duty_period_days > active_duty_period_minimum_days_for_differential_wage_payment
+          and payment_represents_all_or_portion_of_wages_individual_would_have_received_from_employer_if_performing_service_for_employer
+
+  - name: differential_wage_payment_treated_as_wages_for_subsection_a
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3401(h)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if differential_wage_payment: differential_wage_payment_amount else: 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec encoding for 26 USC 3401(h) differential wage payments
- include companion tests for the active-duty threshold and wage-treatment branches
- include signed axiom-encode apply manifest from encoder 0.2.386

## Validation
- axiom-encode validate statutes/26/3401/h.yaml --skip-reviewers
- axiom-encode proof-validate statutes/26/3401/h.yaml
- axiom-encode test statutes/26/3401/h.test.yaml
- axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD
- axiom-encode oracle-coverage --root current --program tax --fail-on-untested-comparable