### PR TITLE
Refresh generated section 3304 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3304.json
+++ b/.axiom/encoding-manifests/statutes/26/3304.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3304.yaml",
-      "sha256": "8d3fecbaac2527e7db2b241088d2cf53c68699f0ee895a966b95098757d444e9"
+      "sha256": "86fc1e04b86968a3fea7737fce53a8297bc20be9c7896e4527512caed95bff86"
     },
     {
       "path": "statutes/26/3304.test.yaml",
-      "sha256": "176c3362b2207a07026d950f58c1bd0d7a94e481a4352ce9e6c7f32d91d8d8b3"
+      "sha256": "22861ff08bc794d80ac3e76e04e88c3c385d91ee4f7a6b28f37f34d2ecd212a4"
     }
   ],
   "axiom_encode_git": {
-    "commit": "5be79ea7d814aa8c516ef3388725c1312fc6e666",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
-    "version": "0.2.343",
-    "version_commit": "5be79ea7d814aa8c516ef3388725c1312fc6e666"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.343",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3304",
-  "context_manifest_file": "/private/tmp/axiom-encode-3304-20260527/_eval_workspaces/codex-gpt-5.5/26-USC-3304/workspace/context-manifest.json",
-  "context_manifest_sha256": "ea24f28f745da1c16679b7b9ec0c3cbc0d2a2eaf4dbd13c7409e3def56158f8b",
-  "generated_at": "2026-05-27T22:12:37.525238+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3304-20260527/codex-gpt-5.5/statutes/26/3304.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3304-20260527",
-  "generated_output_sha256": "8d3fecbaac2527e7db2b241088d2cf53c68699f0ee895a966b95098757d444e9",
-  "generation_prompt_sha256": "1160b3f0193d1d9cde491c1f52410faffab3f13874779cee3d1b7a2c0f860dfa",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3304/workspace/context-manifest.json",
+  "context_manifest_sha256": "b702d3efe02074db516fc174b6bfd7e239743a8945ea4bd5bef885fdb18b488f",
+  "generated_at": "2026-06-02T06:36:12.030004+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3304.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "86fc1e04b86968a3fea7737fce53a8297bc20be9c7896e4527512caed95bff86",
+  "generation_prompt_sha256": "c6684d655c00275dbb6f8ebd631ceb5867acd97bf2d12a0ba192409623d6951f",
   "model": "gpt-5.5",
-  "run_id": "e0299a5f",
-  "runner": "codex-gpt-5.5",
+  "run_id": "8363170e",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "23356cd21725b8a7c1ce10370e77dbd42faf2b913b14cd5d522cb895dc3c55aa"
+    "value": "924ceb494387863d80d4062bd1f89a582d68a92aff9fa4fe4e30b22939c323b5"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3304-20260527/traces/codex-gpt-5.5/26-USC-3304.json",
-  "trace_sha256": "266f320560a22dff93ce493f73b8a9ac1a9440be3a83fb3770d55bd1ef88ae4d"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3304.json",
+  "trace_sha256": "cd140efd81e067973f81f6eef3d163837001c13274e8d1ae6d4e38cea7582d3f"
 }

--- a/statutes/26/3304.test.yaml
+++ b/statutes/26/3304.test.yaml
@@ -1,4 +1,4 @@
-- name: qualifying_institution_of_higher_education
+- name: qualifying_institution_of_higher_education_with_degree_program
   period:
     period_kind: custom
     name: calendar_year
@@ -15,7 +15,7 @@
     us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: true
   output:
     us:statutes/26/3304#institution_of_higher_education: holds
-- name: missing_public_or_nonprofit_status
+- name: missing_public_or_nonprofit_status_is_not_institution_of_higher_education
   period:
     period_kind: custom
     name: calendar_year
@@ -32,3 +32,37 @@
     us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: false
   output:
     us:statutes/26/3304#institution_of_higher_education: not_holds
+- name: no_qualifying_program_is_not_institution_of_higher_education
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3304#input.business_is_educational_institution_in_any_state: true
+    us:statutes/26/3304#input.business_admits_as_regular_students_only_high_school_graduates_or_equivalent: true
+    us:statutes/26/3304#input.business_legally_authorized_in_state_to_provide_beyond_high_school_program: true
+    us:statutes/26/3304#input.business_provides_program_awarding_bachelors_or_higher_degree: false
+    us:statutes/26/3304#input.business_provides_program_acceptable_for_full_credit_toward_bachelors_or_higher_degree: false
+    ? us:statutes/26/3304#input.business_offers_training_program_to_prepare_students_for_gainful_employment_in_recognized_occupation
+    : false
+    us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: true
+  output:
+    us:statutes/26/3304#institution_of_higher_education: not_holds
+- name: training_program_path_qualifies_when_other_requirements_met
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/3304#input.business_is_educational_institution_in_any_state: true
+    us:statutes/26/3304#input.business_admits_as_regular_students_only_high_school_graduates_or_equivalent: true
+    us:statutes/26/3304#input.business_legally_authorized_in_state_to_provide_beyond_high_school_program: true
+    us:statutes/26/3304#input.business_provides_program_awarding_bachelors_or_higher_degree: false
+    us:statutes/26/3304#input.business_provides_program_acceptable_for_full_credit_toward_bachelors_or_higher_degree: false
+    ? us:statutes/26/3304#input.business_offers_training_program_to_prepare_students_for_gainful_employment_in_recognized_occupation
+    : true
+    us:statutes/26/3304#input.business_is_public_or_nonprofit_institution: true
+  output:
+    us:statutes/26/3304#institution_of_higher_education: holds

--- a/statutes/26/3304.yaml
+++ b/statutes/26/3304.yaml
@@ -5,17 +5,18 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3304
   summary: |-
-    26 USC 3304(a) requires the Secretary of Labor to approve State unemployment laws meeting enumerated requirements; subsection (f) defines "institution of higher education" for purposes of subsection (a)(6).
+    26 USC 3304(a) requires the Secretary of Labor to approve a submitted State law within 30 days if it provides the enumerated unemployment-compensation requirements. 26 USC 3304(f) provides: for purposes of subsection (a)(6), “institution of higher education” means an educational institution in any State meeting the admissions, authorization, program, and public/nonprofit requirements.
   deferred_outputs:
     - output: us:statutes/26/3304/a#state_law_approval_requirements
-      reason: Subsection (a) is a broad State-law approval and certification standard with administrative duties and multiple unresolved cross-references, including sections 3305(b), 903, 3306(t), 3306(v), 3309(a)(1), 3309(a)(2), and 6402(f). It is not faithfully representable as a single executable output without encoding those dependencies and State-law compliance process mechanics.
+      source: "26 USC 3304(a): Requirements The Secretary of Labor shall approve any State law submitted to him, within 30 days..."
+      reason: Subsection (a) is a State-law approval and certification standard administered by the Secretary of Labor. It contains multiple process duties and unresolved cross-referenced mechanics, including section 3305(b), Social Security Act sections 903(c)(2), 903(d)(4), and 303(g), 26 USC 3306(t), 26 USC 3306(v), 26 USC 3309(a)(1), 26 USC 3309(a)(2), and 26 USC 6402(f). The full approval surface is therefore not faithfully representable as a single executable output in this module.
 rules:
   - name: institution_of_higher_education
     kind: derived
     entity: Business
     dtype: Judgment
     period: Year
-    source: 26 USC 3304(f)
+    source: "26 USC 3304(f): Definition of institution of higher education For purposes of subsection (a)(6), the term “instit..."
     metadata:
       proof:
         atoms:
@@ -23,7 +24,7 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3304
-              excerpt: "the term “institution of higher education” means an educational institution in any State which—"
+              excerpt: "the term “institution of higher education” means an educational institution in any State which"
           - path: versions[0].formula
             kind: condition
             source:
@@ -38,14 +39,14 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3304
-              excerpt: "awards a bachelor’s or higher degree... acceptable for full credit toward such a degree... training to prepare students for gainful employment"
+              excerpt: "awards a bachelor’s or higher degree, or provides a program which is acceptable for full credit toward such a degree, or offers a program of training"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3304
               excerpt: "is a public or other nonprofit institution"
     versions:
-      - effective_from: '2024-01-01'
+      - effective_from: '1990-01-01'
         formula: |-
           business_is_educational_institution_in_any_state
           and business_admits_as_regular_students_only_high_school_graduates_or_equivalent


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3304 with axiom-encode 0.2.532 and gpt-5.5
- add generated test coverage for the no-qualifying-program and training-program paths in the institution-of-higher-education definition
- refresh signed apply manifest
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3304-20260602/rulespec-us/statutes/26/3304.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3304-20260602/rulespec-us/statutes/26/3304.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3304-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3304-20260602/rulespec-us/statutes/26/3304.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3304-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main