### PR TITLE
Refresh generated section 3310 payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3310.json
+++ b/.axiom/encoding-manifests/statutes/26/3310.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3310.yaml",
-      "sha256": "53be87724a157115b5e4118f41747d64a514a95352d5849d0843e6fc338c9431"
+      "sha256": "9d78ac4d0a6931537ccd2b8054dcc48acfa06f878cbd5873bad797ed77ff64e1"
     },
     {
       "path": "statutes/26/3310.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "94725b47a37f9ffe0fdaddef494f4724d08b8a2a",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-payroll-night-20260527103157/axiom-encode",
-    "version": "0.2.340",
-    "version_commit": "94725b47a37f9ffe0fdaddef494f4724d08b8a2a"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.340",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
-  "citation": "us/statute/26/3310",
-  "context_manifest_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/_eval_workspaces/openai-gpt-5.5/us-statute-26-3310/workspace/context-manifest.json",
-  "context_manifest_sha256": "83d199856fe649f20471dcdbbdf8837b45487e86db1023812c6b5ac1e4712e79",
-  "generated_at": "2026-05-27T21:05:24.177580+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/openai-gpt-5.5/statutes/26/3310.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3310-rerun-signed-20260527",
-  "generated_output_sha256": "53be87724a157115b5e4118f41747d64a514a95352d5849d0843e6fc338c9431",
-  "generation_prompt_sha256": "79bf587fc47ed024f80d75bcaee11ce404f00714301c49ed0f1dd73bc6e08e14",
+  "citation": "26 USC 3310",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3310/workspace/context-manifest.json",
+  "context_manifest_sha256": "5a66a40013e910db6052c22d7e208ddf74918b2e15752a4a612c3240ccd1d5ab",
+  "generated_at": "2026-06-02T06:47:00.749130+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3310.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9d78ac4d0a6931537ccd2b8054dcc48acfa06f878cbd5873bad797ed77ff64e1",
+  "generation_prompt_sha256": "d9a67bc4d9f29df4addeab434b8411713e2309f3d95e82aa60b366737eb64ea4",
   "model": "gpt-5.5",
-  "run_id": "121f9616",
+  "run_id": "467ba9c7",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b1fd3624f0db94d6c598be3b094caf1902f5e08d44f79b7f2d501cd7bd05f958"
+    "value": "f07a299c2f8ab791d266675f99211143ec3802833738c82c706b36939fc35d28"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3310-rerun-signed-20260527/traces/openai-gpt-5.5/us-statute-26-3310.json",
-  "trace_sha256": "6f654485a882f2d12e242de9e8a6f431eb5eebbfb4feb2bc94a7e4a48cf52f66"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3310.json",
+  "trace_sha256": "eb6345f06b00f3b72ca28538710c5c2cc9937555ec408b290571522d49630b71"
 }

--- a/statutes/26/3310.yaml
+++ b/statutes/26/3310.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3310
   summary: |-
-    A State may file a petition for review "within 60 days after the Governor of the State has been notified" of the Secretary of Labor's action. The Secretary "shall not withhold any certification" until the earlier of the expiration of 60 days after notice or the State's filing of a petition. Judicial proceedings "shall stay the Secretary of Labor’s action for a period of 30 days," with possible interim relief thereafter.
+    A State may file a petition for review "within 60 days after the Governor of the State has been notified" of the Secretary of Labor's withholding-certification action. The Secretary "shall not withhold any certification" until the earlier of the expiration of 60 days after notice or the State's filing of a petition. The commencement of judicial proceedings "shall stay the Secretary of Labor’s action for a period of 30 days," with possible interim relief thereafter.
 rules:
   - name: state_petition_for_review_deadline_days
     kind: parameter


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3310 with axiom-encode 0.2.532 and gpt-5.5
- refresh signed apply manifest and generated summary text
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3310-20260602/rulespec-us/statutes/26/3310.yaml --skip-reviewers
- uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3310-20260602/rulespec-us/statutes/26/3310.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3310-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3310-20260602/rulespec-us/statutes/26/3310.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3310-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- git diff --check origin/main