### PR TITLE
Refresh generated section 3306(b)(10) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/10.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/10.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/10.yaml",
-      "sha256": "87186c901bcd0bf93c9246417fdcd8c0c9b84e395c832d57b8a0e1976ccb69f6"
+      "sha256": "cbc20e0748623b1f96992a4a3835b01523079baecf44448d8da5ce9e621b1653"
     },
     {
       "path": "statutes/26/3306/b/10.test.yaml",
-      "sha256": "d44f0417de81b563760dbc01311012009feaab8d0e10a48de300e6c58fcc6e87"
+      "sha256": "e6bd18dcf7ed964b7c213aee033f0e61394584ed4ffcee073adc6f0cbbe5d3a9"
     }
   ],
   "axiom_encode_git": {
-    "commit": "bf4406137ab1d5d783f4a7723685d4439ca4a5c1",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.229",
-    "version_commit": "bf4406137ab1d5d783f4a7723685d4439ca4a5c1"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.229",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(10)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-10/workspace/context-manifest.json",
-  "context_manifest_sha256": "4ed8476f072850ab63b22999be7994ee30fd2d6dd5c662c9efd843053a71c9a1",
-  "generated_at": "2026-05-25T15:30:57.705754+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/10.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-10-regen-20260525",
-  "generated_output_sha256": "87186c901bcd0bf93c9246417fdcd8c0c9b84e395c832d57b8a0e1976ccb69f6",
-  "generation_prompt_sha256": "5a76db6a2eb025a9b11e283423da5bbd3ea17344f8418a0d2199647e87b63a97",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "559b6d3a3da352e658420b709fa26f690a36a73dcba510ad633fa385f4c1c426",
+  "generated_at": "2026-06-02T07:49:30.289487+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/10.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "cbc20e0748623b1f96992a4a3835b01523079baecf44448d8da5ce9e621b1653",
+  "generation_prompt_sha256": "8d32718ec7aad5f96bc00db801412b37999e074c5908f5052983b291eeb0047e",
   "model": "gpt-5.5",
-  "run_id": "f6f0446b",
-  "runner": "codex-gpt-5.5",
+  "run_id": "f18be30b",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "5204b3c1bf26693820bbbba0a22956a816ccf20103d712d4bb15e0373077fef1"
+    "value": "80d90dd3d90d077c53b0fea528ccaa9c2aa3e3079aed443b7d151e84d072e45a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-10-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-10.json",
-  "trace_sha256": "dde6d395365f244f1f301bf4e8bdf46105d0244667b33e69e356d63fcfe859c8"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-10.json",
+  "trace_sha256": "9438f4405555215d1b40ca32358e3b5fd54917f4cdaea8d88ba87888594dd43c"
 }

--- a/statutes/26/3306/b/10.test.yaml
+++ b/statutes/26/3306/b/10.test.yaml
@@ -1,4 +1,5 @@
-- name: qualifying death and disability retirement payments with termination exception
+- name: qualifying death and disability retirement payments are excluded unless they
+    would have been paid without termination
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -32,7 +33,7 @@
     - 1000
     - 800
     - 0
-- name: required termination plan payment gates missing
+- name: required payment termination cause and plan gates missing
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3306/b/10.yaml
+++ b/statutes/26/3306/b/10.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    "any payment or series of payments by an employer to an employee or any of his dependents"; "because of (i) death, or (ii) retirement for disability"; "under a plan established by the employer"; "other than any such payment or series of payments which would have been paid"
+    "any payment or series of payments by an employer to an employee or any of his dependents" paid upon or after termination because of death or disability retirement, under an employer plan, "other than" payments that would have been paid absent termination.
 rules:
   - name: death_or_disability_retirement_termination_plan_payment_excluded_from_wages
     kind: derived
@@ -26,7 +26,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "upon or after the termination"
+              excerpt: "upon or after the termination of an employee’s employment relationship"
           - path: versions[0].formula
             kind: condition
             source:
@@ -36,7 +36,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "under a plan established by the employer which makes provision for his employees generally or a class or classes of his employees"
+              excerpt: "under a plan established by the employer"
           - path: versions[0].formula
             kind: exception
             source:


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(10) with axiom-encode 0.2.532 and gpt-5.5
- preserve the death/disability retirement termination payment exclusion logic while refreshing proof text, test names, and generated provenance
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/10#death_or_disability_retirement_termination_plan_payment_excluded_from_wages`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than this narrow exclusion amount separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602/rulespec-us/statutes/26/3306/b/10.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602/rulespec-us/statutes/26/3306/b/10.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602/rulespec-us/statutes/26/3306/b/10.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b10-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
