### PR TITLE
Refresh generated section 3306(b)(6) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/6.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/6.yaml",
-      "sha256": "bb0056fbb5ffa0389ea9027d5c0ac9e574f0552fad41f185b26125791fe03460"
+      "sha256": "1020e099482231a75da97bf17819963bf545806a832267e586c908f96208b960"
     },
     {
       "path": "statutes/26/3306/b/6.test.yaml",
-      "sha256": "5b0170f289b00f23d03c80b325223af1fbbb3a54f77ec6220712197af4dfe99e"
+      "sha256": "e60693af461d36bcdcd55c591785955465ae346b08636fa912695b4d97032ee8"
     }
   ],
   "axiom_encode_git": {
-    "commit": "55237f16b4454668c3ea5edfc5de20b2d248eaa3",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.226",
-    "version_commit": "55237f16b4454668c3ea5edfc5de20b2d248eaa3"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.226",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(6)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-6/workspace/context-manifest.json",
-  "context_manifest_sha256": "22c8639dc68f775bc8a8c05d8e4f67cbeb565b2b810a950b2a7edf4eb672e7c0",
-  "generated_at": "2026-05-25T14:28:30.843471+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/codex-gpt-5.5/statutes/26/3306/b/6.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-6-20260525-v226",
-  "generated_output_sha256": "bb0056fbb5ffa0389ea9027d5c0ac9e574f0552fad41f185b26125791fe03460",
-  "generation_prompt_sha256": "fb9fae71018d86d0a945a76e0b4345df15bc70747911b324396d6ede34e33ce5",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "2ac0fd529a2af4cf913f6cc1e151214679c8d86d422ec274bb01d0af821b9c77",
+  "generated_at": "2026-06-02T07:31:36.973687+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/6.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1020e099482231a75da97bf17819963bf545806a832267e586c908f96208b960",
+  "generation_prompt_sha256": "889dc8794c92a331302251b9a347e7b124decf58db8e3f87a680ab6c208a9792",
   "model": "gpt-5.5",
-  "run_id": "9ef29654",
-  "runner": "codex-gpt-5.5",
+  "run_id": "cda6f6b4",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8aaaeeeafe276744c3bca8f85bb4c0c720c1dbbe5c38c31f0391a1da233ac549"
+    "value": "d7e27fefd50d00b9351a20879904550ddd88ee795f573620b139b3ba656d4435"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-6-20260525-v226/traces/codex-gpt-5.5/26-USC-3306-b-6.json",
-  "trace_sha256": "acde6ff78e45941bb40569d289a2d068ec34b858f4044d69fd7978132cccae26"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-6.json",
+  "trace_sha256": "8eefdfa3399dd9989624077c9a301bfabeced74a9c9d9a03041f943b764601d0"
 }

--- a/statutes/26/3306/b/6.test.yaml
+++ b/statutes/26/3306/b/6.test.yaml
@@ -1,15 +1,9 @@
 - name: state unemployment payment for domestic service is excluded
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}
-  output:
-    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
-    - holds
-    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
-    - 120
   tables:
     Payment:
     - us:statutes/26/3306/b/6#input.payment_amount: 120
@@ -17,18 +11,17 @@
       us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
-- name: state unemployment payment for agricultural labor is excluded
-  period:
-    period_kind: custom
-    name: calendar_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input: {}
   output:
     us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
     - holds
     us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
-    - 80
+    - 120
+- name: state unemployment payment for agricultural labor is excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
   tables:
     Payment:
     - us:statutes/26/3306/b/6#input.payment_amount: 80
@@ -36,18 +29,17 @@
       us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: false
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: true
-- name: deduction from employee remuneration blocks exclusion
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 80
+- name: deduction from employee remuneration blocks state unemployment payment exclusion
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}
-  output:
-    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
-    - not_holds
-    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
-    - 0
   tables:
     Payment:
     - us:statutes/26/3306/b/6#input.payment_amount: 120
@@ -55,18 +47,17 @@
       us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
-- name: payment not required under state unemployment law is not excluded
-  period:
-    period_kind: custom
-    name: calendar_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input: {}
   output:
     us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
     - not_holds
     us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
     - 0
+- name: payment not required under state unemployment law is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
   tables:
     Payment:
     - us:statutes/26/3306/b/6#input.payment_amount: 120
@@ -74,18 +65,17 @@
       us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: false
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
-- name: non-domestic non-agricultural remuneration is not excluded
-  period:
-    period_kind: custom
-    name: calendar_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input: {}
   output:
     us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
     - not_holds
     us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
     - 0
+- name: non-domestic non-agricultural remuneration is not excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
   tables:
     Payment:
     - us:statutes/26/3306/b/6#input.payment_amount: 120
@@ -93,3 +83,8 @@
       us:statutes/26/3306/b/6#input.payment_required_from_employee_under_state_unemployment_compensation_law: true
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer: false
       us:statutes/26/3306/b/6#input.remuneration_paid_to_employee_for_agricultural_labor: false
+  output:
+    us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies:
+    - not_holds
+    us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/6.yaml
+++ b/statutes/26/3306/b/6.yaml
@@ -5,10 +5,10 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    "payment by an employer (without deduction from the remuneration of the employee)" of "any payment required from an employee under a State unemployment compensation law" with respect to domestic service or agricultural labor remuneration.
+    "the payment by an employer (without deduction from the remuneration of the employee)" of employee section 3101 tax or State unemployment compensation payments, with respect to domestic service in a private home or agricultural labor.
   deferred_outputs:
-    - output: us:statutes/26/3306/b/6#employee_tax_payment_excluded_from_wages
-      reason: The paragraph (6)(A) branch depends on the tax imposed upon an employee under section 3101, but the copied section 3101 context is entity_not_supported and exports no executable employee-tax output; encoding it would require a prohibited local cross-reference fact.
+    - output: us:statutes/26/3306/b/6#employee_section_3101_tax_payment_excluded_from_wages
+      reason: The paragraph (6)(A) branch requires identifying "the tax imposed upon an employee under section 3101"; the copied section 3101 aggregate context is entity_not_supported and exports no executable whole-section employee-tax amount, so this branch cannot be faithfully computed here without a prohibited local section-3101 placeholder.
 rules:
   - name: state_unemployment_payment_exclusion_applies
     kind: derived
@@ -23,7 +23,17 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "payment by an employer (without deduction from the remuneration of the employee)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
               excerpt: "payment required from an employee under a State unemployment compensation law"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "domestic service in a private home of the employer or for agricultural labor"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -33,6 +43,7 @@ rules:
             remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer
             or remuneration_paid_to_employee_for_agricultural_labor
           )
+
   - name: employer_state_unemployment_payment_excluded_from_wages
     kind: derived
     entity: Payment
@@ -48,6 +59,12 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "the payment by an employer ... of any payment required from an employee"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies
+              output: state_unemployment_payment_exclusion_applies
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(6) with axiom-encode 0.2.532 and gpt-5.5
- preserve the state-unemployment payment wage exclusion while refreshing deferred 3101 branch naming, proof atoms, and tests
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602/rulespec-us/statutes/26/3306/b/6.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602/rulespec-us/statutes/26/3306/b/6.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602/rulespec-us/statutes/26/3306/b/6.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b6-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
