### PR TITLE
Regenerate section 3301 rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3301.json
+++ b/.axiom/encoding-manifests/statutes/26/3301.json
@@ -2,40 +2,48 @@
   "applied_files": [
     {
       "path": "statutes/26/3301.yaml",
-      "sha256": "c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27"
+      "sha256": "de967fea9e559963e62bb0dacac424baeeab1fcb6e890a4ee7ac4b8423d1f545"
     },
     {
       "path": "statutes/26/3301.test.yaml",
-      "sha256": "f6bcab6526d283b311ebc800fb89e6174b063c6b2cf0d2eecfa0b3e18c9d739d"
+      "sha256": "d56fb4f8ec6ba917cbdb0fef6dc55b4563a84f9a94d55d2d4bd27870b19ba61e"
+    },
+    {
+      "path": "statutes/26/3302/c/2/A.yaml",
+      "sha256": "a7a7e505001dcbbcb18bd2ca1eefef78f63ddcc09856e53ddf57f8d0859e3639"
+    },
+    {
+      "path": "statutes/26/3302/d/1.yaml",
+      "sha256": "b17f6556b288703622b29fd4f89ea04ce9180a738c04a97d9feeb88092943271"
     }
   ],
   "axiom_encode_git": {
-    "commit": "43b531d43149352028f0687d8f6d489266b6c766",
+    "commit": "89ec677def4a377a06f0a58de68e237b299f8048",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.206",
-    "version_commit": "43b531d43149352028f0687d8f6d489266b6c766"
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
+    "version": "0.2.396",
+    "version_commit": "89ec677def4a377a06f0a58de68e237b299f8048"
   },
-  "axiom_encode_version": "0.2.206",
+  "axiom_encode_version": "0.2.396",
   "backend": "openai",
   "citation": "26 USC 3301",
-  "context_manifest_file": "/private/tmp/axiom-encode-3301-20260525/_eval_workspaces/openai-gpt-5.5/26-USC-3301/workspace/context-manifest.json",
-  "context_manifest_sha256": "ff23076730b0b687d8ebcd0c6447d14e2841c5e1ac1e83e4ff3a6e1d91a79f24",
-  "generated_at": "2026-05-25T09:08:21.623964+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3301-20260525/openai-gpt-5.5/statutes/26/3301.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3301-20260525",
-  "generated_output_sha256": "c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27",
-  "generation_prompt_sha256": "b4cfae538b1d0d28ea72fcd1b0180a2435cf16fd7e6661a5b7cde2416d77d841",
+  "context_manifest_file": "/tmp/axiom-encode-3301-main-0396/_eval_workspaces/openai-gpt-5.5/26-USC-3301/workspace/context-manifest.json",
+  "context_manifest_sha256": "341b38fd332b31542f0b87c7e9f32da3bce510d16e3cf30e9c03bb6f001dc8e9",
+  "generated_at": "2026-05-29T00:47:53.480459+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3301-main-0396/openai-gpt-5.5/statutes/26/3301.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3301-main-0396",
+  "generated_output_sha256": "de967fea9e559963e62bb0dacac424baeeab1fcb6e890a4ee7ac4b8423d1f545",
+  "generation_prompt_sha256": "dae04133a679befe9ef126921402c124fbcfdfe7492fa20bbd37dffef385b932",
   "model": "gpt-5.5",
-  "run_id": "2f8191e7",
+  "run_id": "ae82a35d",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6ab2056ff13da7450490adc82528ee19f10599b90e98bacce7fa4ac164cf2041"
+    "value": "d3f7948d8da6e53082a7fb39f7d60ed6f6e9f7221215d60c803c41eca51d6f22"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3301-20260525/traces/openai-gpt-5.5/26-USC-3301.json",
-  "trace_sha256": "b228c047561670e6bb023e77614f70c395fd002885612d7de529d8a29b3c07e6"
+  "trace_file": "/tmp/axiom-encode-3301-main-0396/traces/openai-gpt-5.5/26-USC-3301.json",
+  "trace_sha256": "c23c9ef1989511f535fa0d7611e71a9c9fe0b23520445c2c91303209d732a486"
 }

--- a/statutes/26/3301.test.yaml
+++ b/statutes/26/3301.test.yaml
@@ -1,7 +1,6 @@
 - name: employer_tax_equals_six_percent_of_wages
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -12,8 +11,7 @@
     us:statutes/26/3301#federal_unemployment_excise_tax: 600
 - name: employer_tax_zero_when_wages_are_zero
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3301.yaml
+++ b/statutes/26/3301.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3301
   summary: |-
-    There is hereby imposed on every employer, for each calendar year, an excise tax equal to 6 percent of the total wages paid by such employer during the calendar year with respect to employment.
+    Imposes on every employer for each calendar year an excise tax equal to 6 percent of total wages paid during the calendar year with respect to employment.
 rules:
   - name: federal_unemployment_excise_tax_rate
     kind: parameter

--- a/statutes/26/3302/c/2/A.yaml
+++ b/statutes/26/3302/c/2/A.yaml
@@ -109,7 +109,7 @@ rules:
             import:
               target: us:statutes/26/3301#federal_unemployment_excise_tax
               output: federal_unemployment_excise_tax
-              hash: sha256:c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27
+              hash: sha256:de967fea9e559963e62bb0dacac424baeeab1fcb6e890a4ee7ac4b8423d1f545
           - path: versions[0].formula
             kind: import
             import:

--- a/statutes/26/3302/d/1.yaml
+++ b/statutes/26/3302/d/1.yaml
@@ -46,7 +46,7 @@ rules:
             import:
               target: us:statutes/26/3301#federal_unemployment_excise_tax
               output: federal_unemployment_excise_tax
-              hash: sha256:c8ab99bf65e149e554b82e856d8497ff9cc7eb2afe853f7e51f17f61fa490c27
+              hash: sha256:de967fea9e559963e62bb0dacac424baeeab1fcb6e890a4ee7ac4b8423d1f545
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3301 from merged axiom-encode 0.2.396 / 89ec677
- refresh the signed apply manifest and dependent 3302 import hashes
- keep 3301 as gross FUTA tax before 3302 credits; oracle coverage marks it tested but known-not-comparable to PE's post-credit FUTA variable

## Verification
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3301.yaml --skip-reviewers`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3302/c/2/A.yaml --skip-reviewers`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3302/d/1.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3301.yaml`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3302/c/2/A.yaml`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3302/d/1.yaml`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us/statutes/26/3301.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301/rulespec-us --base-ref origin/main --head-ref HEAD`
- `AXIOM_CORPUS_LOCAL_ROOT=/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-corpus uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/futa-3301 --oracle policyengine --program tax --fail-on-untested-comparable`