### PR TITLE
Refresh generated section 3308 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3308.json
+++ b/.axiom/encoding-manifests/statutes/26/3308.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3308.yaml",
-      "sha256": "ed985ee5801e874dfd46f2ac75a012ddc7c435598a472789a9c666c68d884413"
+      "sha256": "b691ce8dd8cf2c746aeb72c48710e9310df55874459c411a3f9f4ccfe9121d15"
     },
     {
       "path": "statutes/26/3308.test.yaml",
-      "sha256": "e0d1ee86b7836cf53209e8c12b04030db9d5a1eb66d9af9a08e83487de4e854e"
+      "sha256": "e60f85b955eddbbb216c22cff2e77309f765ebcdf05c65876562a99a0daf593f"
     }
   ],
   "axiom_encode_git": {
-    "commit": "acd42a5da18b1daa28ab7a91318f79fdbbf4d0dd",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
-    "version": "0.2.338",
-    "version_commit": "acd42a5da18b1daa28ab7a91318f79fdbbf4d0dd"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.338",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
-  "citation": "us/statute/26/3308",
-  "context_manifest_file": "/private/tmp/axiom-encode-3308-rerun-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3308/workspace/context-manifest.json",
-  "context_manifest_sha256": "94d86e468638a43d78112913f6fd39e784b72b9139f458763c8cf3b7767d824c",
-  "generated_at": "2026-05-27T20:11:01.228284+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3308-rerun-20260527/openai-gpt-5.5/statutes/26/3308.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3308-rerun-20260527",
-  "generated_output_sha256": "ed985ee5801e874dfd46f2ac75a012ddc7c435598a472789a9c666c68d884413",
-  "generation_prompt_sha256": "1d23c0a48adcd8aff0f93da20851bece6b45e10368fc29aac007d604f2b5a88e",
+  "citation": "26 USC 3308",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3308/workspace/context-manifest.json",
+  "context_manifest_sha256": "c8eb2cebf417cb741ba27fcbb5308bb7881b724015c0a35ca553a6f0f50a26fc",
+  "generated_at": "2026-06-02T06:41:50.182135+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3308.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b691ce8dd8cf2c746aeb72c48710e9310df55874459c411a3f9f4ccfe9121d15",
+  "generation_prompt_sha256": "611a0321c516d5f8d51b5889b07a35a9d3bfe2aaa623f347d223b8d63f141d1d",
   "model": "gpt-5.5",
-  "run_id": "4f4b0947",
+  "run_id": "72c943f1",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2aaf3747a37fc35a03057f618a2ad4a3cb38f1f2525684f4f09be0b90dcec860"
+    "value": "0583ab3f871b38261096a099dc3a2fcf1f68e233e588deaa163a7ac94c3cf519"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3308-rerun-20260527/traces/openai-gpt-5.5/us-statute-26-3308.json",
-  "trace_sha256": "eff2fc5b0d03c9f767dbc06e615459fa27ee174c18084b2dc8fd3c2bd854c932"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3308.json",
+  "trace_sha256": "775b8e19889e8420f4add2f7bea26db3af0fc5e17365f13a21aa5ba21d142b09"
 }

--- a/statutes/26/3308.test.yaml
+++ b/statutes/26/3308.test.yaml
@@ -12,7 +12,7 @@
   output:
     us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: not_holds
     us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: holds
-- name: specific_reference_to_section_3301_satisfies_requirement
+- name: specific_reference_to_section_3301_satisfies_unless_clause
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -26,7 +26,7 @@
   output:
     us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: holds
     us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: not_holds
-- name: specific_reference_to_corresponding_prior_law_satisfies_requirement
+- name: specific_reference_to_corresponding_prior_law_satisfies_unless_clause
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -40,7 +40,7 @@
   output:
     us:statutes/26/3308#other_law_specific_section_3301_exemption_requirement_met: holds
     us:statutes/26/3308#united_states_instrumentality_section_3301_tax_exemption_precluded: not_holds
-- name: non_instrumentality_is_outside_preclusion_rule
+- name: non_instrumentality_is_not_within_preclusion_rule
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3308.yaml
+++ b/statutes/26/3308.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3308
   summary: |-
-    An instrumentality of the United States is not exempt from the tax imposed by section 3301 under another law's general tax exemption unless that other law grants a specific exemption, by reference to section 3301 or the corresponding prior-law section, from the tax imposed by section 3301.
+    Notwithstanding any other provision of law granting a United States instrumentality an exemption from taxation, the instrumentality is not exempt from the section 3301 tax unless that other law grants a specific exemption, by reference to section 3301 or the corresponding section of prior law.
 rules:
   - name: other_law_specific_section_3301_exemption_requirement_met
     kind: derived
@@ -17,7 +17,7 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: condition
+            kind: exception
             source:
               corpus_citation_path: us/statute/26/3308
               excerpt: "unless such other provision of law grants a specific exemption, by reference to section 3301 (or the corresponding section of prior law)"


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3308 with axiom-encode 0.2.532 and gpt-5.5
- mark the generated proof atom for the unless clause as an exception
- refresh companion test names and signed apply manifest
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3308-20260602/rulespec-us/statutes/26/3308.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3308-20260602/rulespec-us/statutes/26/3308.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3308-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3308-20260602/rulespec-us/statutes/26/3308.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3308-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main