### PR TITLE
Refresh generated section 3306(b)(2) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/2.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/2.yaml",
-      "sha256": "07b436f2076d7f2a7b7354dab1b0671cac2c9f9c6aaa40efe7f5bce512a6fc01"
+      "sha256": "3d11a56f340a81069abeb9dbaaaed8058873a96126c17e6c289453741080411a"
     },
     {
       "path": "statutes/26/3306/b/2.test.yaml",
-      "sha256": "14b98db90ab73cf90deebaa298e6894d0a62fb64fab73bd72146b24b43aa3f64"
+      "sha256": "ec4110c5063519987b9ee75e451d76106fc9217000e060f232d8d67abc53af16"
     }
   ],
   "axiom_encode_git": {
-    "commit": "79e996b90d2708b590a7ca8884fabe6eb2e13bd4",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.223",
-    "version_commit": "79e996b90d2708b590a7ca8884fabe6eb2e13bd4"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.223",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(2)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-2/workspace/context-manifest.json",
-  "context_manifest_sha256": "453e32cb1fdd91b2a8424fe8ba5efcc4ae13625ab131e310d658ee96309818d1",
-  "generated_at": "2026-05-25T13:11:36.092342+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/codex-gpt-5.5/statutes/26/3306/b/2.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-2-20260525-v223",
-  "generated_output_sha256": "07b436f2076d7f2a7b7354dab1b0671cac2c9f9c6aaa40efe7f5bce512a6fc01",
-  "generation_prompt_sha256": "067a5e48c91c09446b8a185d0807e550d3ab5ab82dc29017ed6b97c225cdc531",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "6ee231258c72e0df28628a549a01495b139c4618aad81cbddaee5efd9a60c64c",
+  "generated_at": "2026-06-02T07:18:43.593075+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "3d11a56f340a81069abeb9dbaaaed8058873a96126c17e6c289453741080411a",
+  "generation_prompt_sha256": "55db0d1f09640a3ed930ca1537d1230dc2ebdd19d04edca405044fa5f19c551b",
   "model": "gpt-5.5",
-  "run_id": "4737e08b",
-  "runner": "codex-gpt-5.5",
+  "run_id": "2fe68e92",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2fb25d95308cbe76be40caa451328f0c84d6ef04790e698c807d5bcf9851fa1f"
+    "value": "f97ab5e07ce3d936add6e6376962d645f3039da79ca2345dc8892fa0d6ce16ce"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-2-20260525-v223/traces/codex-gpt-5.5/26-USC-3306-b-2.json",
-  "trace_sha256": "da38616978ef9ea30d4e4cf026d7b6950fd0524b3e491932a82d5748d819a162"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-2.json",
+  "trace_sha256": "31a782caab0d58eadd3dfb6d5a163a1a0cbdcd6a19287ca41ece252b07c617cb"
 }

--- a/statutes/26/3306/b/2.test.yaml
+++ b/statutes/26/3306/b/2.test.yaml
@@ -68,7 +68,7 @@
   output:
     us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
     - 0
-- name: plan and employee payment gates are required
+- name: plan and recipient or behalf gates are required
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -98,7 +98,7 @@
     us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages:
     - 0
     - 0
-- name: non enumerated employer plan payment not excluded
+- name: one enumerated account is required
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -106,7 +106,7 @@
   input: {}
   tables:
     Payment:
-    - us:statutes/26/3306/b/2#input.payment_amount: 500
+    - us:statutes/26/3306/b/2#input.payment_amount: 900
       us:statutes/26/3306/b/2#input.payment_made_to_employee_or_dependent: true
       us:statutes/26/3306/b/2#input.payment_made_on_behalf_of_employee_or_dependent: false
       us:statutes/26/3306/b/2#input.employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents: true

--- a/statutes/26/3306/b/2.yaml
+++ b/statutes/26/3306/b/2.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    Excludes "the amount of any payment ... made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer" on account of sickness or accident disability, medical or hospitalization expenses in connection with sickness or accident disability, or death; direct sickness or accident disability payments are limited to amounts "received under a workmen's compensation law."
+    Excludes "the amount of any payment ... made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer" on account of sickness or accident disability, medical or hospitalization expenses in connection with sickness or accident disability, or death; for payments made to an employee or dependent on account of sickness or accident disability, only payments received under a workmen's compensation law are excluded.
 rules:
   - name: employer_plan_payment_excluded_from_wages
     kind: derived
@@ -18,20 +18,40 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: condition
+            kind: formula
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "made to, or on behalf of, an employee or any of his dependents under a plan or system established by an employer"
+              excerpt: "the amount of any payment"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "on account of-- (A) sickness or accident disability ... (B) medical or hospitalization expenses ... (C) death"
+              excerpt: "made to, or on behalf of, an employee or any of his dependents"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "under a plan or system established by an employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "on account of— (A) sickness or accident disability"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "(B) medical or hospitalization expenses"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "(C) death"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "only payments which are received under a workmen's compensation law"
+              excerpt: "only payments which are received under a workmen’s compensation law"
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(2) with axiom-encode 0.2.532 and gpt-5.5
- preserve the employer-plan sickness/disability/medical/death payment wage exclusion while refreshing generated proof provenance
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602/rulespec-us/statutes/26/3306/b/2.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602/rulespec-us/statutes/26/3306/b/2.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602/rulespec-us/statutes/26/3306/b/2.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b2-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
