### PR TITLE
Fix SNAP minimum benefit allotment source

### DIFF
--- a/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
+++ b/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "regulations/7-cfr/273/10.yaml",
-      "sha256": "c9e1bdf6564cb58f9830192830d7c5a97c362b644dadebd63e2edcd8a456f15f"
+      "sha256": "67388c5f860019f9561b05b64a4dda57a6e9d1155c98822067f3e9ec0ba57fc4"
     },
     {
       "path": "regulations/7-cfr/273/10.test.yaml",
-      "sha256": "7243c80d92cc15bc3bac112a2657c0ed53945aa7caeb2753bbf9d281d80c6b5e"
+      "sha256": "2d4e417961fcbd6b604c3bc2a21a4e0455e87598af1b50e1445a6c7347afc9cc"
     }
   ],
   "axiom_encode_git": {
-    "commit": "b42c74c14f903c6bc39d69bc3030da58c588da01",
+    "commit": "566818951a7216be979aa6bb68e566493fe6aced",
     "dirty_tracked": false,
     "root": "/Users/pavelmakarchuk/axiom-encode",
-    "version": "0.2.457",
-    "version_commit": "b42c74c14f903c6bc39d69bc3030da58c588da01"
+    "version": "0.2.503",
+    "version_commit": "566818951a7216be979aa6bb68e566493fe6aced"
   },
-  "axiom_encode_version": "0.2.457",
+  "axiom_encode_version": "0.2.503",
   "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-30T13:22:58.802952+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplz_sk5f8/deterministic-repair/regulations/7-cfr/273/10.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplz_sk5f8",
-  "generated_output_sha256": "c9e1bdf6564cb58f9830192830d7c5a97c362b644dadebd63e2edcd8a456f15f",
+  "generated_at": "2026-05-31T22:54:59.752044+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzlzkgm_1/deterministic-repair/regulations/7-cfr/273/10.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzlzkgm_1",
+  "generated_output_sha256": "67388c5f860019f9561b05b64a4dda57a6e9d1155c98822067f3e9ec0ba57fc4",
   "generation_prompt_sha256": null,
   "model": "snap-273-10-allotment-v1",
   "run_id": "deterministic-repair",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c07e44c6bf8a2e22322ee342d6e5985a59819f56bfdd5f237d8625179cfc1ac8"
+    "value": "76862b5a758f5898718390966e1e334147cdebeeb26c87f73b5b4e739bab918e"
   },
   "tool": "axiom-encode repair-snap-273-10-allotment",
   "trace_file": null,

--- a/regulations/7-cfr/273/10.test.yaml
+++ b/regulations/7-cfr/273/10.test.yaml
@@ -12,7 +12,6 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
@@ -50,7 +49,6 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 200
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 900
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
@@ -75,7 +73,6 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: true
@@ -97,7 +94,6 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
@@ -120,7 +116,6 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: true

--- a/regulations/7-cfr/273/10.yaml
+++ b/regulations/7-cfr/273/10.yaml
@@ -407,7 +407,7 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          floor((snap_maximum_allotment_for_one_person_household * snap_minimum_benefit_rate) + 0.5)
+          floor((snap_one_person_thrifty_food_plan_cost * snap_minimum_benefit_rate) + 0.5)
 
   - name: snap_calculated_monthly_allotment_before_minimums
     kind: derived


### PR DESCRIPTION
## Summary
- repair 7 CFR 273.10 minimum-benefit formula to use the canonical one-person thrifty food plan cost
- remove the orphan one-person maximum-allotment input from 273.10 tests
- refresh the signed axiom-encode apply manifest with axiom-encode 0.2.503

## Verification
- axiom-encode PR #480 merged with the deterministic repair support
- NY SNAP ECPS comparison now has 92/92 eligibility matches; the prior ecps-9901 minimum-benefit mismatch is gone
- CA SNAP ECPS regression rerun completed