### PR TITLE
Refresh generated section 3306(b)(4) payroll tests

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/4.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "statutes/26/3306/b/4.test.yaml",
-      "sha256": "dadb9972c396855e938f849fc6e1496c7605914808a9db9cf0bb89e47c0ea78b"
+      "sha256": "9dace3987eedc5fe467e365499c838fa4a986596c1a5434135e67dd307b973d9"
     }
   ],
   "axiom_encode_git": {
-    "commit": "49fb5263825a9f4cc5ab83f724d803ff8e2be301",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.224",
-    "version_commit": "49fb5263825a9f4cc5ab83f724d803ff8e2be301"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.224",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(4)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-4/workspace/context-manifest.json",
-  "context_manifest_sha256": "782d80c1ed48c520049fac484661358d9da2846ff1949b2326683cdd41beaaba",
-  "generated_at": "2026-05-25T13:35:05.282996+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/codex-gpt-5.5/statutes/26/3306/b/4.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-4-20260525-v224",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "f02e5affeb23b31b998a9aba62aa8ec1eb8f051b56dcad6a9b2c8259024ab25c",
+  "generated_at": "2026-06-02T07:23:20.446496+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/4.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "e227ba9ad7c66375a2ca1a351189986cbc0b100756c2d9c3763f2e0af2415c76",
-  "generation_prompt_sha256": "c1ee959b6dc52fb5f21deadb7491a9b9eb7869ee637bdb5862253da0bf475841",
+  "generation_prompt_sha256": "3e210cd86203d2d664935251309542e85dadd74c3383e66d0af3a6d62c638f11",
   "model": "gpt-5.5",
-  "run_id": "cf542cbe",
-  "runner": "codex-gpt-5.5",
+  "run_id": "17bc2cfc",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6ecd6b643e7f6c1bb2c1b4dc76c5c40fc60841898c46fb9d0082f989bd66bac6"
+    "value": "a53bfcc90a310f426f16f0114640745eae1eaed94297d5396fba3ebf7b19dddf"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-4-20260525-v224/traces/codex-gpt-5.5/26-USC-3306-b-4.json",
-  "trace_sha256": "65a166b3076b1a8b86c45b2ad39afd8be5105169c6fe19c5d44b725647929023"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-4.json",
+  "trace_sha256": "b838f66fa38e599ed130ec38df46f40f9a035bac91bf076fb4e39592e8b0f9cf"
 }

--- a/statutes/26/3306/b/4.test.yaml
+++ b/statutes/26/3306/b/4.test.yaml
@@ -13,6 +13,24 @@
       us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
       us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 6
   output:
+    us:statutes/26/3306/b/4#sickness_accident_disability_payment_waiting_period_calendar_months: 6
+    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - holds
+- name: qualifying_medical_expense_payment_on_behalf_after_waiting_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: false
+      ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+      : true
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: false
+      us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: true
+      us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 7
+  output:
     us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
     - holds
 - name: nonqualifying_payment_category_not_excluded
@@ -32,7 +50,7 @@
   output:
     us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
     - not_holds
-- name: employer_employee_payment_connection_missing
+- name: employer_employee_connection_missing_or_waiting_period_not_expired
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -46,17 +64,6 @@
       us:statutes/26/3306/b/4#input.payment_made_by_employer_to_employee: false
       us:statutes/26/3306/b/4#input.payment_made_by_employer_on_behalf_of_employee: false
       us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 6
-  output:
-    us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
-    - not_holds
-- name: payment_before_waiting_period_expired
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input: {}
-  tables:
-    Payment:
     - us:statutes/26/3306/b/4#input.payment_on_account_of_sickness_or_accident_disability: true
       ? us:statutes/26/3306/b/4#input.payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
       : false
@@ -65,4 +72,5 @@
       us:statutes/26/3306/b/4#input.full_calendar_months_following_last_work_month_expired_before_payment: 5
   output:
     us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages:
+    - not_holds
     - not_holds


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(4) with axiom-encode 0.2.532 and gpt-5.5
- refresh generated companion tests/provenance for the six-month sickness/disability/medical payment wage exclusion
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602/rulespec-us/statutes/26/3306/b/4.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602/rulespec-us/statutes/26/3306/b/4.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602/rulespec-us/statutes/26/3306/b/4.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b4-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
