### PR TITLE
Refresh generated section 3503 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3503.json
+++ b/.axiom/encoding-manifests/statutes/26/3503.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3503.yaml",
-      "sha256": "3ca6b549f672a9f37e8139a126ef38b8a4c5d4c10119433af09af2f5fd1f2005"
+      "sha256": "ac1145eafa4c212e076b4ede3dd0f8a375064c14c98c765b614903366b49ed6f"
     },
     {
       "path": "statutes/26/3503.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "4861a1b08f8c2022a808b6571192ce2b14c6cb56",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-encode-3402p-classifier",
-    "version": "0.2.384",
-    "version_commit": "4861a1b08f8c2022a808b6571192ce2b14c6cb56"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.384",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3503",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3503/workspace/context-manifest.json",
-  "context_manifest_sha256": "3713f78b1f401f351e63b64cd17a93b13dd784efe2b13398763bf0b0036788ee",
-  "generated_at": "2026-05-28T19:37:31.877716+00:00",
+  "context_manifest_sha256": "ae8023b58987de2c1e274a75e0ebf096c02c9da9833837dbba058f46f8d627db",
+  "generated_at": "2026-06-02T06:28:31.528480+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3503.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "3ca6b549f672a9f37e8139a126ef38b8a4c5d4c10119433af09af2f5fd1f2005",
-  "generation_prompt_sha256": "935ae20a63c647c69cb54e3f7d8caa583a3f607d8a4a35ae10a86d271b653f2d",
+  "generated_output_sha256": "ac1145eafa4c212e076b4ede3dd0f8a375064c14c98c765b614903366b49ed6f",
+  "generation_prompt_sha256": "4cf81e0632502b05b3955b67b83ae74869208a2352bb7ff1ce501101b08a8bc4",
   "model": "gpt-5.5",
-  "run_id": "9ef7e033",
+  "run_id": "9344bbea",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "add14231833e0615d02eb1df61b8ead6f2d8c1b0d0b275518c180c02fa7a8341"
+    "value": "21e441613a147404e55d1f6024c606c0e6f81ffaea7a79df21fe18ab07147fff"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3503.json",
-  "trace_sha256": "b5932a1dca3b10b8c264eec4e204ed8568929cfb85180188d9e9a8673f936e9c"
+  "trace_sha256": "79637c92c989e565551bbce2bca61ac89c946f4a42043e64a98acfa8fec7a45e"
 }

--- a/statutes/26/3503.yaml
+++ b/statutes/26/3503.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3503
   summary: |-
-    Tax paid under chapter 21 or 22 for a period for which the taxpayer is not liable under that chapter is credited against tax imposed by the other chapter, and any balance is refunded.
+    Any tax paid under chapter 21 or 22 for a period for which the taxpayer is not liable under that chapter is credited against tax imposed by the other chapter, and any balance is refunded.
 rules:
   - name: chapter_21_or_22_tax_paid_for_period_without_liability
     kind: derived


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3503 with axiom-encode 0.2.532 and gpt-5.5
- refresh signed apply manifest and generated summary text
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3503-20260602/rulespec-us/statutes/26/3503.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3503-20260602/rulespec-us/statutes/26/3503.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3503-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3503-20260602/rulespec-us/statutes/26/3503.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3503-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main