### PR TITLE
Regenerate 36B applicable percentage intervals

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/36B/b/3/A.json
+++ b/.axiom/encoding-manifests/statutes/26/36B/b/3/A.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/36B/b/3/A.yaml",
-      "sha256": "dd1288ffde039a123f2584bb75ee9e8004f0b696dd1373472635314aed38052b"
+      "sha256": "1db1e3823a0e39b935b6437e30e89b8d3eefbf3b967944dc2d280f892cffd189"
     },
     {
       "path": "statutes/26/36B/b/3/A.test.yaml",
-      "sha256": "082a1cc96bc6e795d7e5a9e8a3bd237a07ce626ab2c89b361a6cf2eb41415ef1"
+      "sha256": "c59c68776801fee921c5fa6b859988ab99f80d72ac2686278ae944b9bfadaeac"
     }
   ],
   "axiom_encode_git": {
-    "commit": "b010c63e43f7a7a87b240a5efec7831079900ddb",
+    "commit": "954505ba5700dc411418be629175cbe81800af16",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/co-health-20260601/axiom-encode",
-    "version": "0.2.505",
-    "version_commit": "b010c63e43f7a7a87b240a5efec7831079900ddb"
+    "root": "/Users/maxghenis/_axiom-worktrees/encoder-main-20260601/axiom-encode",
+    "version": "0.2.522",
+    "version_commit": "76436f0ea8198f31b1a1f992df62d8dc5d389183"
   },
-  "axiom_encode_version": "0.2.505",
-  "backend": "openai",
-  "citation": "26 USC 36B(b)(3)(A)",
-  "context_manifest_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/_eval_workspaces/openai-gpt-5.5/26-USC-36B-b-3-A/workspace/context-manifest.json",
-  "context_manifest_sha256": "56752586181759a3eac24749489b6a91b94a8b856056a9395957d94b7dee1754",
-  "generated_at": "2026-06-01T03:32:38.050050+00:00",
-  "generated_output_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/openai-gpt-5.5/statutes/26/36B/b/3/A.yaml",
-  "generated_output_root": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5",
-  "generated_output_sha256": "dd1288ffde039a123f2584bb75ee9e8004f0b696dd1373472635314aed38052b",
-  "generation_prompt_sha256": "782fa5458172acc49a6b565318c2877674c72f1bfeab3cf1e53027ae81d3e6d8",
+  "axiom_encode_version": "0.2.522",
+  "backend": "codex",
+  "citation": "us/statute/26/36B/b/3/A",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-statute-26-36B-b-3-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "92a201ca886fc89c94ba6f42e7220a1c3a9d55da6724cca78a2d28cb886a5e4c",
+  "generated_at": "2026-06-01T14:05:43.892485+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/26/36B/b/3/A.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1db1e3823a0e39b935b6437e30e89b8d3eefbf3b967944dc2d280f892cffd189",
+  "generation_prompt_sha256": "62c3fbb6f0c1e72e4621db60ffedcb171bfbb697ac52a81e0f8af8ab38982a2f",
   "model": "gpt-5.5",
-  "run_id": "1c769e5c",
-  "runner": "openai-gpt-5.5",
+  "run_id": "f4cfb404",
+  "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "22483efd0972fcfa56e19bf47dbc43a46f38a5d1ad663e09794056eaf8647322"
+    "value": "264b004c6cdc26e4241c754cfd3042a51a6ede4470d843b445a8a6a201c68aaa"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-36b-b-3-a-openai-rerun5/traces/openai-gpt-5.5/26-USC-36B-b-3-A.json",
-  "trace_sha256": "178e921746527f796cfda939e54e1540f486f406973cd9c1a0b28f6296eba81b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-statute-26-36B-b-3-A.json",
+  "trace_sha256": "22818365d1fa16d8ef8a1de96b75af5acc9c69dc9086ab6239686f40f94cfab5"
 }

--- a/statutes/26/36B/b/3/A.test.yaml
+++ b/statutes/26/36B/b/3/A.test.yaml
@@ -1,49 +1,40 @@
 - name: up_to_133_percent_income_uses_two_percent
   period:
     period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    start: '1990-01-01'
+    end: '1990-12-31'
   input:
-    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 133
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 1.33
   output:
     us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 0
     us:statutes/26/36B/b/3/A#applicable_percentage: 0.02
 - name: midpoint_of_133_to_150_percent_income_tier
   period:
     period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    start: '1990-01-01'
+    end: '1990-12-31'
   input:
-    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 141.5
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 1.415
   output:
     us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 1
     us:statutes/26/36B/b/3/A#applicable_percentage: 0.035
-- name: midpoint_of_150_to_200_percent_income_tier
+- name: three_hundred_to_four_hundred_percent_income_tier_is_constant
   period:
     period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    start: '1990-01-01'
+    end: '1990-12-31'
   input:
-    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 175
-  output:
-    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 2
-    us:statutes/26/36B/b/3/A#applicable_percentage: 0.0515
-- name: 300_to_400_percent_income_tier_is_constant
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 350
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 3.5
   output:
     us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: 5
     us:statutes/26/36B/b/3/A#applicable_percentage: 0.095
-- name: auto_zero_applicable_percentage
+- name: above_400_percent_income_returns_out_of_table_zero
   period:
     period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    start: '1990-01-01'
+    end: '1990-12-31'
   input:
-    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 401
+    us:statutes/26/36B/b/3/A#input.household_income_as_percent_of_poverty_line: 4.01
   output:
+    us:statutes/26/36B/b/3/A#applicable_percentage_income_tier: -1
     us:statutes/26/36B/b/3/A#applicable_percentage: 0

--- a/statutes/26/36B/b/3/A.yaml
+++ b/statutes/26/36B/b/3/A.yaml
@@ -5,14 +5,14 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/36B
   summary: |-
-    26 USC 36B(b)(3)(A)(i) provides that, except as provided in clause (ii), the applicable percentage for any taxable year increases on a sliding scale in a linear manner from the initial premium percentage to the final premium percentage specified for the taxpayer's household-income tier.
+    "Except as provided in clause (ii), the applicable percentage for any taxable year" increases "on a sliding scale in a linear manner" from the table's initial premium percentage to final premium percentage. Table rows include "Up to 133%" at 2.0%/2.0% through "300% up to 400%" at 9.5%/9.5%.
 rules:
   - name: applicable_percentage_income_tier
     kind: derived
     entity: TaxUnit
     dtype: Integer
     period: Year
-    source: 26 USC 36B(b)(3)(A)(i)
+    source: 26 USC 36B(b)(3)(A)(i), applicable percentage table
     metadata:
       proof:
         atoms:
@@ -20,6 +20,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/36B
+              excerpt: "Up to 133%; 133% up to 150%; 150% up to 200%; 200% up to 250%; 250% up to 300%; 300% up to 400%"
               table:
                 header: "applicable percentage table"
                 row_key: "household income expressed as a percent of poverty line"
@@ -27,31 +28,13 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          if household_income_as_percent_of_poverty_line <= 133:
-              0
-          else:
-              if household_income_as_percent_of_poverty_line <= 150:
-                  1
-              else:
-                  if household_income_as_percent_of_poverty_line <= 200:
-                      2
-                  else:
-                      if household_income_as_percent_of_poverty_line <= 250:
-                          3
-                      else:
-                          if household_income_as_percent_of_poverty_line <= 300:
-                              4
-                          else:
-                              if household_income_as_percent_of_poverty_line <= 400:
-                                  5
-                              else:
-                                  -1
+          if household_income_as_percent_of_poverty_line <= 1.33: 0 else: if household_income_as_percent_of_poverty_line <= 1.50: 1 else: if household_income_as_percent_of_poverty_line <= 2.00: 2 else: if household_income_as_percent_of_poverty_line <= 2.50: 3 else: if household_income_as_percent_of_poverty_line <= 3.00: 4 else: if household_income_as_percent_of_poverty_line <= 4.00: 5 else: -1
 
-  - name: initial_premium_percentage_by_income_tier
+  - name: applicable_percentage_tier_lower_bound
     kind: parameter
-    dtype: Rate
+    dtype: Decimal
     indexed_by: applicable_percentage_income_tier
-    source: 26 USC 36B(b)(3)(A)(i)
+    source: 26 USC 36B(b)(3)(A)(i), lower endpoints in applicable percentage table income tiers
     metadata:
       proof:
         atoms:
@@ -59,6 +42,60 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/36B
+              excerpt: "133% up to 150%; 150% up to 200%; 200% up to 250%; 250% up to 300%; 300% up to 400%"
+              table:
+                header: "applicable percentage table"
+                row_key: "household income expressed as a percent of poverty line"
+                column_key: "lower endpoint of income tier"
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 1.33
+          2: 1.50
+          3: 2.00
+          4: 2.50
+          5: 3.00
+
+  - name: applicable_percentage_tier_upper_bound
+    kind: parameter
+    dtype: Decimal
+    indexed_by: applicable_percentage_income_tier
+    source: 26 USC 36B(b)(3)(A)(i), upper endpoints in applicable percentage table income tiers
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/36B
+              excerpt: "Up to 133%; 133% up to 150%; 150% up to 200%; 200% up to 250%; 250% up to 300%; 300% up to 400%"
+              table:
+                header: "applicable percentage table"
+                row_key: "household income expressed as a percent of poverty line"
+                column_key: "upper endpoint of income tier"
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 1.33
+          1: 1.50
+          2: 2.00
+          3: 2.50
+          4: 3.00
+          5: 4.00
+
+  - name: initial_premium_percentage_by_income_tier
+    kind: parameter
+    dtype: Rate
+    indexed_by: applicable_percentage_income_tier
+    source: 26 USC 36B(b)(3)(A)(i), Initial premium percentage column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/36B
+              excerpt: "The initial premium percentage is— 2.0%, 3.0%, 4.0%, 6.3%, 8.05%, 9.5%"
               table:
                 header: "applicable percentage table"
                 row_key: "household income expressed as a percent of poverty line"
@@ -66,9 +103,9 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         values:
-          0: 0.02
-          1: 0.03
-          2: 0.04
+          0: 0.020
+          1: 0.030
+          2: 0.040
           3: 0.063
           4: 0.0805
           5: 0.095
@@ -77,7 +114,7 @@ rules:
     kind: parameter
     dtype: Rate
     indexed_by: applicable_percentage_income_tier
-    source: 26 USC 36B(b)(3)(A)(i)
+    source: 26 USC 36B(b)(3)(A)(i), Final premium percentage column
     metadata:
       proof:
         atoms:
@@ -85,6 +122,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/statute/26/36B
+              excerpt: "The final premium percentage is— 2.0%, 4.0%, 6.3%, 8.05%, 9.5%, 9.5%"
               table:
                 header: "applicable percentage table"
                 row_key: "household income expressed as a percent of poverty line"
@@ -92,8 +130,8 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         values:
-          0: 0.02
-          1: 0.04
+          0: 0.020
+          1: 0.040
           2: 0.063
           3: 0.0805
           4: 0.095
@@ -114,6 +152,29 @@ rules:
               corpus_citation_path: us/statute/26/36B
               excerpt: "shall increase, on a sliding scale in a linear manner, from the initial premium percentage to the final premium percentage"
           - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/statute/26/36B
+              excerpt: "within an income tier specified in the following table"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#applicable_percentage_income_tier
+              output: applicable_percentage_income_tier
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#applicable_percentage_tier_lower_bound
+              output: applicable_percentage_tier_lower_bound
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/b/3/A#applicable_percentage_tier_upper_bound
+              output: applicable_percentage_tier_upper_bound
+              hash: sha256:local
+          - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/36B/b/3/A#initial_premium_percentage_by_income_tier
@@ -125,63 +186,7 @@ rules:
               target: us:statutes/26/36B/b/3/A#final_premium_percentage_by_income_tier
               output: final_premium_percentage_by_income_tier
               hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/36B/b/3/A#applicable_percentage_income_tier
-              output: applicable_percentage_income_tier
-              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          if applicable_percentage_income_tier == 0:
-              initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-          else:
-              if applicable_percentage_income_tier == 1:
-                  initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                  + (
-                      (household_income_as_percent_of_poverty_line - 133)
-                      / (150 - 133)
-                  )
-                  * (
-                      final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                      - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                  )
-              else:
-                  if applicable_percentage_income_tier == 2:
-                      initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                      + (
-                          (household_income_as_percent_of_poverty_line - 150)
-                          / (200 - 150)
-                      )
-                      * (
-                          final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                          - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                      )
-                  else:
-                      if applicable_percentage_income_tier == 3:
-                          initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                          + (
-                              (household_income_as_percent_of_poverty_line - 200)
-                              / (250 - 200)
-                          )
-                          * (
-                              final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                              - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                          )
-                      else:
-                          if applicable_percentage_income_tier == 4:
-                              initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                              + (
-                                  (household_income_as_percent_of_poverty_line - 250)
-                                  / (300 - 250)
-                              )
-                              * (
-                                  final_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                                  - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                              )
-                          else:
-                              if applicable_percentage_income_tier == 5:
-                                  initial_premium_percentage_by_income_tier[applicable_percentage_income_tier]
-                              else:
-                                  0
+          if applicable_percentage_income_tier < 0: 0 else: if applicable_percentage_income_tier == 0: initial_premium_percentage_by_income_tier[applicable_percentage_income_tier] else: initial_premium_percentage_by_income_tier[applicable_percentage_income_tier] + ((household_income_as_percent_of_poverty_line - applicable_percentage_tier_lower_bound[applicable_percentage_income_tier]) / (applicable_percentage_tier_upper_bound[applicable_percentage_income_tier] - applicable_percentage_tier_lower_bound[applicable_percentage_income_tier])) * (final_premium_percentage_by_income_tier[applicable_percentage_income_tier] - initial_premium_percentage_by_income_tier[applicable_percentage_income_tier])


### PR DESCRIPTION
## Summary
- regenerate `26 USC 36B(b)(3)(A)` with axiom-encode 0.2.522
- convert ACA applicable percentage table income inputs from percent points to ratios
- add indexed lower/upper interval-bound parameters and a negative out-of-table sentinel before table lookups
- update generated tests and apply manifest provenance

## Generated provenance
Produced via signed encoder apply only:

```bash
axiom-encode encode "26 USC 36B(b)(3)(A)" \
  --source-id us/statute/26/36B/b/3/A \
  --mode repo-augmented \
  --apply --apply-target-only
```

Encoder run: `codex-gpt-5.5`, `run_id=f4cfb404`, axiom-encode `0.2.522` at merge commit `954505b`.

## Verification
- signed apply result: `standalone_success=True`, `compile=yes`, `ci=yes`, `grounded=23`, `ungrounded=0`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/reencode-36b-interval-bounds-20260601/rulespec-us/statutes/26/36B/b/3/A.yaml --json --skip-reviewers`
- `uv run axiom-encode interval-table-audit --root /Users/maxghenis/_axiom-worktrees/reencode-36b-interval-bounds-20260601/rulespec-us --json` (`issue_count=0`)
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/reencode-36b-interval-bounds-20260601/rulespec-us --json` (`passed=true`)
- `git diff --check`
- read-only subagent review: no actionable findings
