### PR TITLE
Refresh generated section 3306(b)(9) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/9.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/9.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/9.yaml",
-      "sha256": "591889dc10e836eebb1c61e07539da62d94e7a508f00afcbd2e223ff0432330a"
+      "sha256": "d1066f0c2e3cccfb6470410993759c3781595a62a218613ec26338ac0eba9fcd"
     },
     {
       "path": "statutes/26/3306/b/9.test.yaml",
-      "sha256": "d11739da8be4f269130128ec676e093ee2b0f86ce2d982a4d28d3c20b9583f34"
+      "sha256": "38fe70a2c194e807da3fc3587a253be2424b099ef99be4449667e16641d81662"
     }
   ],
   "axiom_encode_git": {
-    "commit": "43f7d73d9da914aaecb04e3d373562b9e152d504",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.228",
-    "version_commit": "43f7d73d9da914aaecb04e3d373562b9e152d504"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.228",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(9)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-9/workspace/context-manifest.json",
-  "context_manifest_sha256": "064591ff6d46c18adcbd4b512ea848b063740ca1e72eef97566ee46efdd643ca",
-  "generated_at": "2026-05-25T15:09:25.447460+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/codex-gpt-5.5/statutes/26/3306/b/9.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-9-20260525-v228",
-  "generated_output_sha256": "591889dc10e836eebb1c61e07539da62d94e7a508f00afcbd2e223ff0432330a",
-  "generation_prompt_sha256": "99b1c157d05dc2e93d65f61d9f5163a77ed6769284145a143ed8d5e7bde54a33",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "836c8493e1d4d9e1aea71c1bc30f26aeb8e34b7d675ead5454db2881a132df94",
+  "generated_at": "2026-06-02T07:42:16.277195+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/9.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d1066f0c2e3cccfb6470410993759c3781595a62a218613ec26338ac0eba9fcd",
+  "generation_prompt_sha256": "246cdb088de4da7d88dbde9191a6976030b4158a19665874d0c3ab098fe84d2c",
   "model": "gpt-5.5",
-  "run_id": "a30f4ce0",
-  "runner": "codex-gpt-5.5",
+  "run_id": "6c0ea670",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "68f567bc2c85676c32620b5263b5f009f5877b09bfd17f98ef66a7ca0732c3f7"
+    "value": "1ff0becd7c1f269aaadb9148160822b174a4be486affc06c53fff5d25a3827ca"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-9-20260525-v228/traces/codex-gpt-5.5/26-USC-3306-b-9.json",
-  "trace_sha256": "a827c1a23f11ab4a4b33989dbb49a62f7649229540532ddb9451974aac0b9ca7"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-9.json",
+  "trace_sha256": "6f867ad2de0316d8db7c4140e317c87e5df9f15df192613d69a84047e96586dd"
 }

--- a/statutes/26/3306/b/9.test.yaml
+++ b/statutes/26/3306/b/9.test.yaml
@@ -1,7 +1,6 @@
-- name: remuneration paid to employee is excluded to section 217 extent
+- name: remuneration paid to employee is excluded to section 217 deduction extent
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}
@@ -21,8 +20,7 @@
     - 600
 - name: remuneration paid on behalf of employee is capped at payment amount
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}
@@ -42,8 +40,7 @@
     - 700
 - name: no reasonable belief blocks section 217 wage exclusion
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}
@@ -63,8 +60,7 @@
     - 0
 - name: remuneration not paid to or on behalf of employee is not excluded
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input: {}

--- a/statutes/26/3306/b/9.yaml
+++ b/statutes/26/3306/b/9.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    remuneration paid to or on behalf of an employee if (and to the extent that) at the time of payment it is reasonable to believe a corresponding deduction is allowable under section 217, determined without regard to section 274(n)
+    remuneration paid to or on behalf of an employee if, and to the extent that, at payment it is reasonable to believe a corresponding section 217 deduction is allowable, determined without regard to section 274(n)
 rules:
   - name: corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
     kind: derived
@@ -34,7 +34,9 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          (remuneration_paid_to_employee or remuneration_paid_on_behalf_of_employee) and reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+          (remuneration_paid_to_employee or remuneration_paid_on_behalf_of_employee)
+          and reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+
   - name: section_217_deduction_remuneration_excluded_from_wages
     kind: derived
     entity: Payment


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(9) with axiom-encode 0.2.532 and gpt-5.5
- preserve the section 217 deduction wage exclusion and cap logic while refreshing generated provenance and test periods
- keep the change scoped to generated RuleSpec artifacts only

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602/rulespec-us/statutes/26/3306/b/9.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602/rulespec-us/statutes/26/3306/b/9.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602/rulespec-us/statutes/26/3306/b/9.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b9-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
