### PR TITLE
Encode ACA premium tax credit percentages

### DIFF
--- a/.axiom/encoding-manifests/policies/irs/rev-proc-2025-25/aca-ptc.json
+++ b/.axiom/encoding-manifests/policies/irs/rev-proc-2025-25/aca-ptc.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/irs/rev-proc-2025-25/aca-ptc.yaml",
+      "sha256": "968c0392f4c9e996f2dcfa2c1acb799fe32e3afde660817f7b47845a1870e41f"
+    },
+    {
+      "path": "policies/irs/rev-proc-2025-25/aca-ptc.test.yaml",
+      "sha256": "c7d1f4f7baf857ea11a7b3100cc0d04e572a4eaf080f8c79b0dcc71c4f3b9c9f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "57247fb906c4f82897b2e2e6ea4ded884c47de55",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/co-health-20260601/axiom-encode",
+    "version": "0.2.512",
+    "version_commit": "57247fb906c4f82897b2e2e6ea4ded884c47de55"
+  },
+  "axiom_encode_version": "0.2.512",
+  "backend": "openai",
+  "citation": "us/policies/irs/rev-proc-2025-25/aca-ptc",
+  "context_manifest_file": "/tmp/axiom-encode-aca-ptc-rev-proc-2025-25-openai-20260601-rerun2/_eval_workspaces/openai-gpt-5.5/us-policies-irs-rev-proc-2025-25-aca-ptc/workspace/context-manifest.json",
+  "context_manifest_sha256": "c5019acfbc9ded557e8d894fe49aa0daba4d5431838dbc2fd351c6f67c9f4d24",
+  "generated_at": "2026-06-01T04:33:53.416695+00:00",
+  "generated_output_file": "/tmp/axiom-encode-aca-ptc-rev-proc-2025-25-openai-20260601-rerun2/openai-gpt-5.5/policies/irs/rev-proc-2025-25/aca-ptc.yaml",
+  "generated_output_root": "/tmp/axiom-encode-aca-ptc-rev-proc-2025-25-openai-20260601-rerun2",
+  "generated_output_sha256": "968c0392f4c9e996f2dcfa2c1acb799fe32e3afde660817f7b47845a1870e41f",
+  "generation_prompt_sha256": "88c1ca2edf149e3e5e5711e9204d97c35c5a24b42d60ffa969137ac7613666ff",
+  "model": "gpt-5.5",
+  "run_id": "d0241124",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dba1977d830874e314abbfe4e097ddfa1efa4dbcf297153f8182046faca4b80e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-aca-ptc-rev-proc-2025-25-openai-20260601-rerun2/traces/openai-gpt-5.5/us-policies-irs-rev-proc-2025-25-aca-ptc.json",
+  "trace_sha256": "bee59a928b6defd2bf836a82c8a54d1768797faca900b5cd2cf2dd66358303e1"
+}

--- a/.axiom/encoding-manifests/statutes/26/36B/b/3/A.json
+++ b/.axiom/encoding-manifests/statutes/26/36B/b/3/A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/36B/b/3/A.yaml",
+      "sha256": "dd1288ffde039a123f2584bb75ee9e8004f0b696dd1373472635314aed38052b"
+    },
+    {
+      "path": "statutes/26/36B/b/3/A.test.yaml",
+      "sha256": "082a1cc96bc6e795d7e5a9e8a3bd237a07ce626ab2c89b361a6cf2eb41415ef1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b010c63e43f7a7a87b240a5efec7831079900ddb",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/co-health-20260601/axiom-encode",
+    "version": "0.2.505",
+    "version_commit": "b010c63e43f7a7a87b240a5efec7831079900ddb"
+  },
+  "axiom_encode_version": "0.2.505",
+  "backend": "openai",
+  "citation": "26 USC 36B(b)(3)(A)",
+  "context_manifest_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/_eval_workspaces/openai-gpt-5.5/26-USC-36B-b-3-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "56752586181759a3eac24749489b6a91b94a8b856056a9395957d94b7dee1754",
+  "generated_at": "2026-06-01T03:32:38.050050+00:00",
+  "generated_output_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/openai-gpt-5.5/statutes/26/36B/b/3/A.yaml",
+  "generated_output_root": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5",
+  "generated_output_sha256": "dd1288ffde039a123f2584bb75ee9e8004f0b696dd1373472635314aed38052b",
+  "generation_prompt_sha256": "782fa5458172acc49a6b565318c2877674c72f1bfeab3cf1e53027ae81d3e6d8",
+  "model": "gpt-5.5",
+  "run_id": "1c769e5c",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "22483efd0972fcfa56e19bf47dbc43a46f38a5d1ad663e09794056eaf8647322"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/traces/openai-gpt-5.5/26-USC-36B-b-3-A.json",
+  "trace_sha256": "178e921746527f796cfda939e54e1540f486f406973cd9c1a0b28f6296eba81b"
+}

--- a/policies/irs/rev-proc-2025-25/aca-ptc.test.yaml
+++ b/policies/irs/rev-proc-2025-25/aca-ptc.test.yaml
@@ -1,0 +1,60 @@
+- name: applicable_percentage_less_than_133_percent_fpl
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#input.household_income_percentage_of_federal_poverty_line: 1.2
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band: 0
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage: 0.021
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage: 0.021
+- name: applicable_percentage_at_least_150_less_than_200_percent_fpl
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#input.household_income_percentage_of_federal_poverty_line: 1.75
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band: 2
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage: 0.0419
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage: 0.066
+- name: applicable_percentage_at_least_300_not_more_than_400_percent_fpl
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#input.household_income_percentage_of_federal_poverty_line: 3.5
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band: 5
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage: 0.0996
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage: 0.0996
+- name: required_contribution_percentage_for_2026_plan_year
+  period:
+    period_kind: custom
+    name: plan_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#required_contribution_percentage: 0.0996
+- name: auto_zero_applicable_initial_percentage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#input.household_income_percentage_of_federal_poverty_line: 5
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage: 0
+- name: auto_zero_applicable_final_percentage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#input.household_income_percentage_of_federal_poverty_line: 5
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage: 0

--- a/policies/irs/rev-proc-2025-25/aca-ptc.yaml
+++ b/policies/irs/rev-proc-2025-25/aca-ptc.yaml
@@ -1,0 +1,178 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+  summary: |-
+    Rev. Proc. 2025-25 section 3.01: "For taxable years beginning in calendar year 2026, the Applicable Percentage Table for purposes of § 36B(b)(3)(A)(i) and § 1.36B-3(g)" lists initial and final percentages by household income percentage of Federal poverty line: less than 133% (2.10%/2.10%); at least 133% but less than 150% (3.14%/4.19%); at least 150% but less than 200% (4.19%/6.60%); at least 200% but less than 250% (6.60%/8.44%); at least 250% but less than 300% (8.44%/9.96%); at least 300% but not more than 400% (9.96%/9.96%). Section 3.02: "For plan years beginning in calendar year 2026, the Required Contribution Percentage ... is 9.96%." Section 5: effective for taxable years and plan years beginning in calendar year 2026.
+rules:
+  - name: applicable_percentage_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Rev. Proc. 2025-25, section 3.01
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "Household income percentage of Federal poverty line: Less than 133%; At least 133% but less than 150%; At least 150% but less than 200%; At least 200% but less than 250%; At least 250% but less than 300%; At least 300% but not more than 400%"
+              table:
+                header: "Applicable Percentage Table for 2026"
+                row_key: "household_income_percentage_of_federal_poverty_line"
+                column_key: "income_band"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "effective for taxable years and plan years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if household_income_percentage_of_federal_poverty_line < 1.33: 0 else: if household_income_percentage_of_federal_poverty_line < 1.50: 1 else: if household_income_percentage_of_federal_poverty_line < 2.00: 2 else: if household_income_percentage_of_federal_poverty_line < 2.50: 3 else: if household_income_percentage_of_federal_poverty_line < 3.00: 4 else: if household_income_percentage_of_federal_poverty_line <= 4.00: 5 else: -1
+
+  - name: applicable_initial_percentage_table
+    kind: parameter
+    dtype: Rate
+    indexed_by: applicable_percentage_band
+    source: Rev. Proc. 2025-25, section 3.01, Applicable Percentage Table for 2026, Initial percentage column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              table:
+                header: "Applicable Percentage Table for 2026"
+                row_key: "household_income_percentage_of_federal_poverty_line"
+                column_key: "Initial percentage"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For taxable years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.0210
+          1: 0.0314
+          2: 0.0419
+          3: 0.0660
+          4: 0.0844
+          5: 0.0996
+
+  - name: applicable_final_percentage_table
+    kind: parameter
+    dtype: Rate
+    indexed_by: applicable_percentage_band
+    source: Rev. Proc. 2025-25, section 3.01, Applicable Percentage Table for 2026, Final percentage column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              table:
+                header: "Applicable Percentage Table for 2026"
+                row_key: "household_income_percentage_of_federal_poverty_line"
+                column_key: "Final percentage"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For taxable years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.0210
+          1: 0.0419
+          2: 0.0660
+          3: 0.0844
+          4: 0.0996
+          5: 0.0996
+
+  - name: applicable_initial_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: Rev. Proc. 2025-25, section 3.01
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "Applicable Percentage Table ... Initial percentage"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "Initial percentage"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For taxable years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if applicable_percentage_band >= 0: applicable_initial_percentage_table[applicable_percentage_band] else: 0
+
+  - name: applicable_final_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: Rev. Proc. 2025-25, section 3.01
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "Applicable Percentage Table ... Final percentage"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "Final percentage"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For taxable years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if applicable_percentage_band >= 0: applicable_final_percentage_table[applicable_percentage_band] else: 0
+
+  - name: required_contribution_percentage
+    kind: parameter
+    dtype: Rate
+    source: Rev. Proc. 2025-25, section 3.02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For plan years beginning in calendar year 2026, the Required Contribution Percentage ... is 9.96%."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/rev-proc-2025-25
+              excerpt: "For plan years beginning in calendar year 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.0996

--- a/statutes/26/36B/b/3/A.test.yaml
+++ b/statutes/26/36B/b/3/A.test.yaml
@@ -1,0 +1,49 @@
+- name: up_to_133_percent_income_uses_two_percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 133
+  output:
+    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 0
+    us:statutes/26/36B/b/3/A#applicable_percentage: 0.02
+- name: midpoint_of_133_to_150_percent_income_tier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 141.5
+  output:
+    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 1
+    us:statutes/26/36B/b/3/A#applicable_percentage: 0.035
+- name: midpoint_of_150_to_200_percent_income_tier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 175
+  output:
+    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 2
+    us:statutes/26/36B/b/3/A#applicable_percentage: 0.0515
+- name: 300_to_400_percent_income_tier_is_constant
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 350
+  output:
+    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 5
+    us:statutes/26/36B/b/3/A#applicable_percentage: 0.095
+- name: auto_zero_applicable_percentage
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 401
+  output:
+    us:statutes/26/36B/b/3/A#applicable_percentage: 0

--- a/statutes/26/36B/b/3/A.yaml
+++ b/statutes/26/36B/b/3/A.yaml
@@ -1,0 +1,187 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/36B
+  summary: |-
+    26 USC 36B(b)(3)(A)(i) provides that, except as provided in clause (ii), the applicable percentage for any taxable year increases on a sliding scale in a linear manner from the initial premium percentage to the final premium percentage specified for the taxpayer's household-income tier.
+rules:
+  - name: applicable_percentage_income_tier
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 36B(b)(3)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/36B
+              table:
+                header: "applicable percentage table"
+                row_key: "household income expressed as a percent of poverty line"
+                column_key: "income tier"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if household_income_as_percent_of_poverty_line <= 133:
+              0
+          else:
+              if household_income_as_percent_of_poverty_line <= 150:
+                  1
+              else:
+                  if household_income_as_percent_of_poverty_line <= 200:
+                      2
+                  else:
+                      if household_income_as_percent_of_poverty_line <= 250:
+                          3
+                      else:
+                          if household_income_as_percent_of_poverty_line <= 300:
+                              4
+                          else:
+                              if household_income_as_percent_of_poverty_line <= 400:
+                                  5
+                              else:
+                                  -1
+
+  - name: initial_premium_percentage_by_income_tier
+    kind: parameter
+    dtype: Rate
+    indexed_by: applicable_percentage_income_tier
+    source: 26 USC 36B(b)(3)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/36B
+              table:
+                header: "applicable percentage table"
+                row_key: "household income expressed as a percent of poverty line"
+                column_key: "initial premium percentage"
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 0.02
+          1: 0.03
+          2: 0.04
+          3: 0.063
+          4: 0.0805
+          5: 0.095
+
+  - name: final_premium_percentage_by_income_tier
+    kind: parameter
+    dtype: Rate
+    indexed_by: applicable_percentage_income_tier
+    source: 26 USC 36B(b)(3)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/36B
+              table:
+                header: "applicable percentage table"
+                row_key: "household income expressed as a percent of poverty line"
+                column_key: "final premium percentage"
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 0.02
+          1: 0.04
+          2: 0.063
+          3: 0.0805
+          4: 0.095
+          5: 0.095
+
+  - name: applicable_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 36B(b)(3)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/36B
+              excerpt: "shall increase, on a sliding scale in a linear manner, from the initial premium percentage to the final premium percentage"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#initial_premium_percentage_by_income_tier
+              output: initial_premium_percentage_by_income_tier
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#final_premium_percentage_by_income_tier
+              output: final_premium_percentage_by_income_tier
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#applicable_percentage_income_tier
+              output: applicable_percentage_income_tier
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if applicable_percentage_income_tier == 0:
+              initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+          else:
+              if applicable_percentage_income_tier == 1:
+                  initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                  + (
+                      (household_income_as_percent_of_poverty_line - 133)
+                      / (150 - 133)
+                  )
+                  * (
+                      final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                      - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                  )
+              else:
+                  if applicable_percentage_income_tier == 2:
+                      initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                      + (
+                          (household_income_as_percent_of_poverty_line - 150)
+                          / (200 - 150)
+                      )
+                      * (
+                          final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                          - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                      )
+                  else:
+                      if applicable_percentage_income_tier == 3:
+                          initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                          + (
+                              (household_income_as_percent_of_poverty_line - 200)
+                              / (250 - 200)
+                          )
+                          * (
+                              final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                              - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                          )
+                      else:
+                          if applicable_percentage_income_tier == 4:
+                              initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                              + (
+                                  (household_income_as_percent_of_poverty_line - 250)
+                                  / (300 - 250)
+                              )
+                              * (
+                                  final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                                  - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                              )
+                          else:
+                              if applicable_percentage_income_tier == 5:
+                                  initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
+                              else:
+                                  0


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 26 USC 36B(b)(3)(A) base applicable percentage table and interpolation.
- Add generated RuleSpec for IRS Rev. Proc. 2025-25 2026 ACA PTC applicable percentage table and required contribution percentage.
- Include signed axiom-encode apply manifests for all generated artifacts.

## Validation
- `uv run axiom-encode test .../policies/irs/rev-proc-2025-25/aca-ptc.test.yaml`: 6 cases passed.
- `uv run axiom-encode test .../statutes/26/36B/b/3/A.test.yaml`: 5 cases passed.
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD`: passed.
- Manual PE parameter check: 2026 initial/final ACA PTC arrays match PolicyEngine exactly.

## Dependencies
- Corpus source PR: https://github.com/TheAxiomFoundation/axiom-corpus/pull/76
- Encoder provenance PR pending review cycle.
