### PR TITLE
Repair SNAP 273.10 maximum allotment reference

### DIFF
--- a/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
+++ b/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
@@ -2,38 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/7-cfr/273/10.yaml",
-      "sha256": "d3361c37eb10873677c83c9c609aaa914df9516e561df962a4bf14257fcd3c55"
+      "sha256": "c9e1bdf6564cb58f9830192830d7c5a97c362b644dadebd63e2edcd8a456f15f"
     },
     {
       "path": "regulations/7-cfr/273/10.test.yaml",
-      "sha256": "facd3a82a1d3dc20577556f45e5c8d97b95bad4cd361d92e5de967a76d542b4e"
+      "sha256": "7243c80d92cc15bc3bac112a2657c0ed53945aa7caeb2753bbf9d281d80c6b5e"
     }
   ],
   "axiom_encode_git": {
-    "commit": "535ce17258ab442fee38d28e2275737a1db92352",
+    "commit": "b42c74c14f903c6bc39d69bc3030da58c588da01",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.457",
+    "version_commit": "b42c74c14f903c6bc39d69bc3030da58c588da01"
   },
-  "axiom_encode_version": "0.2.68",
+  "axiom_encode_version": "0.2.457",
   "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-22T01:10:20.671530+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpjxeyav6a/deterministic-repair/regulations/7-cfr/273/10.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpjxeyav6a",
-  "generated_output_sha256": "48662fef23fc70bd8645cc6eeb4e3a7215042f297dba45d030993179f4c14b3f",
+  "generated_at": "2026-05-30T13:22:58.802952+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplz_sk5f8/deterministic-repair/regulations/7-cfr/273/10.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplz_sk5f8",
+  "generated_output_sha256": "c9e1bdf6564cb58f9830192830d7c5a97c362b644dadebd63e2edcd8a456f15f",
   "generation_prompt_sha256": null,
-  "model": "manual-repair-v1",
+  "model": "snap-273-10-allotment-v1",
   "run_id": "deterministic-repair",
   "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "e31c883e148e3182877f271ca076d8f0d477fed85af1d4fa0201477fba4d6eb3"
+    "value": "c07e44c6bf8a2e22322ee342d6e5985a59819f56bfdd5f237d8625179cfc1ac8"
   },
-  "tool": "axiom-encode deterministic/manual repair",
+  "tool": "axiom-encode repair-snap-273-10-allotment",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/regulations/7-cfr/273/10.test.yaml
+++ b/regulations/7-cfr/273/10.test.yaml
@@ -13,7 +13,7 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
   output:
@@ -51,7 +51,7 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 200
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 900
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
   output:
@@ -76,7 +76,7 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: true
   output:
@@ -98,7 +98,7 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
   output:
@@ -121,7 +121,7 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: true
   output:

--- a/regulations/7-cfr/273/10.yaml
+++ b/regulations/7-cfr/273/10.yaml
@@ -54,6 +54,7 @@ module:
     7 CFR 273.10(e)(1) provides that, to determine a household's net monthly income, the State agency shall add gross earned income and unearned income minus exclusions; subtract 20 percent of earned income; subtract the standard deduction; subtract excess medical expenses over $35; subtract allowable dependent care and, if applicable, child support; subtract the homeless shelter deduction up to $143; compute excess shelter costs as shelter costs exceeding 50 percent of income after the above deductions; and subtract excess shelter costs up to the applicable maximum unless the household is entitled to the full amount. 7 CFR 273.10(e)(2)(ii) provides that, except as otherwise specified, the monthly allotment equals the maximum SNAP allotment for household size reduced by 30 percent of net monthly income, with specified rounding options; initial-month benefits under $10 are not issued; and, except during an initial month, eligible one- and two-person households receive at least the minimum benefit, equal to 8 percent of the maximum allotment for a household of one, rounded to the nearest whole dollar.
 imports:
   - us:policies/usda/snap/fy-2026-cola/deductions
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
   - us:regulations/7-cfr/273/9
 rules:
   - name: snap_earned_income_deduction_rate_for_net_income
@@ -426,7 +427,7 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          if state_agency_rounds_thirty_percent_net_income_up: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: max(0, floor(snap_maximum_allotment_for_household_size - (snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
+          if state_agency_rounds_thirty_percent_net_income_up: max(0, snap_maximum_allotment - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: max(0, floor(snap_maximum_allotment - (snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
 
   - name: snap_monthly_allotment
     kind: derived


### PR DESCRIPTION
## Summary
- imports FY 2026 SNAP maximum allotments into 7 CFR 273.10
- rewires the allotment formula to canonical snap_maximum_allotment
- updates companion tests to provide the imported household-size input

## Verification
- axiom-encode validate regulations/7-cfr/273/10.yaml --skip-reviewers
- axiom-encode test regulations/7-cfr/273/10.test.yaml --root /Users/pavelmakarchuk/rulespec-us --axiom-rules-engine-path /Users/pavelmakarchuk/axiom-rules-engine
- axiom-encode compile /Users/pavelmakarchuk/rulespec-us/regulations/7-cfr/273/10.yaml --axiom-rules-engine-path /Users/pavelmakarchuk/axiom-rules-engine
- axiom-encode guard-generated --repo /Users/pavelmakarchuk/rulespec-us --base-ref origin/main --head-ref HEAD