### PR TITLE
Refresh generated section 3305 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3305.json
+++ b/.axiom/encoding-manifests/statutes/26/3305.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3305.yaml",
-      "sha256": "59a2273232c38334104056f870588b425e3687e461011f3e794843cda79eedcc"
+      "sha256": "c4cc9bdd6f34f6767e29f88d85a283a9eed6c0605d200a8d37e9deb20a1b540c"
     },
     {
       "path": "statutes/26/3305.test.yaml",
-      "sha256": "b633c013be2a13e48196537faade237f8c59f4ab6b7cc8fc4543cf77ff00ca35"
+      "sha256": "853c27f5ebdb9310ede1f44342b1fac90f844802ec9ae390031eacb8a05ee2cb"
     }
   ],
   "axiom_encode_git": {
-    "commit": "779bf699686dc32fcb1143aeb9e86a4913c33982",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
-    "version": "0.2.344",
-    "version_commit": "779bf699686dc32fcb1143aeb9e86a4913c33982"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.344",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3305",
-  "context_manifest_file": "/private/tmp/axiom-encode-3305-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3305/workspace/context-manifest.json",
-  "context_manifest_sha256": "f25ffe6163f048bdae44c8162c6db78ea1a6af9697ed3bb42209103f83b24eab",
-  "generated_at": "2026-05-27T22:32:20.055983+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3305-20260527/codex-gpt-5.5/statutes/26/3305.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3305-20260527",
-  "generated_output_sha256": "59a2273232c38334104056f870588b425e3687e461011f3e794843cda79eedcc",
-  "generation_prompt_sha256": "4aee716450dfc91c917edc109269ae0b91146100a334015ffd2195dfd8a8ec8b",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3305/workspace/context-manifest.json",
+  "context_manifest_sha256": "b828b010cf4f59cc42bb84169dffba5f42c58f850c25828da4d0e0c7a3bfce04",
+  "generated_at": "2026-06-02T06:32:15.055555+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3305.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "c4cc9bdd6f34f6767e29f88d85a283a9eed6c0605d200a8d37e9deb20a1b540c",
+  "generation_prompt_sha256": "ec122280dbf3668b984c30a4e02a9ddc5b16ca51e5c73a686bc8683cbefb75ad",
   "model": "gpt-5.5",
-  "run_id": "6f52d582",
-  "runner": "codex-gpt-5.5",
+  "run_id": "2f52df97",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "e23e621d9166da0f0931adc95920dd5e7ecf0f605382b071ba8c994e327f8a5d"
+    "value": "90931fb5da2219e4d6548642bfd6d44bc4a3ac8d41de91ab63ed9e495338d313"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3305-20260527/traces/codex-gpt-5.5/26-USC-3305.json",
-  "trace_sha256": "3e3c8683439becc1c8344f7225fd595afcdccb30f878e54c9ca2a002d16820c3"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3305.json",
+  "trace_sha256": "1741009d3b20c9322213ffbd41d959198c1759d690634c0baad3a008f2b2cff8"
 }

--- a/statutes/26/3305.test.yaml
+++ b/statutes/26/3305.test.yaml
@@ -1,4 +1,4 @@
-- name: commerce_federal_property_and_credit_denial_rules_apply
+- name: commerce_ground_federal_property_ground_and_credit_denial_apply
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -17,7 +17,7 @@
     us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: holds
     us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: holds
     us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: holds
-- name: nondistinguishing_state_law_alternative_applies_without_federal_property_ground
+- name: nondistinguishing_state_law_alternative_triggers_commerce_rule
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -36,7 +36,7 @@
     us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: holds
     us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: not_holds
     us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: holds
-- name: requirements_absent_make_rules_inapplicable
+- name: absent_underlying_state_law_requirements_make_rules_inapplicable
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -55,7 +55,7 @@
     us:statutes/26/3305#state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground: not_holds
     us:statutes/26/3305#state_unemployment_compensation_compliance_not_relieved_by_federal_property_services: not_holds
     us:statutes/26/3305#state_unemployment_contribution_credits_denied_for_permission_condition_failure: not_holds
-- name: no_commerce_ground_and_no_certification_prevent_denial
+- name: no_commerce_ground_and_no_secretary_certification_prevent_two_rules
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3305.yaml
+++ b/statutes/26/3305.yaml
@@ -5,9 +5,14 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3305
   summary: |-
-    (a) No person required under a State law to make payments to an unemployment fund shall be relieved from compliance therewith on the ground that he is engaged in interstate or foreign commerce...
-    (d) No person shall be relieved from compliance with a State unemployment compensation law on the ground that services were performed on land or premises owned, held, or possessed by the United States...
-    (j) Any person required, pursuant to the permission granted by this section, to make contributions... shall not be entitled to the credits permitted... by subsections (a) and (b) of section 3302... if... the Secretary of Labor certifies...
+    (a) No person required under a State law to make payments to an unemployment fund shall be relieved from compliance therewith on the ground that he is engaged in interstate or foreign commerce, or that the State law does not distinguish interstate or foreign commerce employees from intrastate commerce employees. (d) No person shall be relieved from compliance with a State unemployment compensation law on the ground that services were performed on land or premises owned, held, or possessed by the United States. (j) A person required, pursuant to the permission granted by this section, to make unemployment-fund contributions under an approved State unemployment compensation law is not entitled to credits under section 3302(a) and (b) against the section 3301 tax for a taxable year if the Secretary of Labor makes the stated October 31 certification.
+  deferred_outputs:
+    - output: us:statutes/26/3305#state_permission_to_require_federal_instrumentality_contributions_and_compliance
+      reason: Subsection (b) grants State legislative permission subject to nondiscrimination, refund, and unemployment-compensation parity conditions, with exceptions and modifications under section 5240 of the Revised Statutes and subsection (c). The copied context does not provide an executable representation of national-bank examination restrictions or the State-law approval/certification mechanics under section 3304 needed to compute the full permission surface.
+    - output: us:statutes/26/3305#state_permission_to_require_american_vessel_operating_office_contributions
+      reason: Subsection (f) depends on identifying the State in which a person maintains the operating office from which American-vessel operations are ordinarily and regularly supervised, managed, directed, and controlled, and applies conditions and limitations by reference to subsection (b). The current schema/context does not provide a relation tying vessel service, operating office State, person, officers, and crew to one State-specific unemployment fund contribution surface.
+    - output: us:statutes/26/3305#state_permission_for_secretary_of_transportation_general_agent_vessel_service_contributions
+      reason: Subsections (g), (h), and (i) establish special treatment for general agents of the Secretary of Transportation, American vessels owned by or bareboat chartered to the United States, and temporary disability insurance contributions and wage deductions. The current schema/context does not provide the required vessel, general-agent, State, service, and temporary-disability-insurance relations needed for faithful execution.
 rules:
   - name: state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground
     kind: derived
@@ -90,7 +95,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3305
-              excerpt: "shall not be entitled to the credits permitted... by subsections (a) and (b) of section 3302 against the tax imposed by section 3301"
+              excerpt: "shall not be entitled to the credits permitted ... by subsections (a) and (b) of section 3302 against the tax imposed by section 3301"
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3305 with axiom-encode 0.2.532 and gpt-5.5
- add generated deferred-output coverage for larger State/vessel permission surfaces
- refresh companion test names and signed apply manifest
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3305-20260602/rulespec-us/statutes/26/3305.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3305-20260602/rulespec-us/statutes/26/3305.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3305-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3305-20260602/rulespec-us/statutes/26/3305.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3305-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main