### PR TITLE
Refresh generated section 3504 payroll agent rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3504.json
+++ b/.axiom/encoding-manifests/statutes/26/3504.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3504.yaml",
-      "sha256": "da65366e0b33cb8fdbbfa36eb046b78d1d9d8fde5f0ae223a6cd22df2edd4a6f"
+      "sha256": "ee9c24f17c36ccc6ca3dbcb0279516d07d39a065aead2e4bdd388ca0a5270a3f"
     },
     {
       "path": "statutes/26/3504.test.yaml",
-      "sha256": "c55472580bfa5c0e7c6d23dcf7f6c336d32923994340b96c50db8cdb666ec425"
+      "sha256": "014d3c1f4b7708f21ad1f7e9375c839e3a53bb3a7172c20104a72ac750cc25b7"
     }
   ],
   "axiom_encode_git": {
-    "commit": "4bd1dff74d2e346d9d6fb718667ab67e4331e490",
+    "commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
-    "version": "0.2.302",
-    "version_commit": "4bd1dff74d2e346d9d6fb718667ab67e4331e490"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.302",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3504",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3504/workspace/context-manifest.json",
-  "context_manifest_sha256": "4d4ce5a01435bcf939d9931709f9d0150c747f4c3c2fb454c0cbc98029bd651b",
-  "generated_at": "2026-05-27T00:11:01.278003+00:00",
+  "context_manifest_sha256": "1ae1b6c3888bc3d7dfaa70dbe6ad18a0ab488fc72c1e8c305e3c3927bfeb6e89",
+  "generated_at": "2026-06-02T06:06:35.615381+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3504.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "da65366e0b33cb8fdbbfa36eb046b78d1d9d8fde5f0ae223a6cd22df2edd4a6f",
-  "generation_prompt_sha256": "bf14e6216d8789c24d7f31f2fd8ec332d2d0b521048471dfb83fad5ecf17199b",
+  "generated_output_sha256": "ee9c24f17c36ccc6ca3dbcb0279516d07d39a065aead2e4bdd388ca0a5270a3f",
+  "generation_prompt_sha256": "f1a20ed299c5ace76e0e2959bb55871134e728a2f8003d5fa82c64de422c9da5",
   "model": "gpt-5.5",
-  "run_id": "1c4b95aa",
+  "run_id": "7a2c3148",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b68f308b43268ba053e5ea17dd37a8ea1dee2f7a48e9e8b48c57df3149bfeb50"
+    "value": "571843c9b3594327189214d9e6cf9f3580c4823e97c69b4719309b389b5a7660"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3504.json",
-  "trace_sha256": "b31315fbe0b069d20e67c944b3cea0a277066d6ac80a9ab3ea89f65a734e6a2c"
+  "trace_sha256": "3e06a8e17daec5815df0adc44c5a2b2835549f13f824d6a9156c1521674dde6f"
 }

--- a/statutes/26/3504.test.yaml
+++ b/statutes/26/3504.test.yaml
@@ -1,11 +1,11 @@
-- name: secretary_designation_authorized_when_wage_control_conditions_hold
+- name: secretary_designation_authorized_when_all_conditions_hold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
     us:statutes/26/3504#input.person_is_fiduciary_agent_or_other_person: true
-    us:statutes/26/3504#input.person_has_control_receipt_custody_or_disposal_of_employee_wages: true
+    us:statutes/26/3504#input.person_has_control_receipt_custody_disposal_or_pays_employee_wages: true
     us:statutes/26/3504#input.wages_are_of_employee_or_group_employed_by_one_or_more_employers: true
     us:statutes/26/3504#input.designation_is_under_secretary_regulations: true
   output:
@@ -17,7 +17,7 @@
     end: '2026-12-31'
   input:
     us:statutes/26/3504#input.person_is_fiduciary_agent_or_other_person: true
-    us:statutes/26/3504#input.person_has_control_receipt_custody_or_disposal_of_employee_wages: false
+    us:statutes/26/3504#input.person_has_control_receipt_custody_disposal_or_pays_employee_wages: false
     us:statutes/26/3504#input.wages_are_of_employee_or_group_employed_by_one_or_more_employers: true
     us:statutes/26/3504#input.designation_is_under_secretary_regulations: true
   output:
@@ -52,3 +52,13 @@
     us:statutes/26/3504#input.secretary_provides_employer_not_subject_to_employer_law_provisions: false
   output:
     us:statutes/26/3504#employer_remains_subject_to_employer_law_provisions: holds
+- name: secretary_provides_employer_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3504#input.designated_person_acts_for_employer: true
+    us:statutes/26/3504#input.secretary_provides_employer_not_subject_to_employer_law_provisions: true
+  output:
+    us:statutes/26/3504#employer_remains_subject_to_employer_law_provisions: not_holds

--- a/statutes/26/3504.yaml
+++ b/statutes/26/3504.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3504
   summary: |-
-    In case a fiduciary, agent, or other person has the control, receipt, custody, or disposal of, or pays the wages of an employee or group of employees, employed by one or more employers, the Secretary, under regulations prescribed by him, is authorized to designate such fiduciary, agent, or other person to perform such acts as are required of employers under this title and as the Secretary may specify. Except as may be otherwise prescribed by the Secretary, all provisions of law (including penalties) applicable in respect of an employer shall be applicable to a fiduciary, agent, or other person so designated but, except as so provided, the employer for whom such fiduciary, agent, or other person acts shall remain subject to the provisions of law (including penalties) applicable in respect of employers.
+    The Secretary may designate a fiduciary, agent, or other person with control, receipt, custody, disposal, or payment of wages of employees employed by one or more employers to perform specified employer acts. Except as otherwise prescribed by the Secretary, employer-law provisions, including penalties, apply to the designated person, and the employer remains subject to those provisions except as so provided.
 rules:
   - name: secretary_may_designate_wage_control_person_to_perform_employer_acts
     kind: derived
@@ -25,17 +25,17 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3504
-              excerpt: "employed by one or more employers"
+              excerpt: "wages of an employee or group of employees, employed by one or more employers"
           - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3504
-              excerpt: "the Secretary, under regulations prescribed by him, is authorized to designate such fiduciary, agent, or other person to perform such acts as are required of employers under this title and as the Secretary may specify"
+              excerpt: "the Secretary, under regulations prescribed by him, is authorized to designate"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
           person_is_fiduciary_agent_or_other_person
-          and person_has_control_receipt_custody_or_disposal_of_employee_wages
+          and person_has_control_receipt_custody_disposal_or_pays_employee_wages
           and wages_are_of_employee_or_group_employed_by_one_or_more_employers
           and designation_is_under_secretary_regulations
 


### PR DESCRIPTION
## Summary\n- Re-encode 26 USC 3504 with axiom-encode 0.2.532 / gpt-5.5\n- Update the wage-control condition to include payment of wages, matching the statutory control/receipt/custody/disposal-or-payment phrasing\n- Add a generated negative test for the employer exception when the Secretary provides otherwise\n\n## Validation\n- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-adjacent-20260602/rulespec-us/statutes/26/3504.yaml --skip-reviewers\n- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-adjacent-20260602/rulespec-us/statutes/26/3504.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-adjacent-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine\n- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-adjacent-20260602/rulespec-us/statutes/26/3504.yaml\n- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-adjacent-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"\n- git diff --check origin/main