### PR TITLE
Refresh generated section 3511 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3511.json
+++ b/.axiom/encoding-manifests/statutes/26/3511.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3511.yaml",
-      "sha256": "376859451d8bbfe50b0ce1c6fe333e1a0460a770d2d33bc812c4ac11da5fa8bf"
+      "sha256": "c297dc3715c5436be27be35d7cb23c11c346ecab003e8fd7cbcf8dc9f81331e9"
     },
     {
       "path": "statutes/26/3511.test.yaml",
-      "sha256": "436d7e40dd85e85e12b79c369aadac1eadee9f3e25c70c089ba36970aa28d01e"
+      "sha256": "24b21a9678363cba88d1dffa96409e18b9bef3b9dddbdfd2f60cd9d30b8184f6"
     }
   ],
   "axiom_encode_git": {
-    "commit": "31539324b3e677eb05bf7c1ac6198a5f631dbea2",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-night-20260526190810/axiom-encode",
-    "version": "0.2.303",
-    "version_commit": "31539324b3e677eb05bf7c1ac6198a5f631dbea2"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.303",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3511",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3511/workspace/context-manifest.json",
-  "context_manifest_sha256": "b199180fcbfe7ec6d3aa0808ad8599d9f76970c9fa571b7efdcf0df22a1c9bbf",
-  "generated_at": "2026-05-27T00:27:45.374791+00:00",
+  "context_manifest_sha256": "96514bedd4fae9833033af21304e3ac9a28eed00f81170fef484e1ab38e70339",
+  "generated_at": "2026-06-02T06:12:36.312825+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3511.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "376859451d8bbfe50b0ce1c6fe333e1a0460a770d2d33bc812c4ac11da5fa8bf",
-  "generation_prompt_sha256": "90b285d357845693ff71fe802441f3fa6b7782f2a3d54954af4169b4769d1501",
+  "generated_output_sha256": "c297dc3715c5436be27be35d7cb23c11c346ecab003e8fd7cbcf8dc9f81331e9",
+  "generation_prompt_sha256": "df9ba789a2bfd1cc8043d0f605dc52d006b7827dda2e49aeca1161553d51889e",
   "model": "gpt-5.5",
-  "run_id": "3eb85cd6",
+  "run_id": "1cce8534",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bc0bdceb668ade98a75329824202eabd6135589466470307c8191a5ad3899cd4"
+    "value": "e9ba6775d763b50d811008af473c8a13775284c156cf74a4215572a8300778fe"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3511.json",
-  "trace_sha256": "471fc8f723d5fb2a9369158dd9f5231b287de4a28cad30fce486db42a149b383"
+  "trace_sha256": "54223969f8779546d019546b71a4a8625e6cde8991c8ab912d1a75eee7d2c2cd"
 }

--- a/statutes/26/3511.test.yaml
+++ b/statutes/26/3511.test.yaml
@@ -1,4 +1,4 @@
-- name: work_site_employee_remuneration_cpeo_treated_as_exclusive_employer
+- name: work_site_employee_remuneration_and_successor_rules_apply_for_non_related_customer
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -41,52 +41,13 @@
     us:statutes/26/3511#cpeo_exclusive_employer_for_work_site_employee_remuneration: not_holds
     us:statutes/26/3511#employer_type_based_rules_apply_to_cpeo_remitted_work_site_remuneration: not_holds
     us:statutes/26/3511#cpeo_successor_customer_predecessor_during_service_contract: not_holds
-- name: customer_successor_status_after_service_contract_termination
+    us:statutes/26/3511#customer_successor_cpeo_predecessor_after_service_contract_termination: not_holds
+- name: credit_treatment_and_information_furnishing_apply_to_customer
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/3511#input.customer_bears_relationship_to_cpeo_described_in_section_267_b_after_10_percent_substitution: false
-    us:statutes/26/3511#input.customer_bears_relationship_to_cpeo_described_in_section_707_b_after_10_percent_substitution: false
-    us:statutes/26/3511#input.organization_is_certified_professional_employer_organization: false
-    us:statutes/26/3511#input.individual_is_work_site_employee: false
-    us:statutes/26/3511#input.work_site_employee_performs_services_for_customer_of_organization: false
-    us:statutes/26/3511#input.remuneration_remitted_by_certified_professional_employer_organization: false
-    us:statutes/26/3511#input.organization_entering_into_service_contract_with_customer_with_respect_to_work_site_employee: false
-    us:statutes/26/3511#input.service_contract_is_during_term: false
-    ? us:statutes/26/3511#input.customer_service_contract_with_certified_professional_employer_organization_terminated_with_respect_to_work_site_employee
-    : true
-  output:
-    us:statutes/26/3511#related_party_nonapplication_applies: not_holds
-    us:statutes/26/3511#cpeo_exclusive_employer_for_work_site_employee_remuneration: not_holds
-    us:statutes/26/3511#cpeo_successor_customer_predecessor_during_service_contract: not_holds
-    us:statutes/26/3511#customer_successor_cpeo_predecessor_after_service_contract_termination: holds
-- name: self_employment_rule_and_credit_information_rules
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3511#input.individual_has_net_earnings_from_self_employment_derived_from_customer_trade_or_business: true
-    us:statutes/26/3511#input.remuneration_paid_by_certified_professional_employer_organization: true
-    us:statutes/26/3511#input.credit_is_specified_in_subsection_d: true
-    us:statutes/26/3511#input.work_site_employee_performs_services_for_customer_of_organization: true
-    ? us:statutes/26/3511#input.wages_and_employment_taxes_paid_by_certified_professional_employer_organization_with_respect_to_work_site_employee
-    : true
-    ? us:statutes/26/3511#input.certified_professional_employer_organization_receives_payment_from_customer_for_wages_and_employment_taxes
-    : true
-    us:statutes/26/3511#input.information_is_necessary_for_customer_to_claim_specified_credit: true
-  output:
-    us:statutes/26/3511#individual_not_work_site_employee_due_to_self_employment: holds
-- name: self_employment_rule_and_credit_information_rules_employer_outputs
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3511#input.individual_has_net_earnings_from_self_employment_derived_from_customer_trade_or_business: true
-    us:statutes/26/3511#input.remuneration_paid_by_certified_professional_employer_organization: true
     us:statutes/26/3511#input.credit_is_specified_in_subsection_d: true
     us:statutes/26/3511#input.work_site_employee_performs_services_for_customer_of_organization: true
     ? us:statutes/26/3511#input.wages_and_employment_taxes_paid_by_certified_professional_employer_organization_with_respect_to_work_site_employee
@@ -98,3 +59,25 @@
     us:statutes/26/3511#specified_credit_applies_to_customer_not_cpeo: holds
     us:statutes/26/3511#customer_takes_cpeo_paid_wages_and_employment_taxes_into_account_for_specified_credit: holds
     us:statutes/26/3511#cpeo_information_furnishing_required_for_customer_credit: holds
+- name: self_employment_rule_makes_individual_not_work_site_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3511#input.individual_has_net_earnings_from_self_employment_derived_from_customer_trade_or_business: true
+    us:statutes/26/3511#input.remuneration_paid_by_certified_professional_employer_organization: true
+  output:
+    us:statutes/26/3511#individual_not_work_site_employee_due_to_self_employment: holds
+- name: auto_positive_customer_successor_cpeo_predecessor_after_service_contract_termination
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3511#input.customer_bears_relationship_to_cpeo_described_in_section_267_b_after_10_percent_substitution: false
+    ? us:statutes/26/3511#input.customer_service_contract_with_certified_professional_employer_organization_terminated_with_respect_to_work_site_employee
+    : true
+    us:statutes/26/3511#input.customer_bears_relationship_to_cpeo_described_in_section_707_b_after_10_percent_substitution: false
+  output:
+    us:statutes/26/3511#customer_successor_cpeo_predecessor_after_service_contract_termination: holds

--- a/statutes/26/3511.yaml
+++ b/statutes/26/3511.yaml
@@ -4,297 +4,256 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3511
-  summary: 26 USC 3511 provides that a certified professional employer organization
-    is treated as the employer, and no other person is treated as the employer, of
-    a work site employee performing services for a customer, but only with respect
-    to remuneration remitted by the organization. It also provides successor/predecessor
-    employer treatment for specified wage-base purposes when service contracts begin
-    or terminate, liability treatment for certain non-work-site individuals covered
-    by section 7705(e)(2) contracts, customer treatment for specified credits, a related-party
-    nonapplication rule, and a self-employment special rule.
+  summary: |-
+    26 USC 3511 treats a certified professional employer organization as the exclusive employer of work site employees for subtitle taxes and obligations with respect to remuneration remitted by the organization; provides successor/predecessor employer treatment for sections 3121(a)(1), 3231(e)(2)(C), and 3306(b)(1); assigns specified-credit treatment to the customer; makes the section inapplicable for certain related-party customers using a 10 percent substitution; and provides that certain self-employed individuals are not work site employees with respect to CPEO-paid remuneration.
   deferred_outputs:
-  - output: us:statutes/26/3511/c#non_work_site_individual_employer_for_liability
-    reason: Subsection (c) depends on determining whether services are covered by
-      a contract meeting section 7705(e)(2). No copied RuleSpec context provides section
-      7705(e)(2), so the executable liability surface is deferred.
-  - output: us:statutes/26/3511/b#successor_employer_status_for_section_3231_e_2_C
-    reason: Subsection (b) applies for purposes of sections 3121(a)(1), 3231(e)(2)(C),
-      and 3306(b)(1), but no copied RuleSpec context provides section 3231(e)(2)(C).
-      The section-3231-specific executable surface is deferred.
-  - output: us:statutes/26/3511/d#customer_credit_treatment_for_all_specified_credits
-    reason: Subsection (d) enumerates credits under sections 41, 45A, 45B, 45C, 45R,
-      45AA, 51, 1396, and other sections provided by the Secretary. Several cited
-      credit provisions are not available as copied RuleSpec context, so the all-specified-credits
-      credit-treatment surface is deferred.
-imports:
+    - output: us:statutes/26/3511/c#non_work_site_individual_employer_for_liability
+      reason: Subsection (c) depends on whether services are covered by a contract meeting section 7705(e)(2). No copied RuleSpec context provides section 7705(e)(2), so the liability-only treatment for non-work-site individuals is deferred.
+    - output: us:statutes/26/3511/g#secretary_reporting_recordkeeping_rules
+      reason: Subsection (g) directs the Secretary to develop reporting and recordkeeping rules, regulations, and procedures. The clause is administrative and does not provide a direct executable taxpayer computation in this artifact.
+    - output: us:statutes/26/3511/h#secretary_regulations
+      reason: Subsection (h) directs the Secretary to prescribe regulations as necessary or appropriate. The clause is administrative and does not provide a direct executable taxpayer computation in this artifact.
 rules:
-- name: related_party_nonapplication_applies
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(e)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: This section shall not apply in the case of a customer which bears
-            a relationship to a certified professional employer organization described
-            in section 267(b) or 707(b).
-      - path: versions[0].formula
-        kind: parameter
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: "substituting \u201C10 percent\u201D for \u201C50 percent\u201D"
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'customer_bears_relationship_to_cpeo_described_in_section_267_b_after_10_percent_substitution
+  - name: related_party_nonapplication_applies
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "This section shall not apply in the case of a customer which bears a relationship to a certified professional employer organization described in section 267(b) or 707(b)."
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "substituting “10 percent” for “50 percent”"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          customer_bears_relationship_to_cpeo_described_in_section_267_b_after_10_percent_substitution
+          or customer_bears_relationship_to_cpeo_described_in_section_707_b_after_10_percent_substitution
 
-      or customer_bears_relationship_to_cpeo_described_in_section_707_b_after_10_percent_substitution'
-- name: cpeo_exclusive_employer_for_work_site_employee_remuneration
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(a)(1), 26 USC 3511(e)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: a certified professional employer organization shall be treated
-            as the employer (and no other person shall be treated as the employer)
-            of any work site employee performing services for any customer
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: but only with respect to remuneration remitted by such organization
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#related_party_nonapplication_applies
-          output: related_party_nonapplication_applies
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'organization_is_certified_professional_employer_organization
+  - name: cpeo_exclusive_employer_for_work_site_employee_remuneration
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(a)(1), 26 USC 3511(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "a certified professional employer organization shall be treated as the employer (and no other person shall be treated as the employer) of any work site employee performing services for any customer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "but only with respect to remuneration remitted by such organization"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3511#related_party_nonapplication_applies
+              output: related_party_nonapplication_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          organization_is_certified_professional_employer_organization
+          and individual_is_work_site_employee
+          and work_site_employee_performs_services_for_customer_of_organization
+          and remuneration_remitted_by_certified_professional_employer_organization
+          and not related_party_nonapplication_applies
 
-      and individual_is_work_site_employee
+  - name: employer_type_based_rules_apply_to_cpeo_remitted_work_site_remuneration
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(a)(2), 26 USC 3511(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "the exemptions, exclusions, definitions, and other rules which are based on type of employer ... shall apply with respect to such taxes imposed on such remuneration"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3511#cpeo_exclusive_employer_for_work_site_employee_remuneration
+              output: cpeo_exclusive_employer_for_work_site_employee_remuneration
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cpeo_exclusive_employer_for_work_site_employee_remuneration
 
-      and work_site_employee_performs_services_for_customer_of_organization
+  - name: cpeo_successor_customer_predecessor_during_service_contract
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(b)(1), 26 USC 3511(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "a certified professional employer organization entering into a service contract with a customer with respect to a work site employee shall be treated as a successor employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "the customer shall be treated as a predecessor employer during the term of such service contract"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3511#related_party_nonapplication_applies
+              output: related_party_nonapplication_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          organization_is_certified_professional_employer_organization
+          and organization_entering_into_service_contract_with_customer_with_respect_to_work_site_employee
+          and service_contract_is_during_term
+          and not related_party_nonapplication_applies
 
-      and remuneration_remitted_by_certified_professional_employer_organization
+  - name: customer_successor_cpeo_predecessor_after_service_contract_termination
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(b)(2), 26 USC 3511(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "A customer whose service contract with a certified professional employer organization is terminated with respect to a work site employee shall be treated as a successor employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "the certified professional employer organization shall be treated as a predecessor employer"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3511#related_party_nonapplication_applies
+              output: related_party_nonapplication_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          customer_service_contract_with_certified_professional_employer_organization_terminated_with_respect_to_work_site_employee
+          and not related_party_nonapplication_applies
 
-      and not related_party_nonapplication_applies'
-- name: employer_type_based_rules_apply_to_cpeo_remitted_work_site_remuneration
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(a)(2), 26 USC 3511(e)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: the exemptions, exclusions, definitions, and other rules which
-            are based on type of employer ... shall apply with respect to such taxes
-            imposed on such remuneration
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#cpeo_exclusive_employer_for_work_site_employee_remuneration
-          output: cpeo_exclusive_employer_for_work_site_employee_remuneration
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: cpeo_exclusive_employer_for_work_site_employee_remuneration
-- name: cpeo_successor_customer_predecessor_during_service_contract
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(b)(1), 26 USC 3511(e)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: a certified professional employer organization entering into a
-            service contract with a customer with respect to a work site employee
-            shall be treated as a successor employer
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: the customer shall be treated as a predecessor employer during
-            the term of such service contract
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#related_party_nonapplication_applies
-          output: related_party_nonapplication_applies
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'organization_is_certified_professional_employer_organization
+  - name: individual_not_work_site_employee_due_to_self_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "an individual with net earnings from self-employment derived from the customer’s trade or business ... is not a work site employee with respect to remuneration paid by a certified professional employer organization"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_has_net_earnings_from_self_employment_derived_from_customer_trade_or_business
+          and remuneration_paid_by_certified_professional_employer_organization
 
-      and organization_entering_into_service_contract_with_customer_with_respect_to_work_site_employee
+  - name: specified_credit_applies_to_customer_not_cpeo
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(d)(1)(A), 26 USC 3511(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "such credit with respect to a work site employee performing services for the customer applies to the customer, not the certified professional employer organization"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "A credit is specified in this paragraph if such credit is allowed under"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          credit_is_specified_in_subsection_d
+          and work_site_employee_performs_services_for_customer_of_organization
 
-      and service_contract_is_during_term
+  - name: customer_takes_cpeo_paid_wages_and_employment_taxes_into_account_for_specified_credit
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(d)(1)(B), 26 USC 3511(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "the customer, and not the certified professional employer organization, shall take into account wages and employment taxes"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "paid by the certified professional employer organization with respect to the work site employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "for which the certified professional employer organization receives payment from the customer"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          credit_is_specified_in_subsection_d
+          and wages_and_employment_taxes_paid_by_certified_professional_employer_organization_with_respect_to_work_site_employee
+          and certified_professional_employer_organization_receives_payment_from_customer_for_wages_and_employment_taxes
 
-      and not related_party_nonapplication_applies'
-- name: customer_successor_cpeo_predecessor_after_service_contract_termination
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(b)(2), 26 USC 3511(e)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: a customer whose service contract with a certified professional
-            employer organization is terminated with respect to a work site employee
-            shall be treated as a successor employer
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: the certified professional employer organization shall be treated
-            as a predecessor employer
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#related_party_nonapplication_applies
-          output: related_party_nonapplication_applies
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'customer_service_contract_with_certified_professional_employer_organization_terminated_with_respect_to_work_site_employee
-
-      and not related_party_nonapplication_applies'
-- name: individual_not_work_site_employee_due_to_self_employment
-  kind: derived
-  entity: Person
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(f)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: "an individual with net earnings from self-employment derived from\
-            \ the customer\u2019s trade or business ... is not a work site employee\
-            \ with respect to remuneration paid by a certified professional employer\
-            \ organization"
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'individual_has_net_earnings_from_self_employment_derived_from_customer_trade_or_business
-
-      and remuneration_paid_by_certified_professional_employer_organization'
-- name: specified_credit_applies_to_customer_not_cpeo
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(d)(1)(A), 26 USC 3511(d)(2)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: such credit with respect to a work site employee performing services
-            for the customer applies to the customer, not the certified professional
-            employer organization
-      - path: versions[0].formula
-        kind: definition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: A credit is specified in this paragraph if such credit is allowed
-            under
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'credit_is_specified_in_subsection_d
-
-      and work_site_employee_performs_services_for_customer_of_organization'
-- name: customer_takes_cpeo_paid_wages_and_employment_taxes_into_account_for_specified_credit
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(d)(1)(B), 26 USC 3511(d)(2)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: the customer, and not the certified professional employer organization,
-            shall take into account wages and employment taxes
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: paid by the certified professional employer organization ... and
-            ... for which the certified professional employer organization receives
-            payment from the customer
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#specified_credit_applies_to_customer_not_cpeo
-          output: specified_credit_applies_to_customer_not_cpeo
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'specified_credit_applies_to_customer_not_cpeo
-
-      and wages_and_employment_taxes_paid_by_certified_professional_employer_organization_with_respect_to_work_site_employee
-
-      and certified_professional_employer_organization_receives_payment_from_customer_for_wages_and_employment_taxes'
-- name: cpeo_information_furnishing_required_for_customer_credit
-  kind: derived
-  entity: Employer
-  dtype: Judgment
-  period: Year
-  source: 26 USC 3511(d)(1)(C), 26 USC 3511(d)(2)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us/statute/26/3511
-          excerpt: the certified professional employer organization shall furnish
-            the customer and the Secretary with any information necessary for the
-            customer to claim such credit
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us:statutes/26/3511#specified_credit_applies_to_customer_not_cpeo
-          output: specified_credit_applies_to_customer_not_cpeo
-          hash: sha256:local
-  versions:
-  - effective_from: '1990-01-01'
-    formula: 'specified_credit_applies_to_customer_not_cpeo
-
-      and information_is_necessary_for_customer_to_claim_specified_credit'
+  - name: cpeo_information_furnishing_required_for_customer_credit
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3511(d)(1)(C), 26 USC 3511(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3511
+              excerpt: "the certified professional employer organization shall furnish the customer and the Secretary with any information necessary for the customer to claim such credit"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          credit_is_specified_in_subsection_d
+          and information_is_necessary_for_customer_to_claim_specified_credit


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3511 with axiom-encode 0.2.532 and gpt-5.5
- refresh companion tests and signed apply manifest
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3511-20260602/rulespec-us/statutes/26/3511.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3511-20260602/rulespec-us/statutes/26/3511.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3511-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3511-20260602/rulespec-us/statutes/26/3511.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3511-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main