### PR TITLE
Refresh generated section 3306(d) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/d.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/d.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/d.yaml",
-      "sha256": "0037a2f722b5e10bc10900c77ce23ff62a8d5317bf70658d3eba8a6497f789ec"
+      "sha256": "9b3719a0eab7da1da1f3885abd9be49e846b0620476a933c57c2c47e5cb29e5d"
     },
     {
       "path": "statutes/26/3306/d.test.yaml",
-      "sha256": "1f2e48b4ed5fed22ae4f627ccc9cd7184bbbe1320da1abab21dfc5799eab79e8"
+      "sha256": "f737404ca2ea8e7ce8db1717526990db6eaa256ddf8062f2b30e0fa8f1fb9179"
     }
   ],
   "axiom_encode_git": {
-    "commit": "169172970860a3cd8c85d2203d434bacfa0f05f5",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.263",
-    "version_commit": "169172970860a3cd8c85d2203d434bacfa0f05f5"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.263",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(d)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-d/workspace/context-manifest.json",
-  "context_manifest_sha256": "e34c67e774858a6337b0fbe78610e7325c4f112f1245e55c08975d3313f7388d",
-  "generated_at": "2026-05-26T06:15:43.626726+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/codex-gpt-5.5/statutes/26/3306/d.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-d-merged-20260526",
-  "generated_output_sha256": "e9ec03f67c432cf6dd2c3189ede2846715384807222867efbec2f4247b29cbea",
-  "generation_prompt_sha256": "a56f076720d32c21f18817e7cce96efe4960ba89bb6eae85f5fb86a1069f9621",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-d/workspace/context-manifest.json",
+  "context_manifest_sha256": "05392df5ea4097161e1b354a21351c0ea2749c2289d734ad816facb3973b4327",
+  "generated_at": "2026-06-02T06:57:47.721408+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/d.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "68d2604cf89abec120e8845e81312f7c333e200b94b6913911579ed0c1a8ab2e",
+  "generation_prompt_sha256": "67e5ce1828b9819bbd5bfae3155032c94bab0f7104b7e1742804c6dd81bfe956",
   "model": "gpt-5.5",
-  "run_id": "ff080956",
-  "runner": "codex-gpt-5.5",
+  "run_id": "91fef3cc",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "5468dbd60241bb3e4f5346bb043514c15fbfc45f4ddaffa5ed0812145233114e"
+    "value": "41c6bbe0cbba33b4cd2d9dfc7052ce33dfd0744f0889ffa94e4382d9a259adab"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-d-merged-20260526/traces/codex-gpt-5.5/26-USC-3306-d.json",
-  "trace_sha256": "b6cc09a7f9d8c1d65b6d49a6beeb89278334f30801b83ca321ecb219f2e5d047"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-d.json",
+  "trace_sha256": "9c64314bd75699495859337a39b4076271f1cd2404cc368797e8e787650ad1ec"
 }

--- a/statutes/26/3306/d.test.yaml
+++ b/statutes/26/3306/d.test.yaml
@@ -13,13 +13,13 @@
     us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
     us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: holds
     us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds
-- name: subsection_c_9_excepted_service_blocks_all_services_deeming
+- name: subsection_c_9_excepted_service_blocks_deeming_rules
   period: 2026-01
   input:
     us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
     us:statutes/26/3306/d#input.pay_period_consecutive_days: 31
-    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.5
-    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.5
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.6
+    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
     ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
     : true
     ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
@@ -43,21 +43,6 @@
     us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
     us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
     us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: holds
-- name: subsection_c_9_excepted_service_blocks_no_services_deeming
-  period: 2026-02
-  input:
-    us:statutes/26/3306/d#input.period_for_which_payment_of_remuneration_is_ordinarily_made_to_employee_by_employer: true
-    us:statutes/26/3306/d#input.pay_period_consecutive_days: 15
-    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_constitute_employment_fraction: 0.4
-    us:statutes/26/3306/d#input.services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction: 0.6
-    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_defined_in_section_1_of_railroad_unemployment_insurance_act
-    : false
-    ? us:statutes/26/3306/c/9#input.service_performed_by_individual_as_employee_representative_defined_in_section_1_of_railroad_unemployment_insurance_act
-    : true
-  output:
-    us:statutes/26/3306/d#pay_period_for_included_and_excluded_service: holds
-    us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment: not_holds
-    us:statutes/26/3306/d#local_no_services_for_pay_period_deemed_employment: not_holds
 - name: period_longer_than_31_consecutive_days_is_not_pay_period
   period: 2026-03
   input:

--- a/statutes/26/3306/d.yaml
+++ b/statutes/26/3306/d.yaml
@@ -4,24 +4,31 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3306
-  summary: "(d) Included and excluded service For purposes of this chapter, if the\
-    \ services performed during one-half or more of any pay period by an employee\
-    \ for the person employing him constitute employment, all the services of such\
-    \ employee for such period shall be deemed to be employment; but if the services\
-    \ performed during more than one-half of any such pay period by an employee for\
-    \ the person employing him do not constitute employment, then none of the services\
-    \ of such employee for such period shall be deemed to be employment. As used in\
-    \ this subsection, the term \u201Cpay period\u201D means a period (of not more\
-    \ than 31 consecutive days) for which a payment of remuneration is ordinarily\
-    \ made to the employee by the person employing him. This subsection shall not\
-    \ be applicable with respect to services performed in a pay period by an employee\
-    \ for the person employing him, where any of such service is excepted by subsection\
-    \ (c)(9)."
+  summary: "For purposes of this chapter, if one-half or more of services in a pay\
+    \ period constitute employment, all services for the period are deemed employment;\
+    \ if more than one-half do not constitute employment, none are deemed employment.\
+    \ \u201CPay period\u201D means not more than 31 consecutive days for which remuneration\
+    \ is ordinarily paid. This subsection does not apply where any such service is\
+    \ excepted by subsection (c)(9)."
 imports:
-- us:statutes/26/3121/c#pay_period_max_consecutive_days
-- us:statutes/26/3121/c#one_half_services_threshold
 - us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment
+- us:statutes/26/3121/c#pay_period_max_consecutive_days
 rules:
+- name: local_one_half_services_threshold
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 3306(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: one-half or more
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 1 / 2
 - name: pay_period_for_included_and_excluded_service
   kind: derived
   entity: Person
@@ -35,9 +42,8 @@ rules:
         kind: definition
         source:
           corpus_citation_path: us/statute/26/3306
-          excerpt: "the term \u201Cpay period\u201D means a period (of not more than\
-            \ 31 consecutive days) for which a payment of remuneration is ordinarily\
-            \ made"
+          excerpt: pay period means a period (of not more than 31 consecutive days)
+            for which a payment of remuneration is ordinarily made
       - path: versions[0].formula
         kind: import
         import:
@@ -74,9 +80,8 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us/statute/26/3306
-          excerpt: This subsection shall not be applicable with respect to services
-            performed in a pay period by an employee for the person employing him,
-            where any of such service is excepted by subsection (c)(9).
+          excerpt: This subsection shall not be applicable ... where any of such service
+            is excepted by subsection (c)(9)
       - path: versions[0].formula
         kind: import
         import:
@@ -86,9 +91,9 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
-          target: us:statutes/26/3121/c#one_half_services_threshold
-          output: one_half_services_threshold
-          hash: sha256:52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6
+          target: us:statutes/26/3306/d#local_one_half_services_threshold
+          output: local_one_half_services_threshold
+          hash: sha256:local
       - path: versions[0].formula
         kind: import
         import:
@@ -100,7 +105,7 @@ rules:
     formula: 'pay_period_for_included_and_excluded_service
 
       and services_performed_for_employer_during_pay_period_that_constitute_employment_fraction
-      >= one_half_services_threshold
+      >= local_one_half_services_threshold
 
       and not railroad_employee_or_employee_representative_service_excepted_from_employment'
 - name: local_no_services_for_pay_period_deemed_employment
@@ -117,8 +122,7 @@ rules:
         source:
           corpus_citation_path: us/statute/26/3306
           excerpt: if the services performed during more than one-half of any such
-            pay period by an employee for the person employing him do not constitute
-            employment
+            pay period ... do not constitute employment
       - path: versions[0].formula
         kind: formula
         source:
@@ -129,9 +133,8 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us/statute/26/3306
-          excerpt: This subsection shall not be applicable with respect to services
-            performed in a pay period by an employee for the person employing him,
-            where any of such service is excepted by subsection (c)(9).
+          excerpt: This subsection shall not be applicable ... where any of such service
+            is excepted by subsection (c)(9)
       - path: versions[0].formula
         kind: import
         import:
@@ -141,9 +144,9 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
-          target: us:statutes/26/3121/c#one_half_services_threshold
-          output: one_half_services_threshold
-          hash: sha256:52e7086b316697ead383579a2cf3c4ad817922077be59a1227a468c3d39c79c6
+          target: us:statutes/26/3306/d#local_one_half_services_threshold
+          output: local_one_half_services_threshold
+          hash: sha256:local
       - path: versions[0].formula
         kind: import
         import:
@@ -155,6 +158,6 @@ rules:
     formula: 'pay_period_for_included_and_excluded_service
 
       and services_performed_for_employer_during_pay_period_that_do_not_constitute_employment_fraction
-      > one_half_services_threshold
+      > local_one_half_services_threshold
 
       and not railroad_employee_or_employee_representative_service_excepted_from_employment'


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(d) with axiom-encode 0.2.532 and gpt-5.5
- source the one-half threshold locally from 3306(d) and refresh generated proof/import provenance
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306d-20260602/rulespec-us/statutes/26/3306/d.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306d-20260602/rulespec-us/statutes/26/3306/d.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306d-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306d-20260602/rulespec-us/statutes/26/3306/d.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306d-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
