### PR TITLE
Refresh generated section 3306(a) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/a.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/a.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/a.yaml",
-      "sha256": "e468d76c46a42e3ca18a424aa92b89bad8062aba265dbd55f7669e0ad34c31fe"
+      "sha256": "eae7eaee47aa22c320a07750767dbeea8545a3f8a62bb7d4679c098aab0e8012"
     },
     {
       "path": "statutes/26/3306/a.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "c477dfdcf8d7d2c0568e4f2205c9f14f4068f86e",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.264",
-    "version_commit": "c477dfdcf8d7d2c0568e4f2205c9f14f4068f86e"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.264",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(a)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-a-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-a/workspace/context-manifest.json",
-  "context_manifest_sha256": "a8ea4e5a982601d7e0180da5501943eebbb58e59f1eebc50a1fdbfe773d14395",
-  "generated_at": "2026-05-26T06:48:57.891879+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-a-20260526/codex-gpt-5.5/statutes/26/3306/a.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-a-20260526",
-  "generated_output_sha256": "e468d76c46a42e3ca18a424aa92b89bad8062aba265dbd55f7669e0ad34c31fe",
-  "generation_prompt_sha256": "d291ea5d25a25d0503c09dafff87d6a5b2571048506e4d3d2efa7cce880fed58",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "c54befe28dbbf55c04de4c062ca1f756e4ce3332f5c152aa791f0cb382796601",
+  "generated_at": "2026-06-02T06:51:20.233015+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/a.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "eae7eaee47aa22c320a07750767dbeea8545a3f8a62bb7d4679c098aab0e8012",
+  "generation_prompt_sha256": "64e9294ce20ab4faa7d6d65547c50b4463e82f5d7a6fa0f5237c3b5eb4d8b1a1",
   "model": "gpt-5.5",
-  "run_id": "7a73eff7",
-  "runner": "codex-gpt-5.5",
+  "run_id": "b0b44f11",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ecb5816dedb8c4ea14ebe6c4cc09be1d24b510ef399e20cac443d0f4cf463d2b"
+    "value": "c94aca126c08554a64d5cc56edab779735b53eadb08d2509d09b048415f190a9"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-a-20260526/traces/codex-gpt-5.5/26-USC-3306-a.json",
-  "trace_sha256": "0c3b960d212e49a23411477fe2b03ca9a3a0ff150f32b8a24ea5f0470d74a517"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-a.json",
+  "trace_sha256": "03b672f27c864ce903485a6e052188af64b74da00c021d75748ba97b193506f0"
 }

--- a/statutes/26/3306/a.yaml
+++ b/statutes/26/3306/a.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (a) Employer ... (1) ... paid wages of $1,500 or more, or ... 20 days ... employed at least one individual ... domestic services ... not be taken into account. (2) Agricultural labor ... paid wages of $20,000 or more ... 20 days ... at least 10 individuals. (3) Domestic service ... paid wages in cash of $1,000 or more. (4) Special rule ... paragraph (3) shall not be treated as an employer with respect to wages paid for any service other than domestic service ... unless ... paragraph (1) or (2).
+    Employer means, for a calendar year, a person meeting the general wage or employment-day tests; in the case of agricultural labor, meeting the agricultural wage or employment-day tests; and in the case of specified domestic service, paying cash wages of $1,000 or more. Domestic-service wages and employment are excluded from the general rule, and paragraph (3) employer status does not extend to other services unless paragraph (1) or (2) applies.
 rules:
   - name: general_calendar_quarter_wage_threshold
     kind: parameter
@@ -146,6 +146,25 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "there shall not be taken into account any wages paid to, or employment of, an employee performing domestic services"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#general_calendar_quarter_wage_threshold
+              output: general_calendar_quarter_wage_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#general_employment_day_threshold
+              output: general_employment_day_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#general_individuals_per_employment_day_threshold
+              output: general_individuals_per_employment_day_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -168,6 +187,24 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#agricultural_calendar_quarter_wage_threshold
+              output: agricultural_calendar_quarter_wage_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#agricultural_employment_day_threshold
+              output: agricultural_employment_day_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#agricultural_individuals_per_employment_day_threshold
+              output: agricultural_individuals_per_employment_day_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -190,6 +227,12 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#domestic_service_cash_wage_threshold
+              output: domestic_service_cash_wage_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -205,20 +248,39 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
+            kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "shall not be treated as an employer with respect to wages paid for any service other than domestic service"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "unless such person is treated as an employer under paragraph (1) or (2)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#employer_under_general_rule
+              output: employer_under_general_rule
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#employer_for_agricultural_labor
+              output: employer_for_agricultural_labor
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          employer_under_general_rule or employer_for_agricultural_labor
+          employer_under_general_rule
+          or employer_for_agricultural_labor
 
   - name: employer
     kind: derived
     entity: Employer
     dtype: Judgment
     period: Year
-    source: 26 USC 3306(a)
+    source: "26 USC 3306(a): Employer For purposes of this chapter— (1) In general The term “employer” means, with respect to..."
     metadata:
       proof:
         atoms:
@@ -226,7 +288,27 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3306
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#employer_under_general_rule
+              output: employer_under_general_rule
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#employer_for_agricultural_labor
+              output: employer_for_agricultural_labor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/a#employer_for_domestic_service
+              output: employer_for_domestic_service
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          employer_under_general_rule or employer_for_agricultural_labor or employer_for_domestic_service
+          employer_under_general_rule
+          or employer_for_agricultural_labor
+          or employer_for_domestic_service


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(a) with axiom-encode 0.2.532 and gpt-5.5
- add generated proof/import provenance for the FUTA employer threshold formulas
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306a-20260602/rulespec-us/statutes/26/3306/a.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306a-20260602/rulespec-us/statutes/26/3306/a.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306a-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306a-20260602/rulespec-us/statutes/26/3306/a.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306a-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
