### PR TITLE
Add generated section 3406(d) rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3406/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/d.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3406/d.yaml",
-      "sha256": "7f815d4b5bdd4b7ce93c7b0b082ee385fb21eaf455d841979c4c9f67e35a302c"
+      "sha256": "eee336993505649406b66771546f1eea9f910e12f36e560b8a140f89f74cf1af"
     },
     {
       "path": "statutes/26/3406/d.test.yaml",
-      "sha256": "c074a888d33084476e4e07bee579b5e537480ee30ae89bffcf2dccbd809cfcfe"
+      "sha256": "192d05bdd45c7e88ce71b7036fad78a41ee53a96dce1b6683317f9e14b22d014"
     }
   ],
   "axiom_encode_git": {
-    "commit": "6ba77fe87e9784018773db14957644310ab9dcb5",
+    "commit": "a1a330ccaae655ca741a9549445bdcfc838dcc1a",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
-    "version": "0.2.390",
-    "version_commit": "6ba77fe87e9784018773db14957644310ab9dcb5"
+    "version": "0.2.392",
+    "version_commit": "a1a330ccaae655ca741a9549445bdcfc838dcc1a"
   },
-  "axiom_encode_version": "0.2.390",
+  "axiom_encode_version": "0.2.392",
   "backend": "openai",
   "citation": "26 USC 3406(d)",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3406-d/workspace/context-manifest.json",
-  "context_manifest_sha256": "3c06da35e1ae9839ed30e05e1987b4eef6687a08aa9173701153d9b04c3394cc",
-  "generated_at": "2026-05-28T22:12:18.865615+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3406/d.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "80c0b3c1671676cb1f834366005ed1040d22ffefd909836b95e7fbab4489637a",
-  "generation_prompt_sha256": "eb836103cdc5872d6250c0d15059793322234bb428f2f84a58c2713e7f786c45",
+  "context_manifest_file": "/tmp/axiom-encode-3406d-main-0392/_eval_workspaces/openai-gpt-5.5/26-USC-3406-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "f48d912888f1203b220ae4fcdc472487a0d6a718df8fb2e7c37590b181b2fa42",
+  "generated_at": "2026-05-28T23:16:09.654437+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406d-main-0392/openai-gpt-5.5/statutes/26/3406/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406d-main-0392",
+  "generated_output_sha256": "eee336993505649406b66771546f1eea9f910e12f36e560b8a140f89f74cf1af",
+  "generation_prompt_sha256": "13bb920951d26edf90cfdc23d6b5227908e334b7707771adb0d96ed3b17d0bf0",
   "model": "gpt-5.5",
-  "run_id": "9ccaf94f",
+  "run_id": "41448ad0",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ff5904fe1e8accc76966d5cd035b71051418232743157421d229a763d7e31f42"
+    "value": "089202756f77e7e596fa4b44b186b84801f66fa19b297afad6a4403435b801e7"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3406-d.json",
-  "trace_sha256": "29660463a86ca788ecb26f8aadc6edb3fdb2c10cc24bbe847914d44e0404309d"
+  "trace_file": "/tmp/axiom-encode-3406d-main-0392/traces/openai-gpt-5.5/26-USC-3406-d.json",
+  "trace_sha256": "b89156e7f05227e56196277f0f2c8dc3f9372cd6940270f84fdd683d0af7da12"
 }

--- a/.axiom/encoding-manifests/statutes/26/3406/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/d.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3406/d.yaml",
+      "sha256": "7f815d4b5bdd4b7ce93c7b0b082ee385fb21eaf455d841979c4c9f67e35a302c"
+    },
+    {
+      "path": "statutes/26/3406/d.test.yaml",
+      "sha256": "c074a888d33084476e4e07bee579b5e537480ee30ae89bffcf2dccbd809cfcfe"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6ba77fe87e9784018773db14957644310ab9dcb5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.390",
+    "version_commit": "6ba77fe87e9784018773db14957644310ab9dcb5"
+  },
+  "axiom_encode_version": "0.2.390",
+  "backend": "openai",
+  "citation": "26 USC 3406(d)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3406-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "3c06da35e1ae9839ed30e05e1987b4eef6687a08aa9173701153d9b04c3394cc",
+  "generated_at": "2026-05-28T22:12:18.865615+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3406/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "80c0b3c1671676cb1f834366005ed1040d22ffefd909836b95e7fbab4489637a",
+  "generation_prompt_sha256": "eb836103cdc5872d6250c0d15059793322234bb428f2f84a58c2713e7f786c45",
+  "model": "gpt-5.5",
+  "run_id": "9ccaf94f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ff5904fe1e8accc76966d5cd035b71051418232743157421d229a763d7e31f42"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3406-d.json",
+  "trace_sha256": "29660463a86ca788ecb26f8aadc6edb3fdb2c10cc24bbe847914d44e0404309d"
+}

--- a/.axiom/encoding-manifests/statutes/26/3406/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3406/d.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3406/d.yaml",
-      "sha256": "eee336993505649406b66771546f1eea9f910e12f36e560b8a140f89f74cf1af"
+      "sha256": "1476f5f929087c4ad7ad4f2f7dcb601e82e5843559580e4c1372d10c8c52d2cd"
     },
     {
       "path": "statutes/26/3406/d.test.yaml",
-      "sha256": "192d05bdd45c7e88ce71b7036fad78a41ee53a96dce1b6683317f9e14b22d014"
+      "sha256": "26efc5e1f4ecc6b2d7c8c2708bc27f685f3c2fa57e7061a2a492424fb34c8ed9"
     }
   ],
   "axiom_encode_git": {
-    "commit": "a1a330ccaae655ca741a9549445bdcfc838dcc1a",
+    "commit": "89ec677def4a377a06f0a58de68e237b299f8048",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
-    "version": "0.2.392",
-    "version_commit": "a1a330ccaae655ca741a9549445bdcfc838dcc1a"
+    "version": "0.2.396",
+    "version_commit": "89ec677def4a377a06f0a58de68e237b299f8048"
   },
-  "axiom_encode_version": "0.2.392",
+  "axiom_encode_version": "0.2.396",
   "backend": "openai",
   "citation": "26 USC 3406(d)",
-  "context_manifest_file": "/tmp/axiom-encode-3406d-main-0392/_eval_workspaces/openai-gpt-5.5/26-USC-3406-d/workspace/context-manifest.json",
+  "context_manifest_file": "/tmp/axiom-encode-3406d-main-0396/_eval_workspaces/openai-gpt-5.5/26-USC-3406-d/workspace/context-manifest.json",
   "context_manifest_sha256": "f48d912888f1203b220ae4fcdc472487a0d6a718df8fb2e7c37590b181b2fa42",
-  "generated_at": "2026-05-28T23:16:09.654437+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3406d-main-0392/openai-gpt-5.5/statutes/26/3406/d.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3406d-main-0392",
-  "generated_output_sha256": "eee336993505649406b66771546f1eea9f910e12f36e560b8a140f89f74cf1af",
-  "generation_prompt_sha256": "13bb920951d26edf90cfdc23d6b5227908e334b7707771adb0d96ed3b17d0bf0",
+  "generated_at": "2026-05-29T00:39:33.943604+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3406d-main-0396/openai-gpt-5.5/statutes/26/3406/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3406d-main-0396",
+  "generated_output_sha256": "1476f5f929087c4ad7ad4f2f7dcb601e82e5843559580e4c1372d10c8c52d2cd",
+  "generation_prompt_sha256": "45ca9cdba4f038ace8742f0e9e1f9bbf3d5e945bcb3f0c3feb77c5a1d08435d8",
   "model": "gpt-5.5",
-  "run_id": "41448ad0",
+  "run_id": "65d936fa",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "089202756f77e7e596fa4b44b186b84801f66fa19b297afad6a4403435b801e7"
+    "value": "6a7aa6d48aca14000decbae20d113ecad5372df45180362f67579018376ae5d6"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3406d-main-0392/traces/openai-gpt-5.5/26-USC-3406-d.json",
-  "trace_sha256": "b89156e7f05227e56196277f0f2c8dc3f9372cd6940270f84fdd683d0af7da12"
+  "trace_file": "/tmp/axiom-encode-3406d-main-0396/traces/openai-gpt-5.5/26-USC-3406-d.json",
+  "trace_sha256": "034d755d7b13c571209c77041661e7815ae0e46b30b4537711ffa47565fab38d"
 }

--- a/statutes/26/3406/d.test.yaml
+++ b/statutes/26/3406/d.test.yaml
@@ -8,17 +8,7 @@
     : false
   output:
     us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: holds
-- name: payee_with_required_payor_certification_has_no_certification_failure
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
-    : true
-  output:
-    us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: not_holds
-- name: broker_tin_failure_requires_timely_notification_when_existing_brokerage_exception_does_not_apply
+- name: broker_tin_failure_requires_notification_within_outer_limit
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -29,8 +19,9 @@
     us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
     us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
     us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
-    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
-    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+    ? us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_through_such_account_during_transition_year
+    : true
+    ? us:statutes/26/3406/d#input.instrument_acquired_through_such_account_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
     : true
     us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
     us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
@@ -43,7 +34,7 @@
     us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: not_holds
     us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: holds
     us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: holds
-- name: existing_brokerage_exception_blocks_broker_notification_duty
+- name: existing_brokerage_account_exception_blocks_broker_notification_duty
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -54,8 +45,9 @@
     us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
     us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
     us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
-    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
-    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+    ? us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_through_such_account_during_transition_year
+    : true
+    ? us:statutes/26/3406/d#input.instrument_acquired_through_such_account_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
     : false
     us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
     us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
@@ -67,7 +59,7 @@
     us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: holds
     us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: not_holds
     us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: not_holds
-- name: readily_tradable_pre_existing_account_condition_holds_for_no_payor_certification_and_direct_acquisition
+- name: readily_tradable_condition_holds_for_direct_acquisition_without_payor_certification
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -80,7 +72,7 @@
     us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
     us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
   output:
-    us:statutes/26/3406/d#readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_1_D: holds
+    us:statutes/26/3406/d#readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_certification_failure: holds
 - name: auto_positive_certification_to_broker_is_timely_for_readily_tradable_instrument
   period:
     period_kind: tax_year

--- a/statutes/26/3406/d.test.yaml
+++ b/statutes/26/3406/d.test.yaml
@@ -1,4 +1,4 @@
-- name: no_payor_certification_is_payee_certification_failure_and_direct_readily_tradable_payment_triggers_a_1_D
+- name: payee_without_required_payor_certification_has_certification_failure
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -6,31 +6,9 @@
   input:
     ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
     : false
-    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
-    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
-    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
-    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: true
-    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
-    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
   output:
     us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: holds
-- name: no_payor_certification_is_payee_certification_failure_and_direct_readily_tradable_payment_triggers_a_1_D_payment_outputs
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
-    : false
-    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
-    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
-    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
-    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: true
-    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
-    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
-  output:
-    us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies: holds
-- name: payor_certification_prevents_certification_failure_and_readily_tradable_rule_lacks_notification_or_no_certification_path
+- name: payee_with_required_payor_certification_has_no_certification_failure
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -38,55 +16,9 @@
   input:
     ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
     : true
-    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
-    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
-    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
-    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: false
-    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
-    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
   output:
     us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: not_holds
-- name: payor_certification_prevents_certification_failure_and_readily_tradable_rule_lacks_notification_or_no_certification_path_payment_outputs
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
-    : true
-    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
-    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
-    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
-    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: false
-    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
-    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
-  output:
-    us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies: not_holds
-- name: broker_tin_failure_requires_notification_within_outer_limit_when_existing_account_exception_does_not_apply
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
-    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: false
-    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
-    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
-    us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
-    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
-    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
-    : true
-    us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
-    us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
-    ? us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
-    : false
-    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 15
-  output:
-    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: not_holds
-    us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: not_holds
-    us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: holds
-    us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: holds
-- name: broker_tin_failure_requires_notification_within_outer_limit_when_existing_account_exception_does_not_apply_scalar_outputs
+- name: broker_tin_failure_requires_timely_notification_when_existing_brokerage_exception_does_not_apply
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -107,14 +39,18 @@
     us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 15
   output:
     us:statutes/26/3406/d#broker_notification_outer_limit_days: 15
-- name: existing_account_exceptions_block_broker_notification_and_subsection_d_for_pre_transition_categories
+    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: not_holds
+    us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: not_holds
+    us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: holds
+    us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: holds
+- name: existing_brokerage_exception_blocks_broker_notification_duty
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
     us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
-    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: false
     us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
     us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
     us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
@@ -125,19 +61,34 @@
     us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
     ? us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
     : false
-    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 16
-    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
-    us:statutes/26/3406/d#input.payment_is_interest_or_other_amount_of_a_kind_reportable_under_section_6049: true
-    us:statutes/26/3406/d#input.account_established_before_transition_date: true
-    us:statutes/26/3406/d#input.instrument_acquired_before_transition_date: false
-    us:statutes/26/3406/d#input.payment_is_dividend_or_other_amount_reportable_under_section_6042: false
-    us:statutes/26/3406/d#input.stock_or_other_instrument_acquired_before_transition_date: false
-    us:statutes/26/3406/d#input.payment_is_patronage_dividend_or_other_amount_of_a_kind_reportable_under_section_6044: false
-    us:statutes/26/3406/d#input.membership_acquired_before_transition_date: false
-    us:statutes/26/3406/d#input.contract_entered_into_before_transition_date: false
+    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 15
   output:
-    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: holds
+    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: not_holds
     us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: holds
     us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: not_holds
     us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: not_holds
-    us:statutes/26/3406/d#existing_account_or_instrument_exception_to_subsection_d_and_a_1_D: holds
+- name: readily_tradable_pre_existing_account_condition_holds_for_no_payor_certification_and_direct_acquisition
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
+    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
+    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: true
+    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
+    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
+  output:
+    us:statutes/26/3406/d#readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_1_D: holds
+- name: auto_positive_certification_to_broker_is_timely_for_readily_tradable_instrument
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: true
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
+  output:
+    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: holds

--- a/statutes/26/3406/d.test.yaml
+++ b/statutes/26/3406/d.test.yaml
@@ -1,0 +1,143 @@
+- name: no_payor_certification_is_payee_certification_failure_and_direct_readily_tradable_payment_triggers_a_1_D
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
+    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
+    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: true
+    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
+    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
+  output:
+    us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: holds
+- name: no_payor_certification_is_payee_certification_failure_and_direct_readily_tradable_payment_triggers_a_1_D_payment_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
+    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
+    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: true
+    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
+    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
+  output:
+    us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies: holds
+- name: payor_certification_prevents_certification_failure_and_readily_tradable_rule_lacks_notification_or_no_certification_path
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
+    : true
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
+    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
+    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: false
+    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
+    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
+  output:
+    us:statutes/26/3406/d#payee_certification_failure_described_in_subsection_d: not_holds
+- name: payor_certification_prevents_certification_failure_and_readily_tradable_rule_lacks_notification_or_no_certification_path_payment_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us:statutes/26/3406/d#input.payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
+    : true
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_on_readily_tradable_instrument: true
+    us:statutes/26/3406/d#input.payor_was_notified_by_broker_under_subparagraph_B: false
+    us:statutes/26/3406/d#input.no_certification_was_provided_to_payor_by_payee_under_paragraph_1: false
+    us:statutes/26/3406/d#input.instrument_acquired_directly_by_payee_from_payor: true
+    us:statutes/26/3406/d#input.instrument_held_by_payor_as_nominee_for_payee: false
+  output:
+    us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies: not_holds
+- name: broker_tin_failure_requires_notification_within_outer_limit_when_existing_account_exception_does_not_apply
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: false
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
+    us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
+    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
+    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+    : true
+    us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
+    us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
+    ? us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 15
+  output:
+    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: not_holds
+    us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: not_holds
+    us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: holds
+    us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: holds
+- name: broker_tin_failure_requires_notification_within_outer_limit_when_existing_account_exception_does_not_apply_scalar_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: false
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
+    us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
+    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
+    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+    : true
+    us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
+    us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
+    ? us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 15
+  output:
+    us:statutes/26/3406/d#broker_notification_outer_limit_days: 15
+- name: existing_account_exceptions_block_broker_notification_and_subsection_d_for_pre_transition_categories
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_by_payee_through_broker: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_after_account_established_and_before_acquisition: true
+    us:statutes/26/3406/d#input.payee_provided_certification_to_broker_in_connection_with_acquisition: false
+    us:statutes/26/3406/d#input.readily_tradable_instrument_acquired_through_broker_account: true
+    us:statutes/26/3406/d#input.broker_account_established_before_transition_date: true
+    us:statutes/26/3406/d#input.broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year: true
+    ? us:statutes/26/3406/d#input.instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.payee_fails_to_furnish_tin_to_broker_in_required_manner: true
+    us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect: false
+    ? us:statutes/26/3406/d#input.secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
+    : false
+    us:statutes/26/3406/d#input.days_after_acquisition_when_broker_notifies_payor: 16
+    us:statutes/26/3406/d#input.reportable_interest_or_dividend_payment: true
+    us:statutes/26/3406/d#input.payment_is_interest_or_other_amount_of_a_kind_reportable_under_section_6049: true
+    us:statutes/26/3406/d#input.account_established_before_transition_date: true
+    us:statutes/26/3406/d#input.instrument_acquired_before_transition_date: false
+    us:statutes/26/3406/d#input.payment_is_dividend_or_other_amount_reportable_under_section_6042: false
+    us:statutes/26/3406/d#input.stock_or_other_instrument_acquired_before_transition_date: false
+    us:statutes/26/3406/d#input.payment_is_patronage_dividend_or_other_amount_of_a_kind_reportable_under_section_6044: false
+    us:statutes/26/3406/d#input.membership_acquired_before_transition_date: false
+    us:statutes/26/3406/d#input.contract_entered_into_before_transition_date: false
+  output:
+    us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument: holds
+    us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification: holds
+    us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status: not_holds
+    us:statutes/26/3406/d#broker_notification_within_statutory_outer_limit: not_holds
+    us:statutes/26/3406/d#existing_account_or_instrument_exception_to_subsection_d_and_a_1_D: holds

--- a/statutes/26/3406/d.yaml
+++ b/statutes/26/3406/d.yaml
@@ -1,0 +1,318 @@
+format: rulespec/v1
+imports:
+  - us:statutes/26/3406/a
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+  summary: |-
+    There is a payee certification failure unless the payee has certified to the payor, under penalty of perjury, that the payee is not subject to withholding under subsection (a)(1)(C). Special rules apply subsection (a)(1)(D) to reportable interest or dividend payments on readily tradable instruments only if broker notification or no payor certification conditions are met and the instrument was acquired directly from, or held as nominee by, the payor. Brokers acquiring readily tradable instruments must notify payors within the prescribed period, but not later than 15 days, when specified TIN, incorrect-TIN, underreporting, or certification failures occur, subject to existing-account exceptions. Existing pre-transition accounts, instruments, stock, memberships, and contracts are excepted.
+rules:
+  - name: broker_notification_outer_limit_days
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3406(d)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "but not later than 15 days after such acquisition"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          15
+
+  - name: payee_certification_failure_described_in_subsection_d
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "There is a payee certification failure unless the payee has certified to the payor, under penalty of perjury"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "that such payee is not subject to withholding under subsection (a)(1)(C)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          not payee_certified_to_payor_under_penalty_of_perjury_not_subject_to_withholding_under_subsection_a_1_C
+
+  - name: certification_to_broker_is_timely_for_readily_tradable_instrument
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "any readily tradable instrument acquired by a payee through a broker"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "at any time after the payee’s account with the broker was established and before the acquisition"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "in connection with the acquisition of such instrument"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          readily_tradable_instrument_acquired_by_payee_through_broker
+          and (
+              payee_provided_certification_to_broker_after_account_established_and_before_acquisition
+              or payee_provided_certification_to_broker_in_connection_with_acquisition
+          )
+
+  - name: existing_brokerage_account_exception_to_broker_notification
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Subparagraph (B) of paragraph (2) shall not apply"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "such account was established before January 1, 1984"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "during 1983, such broker bought or sold instruments for the payee (or acted as a nominee for the payee)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "shall not apply with respect to any readily tradable instrument acquired through such account after the broker was notified by the Secretary"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          readily_tradable_instrument_acquired_through_broker_account
+          and broker_account_established_before_transition_date
+          and broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year
+          and not instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+
+  - name: broker_must_notify_payor_of_withholding_subject_status
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "a payee acquires any readily tradable instrument through a broker"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee fails to furnish his TIN to the broker"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies such broker before such acquisition that the TIN furnished by the payee is incorrect"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies such broker before such acquisition that such payee is subject to withholding under subsection (a)(1)(C)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee does not provide a certification to such broker under subparagraph (C)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#certification_to_broker_is_timely_for_readily_tradable_instrument
+              output: certification_to_broker_is_timely_for_readily_tradable_instrument
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notification
+              output: existing_brokerage_account_exception_to_broker_notification
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          readily_tradable_instrument_acquired_by_payee_through_broker
+          and not existing_brokerage_account_exception_to_broker_notification
+          and (
+              payee_fails_to_furnish_tin_to_broker_in_required_manner
+              or secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect
+              or secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
+              or not certification_to_broker_is_timely_for_readily_tradable_instrument
+          )
+
+  - name: broker_notification_within_statutory_outer_limit
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "within such period as the Secretary may prescribe by regulations"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#broker_notification_outer_limit_days
+              output: broker_notification_outer_limit_days
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#broker_must_notify_payor_of_withholding_subject_status
+              output: broker_must_notify_payor_of_withholding_subject_status
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          broker_must_notify_payor_of_withholding_subject_status
+          and days_after_acquisition_when_broker_notifies_payor <= broker_notification_outer_limit_days
+
+  - name: readily_tradable_instrument_subsection_a_1_D_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "Subsection (a)(1)(D) shall apply to any reportable interest or dividend payment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "on any readily tradable instrument"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "if (and only if) the payor was notified by a broker under subparagraph (B) or no certification was provided to the payor by the payee under paragraph (1)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "such instrument was acquired directly by the payee from the payor"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "such instrument is held by the payor as nominee for the payee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and payment_on_readily_tradable_instrument
+          and (
+              payor_was_notified_by_broker_under_subparagraph_B
+              or no_certification_was_provided_to_payor_by_payee_under_paragraph_1
+          )
+          and (
+              instrument_acquired_directly_by_payee_from_payor
+              or instrument_held_by_payor_as_nominee_for_payee
+          )
+
+  - name: existing_account_or_instrument_exception_to_subsection_d_and_a_1_D
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3406(d)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "This subsection and subsection (a)(1)(D) shall not apply"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "account ... established before January 1, 1984"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "instrument acquired before January 1, 1984"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "stock or other instrument acquired before January 1, 1984"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "membership acquired, or contract entered into, before January 1, 1984"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and (
+              (
+                  payment_is_interest_or_other_amount_of_a_kind_reportable_under_section_6049
+                  and (
+                      account_established_before_transition_date
+                      or instrument_acquired_before_transition_date
+                  )
+              )
+              or (
+                  payment_is_dividend_or_other_amount_reportable_under_section_6042
+                  and stock_or_other_instrument_acquired_before_transition_date
+              )
+              or (
+                  payment_is_patronage_dividend_or_other_amount_of_a_kind_reportable_under_section_6044
+                  and (
+                      membership_acquired_before_transition_date
+                      or contract_entered_into_before_transition_date
+                  )
+              )
+          )

--- a/statutes/26/3406/d.yaml
+++ b/statutes/26/3406/d.yaml
@@ -7,32 +7,32 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3406
   deferred_outputs:
-    - output: us:statutes/26/3406/d#existing_account_or_instrument_exception_to_subsection_d_and_a_1_D
+    - output: us:statutes/26/3406/d#existing_account_or_instrument_exception_to_subsection_d_and_subsection_a_certification_failure
       reason: >-
-        Section 3406(d)(3) excepts reportable interest or dividend payments by
-        reference to amounts of a kind reportable under sections 6049, 6042, and
-        6044. Those upstream reporting-category definitions are not available as
-        executable RuleSpec context, and the exception cannot be computed
-        faithfully without them.
-    - output: us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies
+        Section 3406(d)(3) provides that this subsection and subsection
+        (a)(1)(D) shall not apply to reportable interest or dividend payments
+        paid or credited with respect to existing accounts, instruments, stock,
+        memberships, or contracts, but the categories are defined by reference
+        to sections 6049, 6042, and 6044, which are not available as executable
+        RuleSpec context.
+    - output: us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_certification_failure_applies
       reason: >-
-        Section 3406(d)(2)(A) supplies readily tradable instrument conditions
-        for subsection (a)(1)(D), but section 3406(d)(3) states that subsection
-        (a)(1)(D) shall not apply to specified existing accounts, instruments,
-        stock, memberships, and contracts. The section 3406(d)(3) exception
-        depends on unavailable reporting-category definitions under sections
-        6049, 6042, and 6044, so the final applies output is deferred. The
-        pre-exception readily tradable condition is encoded separately.
+        Section 3406(d)(2)(A) states pre-existing-account conditions under
+        which subsection (a)(1)(D) applies to readily tradable instruments, but
+        section 3406(d)(3) creates exceptions dependent on unavailable sections
+        6049, 6042, and 6044. The pre-exception readily tradable condition is
+        encoded separately.
   summary: |-
-    “There is a payee certification failure unless the payee has certified to
-    the payor, under penalty of perjury,” that the payee is not subject to
-    subsection (a)(1)(C) withholding. For readily tradable instruments,
-    subsection (a)(1)(D) applies only under specified broker-notification or
-    no-certification conditions and direct-acquisition or nominee conditions.
-    Brokers must notify payors within the prescribed period, but not later than
-    15 days after acquisition, subject to an existing brokerage account
-    exception. Existing accounts and instruments are excepted in cases tied to
-    sections 6049, 6042, and 6044.
+    There is a payee certification failure unless the payee certifies to the
+    payor, under penalty of perjury, that the payee is not subject to subsection
+    (a)(1)(C) withholding. For readily tradable instruments, subsection
+    (a)(1)(D) applies only for reportable interest or dividend payments where
+    the payor was broker-notified or no payor certification was provided and
+    the instrument was directly acquired from, or held by, the payor. A broker
+    must notify the payor within the Secretary-prescribed period, but not later
+    than 15 days after acquisition, subject to the existing brokerage account
+    exception. Existing-account exceptions tied to sections 6049, 6042, and
+    6044 are deferred.
 rules:
   - name: broker_notification_outer_limit_days
     kind: parameter
@@ -64,10 +64,12 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "There is a payee certification failure unless the payee has certified to the payor, under penalty of perjury"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "that such payee is not subject to withholding under subsection (a)(1)(C)"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -86,6 +88,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "readily tradable instrument acquired by a payee through a broker"
           - path: versions[0].formula
             kind: condition
             source:
@@ -118,6 +121,7 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "Subparagraph (B) of paragraph (2) shall not apply"
           - path: versions[0].formula
             kind: condition
             source:
@@ -127,7 +131,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "during 1983, such broker bought or sold instruments for the payee"
+              excerpt: "during 1983, such broker bought or sold instruments for the payee (or acted as a nominee for the payee) through such account"
           - path: versions[0].formula
             kind: exception
             source:
@@ -138,15 +142,15 @@ rules:
         formula: |-
           readily_tradable_instrument_acquired_through_broker_account
           and broker_account_established_before_transition_date
-          and broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_during_transition_year
-          and not instrument_acquired_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
+          and broker_bought_or_sold_instruments_or_acted_as_nominee_for_payee_through_such_account_during_transition_year
+          and not instrument_acquired_through_such_account_after_broker_was_notified_by_secretary_payee_subject_to_withholding_under_subsection_a_1_C
 
   - name: broker_must_notify_payor_of_withholding_subject_status
     kind: derived
     entity: Payment
     dtype: Judgment
     period: Year
-    source: 26 USC 3406(d)(2)(B)
+    source: 26 USC 3406(d)(2)(B), 3406(d)(4)
     metadata:
       proof:
         atoms:
@@ -154,10 +158,27 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "a payee acquires any readily tradable instrument through a broker"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee fails to furnish his TIN to the broker"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies such broker before such acquisition that the TIN furnished by the payee is incorrect"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the Secretary notifies such broker before such acquisition that such payee is subject to withholding"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "the payee does not provide a certification to such broker under subparagraph (C)"
           - path: versions[0].formula
             kind: import
             import:
@@ -195,6 +216,11 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "such broker shall, within such period as the Secretary may prescribe by regulations"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/3406
               excerpt: "but not later than 15 days after such acquisition"
           - path: versions[0].formula
             kind: import
@@ -214,7 +240,7 @@ rules:
           broker_must_notify_payor_of_withholding_subject_status
           and days_after_acquisition_when_broker_notifies_payor <= broker_notification_outer_limit_days
 
-  - name: readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_1_D
+  - name: readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_certification_failure
     kind: derived
     entity: Payment
     dtype: Judgment
@@ -227,14 +253,22 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "any reportable interest or dividend payment to any payee on any readily tradable instrument"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "if (and only if) the payor was notified by a broker under subparagraph (B) or no certification was provided"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
+              excerpt: "such instrument was acquired directly by the payee from the payor"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: "such instrument is held by the payor as nominee for the payee"
     versions:
       - effective_from: '1990-01-01'
         formula: |-

--- a/statutes/26/3406/d.yaml
+++ b/statutes/26/3406/d.yaml
@@ -6,8 +6,33 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3406
+  deferred_outputs:
+    - output: us:statutes/26/3406/d#existing_account_or_instrument_exception_to_subsection_d_and_a_1_D
+      reason: >-
+        Section 3406(d)(3) excepts reportable interest or dividend payments by
+        reference to amounts of a kind reportable under sections 6049, 6042, and
+        6044. Those upstream reporting-category definitions are not available as
+        executable RuleSpec context, and the exception cannot be computed
+        faithfully without them.
+    - output: us:statutes/26/3406/d#readily_tradable_instrument_subsection_a_1_D_applies
+      reason: >-
+        Section 3406(d)(2)(A) supplies readily tradable instrument conditions
+        for subsection (a)(1)(D), but section 3406(d)(3) states that subsection
+        (a)(1)(D) shall not apply to specified existing accounts, instruments,
+        stock, memberships, and contracts. The section 3406(d)(3) exception
+        depends on unavailable reporting-category definitions under sections
+        6049, 6042, and 6044, so the final applies output is deferred. The
+        pre-exception readily tradable condition is encoded separately.
   summary: |-
-    There is a payee certification failure unless the payee has certified to the payor, under penalty of perjury, that the payee is not subject to withholding under subsection (a)(1)(C). Special rules apply subsection (a)(1)(D) to reportable interest or dividend payments on readily tradable instruments only if broker notification or no payor certification conditions are met and the instrument was acquired directly from, or held as nominee by, the payor. Brokers acquiring readily tradable instruments must notify payors within the prescribed period, but not later than 15 days, when specified TIN, incorrect-TIN, underreporting, or certification failures occur, subject to existing-account exceptions. Existing pre-transition accounts, instruments, stock, memberships, and contracts are excepted.
+    “There is a payee certification failure unless the payee has certified to
+    the payor, under penalty of perjury,” that the payee is not subject to
+    subsection (a)(1)(C) withholding. For readily tradable instruments,
+    subsection (a)(1)(D) applies only under specified broker-notification or
+    no-certification conditions and direct-acquisition or nominee conditions.
+    Brokers must notify payors within the prescribed period, but not later than
+    15 days after acquisition, subject to an existing brokerage account
+    exception. Existing accounts and instruments are excepted in cases tied to
+    sections 6049, 6042, and 6044.
 rules:
   - name: broker_notification_outer_limit_days
     kind: parameter
@@ -39,12 +64,10 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "There is a payee certification failure unless the payee has certified to the payor, under penalty of perjury"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "that such payee is not subject to withholding under subsection (a)(1)(C)"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -63,12 +86,11 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "any readily tradable instrument acquired by a payee through a broker"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "at any time after the payee’s account with the broker was established and before the acquisition"
+              excerpt: "after the payee’s account with the broker was established and before the acquisition"
           - path: versions[0].formula
             kind: condition
             source:
@@ -96,7 +118,6 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "Subparagraph (B) of paragraph (2) shall not apply"
           - path: versions[0].formula
             kind: condition
             source:
@@ -106,12 +127,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "during 1983, such broker bought or sold instruments for the payee (or acted as a nominee for the payee)"
+              excerpt: "during 1983, such broker bought or sold instruments for the payee"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "shall not apply with respect to any readily tradable instrument acquired through such account after the broker was notified by the Secretary"
+              excerpt: "shall not apply with respect to any readily tradable instrument acquired through such account after the broker was notified"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -133,27 +154,10 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "a payee acquires any readily tradable instrument through a broker"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "the payee fails to furnish his TIN to the broker"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "the Secretary notifies such broker before such acquisition that the TIN furnished by the payee is incorrect"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "the Secretary notifies such broker before such acquisition that such payee is subject to withholding under subsection (a)(1)(C)"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "the payee does not provide a certification to such broker under subparagraph (C)"
           - path: versions[0].formula
             kind: import
             import:
@@ -170,13 +174,13 @@ rules:
       - effective_from: '1990-01-01'
         formula: |-
           readily_tradable_instrument_acquired_by_payee_through_broker
-          and not existing_brokerage_account_exception_to_broker_notification
           and (
               payee_fails_to_furnish_tin_to_broker_in_required_manner
               or secretary_notified_broker_before_acquisition_that_tin_furnished_by_payee_is_incorrect
               or secretary_notified_broker_before_acquisition_that_payee_is_subject_to_withholding_under_subsection_a_1_C
               or not certification_to_broker_is_timely_for_readily_tradable_instrument
           )
+          and not existing_brokerage_account_exception_to_broker_notification
 
   - name: broker_notification_within_statutory_outer_limit
     kind: derived
@@ -191,7 +195,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "within such period as the Secretary may prescribe by regulations"
+              excerpt: "but not later than 15 days after such acquisition"
           - path: versions[0].formula
             kind: import
             import:
@@ -210,7 +214,7 @@ rules:
           broker_must_notify_payor_of_withholding_subject_status
           and days_after_acquisition_when_broker_notifies_payor <= broker_notification_outer_limit_days
 
-  - name: readily_tradable_instrument_subsection_a_1_D_applies
+  - name: readily_tradable_instrument_pre_existing_account_condition_for_subsection_a_1_D
     kind: derived
     entity: Payment
     dtype: Judgment
@@ -223,27 +227,14 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "Subsection (a)(1)(D) shall apply to any reportable interest or dividend payment"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "on any readily tradable instrument"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3406
-              excerpt: "if (and only if) the payor was notified by a broker under subparagraph (B) or no certification was provided to the payor by the payee under paragraph (1)"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "such instrument was acquired directly by the payee from the payor"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "such instrument is held by the payor as nominee for the payee"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -256,63 +247,4 @@ rules:
           and (
               instrument_acquired_directly_by_payee_from_payor
               or instrument_held_by_payor_as_nominee_for_payee
-          )
-
-  - name: existing_account_or_instrument_exception_to_subsection_d_and_a_1_D
-    kind: derived
-    entity: Payment
-    dtype: Judgment
-    period: Year
-    source: 26 USC 3406(d)(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: exception
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "This subsection and subsection (a)(1)(D) shall not apply"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "account ... established before January 1, 1984"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "instrument acquired before January 1, 1984"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "stock or other instrument acquired before January 1, 1984"
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3406
-              excerpt: "membership acquired, or contract entered into, before January 1, 1984"
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          reportable_interest_or_dividend_payment
-          and (
-              (
-                  payment_is_interest_or_other_amount_of_a_kind_reportable_under_section_6049
-                  and (
-                      account_established_before_transition_date
-                      or instrument_acquired_before_transition_date
-                  )
-              )
-              or (
-                  payment_is_dividend_or_other_amount_reportable_under_section_6042
-                  and stock_or_other_instrument_acquired_before_transition_date
-              )
-              or (
-                  payment_is_patronage_dividend_or_other_amount_of_a_kind_reportable_under_section_6044
-                  and (
-                      membership_acquired_before_transition_date
-                      or contract_entered_into_before_transition_date
-                  )
-              )
           )


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3406(d) from merged axiom-encode 0.2.396 / 89ec677
- keep generated RuleSpec provenance manifest signed by axiom-encode --apply
- encode the broker notification and broker existing-account exception path, with anaphoric same-account scope preserved for the 3406(d)(4) transition-year broker activity and post-notification carveout
- defer the final subsection (a)(1)(D) applies output and existing-account exception where 3406(d)(3) depends on unavailable 6042/6044/6049 reporting-category definitions

## Verification
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/d.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/d.yaml`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/d.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us --base-ref origin/main --head-ref HEAD`
- `AXIOM_CORPUS_LOCAL_ROOT=/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-corpus uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-untested-comparable`
- mutation check from the earlier branch: deleting the broker exception negation is caught by the merged unconsumed-exception validator