### PR TITLE
Regenerate 3241(b) interval bounds

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3201.json
+++ b/.axiom/encoding-manifests/statutes/26/3201.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3201.yaml",
-      "sha256": "e14fcec5da86bf74e15144e873234194e342cba5d749e286153aee4ff2ad1291"
+      "sha256": "4cbe6858fae103e2ab8964e323f5b1acb6d51125d19cfdffb83cf7e072113be5"
     },
     {
       "path": "statutes/26/3201.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "d7b136d4ddc1663da6e47ae057291b3cf3fd4b05",
+    "commit": "d7e7079666f824449d100d17c60d1f3e39f67213",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.291",
-    "version_commit": "d7b136d4ddc1663da6e47ae057291b3cf3fd4b05"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.524",
+    "version_commit": "d7e7079666f824449d100d17c60d1f3e39f67213"
   },
-  "axiom_encode_version": "0.2.291",
-  "backend": "openai",
-  "citation": "26 USC 3201",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3201/workspace/context-manifest.json",
-  "context_manifest_sha256": "89ce13a830de8dbdccbeedd97cf4d2e9d1480b756663166c6a87344b14ed1e29",
-  "generated_at": "2026-05-26T19:14:25.411573+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3201.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "5b8d6a91bc8ee20ba396984c5837fd1e76ecfb40dde8aacc9cf29d2f3e323d09",
-  "generation_prompt_sha256": "e1b435152c23ac94202e82fbc4099b5ee1d16c3ede35b5c87f59a486601c5147",
-  "model": "gpt-5.5",
-  "run_id": "cde74a24",
-  "runner": "openai-gpt-5.5",
+  "axiom_encode_version": "0.2.524",
+  "backend": "deterministic",
+  "citation": "us:statutes/26/3201",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-01T18:12:23.761811+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpov_recpi/deterministic-repair/statutes/26/3201.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpov_recpi",
+  "generated_output_sha256": "4cbe6858fae103e2ab8964e323f5b1acb6d51125d19cfdffb83cf7e072113be5",
+  "generation_prompt_sha256": null,
+  "model": "proof-import-hash-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "88dbeead36788bf4edec83d586a9f56c63cf5100e9ef2153da1e6fd7cb892e65"
+    "value": "5e9b09ab3665c2d3c5c63f2484e819d82c10004b055594f68b7096f04915ff53"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3201.json",
-  "trace_sha256": "05c73268e029c8adc3dac36cdca8aa529bacfd1a941380b0f8e9f49157f7e796"
+  "tool": "axiom-encode repair-proof-import-hashes",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,48 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878"
+      "sha256": "b56dc9d57da063b066a300ab6fd6877a6a0c9b6bd8af317bb973d4e20e9e0b54"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
       "sha256": "db1cbb2340707eedc4507b84da62b93ce70ff92a2e6db625ba3b0e5fbf83a86f"
-    },
-    {
-      "path": "statutes/26/3201.yaml",
-      "sha256": "f1a78c4d072248eaab3e4ed7c2908323a03172743723b435def41ff624cba4eb"
-    },
-    {
-      "path": "statutes/26/3241/a.yaml",
-      "sha256": "dfa38cc46ca8805c3f301ed25e3187d440c47bce5891cc5ff94f0fb99af4cfb6"
     }
   ],
   "axiom_encode_git": {
-    "commit": "44d4cca8f7797dcc553ebe4f3bc084cef7b3de2f",
+    "commit": "d7e7079666f824449d100d17c60d1f3e39f67213",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
-    "version": "0.2.320",
-    "version_commit": "44d4cca8f7797dcc553ebe4f3bc084cef7b3de2f"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.524",
+    "version_commit": "d7e7079666f824449d100d17c60d1f3e39f67213"
   },
-  "axiom_encode_version": "0.2.320",
-  "backend": "openai",
+  "axiom_encode_version": "0.2.524",
+  "backend": "codex",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "b088f9c989f85727935d0ee60e91763f0ef25ea0a3dc538e1184ed109966218c",
-  "generated_at": "2026-05-27T06:51:04.832233+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3241/b.yaml",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "e38b3c226857074d104d65a93380a404e53ea95ca0ee4901d8e812f9ffaf75a2",
+  "generated_at": "2026-06-01T18:08:12.886882+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/26/3241/b.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878",
-  "generation_prompt_sha256": "9ea88bfa6a1317aaf06b29b1e3ca8b303694b576a81e35c1162717d96f5dc909",
+  "generated_output_sha256": "b56dc9d57da063b066a300ab6fd6877a6a0c9b6bd8af317bb973d4e20e9e0b54",
+  "generation_prompt_sha256": "5fbe4d764454186b77530b95e180501569add951b977297143f0d5de8911d7de",
   "model": "gpt-5.5",
-  "run_id": "0bc3acc8",
-  "runner": "openai-gpt-5.5",
+  "run_id": "79d71d25",
+  "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6f367c40976510c706aa9e4aaa2232836ac5405a234f109c49872245960f2872"
+    "value": "366c6745e0665f046b4c643dfd2acda5bf379a2722cc0d2d4a1c3035b7a6d730"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3241-b.json",
-  "trace_sha256": "101508e95ffe65ce2f6963d2e59dcf1c70166974bfcd1319b8ab7c78c12cd883"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/26-USC-3241-b.json",
+  "trace_sha256": "42629f6e852f102b71d7594bea0229a58adaf4bba99792a46dcb1ea10edd580b"
 }

--- a/statutes/26/3201.yaml
+++ b/statutes/26/3201.yaml
@@ -62,7 +62,7 @@ rules:
         import:
           target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b
           output: applicable_percentage_for_section_3201_b
-          hash: sha256:f98257ec36dbefa0adaafa66669a1f353a04d7cd2095f7d78d680a3e6c1af878
+          hash: sha256:b56dc9d57da063b066a300ab6fd6877a6a0c9b6bd8af317bb973d4e20e9e0b54
   versions:
   - effective_from: '1990-01-01'
     formula: applicable_percentage_for_section_3201_b

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -4,146 +4,246 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3241
-  summary: |-
-    26 USC 3241(b) tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and the applicable percentage for section 3201(b).
+  summary: (b) Tax rate schedule | Average account benefits ratio | Applicable percentage
+    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b).
 rules:
-  - name: average_account_benefits_ratio_band
-    kind: derived
-    entity: TaxUnit
-    dtype: Integer
-    period: Year
-    source: 26 USC 3241(b), tax rate schedule
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/statute/26/3241
-              excerpt: "Average account benefits ratio | At least | But less than"
-              table:
-                header: Tax rate schedule
-                row_key: Average account benefits ratio
-                column_key: Average account benefits ratio band
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          if average_account_benefits_ratio < 2.5: 1 else: if average_account_benefits_ratio >= 2.5 and average_account_benefits_ratio < 3.0: 2 else: if average_account_benefits_ratio >= 3.0 and average_account_benefits_ratio < 3.5: 3 else: if average_account_benefits_ratio >= 3.5 and average_account_benefits_ratio < 4.0: 4 else: if average_account_benefits_ratio >= 4.0 and average_account_benefits_ratio < 6.1: 5 else: if average_account_benefits_ratio >= 6.1 and average_account_benefits_ratio < 6.5: 6 else: if average_account_benefits_ratio >= 6.5 and average_account_benefits_ratio < 7.0: 7 else: if average_account_benefits_ratio >= 7.0 and average_account_benefits_ratio < 7.5: 8 else: if average_account_benefits_ratio >= 7.5 and average_account_benefits_ratio < 8.0: 9 else: if average_account_benefits_ratio >= 8.0 and average_account_benefits_ratio < 8.5: 10 else: if average_account_benefits_ratio >= 8.5 and average_account_benefits_ratio < 9.0: 11 else: 12
-
-  - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
-    kind: parameter
-    dtype: Rate
-    indexed_by: average_account_benefits_ratio_band
-    source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/statute/26/3241
-              excerpt: "22.1, 18.1, 15.1, 14.1, 13.1, 12.6, 12.1, 11.6, 11.1, 10.1, 9.1, 8.2"
-              table:
-                header: Tax rate schedule
-                row_key: Average account benefits ratio
-                column_key: Applicable percentage for sections 3211(b) and 3221(b)
-    versions:
-      - effective_from: '1990-01-01'
-        values:
-          1: 0.221
-          2: 0.181
-          3: 0.151
-          4: 0.141
-          5: 0.131
-          6: 0.126
-          7: 0.121
-          8: 0.116
-          9: 0.111
-          10: 0.101
-          11: 0.091
-          12: 0.082
-
-  - name: applicable_percentage_for_section_3201_b_by_ratio_band
-    kind: parameter
-    dtype: Rate
-    indexed_by: average_account_benefits_ratio_band
-    source: 26 USC 3241(b), applicable percentage for section 3201(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/statute/26/3241
-              excerpt: "4.9, 4.9, 4.9, 4.9, 4.9, 4.4, 3.9, 3.4, 2.9, 1.9, 0.9, 0"
-              table:
-                header: Tax rate schedule
-                row_key: Average account benefits ratio
-                column_key: Applicable percentage for section 3201(b)
-    versions:
-      - effective_from: '1990-01-01'
-        values:
-          1: 0.049
-          2: 0.049
-          3: 0.049
-          4: 0.049
-          5: 0.049
-          6: 0.044
-          7: 0.039
-          8: 0.034
-          9: 0.029
-          10: 0.019
-          11: 0.009
-          12: 0
-
-  - name: applicable_percentage_for_sections_3211_b_and_3221_b
-    kind: derived
-    entity: TaxUnit
-    dtype: Rate
-    period: Year
-    source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/3241/b#average_account_benefits_ratio_band
-              output: average_account_benefits_ratio_band
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
-              output: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
-              hash: sha256:local
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
-
-  - name: applicable_percentage_for_section_3201_b
-    kind: derived
-    entity: TaxUnit
-    dtype: Rate
-    period: Year
-    source: 26 USC 3241(b), applicable percentage for section 3201(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/3241/b#average_account_benefits_ratio_band
-              output: average_account_benefits_ratio_band
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b_by_ratio_band
-              output: applicable_percentage_for_section_3201_b_by_ratio_band
-              hash: sha256:local
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]
+- name: average_account_benefits_ratio_band_lower_bound
+  kind: parameter
+  dtype: Decimal
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b), tax rate schedule, Average account benefits ratio At least
+    column
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: At least | 2.5 | 3.0 | 3.5 | 4.0 | 6.1 | 6.5 | 7.0 | 7.5 | 8.0
+            | 8.5 | 9.0
+          table:
+            header: Tax rate schedule
+            row_key: Average account benefits ratio band
+            column_key: At least
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      2: 2.5
+      3: 3.0
+      4: 3.5
+      5: 4.0
+      6: 6.1
+      7: 6.5
+      8: 7.0
+      9: 7.5
+      10: 8.0
+      11: 8.5
+      12: 9.0
+- name: average_account_benefits_ratio_band_upper_bound
+  kind: parameter
+  dtype: Decimal
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b), tax rate schedule, Average account benefits ratio But less
+    than column
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: But less than | 2.5 | 3.0 | 3.5 | 4.0 | 6.1 | 6.5 | 7.0 | 7.5 |
+            8.0 | 8.5 | 9.0
+          table:
+            header: Tax rate schedule
+            row_key: Average account benefits ratio band
+            column_key: But less than
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      1: 2.5
+      2: 3.0
+      3: 3.5
+      4: 4.0
+      5: 6.1
+      6: 6.5
+      7: 7.0
+      8: 7.5
+      9: 8.0
+      10: 8.5
+      11: 9.0
+- name: average_account_benefits_ratio_band
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: 26 USC 3241(b), tax rate schedule
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: Average account benefits ratio | At least | But less than
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#average_account_benefits_ratio_band_lower_bound
+          output: average_account_benefits_ratio_band_lower_bound
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#average_account_benefits_ratio_band_upper_bound
+          output: average_account_benefits_ratio_band_upper_bound
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[1]:
+      1 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[2]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[2]:
+      2 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[3]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[3]:
+      3 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[4]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[4]:
+      4 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[5]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[5]:
+      5 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[6]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[6]:
+      6 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[7]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[7]:
+      7 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[8]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[8]:
+      8 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[9]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[9]:
+      9 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[10]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[10]:
+      10 else: if average_account_benefits_ratio >= average_account_benefits_ratio_band_lower_bound[11]
+      and average_account_benefits_ratio < average_account_benefits_ratio_band_upper_bound[11]:
+      11 else: 12'
+- name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+  kind: parameter
+  dtype: Rate
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: 22.1 | 18.1 | 15.1 | 14.1 | 13.1 | 12.6 | 12.1 | 11.6 | 11.1 |
+            10.1 | 9.1 | 8.2
+          table:
+            header: Tax rate schedule
+            row_key: Average account benefits ratio
+            column_key: Applicable percentage for sections 3211(b) and 3221(b)
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      1: 0.221
+      2: 0.181
+      3: 0.151
+      4: 0.141
+      5: 0.131
+      6: 0.126
+      7: 0.121
+      8: 0.116
+      9: 0.111
+      10: 0.101
+      11: 0.091
+      12: 0.082
+- name: applicable_percentage_for_section_3201_b_by_ratio_band
+  kind: parameter
+  dtype: Rate
+  indexed_by: average_account_benefits_ratio_band
+  source: 26 USC 3241(b), applicable percentage for section 3201(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: 4.9 | 4.9 | 4.9 | 4.9 | 4.9 | 4.4 | 3.9 | 3.4 | 2.9 | 1.9 | 0.9
+            | 0
+          table:
+            header: Tax rate schedule
+            row_key: Average account benefits ratio
+            column_key: Applicable percentage for section 3201(b)
+  versions:
+  - effective_from: '1990-01-01'
+    values:
+      1: 0.049
+      2: 0.049
+      3: 0.049
+      4: 0.049
+      5: 0.049
+      6: 0.044
+      7: 0.039
+      8: 0.034
+      9: 0.029
+      10: 0.019
+      11: 0.009
+      12: 0.0
+- name: applicable_percentage_for_sections_3211_b_and_3221_b
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  source: 26 USC 3241(b), applicable percentage for sections 3211(b) and 3221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: Applicable percentage for sections 3211(b) and 3221(b)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#average_account_benefits_ratio_band
+          output: average_account_benefits_ratio_band
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+          output: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
+- name: applicable_percentage_for_section_3201_b
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  source: 26 USC 3241(b), applicable percentage for section 3201(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3241
+          excerpt: Applicable percentage for section 3201(b)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#average_account_benefits_ratio_band
+          output: average_account_benefits_ratio_band
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#applicable_percentage_for_section_3201_b_by_ratio_band
+          output: applicable_percentage_for_section_3201_b_by_ratio_band
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]


### PR DESCRIPTION
## Summary
- regenerate `26 USC 3241(b)` with named interval-bound concepts for the average account benefits ratio schedule
- refresh the `26 USC 3201` proof import hash after the generated `3241(b)` content hash changed
- update signed encoder apply manifests from `axiom-encode` 0.2.524 / `gpt-5.5`

## Validation
- `uv run axiom-encode validate .../statutes/26/3241/b.yaml --skip-reviewers --json`
- `uv run axiom-encode validate .../statutes/26/3201.yaml --skip-reviewers --json`
- `uv run axiom-encode test .../statutes/26/3241/b.test.yaml .../statutes/26/3201.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --json`
- `uv run axiom-encode interval-table-audit --root .../rulespec-us --fail-on-issues --json`
- `uvx --with pyyaml --with pytest pytest tests/test_repository_layout.py -q`
- read-only subagent review: clean