### PR TITLE
Refresh generated section 3509 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3509.json
+++ b/.axiom/encoding-manifests/statutes/26/3509.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3509.yaml",
-      "sha256": "c0ada2bdac091c20730035055b187a8661fd0bacde824a8158d7ed043006692e"
+      "sha256": "71e3d87db0b03f55cfab4f80c799c7431d26f248b5b29a04ba50dba7d6ec08d6"
     },
     {
       "path": "statutes/26/3509.test.yaml",
-      "sha256": "3772f3e06cd06c4d27277ed3a256563b70a19c21040c1b0361f6c7b177c851a3"
+      "sha256": "8289c0ff8c3e51b93a2902bc8dea1e8fd78e898e3b348f1b1206bc33c88b2246"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1676055841a004ad3108b0796925a0417f8b05da",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
-    "version": "0.2.364",
-    "version_commit": "1676055841a004ad3108b0796925a0417f8b05da"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.364",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3509",
-  "context_manifest_file": "/tmp/axiom-encode-3509-20260528-001/_eval_workspaces/openai-gpt-5.5/26-USC-3509/workspace/context-manifest.json",
-  "context_manifest_sha256": "80975455464be29ef4d9653fe203815c2ca8fd096334e9571d59e8eb7a09bb8b",
-  "generated_at": "2026-05-28T07:25:42.247349+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3509-20260528-001/openai-gpt-5.5/statutes/26/3509.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3509-20260528-001",
-  "generated_output_sha256": "c0ada2bdac091c20730035055b187a8661fd0bacde824a8158d7ed043006692e",
-  "generation_prompt_sha256": "ccb11c3dfffb9d2179deed11913d3c107bc48b1e935f70774060441adc8d8027",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3509/workspace/context-manifest.json",
+  "context_manifest_sha256": "765674e476783bbad1f8191cd4335f617f49594adf9e5d54b34e4807d5f90b61",
+  "generated_at": "2026-06-02T06:24:02.895914+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3509.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "71e3d87db0b03f55cfab4f80c799c7431d26f248b5b29a04ba50dba7d6ec08d6",
+  "generation_prompt_sha256": "36c0da96543d441fe88e0bbb6ae32e54a0f7b36787951f6b1d1b8680712c231f",
   "model": "gpt-5.5",
-  "run_id": "281b6855",
+  "run_id": "f4ea15d6",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c823b84be6ddbb5fe0165e2b9c4a501de1bdbad08855a2ab82f511a0c91c26ce"
+    "value": "dfdb5fc699cb59b2245eec8d9b9fc3b6f32608d68dbf0743429b176d5d526bd2"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3509-20260528-001/traces/openai-gpt-5.5/26-USC-3509.json",
-  "trace_sha256": "27f32f28de61e7386e6ea0dd1d671fc7c4105be8b9547048b67f667ff430f370"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3509.json",
+  "trace_sha256": "3c1865b666ffb723d687074cfb5dcb1bfd2d78d02f27b48387e6aaae344994a2"
 }

--- a/statutes/26/3509.test.yaml
+++ b/statutes/26/3509.test.yaml
@@ -1,4 +1,4 @@
-- name: scalar_rates_under_default_and_increased_subsections
+- name: qualifying_misclassification_default_and_increased_rate_surfaces_apply
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -10,17 +10,39 @@
     ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
     : false
     us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.employer_failed_to_meet_applicable_reporting_requirements_consistent_with_nonemployee_treatment: true
+    us:statutes/26/3509#input.reporting_failure_due_to_reasonable_cause_and_not_willful_neglect: false
     us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
   output:
     us:statutes/26/3509#default_withholding_liability_rate: 0.015
     us:statutes/26/3509#default_employee_social_security_tax_liability_percentage: 0.2
     us:statutes/26/3509#increased_withholding_liability_rate: 0.03
     us:statutes/26/3509#increased_employee_social_security_tax_liability_percentage: 0.4
+    us:statutes/26/3509#reporting_failure_increased_rates_apply: holds
     us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: holds
     us:statutes/26/3509#section_applies_to_employee_social_security_tax: holds
     us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: holds
     us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: holds
     us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: holds
+- name: reasonable_cause_blocks_increased_rates_but_not_basic_section_application
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
+    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
+    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
+    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
+    : false
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.employer_failed_to_meet_applicable_reporting_requirements_consistent_with_nonemployee_treatment: true
+    us:statutes/26/3509#input.reporting_failure_due_to_reasonable_cause_and_not_willful_neglect: true
+    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
+  output:
+    us:statutes/26/3509#reporting_failure_increased_rates_apply: not_holds
+    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: holds
+    us:statutes/26/3509#section_applies_to_employee_social_security_tax: holds
 - name: intentional_disregard_blocks_section_application
   period:
     period_kind: tax_year
@@ -33,14 +55,17 @@
     ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
     : false
     us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.employer_failed_to_meet_applicable_reporting_requirements_consistent_with_nonemployee_treatment: false
+    us:statutes/26/3509#input.reporting_failure_due_to_reasonable_cause_and_not_willful_neglect: false
     us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: false
   output:
+    us:statutes/26/3509#reporting_failure_increased_rates_apply: not_holds
     us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: not_holds
     us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds
     us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: not_holds
     us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: not_holds
     us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: not_holds
-- name: wage_withholding_but_no_social_security_withholding_blocks_section_application_for_wages
+- name: wage_withholding_only_exception_and_statutory_employee_social_security_exception
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -51,27 +76,14 @@
     us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
     ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
     : true
-    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: false
+    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: true
+    us:statutes/26/3509#input.employer_failed_to_meet_applicable_reporting_requirements_consistent_with_nonemployee_treatment: false
+    us:statutes/26/3509#input.reporting_failure_due_to_reasonable_cause_and_not_willful_neglect: false
     us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
   output:
+    us:statutes/26/3509#reporting_failure_increased_rates_apply: not_holds
     us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: not_holds
     us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds
     us:statutes/26/3509#employee_tax_liability_unaffected_by_section_assessment_or_collection: holds
     us:statutes/26/3509#employer_not_entitled_to_recover_section_tax_from_employee: holds
     us:statutes/26/3509#section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax: holds
-- name: statutory_employee_described_in_section_3121_d_3_blocks_social_security_tax_application_only
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3509#input.employer_failed_to_deduct_and_withhold_chapter_24_or_chapter_21_subchapter_a_tax: true
-    us:statutes/26/3509#input.failure_due_to_treating_employee_as_not_employee_for_chapter_or_subchapter: true
-    us:statutes/26/3509#input.liability_due_to_employer_intentional_disregard_of_withholding_requirement: false
-    ? us:statutes/26/3509#input.employer_withheld_chapter_24_tax_but_failed_to_withhold_chapter_21_subchapter_a_tax_on_same_wages
-    : false
-    us:statutes/26/3509#input.individual_described_in_section_3121_d_3: true
-    us:statutes/26/3509#input.amount_of_liability_for_tax_determined_under_this_section: true
-  output:
-    us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure: holds
-    us:statutes/26/3509#section_applies_to_employee_social_security_tax: not_holds

--- a/statutes/26/3509.yaml
+++ b/statutes/26/3509.yaml
@@ -5,30 +5,24 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3509
   summary: |-
-    26 USC 3509 sets reduced employer liability rates when an employer fails to deduct and withhold chapter 24 or subchapter A of chapter 21 tax because the employer treated an employee as not an employee. It substitutes 1.5 percent of section 3401 wages for chapter 24 withholding and 20 percent of the otherwise imposed subchapter A chapter 21 employee tax; increases those rates to 3 percent and 40 percent where specified reporting requirements are disregarded without reasonable cause; excludes intentional disregard cases; and states special nonapplication and recovery/collection rules.
+    If an employer fails to deduct and withhold chapter 24 or subchapter A of chapter 21 tax because the employer treated an employee as not an employee, section 3509 substitutes 1.5 percent of section 3401 wages and 20 percent of the otherwise imposed subchapter A chapter 21 employee tax. Where applicable reporting requirements are not met without reasonable cause, those rates become 3 percent and 40 percent. The section does not apply in intentional-disregard cases, in wage-withholding-only cases described in subsection (d)(2), or for subchapter A chapter 21 tax for statutory employees described in section 3121(d)(3). If liability is determined under the section, employee liability is unaffected, the employer may not recover the tax from the employee, and sections 3402(d) and 6521 do not apply.
   deferred_outputs:
     - output: us:statutes/26/3509#employer_chapter_24_withholding_tax_liability
       reason: >-
-        The chapter 24 liability amount depends on wages as defined in section
-        3401. The copied section 3401(a) context is deferred and has no
-        executable wages export, so a faithful wage-based amount cannot be
-        computed here.
+        The amount depends on wages as defined in section 3401 and on whether subsection
+        (b)'s increased reporting-failure rates apply to the employee. The copied
+        section 3401(a) context has no executable wages export, so a final wage-based
+        liability amount is deferred.
+      source_values:
+        - us:statutes/26/3509#default_withholding_liability_rate
+        - us:statutes/26/3509#increased_withholding_liability_rate
     - output: us:statutes/26/3509#employer_employee_social_security_tax_liability
       reason: >-
-        The subchapter A of chapter 21 liability amount is computed as a
-        percentage of the tax imposed under that subchapter without regard to the
-        section 3509 substitution. No executable copied context provides that
+        The amount depends on the tax imposed under subchapter A of chapter 21 without
+        regard to the section 3509 substitution. No copied context provides that
         otherwise-imposed employee tax amount for this computation.
-    - output: us:statutes/26/3509/b#employer_liability_increased_for_reporting_requirement_disregard
-      reason: >-
-        Subsection (b) applies the increased 3 percent and 40 percent rates when
-        the employer fails to meet applicable requirements of sections 6041(a),
-        6041A, or 6051, unless due to reasonable cause and not willful neglect.
-        No copied RuleSpec context provides executable targets for those
-        reporting requirements, so the reporting-disregard condition and final
-        increased-liability surface are deferred.
       source_values:
-        - us:statutes/26/3509#increased_withholding_liability_rate
+        - us:statutes/26/3509#default_employee_social_security_tax_liability_percentage
         - us:statutes/26/3509#increased_employee_social_security_tax_liability_percentage
 rules:
   - name: default_withholding_liability_rate
@@ -68,7 +62,7 @@ rules:
   - name: increased_withholding_liability_rate
     kind: parameter
     dtype: Rate
-    source: 26 USC 3509(b)(1)(A)
+    source: "26 USC 3509(b): Employer’s liability increased where employer disregards reporting requirements (1) In general In..."
     metadata:
       proof:
         atoms:
@@ -76,7 +70,7 @@ rules:
             kind: amount
             source:
               corpus_citation_path: us/statute/26/3509
-              excerpt: "by substituting “3 percent” for “1.5 percent”"
+              excerpt: "substituting “3 percent” for “1.5 percent”"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -93,11 +87,41 @@ rules:
             kind: amount
             source:
               corpus_citation_path: us/statute/26/3509
-              excerpt: "by substituting “40 percent” for “20 percent”"
+              excerpt: "substituting “40 percent” for “20 percent”"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
           0.40
+
+  - name: reporting_failure_increased_rates_apply
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3509(b)(1), 3509(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "fails to meet the applicable requirements of section 6041(a), 6041A, or 6051"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "unless such failure is due to reasonable cause and not willful neglect"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "applicable consistent with the employer’s treatment of the employee as not being an employee"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_failed_to_meet_applicable_reporting_requirements_consistent_with_nonemployee_treatment
+          and not reporting_failure_due_to_reasonable_cause_and_not_willful_neglect
 
   - name: section_applies_to_misclassified_employee_withholding_failure
     kind: derived
@@ -122,7 +146,7 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3509
-              excerpt: "shall not apply to any employer with respect to any wages if ... deducted and withheld any amount of the tax imposed by chapter 24 ... but ... failed to deduct and withhold ... subchapter A of chapter 21"
+              excerpt: "deducted and withheld any amount of the tax imposed by chapter 24 ... but ... failed to deduct and withhold ... subchapter A of chapter 21"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -141,16 +165,16 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3509
+              excerpt: "This section shall not apply to any tax under subchapter A of chapter 21 with respect to an individual described in subsection (d)(3) of section 3121"
+          - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/3509#section_applies_to_misclassified_employee_withholding_failure
               output: section_applies_to_misclassified_employee_withholding_failure
               hash: sha256:local
-          - path: versions[0].formula
-            kind: exception
-            source:
-              corpus_citation_path: us/statute/26/3509
-              excerpt: "shall not apply to any tax under subchapter A of chapter 21 with respect to an individual described in subsection (d)(3) of section 3121"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -175,7 +199,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3509
-              excerpt: "the employee’s liability for tax shall not be affected by the assessment or collection of the tax so determined"
+              excerpt: "the employee’s liability for tax shall not be affected"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -199,7 +223,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3509
-              excerpt: "the employer shall not be entitled to recover from the employee any tax so determined"
+              excerpt: "the employer shall not be entitled to recover from the employee"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -220,7 +244,7 @@ rules:
               corpus_citation_path: us/statute/26/3509
               excerpt: "If the amount of any liability for tax is determined under this section"
           - path: versions[0].formula
-            kind: exception
+            kind: formula
             source:
               corpus_citation_path: us/statute/26/3509
               excerpt: "section 3402(d) and section 6521 shall not apply"


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3509 with axiom-encode 0.2.532 and gpt-5.5
- add generated executable helper for reporting-failure increased-rate applicability
- refresh companion tests and signed apply manifest
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3509-20260602/rulespec-us/statutes/26/3509.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3509-20260602/rulespec-us/statutes/26/3509.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3509-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3509-20260602/rulespec-us/statutes/26/3509.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3509-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main