### PR TITLE
Refresh generated section 3508 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3508.json
+++ b/.axiom/encoding-manifests/statutes/26/3508.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3508.yaml",
-      "sha256": "27cf6193095ef4392bff83a98438ca352f4a323a93af26d520738eb0c0f072bf"
+      "sha256": "10515a35eab980eb505e6fbd9b6b714113caa38b5eada50ee4a92f58e208a3b1"
     },
     {
       "path": "statutes/26/3508.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "88d8f37a29fe5c940bf6eeb2c17e0eef0f3cd9be",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
-    "version": "0.2.363",
-    "version_commit": "88d8f37a29fe5c940bf6eeb2c17e0eef0f3cd9be"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.363",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3508",
-  "context_manifest_file": "/tmp/axiom-encode-3508-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3508/workspace/context-manifest.json",
-  "context_manifest_sha256": "4172f56a930324afd91e1cbfbc37df7544631256306ff30e64949537492baec4",
-  "generated_at": "2026-05-28T07:08:42.439443+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3508-20260528-001/openai-gpt-5.5/statutes/26/3508.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3508-20260528-001",
-  "generated_output_sha256": "27cf6193095ef4392bff83a98438ca352f4a323a93af26d520738eb0c0f072bf",
-  "generation_prompt_sha256": "102ad00bced030df913b56cef37716c0e258e2abfa9961befe46cc41ed80c004",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3508/workspace/context-manifest.json",
+  "context_manifest_sha256": "199fb96c11db6f174df2e8d35562b4218014d15c5c7365c32247f93fa26eebf6",
+  "generated_at": "2026-06-02T06:21:15.587047+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3508.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "10515a35eab980eb505e6fbd9b6b714113caa38b5eada50ee4a92f58e208a3b1",
+  "generation_prompt_sha256": "1d6bd88aef687ea6315e2fa88a9510e1253550e7c5cf33d168a10b329ea39b5d",
   "model": "gpt-5.5",
-  "run_id": "af1bc871",
+  "run_id": "d27b64cb",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "1b02809432c1f7aa4e63ebb8637c064c6fb68b68f71070475e642a91b165125f"
+    "value": "061528690fe34d48e572b73f4941aa05c1a58975579d5b316b13a8bbc477bc3d"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3508-20260528-001/traces/openai-gpt-5.5/26-USC-3508.json",
-  "trace_sha256": "d6dca813c7210b8d39e2f4938a6fe979d26be4b5c1273938c85f56b77bacbb41"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3508.json",
+  "trace_sha256": "bc3334bc6e8565d72b66ace4942ab4f2a849b8ab73c43f846bde63bccb365df1"
 }

--- a/statutes/26/3508.yaml
+++ b/statutes/26/3508.yaml
@@ -7,41 +7,39 @@ module:
   deferred_outputs:
     - output: us:statutes/26/3508/a#individual_performing_services_not_treated_as_employee
       reason: >-
-        The general non-employee treatment in subsection (a) is limited by
-        subsection (b)(3) for purposes of subtitle A to the extent the individual
-        is treated as an employee under section 401(c)(1); no copied RuleSpec
-        source provides the section 401(c)(1) treatment needed to encode that
-        coordination faithfully.
+        Subsection (a)'s non-employee treatment is limited by subsection
+        (b)(3) for purposes of subtitle A to the extent the individual is
+        treated as an employee under section 401(c)(1); no copied RuleSpec
+        source provides the section 401(c)(1) employee-treatment dependency.
       source_values:
         - us:statutes/26/3508#qualified_real_estate_agent
         - us:statutes/26/3508#direct_seller
     - output: us:statutes/26/3508/a#service_recipient_not_treated_as_employer
       reason: >-
-        The general non-employer treatment in subsection (a) is limited by
-        subsection (b)(3) for purposes of subtitle A to the extent the individual
-        is treated as an employee under section 401(c)(1); no copied RuleSpec
-        source provides the section 401(c)(1) treatment needed to encode that
-        coordination faithfully.
+        Subsection (a)'s non-employer treatment is limited by subsection
+        (b)(3) for purposes of subtitle A to the extent the individual is
+        treated as an employee under section 401(c)(1); no copied RuleSpec
+        source provides the section 401(c)(1) employee-treatment dependency.
       source_values:
         - us:statutes/26/3508#qualified_real_estate_agent
         - us:statutes/26/3508#direct_seller
     - output: us:statutes/26/3508/b/3#section_3508_applies_for_subtitle_a
       reason: >-
-        Subsection (b)(3) makes section 3508 inapplicable for subtitle A to the
-        extent the individual is treated as an employee under section 401(c)(1),
-        but the section 401(c)(1) employee-treatment dependency is not available
-        as copied RuleSpec context.
+        Subsection (b)(3) provides that section 3508 shall not apply for
+        purposes of subtitle A to the extent the individual is treated as an
+        employee under section 401(c)(1), but the section 401(c)(1)
+        employee-treatment dependency is not available as copied RuleSpec
+        context.
       source_values:
         - us:statutes/26/3508#qualified_real_estate_agent
         - us:statutes/26/3508#direct_seller
   summary: |-
     For purposes of this title, services performed as a qualified real estate
-    agent or direct seller are not treated as employment by an employee/employer.
-    For purposes of this section, “qualified real estate agent” and “direct
-    seller” are defined by licensing or trade/business categories, remuneration
-    directly related to sales or other output rather than hours worked, and a
-    written Federal-tax contract stating non-employee treatment. Section 3508
-    does not apply for subtitle A to the extent the individual is treated as an
+    agent or as a direct seller are not treated as employee/employer services.
+    For purposes of this section, qualified real estate agent and direct seller
+    are defined by status or trade/business category, output-based remuneration,
+    and a written Federal-tax nonemployee-treatment contract. Section 3508 does
+    not apply for subtitle A to the extent the individual is treated as an
     employee under section 401(c)(1).
 rules:
   - name: qualified_real_estate_agent
@@ -49,7 +47,7 @@ rules:
     entity: Person
     dtype: Judgment
     period: Year
-    source: 26 USC 3508(b)(1)
+    source: 26 USC 3508(b)
     metadata:
       proof:
         atoms:
@@ -57,6 +55,7 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3508
+              excerpt: "The term “qualified real estate agent” means any individual who is a sales person if—"
           - path: versions[0].formula
             kind: condition
             source:
@@ -66,7 +65,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3508
-              excerpt: "substantially all of the remuneration ... is directly related to sales or other output ... rather than to the number of hours worked"
+              excerpt: "remuneration ... directly related to sales or other output ... rather than to the number of hours worked"
           - path: versions[0].formula
             kind: condition
             source:
@@ -89,10 +88,6 @@ rules:
     metadata:
       proof:
         atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us/statute/26/3508
           - path: versions[0].formula
             kind: condition
             source:
@@ -128,6 +123,7 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3508
+              excerpt: "The term “direct seller” means any person if—"
           - path: versions[0].formula
             kind: import
             import:
@@ -138,7 +134,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3508
-              excerpt: "substantially all the remuneration ... is directly related to sales or other output ... rather than to the number of hours worked"
+              excerpt: "remuneration ... directly related to sales or other output ... rather than to the number of hours worked"
           - path: versions[0].formula
             kind: condition
             source:
@@ -156,10 +152,15 @@ rules:
     entity: Person
     dtype: Judgment
     period: Year
-    source: 26 USC 3508(a), 26 USC 3508(b)
+    source: 26 USC 3508(a), 26 USC 3508(b)(1), 26 USC 3508(b)(2)
     metadata:
       proof:
         atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3508
+              excerpt: "services performed as a qualified real estate agent or as a direct seller"
           - path: versions[0].formula
             kind: import
             import:
@@ -172,11 +173,6 @@ rules:
               target: us:statutes/26/3508#direct_seller
               output: direct_seller
               hash: sha256:local
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/statute/26/3508
-              excerpt: "services performed as a qualified real estate agent or as a direct seller"
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3508 with axiom-encode 0.2.532 and gpt-5.5
- refresh signed apply manifest and proof excerpts for the existing executable definition surface
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3508-20260602/rulespec-us/statutes/26/3508.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3508-20260602/rulespec-us/statutes/26/3508.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3508-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3508-20260602/rulespec-us/statutes/26/3508.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3508-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main