### PR TITLE
Refresh generated section 3307 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3307.json
+++ b/.axiom/encoding-manifests/statutes/26/3307.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3307.yaml",
-      "sha256": "51a811f8ff487aaf85232745b296274dde20643e4e368fb99ff4fb00f2bdd596"
+      "sha256": "c8f4a8a051701385e698f1e5a163717b4f60dec7f1e4107ff824047de4ad9107"
     },
     {
       "path": "statutes/26/3307.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "ba6412f2f376a31435f909d25b7957e8ede05a8b",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
-    "version": "0.2.337",
-    "version_commit": "ba6412f2f376a31435f909d25b7957e8ede05a8b"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.337",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
-  "citation": "us/statute/26/3307",
-  "context_manifest_file": "/private/tmp/axiom-encode-3307-rerun-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3307/workspace/context-manifest.json",
-  "context_manifest_sha256": "acadd4bd48fb1eaf43a6152e8bd756428a80861101ee83a226170f6697e32b74",
-  "generated_at": "2026-05-27T19:46:32.754387+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3307-rerun-20260527/openai-gpt-5.5/statutes/26/3307.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3307-rerun-20260527",
-  "generated_output_sha256": "51a811f8ff487aaf85232745b296274dde20643e4e368fb99ff4fb00f2bdd596",
-  "generation_prompt_sha256": "bfd6fd0b92d8315d99323614d568161e1607e3c09eea46207b734a7e5c7476d4",
+  "citation": "26 USC 3307",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3307/workspace/context-manifest.json",
+  "context_manifest_sha256": "b1836477c496e2bfec258de8ea308832f50497dfa296b110bfc829d0656aac79",
+  "generated_at": "2026-06-02T06:39:10.076319+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3307.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "c8f4a8a051701385e698f1e5a163717b4f60dec7f1e4107ff824047de4ad9107",
+  "generation_prompt_sha256": "afe8e3f352d69a1c219078b887bf9af2e70e1d4091ef0ff421e7f88e3caf6a6a",
   "model": "gpt-5.5",
-  "run_id": "c90c8d1a",
+  "run_id": "26b74631",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0e8ce2343537e88db1a04ab35890b82bbdcb108dfdd1aaf839947bb4e6f007bf"
+    "value": "a72278e9695fd88aa2fe3221e9cbab2e9ccbc8f1881c05b8e8b5fc29e93aa2c8"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3307-rerun-20260527/traces/openai-gpt-5.5/us-statute-26-3307.json",
-  "trace_sha256": "6242f8398316cb9fef8ef1fc734702fe8f60b1868762f2d3d2c4314b63121b0b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3307.json",
+  "trace_sha256": "1f8cc8aa55c07620c107f54ea41d1bf3dab0ee8fdbda7c9eb8dbe62b10c78b0b"
 }

--- a/statutes/26/3307.yaml
+++ b/statutes/26/3307.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3307
   summary: |-
-    Whenever an employer is required or permitted under this chapter, any act of Congress, or State law to deduct an amount from an employee's remuneration and pay it to the United States, a State, or a political subdivision, the deducted amount is considered paid to the employee at the time of deduction for purposes of this chapter.
+    Whenever an employer is required or permitted under this chapter, any act of Congress, or State law to deduct an amount from an employee's remuneration and pay the deducted amount to the United States, a State, or a political subdivision, the amount deducted is considered paid to the employee at the time of deduction for purposes of this chapter.
 rules:
   - name: remuneration_deduction_payment_treatment_applies
     kind: derived


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3307 with axiom-encode 0.2.532 and gpt-5.5
- refresh signed apply manifest and generated summary text
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3307-20260602/rulespec-us/statutes/26/3307.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3307-20260602/rulespec-us/statutes/26/3307.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3307-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3307-20260602/rulespec-us/statutes/26/3307.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3307-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main