### PR TITLE
Refresh generated section 3306(g) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/g.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/g.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/g.yaml",
-      "sha256": "ee99ed4856c0d0504252d3650ad2c8a1453bf822038415d438089c76120dbb65"
+      "sha256": "55093751827eccbd54d1709187f430accd2f79fae362a5a3681736357a313dae"
     },
     {
       "path": "statutes/26/3306/g.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "84e98c811c25af73fdfbfc5e691f3e2ea61d33bb",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.268",
-    "version_commit": "84e98c811c25af73fdfbfc5e691f3e2ea61d33bb"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.268",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(g)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-g-final-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-g/workspace/context-manifest.json",
-  "context_manifest_sha256": "deb47a696771225388209bc5275ff54a0630e5bf3b79955b01f5c14f4727afc6",
-  "generated_at": "2026-05-26T08:25:55.736051+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-g-final-20260526/codex-gpt-5.5/statutes/26/3306/g.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-g-final-20260526",
-  "generated_output_sha256": "ee99ed4856c0d0504252d3650ad2c8a1453bf822038415d438089c76120dbb65",
-  "generation_prompt_sha256": "d8eefaea3dac4e570bd590adca84ac1a4ef39e994f51f467359b2dbcccf980f8",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "d5101b0f20f2b72e2fef1eed9b0f35a4ad7017dd37193ecf7c9f8aa5ad530853",
+  "generated_at": "2026-06-02T07:03:27.670988+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/g.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "55093751827eccbd54d1709187f430accd2f79fae362a5a3681736357a313dae",
+  "generation_prompt_sha256": "86a518e694004068d731ff2d6e4bd5dc85f019bcc4218b40ca94e43324316cd8",
   "model": "gpt-5.5",
-  "run_id": "c6cc95d8",
-  "runner": "codex-gpt-5.5",
+  "run_id": "18870b63",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "dc62cd4ceb097bcd7fff46474cfec8b6b5a6e622bcb6e3cd1b9215c64200b277"
+    "value": "bf548ca51a5e1482222c542de73fe65e633796512dca5811cf244331f148293e"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-g-final-20260526/traces/codex-gpt-5.5/26-USC-3306-g.json",
-  "trace_sha256": "eabf7b6ef68f88baf9308ea610000c18a6dca25391674a9085898f89ea91debc"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-g.json",
+  "trace_sha256": "3fe0c53b63cb6dbc89df06479a17a653eb39556030f1472e68709f700665260a"
 }

--- a/statutes/26/3306/g.yaml
+++ b/statutes/26/3306/g.yaml
@@ -4,40 +4,45 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3306
-  summary: |-
-    (g) Contributions For purposes of this chapter, the term "contributions" means payments required by a State law to be made into an unemployment fund by any person on account of having individuals in his employ, to the extent that such payments are made by him without being deducted or deductible from the remuneration of individuals in his employ.
+  summary: For purposes of this chapter, "contributions" means payments required by
+    State law to be made into an unemployment fund by a person on account of having
+    individuals in employ, to the extent made without being deducted or deductible
+    from employees' remuneration.
 imports:
-  - us:statutes/26/3306/f#unemployment_fund
+- us:statutes/26/3306/f#unemployment_fund
 rules:
-  - name: payment_destination_fund
-    kind: data_relation
-    source: 26 USC 3306(g), "made into an unemployment fund"
-    data_relation:
-      predicate: payment_destination_fund
-      arity: 2
-      arguments: [Payment, Asset]
-
-  - name: contributions
-    kind: derived
-    entity: Payment
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 26 USC 3306(g)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us/statute/26/3306
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/3306/f#unemployment_fund
-              output: unemployment_fund
-              hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
-    versions:
-      - effective_from: '1990-01-01'
-        formula: |-
-          if count_where(payment_destination_fund, unemployment_fund) >= 1 and payment_required_by_state_law_to_be_made_into_destination_fund and payment_made_by_person_on_account_of_having_individuals_in_employ: max(0, payment_amount_made_by_person - payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ) else: 0
+- name: payment_destination_fund
+  kind: data_relation
+  source: 26 USC 3306(g), "made into an unemployment fund"
+  data_relation:
+    predicate: payment_destination_fund
+    arity: 2
+    arguments:
+    - Payment
+    - Asset
+- name: contributions
+  kind: derived
+  entity: Payment
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 3306(g)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3306/f#unemployment_fund
+          output: unemployment_fund
+          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if count_where(payment_destination_fund, unemployment_fund) >= 1 and
+      payment_required_by_state_law_to_be_made_into_destination_fund and payment_made_by_person_on_account_of_having_individuals_in_employ:
+      max(0, payment_amount_made_by_person - payment_amount_deducted_or_deductible_from_remuneration_of_individuals_in_employ)
+      else: 0'


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(g) with axiom-encode 0.2.532 and gpt-5.5
- preserve the unemployment-fund relation and contributions formula while refreshing generated provenance
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306g-20260602/rulespec-us/statutes/26/3306/g.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306g-20260602/rulespec-us/statutes/26/3306/g.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306g-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306g-20260602/rulespec-us/statutes/26/3306/g.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306g-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
