### PR TITLE
Add generated section 3401(d) employer rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3401/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3401/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3401/d.yaml",
+      "sha256": "93bed4f1ba8aa7ec6446a451813fd5aabeb8424336043fa6e32364abc4664892"
+    },
+    {
+      "path": "statutes/26/3401/d.test.yaml",
+      "sha256": "38d7819962986d4b1bd7bedca5377beb1ec43df8e0c72e919bbe6482141aba9b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8babaad364654991274ed91f04beeb504f4e962b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.387",
+    "version_commit": "8babaad364654991274ed91f04beeb504f4e962b"
+  },
+  "axiom_encode_version": "0.2.387",
+  "backend": "openai",
+  "citation": "26 USC 3401(d)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3401-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "698f34d6f1f0cdf5d74b94551e17027ef5fc635c8e86e6925e0e76bf957c2b34",
+  "generated_at": "2026-05-28T21:18:04.220682+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3401/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "93bed4f1ba8aa7ec6446a451813fd5aabeb8424336043fa6e32364abc4664892",
+  "generation_prompt_sha256": "caba9f36a3743c5d2a809cca21a88994a89ce08986150dc97fd699ea5e7fb523",
+  "model": "gpt-5.5",
+  "run_id": "3f55548b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4e4e7273237187a7088bdde4ab7b6614cfb01da798dc81fe183718207553ee76"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3401-d.json",
+  "trace_sha256": "95df11f6da45195e26db5def060aec1ead95ab04a9ba723a1911e8f31eff71c7"
+}

--- a/statutes/26/3401/d.test.yaml
+++ b/statutes/26/3401/d.test.yaml
@@ -1,0 +1,60 @@
+- name: service_recipient_with_wage_payment_control_is_employer
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_service_as_employee: true
+    us:statutes/26/3401/d#input.person_has_control_of_payment_of_wages_for_services: true
+    ? us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_services_does_not_have_control_of_payment_of_wages
+    : false
+    ? us:statutes/26/3401/d#input.person_pays_wages_on_behalf_of_nonresident_alien_individual_foreign_partnership_or_foreign_corporation_not_engaged_in_trade_or_business_within_united_states
+    : false
+  output:
+    us:statutes/26/3401/d#employer_for_subsection_a: holds
+    us:statutes/26/3401/d#employer: holds
+- name: service_recipient_without_wage_payment_control_is_employer_only_for_subsection_a
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_service_as_employee: true
+    us:statutes/26/3401/d#input.person_has_control_of_payment_of_wages_for_services: false
+    ? us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_services_does_not_have_control_of_payment_of_wages
+    : true
+    ? us:statutes/26/3401/d#input.person_pays_wages_on_behalf_of_nonresident_alien_individual_foreign_partnership_or_foreign_corporation_not_engaged_in_trade_or_business_within_united_states
+    : false
+  output:
+    us:statutes/26/3401/d#employer_for_subsection_a: holds
+    us:statutes/26/3401/d#employer: not_holds
+- name: wage_payment_controller_is_employer_when_service_recipient_lacks_control
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_service_as_employee: false
+    us:statutes/26/3401/d#input.person_has_control_of_payment_of_wages_for_services: true
+    ? us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_services_does_not_have_control_of_payment_of_wages
+    : true
+    ? us:statutes/26/3401/d#input.person_pays_wages_on_behalf_of_nonresident_alien_individual_foreign_partnership_or_foreign_corporation_not_engaged_in_trade_or_business_within_united_states
+    : false
+  output:
+    us:statutes/26/3401/d#employer_for_subsection_a: not_holds
+    us:statutes/26/3401/d#employer: holds
+- name: qualifying_foreign_payor_is_employer_outside_subsection_a
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_service_as_employee: false
+    us:statutes/26/3401/d#input.person_has_control_of_payment_of_wages_for_services: false
+    ? us:statutes/26/3401/d#input.person_for_whom_individual_performs_or_performed_services_does_not_have_control_of_payment_of_wages
+    : false
+    ? us:statutes/26/3401/d#input.person_pays_wages_on_behalf_of_nonresident_alien_individual_foreign_partnership_or_foreign_corporation_not_engaged_in_trade_or_business_within_united_states
+    : true
+  output:
+    us:statutes/26/3401/d#employer_for_subsection_a: not_holds
+    us:statutes/26/3401/d#employer: holds

--- a/statutes/26/3401/d.yaml
+++ b/statutes/26/3401/d.yaml
@@ -1,0 +1,53 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3401/a
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3401
+  summary: |-
+    26 USC 3401(d): “Employer” means the person for whom an individual performs or performed services as that person's employee, except that, outside subsection (a), if that person lacks control of wage payment, the employer is the person having control of payment, and certain persons paying wages on behalf of nonresident alien individuals, foreign partnerships, or foreign corporations not engaged in U.S. trade or business are employers.
+rules:
+  - name: employer_for_subsection_a
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3401(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_for_whom_individual_performs_or_performed_service_as_employee
+  - name: employer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3401(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3401
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            person_for_whom_individual_performs_or_performed_service_as_employee
+            and person_has_control_of_payment_of_wages_for_services
+          )
+          or (
+            person_has_control_of_payment_of_wages_for_services
+            and person_for_whom_individual_performs_or_performed_services_does_not_have_control_of_payment_of_wages
+          )
+          or person_pays_wages_on_behalf_of_nonresident_alien_individual_foreign_partnership_or_foreign_corporation_not_engaged_in_trade_or_business_within_united_states


### PR DESCRIPTION
## Summary

- add generated RuleSpec for `26 USC 3401(d)` employer definitions
- add generated companion tests for subsection (d)
- include the signed `axiom-encode encode --apply` manifest

## Provenance

Generated with `axiom-encode encode --apply` using:

- encoder version: `0.2.387`
- encoder commit: `8babaad364654991274ed91f04beeb504f4e962b`
- model: `openai:gpt-5.5`
- run id: `3f55548b`

No RuleSpec files were edited by hand.

## Validation

- `axiom-encode validate statutes/26/3401/d.yaml --skip-reviewers`
- `axiom-encode proof-validate statutes/26/3401/d.yaml`
- `axiom-encode test statutes/26/3401/d.test.yaml --root rulespec-us --axiom-rules-engine-path axiom-rules-engine`
- `axiom-encode guard-generated --repo rulespec-us --base-ref origin/main --head-ref HEAD`
- `axiom-encode oracle-coverage --root current --program tax --fail-on-untested-comparable` with encoder `0.2.388` (`comparable=227`, `known_not_comparable=1344`, `untested comparable=0`)
