### PR TITLE
Refresh generated section 3306(b)(7) payroll manifest

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/7.json
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "8e5189d2da399b802956f5745b6d2e356b7daa9a",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.227",
-    "version_commit": "8e5189d2da399b802956f5745b6d2e356b7daa9a"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.227",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(7)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-7/workspace/context-manifest.json",
-  "context_manifest_sha256": "e1b878c16b586af5ba405c5644b096f9e02f6fc897936ce186f36e4130781bf8",
-  "generated_at": "2026-05-25T14:47:25.506858+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/codex-gpt-5.5/statutes/26/3306/b/7.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-7-20260525-v227",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "b5829cb2536068310db07727240e4617236e82563305a11e283ed16dafe52085",
+  "generated_at": "2026-06-02T07:37:16.955990+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/7.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "301863e37b93eed022c1c9b688eaea1abbcf6e361e71fada3c9a84c75bf366d4",
-  "generation_prompt_sha256": "39df2bd35482733326c1091c7e9a3a305cdaf5c02253b82986dc59deea769758",
+  "generation_prompt_sha256": "130771d658a78683bf361db77c2d995097a25c273082cb90594bc94c4be3971d",
   "model": "gpt-5.5",
-  "run_id": "d2ff1dec",
-  "runner": "codex-gpt-5.5",
+  "run_id": "d8cc2a89",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "9b175512f774006a38a9c383b0018ac0fa435098786b20ec74c69c203863c31d"
+    "value": "bc70a82d40255cf83b7a360c0e2bf5bacf565ba833a1df2f9f8d55560214dae8"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-7-20260525-v227/traces/codex-gpt-5.5/26-USC-3306-b-7.json",
-  "trace_sha256": "6b68f76f6d413a18006c12b1c6d365e17b7cdea756f0c0c536d70b6435e210db"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-7.json",
+  "trace_sha256": "e388157c65eb45e537111f25c07e7331bb8de775e99cada923f649d626be762c"
 }


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(7) with axiom-encode 0.2.532 and gpt-5.5
- refresh generated provenance for the noncash nonbusiness-service remuneration wage exclusion
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602/rulespec-us/statutes/26/3306/b/7.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602/rulespec-us/statutes/26/3306/b/7.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602/rulespec-us/statutes/26/3306/b/7.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b7-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
