### PR TITLE
Refresh generated section 3306(b)(11) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/11.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/11.yaml",
-      "sha256": "0d66bbbc3049119d26aa8c6b3293b171e3f641657a7518f122292c90d94239e5"
+      "sha256": "9b1e89355848cf8eada2e954d9982ba829c6cee741e6c068b2d92155fe58edb4"
     },
     {
       "path": "statutes/26/3306/b/11.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "884ecffb54d204ead21abf540c4258a6123cc97b",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.230",
-    "version_commit": "884ecffb54d204ead21abf540c4258a6123cc97b"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.230",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(11)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-11/workspace/context-manifest.json",
-  "context_manifest_sha256": "3b7281b5ebccddc13ab66fbf732cdad25bfaaa33c5f1512344085e27ba913b26",
-  "generated_at": "2026-05-25T15:52:02.142389+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/11.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-11-regen-20260525",
-  "generated_output_sha256": "0d66bbbc3049119d26aa8c6b3293b171e3f641657a7518f122292c90d94239e5",
-  "generation_prompt_sha256": "45726465a1f59792225be57a13196442ecd691e2c3c6ee714728716611faddd8",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "671e85a4cf34c9ba3ae41553aff5df0b8677ac64464663eddf0fc253601c2664",
+  "generated_at": "2026-06-02T07:53:52.769080+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/11.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9b1e89355848cf8eada2e954d9982ba829c6cee741e6c068b2d92155fe58edb4",
+  "generation_prompt_sha256": "196cdaa77f70790466eb979650ed9e50089a9ca12363dbc1ee407d0df1252606",
   "model": "gpt-5.5",
-  "run_id": "061457d9",
-  "runner": "codex-gpt-5.5",
+  "run_id": "18205b75",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bbef23732eaa80a89a0b41a7654eb02706c0b4424fbf7cee6a577b315fec8d21"
+    "value": "2631802b43514472e919db5d2ac1d189d2218e452100cb7300c008356ee74287"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-11-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-11.json",
-  "trace_sha256": "65483264fa7114a700943fc3bf5722552a8001291d816e97ac545831c1904d83"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-11.json",
+  "trace_sha256": "5024cc66b495cf5c0b7be7d47981e9e3a28b6be9d4d65b33e0f74718b6f7684b"
 }

--- a/statutes/26/3306/b/11.yaml
+++ b/statutes/26/3306/b/11.yaml
@@ -18,10 +18,19 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "remuneration for agricultural labor"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "paid in any medium other than cash"
+          - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "remuneration for agricultural labor paid in any medium other than cash"
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(11) with axiom-encode 0.2.532 and gpt-5.5
- preserve the noncash agricultural labor remuneration exclusion formula and tests while refreshing proof atoms and generated provenance
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/11#noncash_agricultural_labor_remuneration_excluded_from_wages`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than this narrow exclusion amount separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602/rulespec-us/statutes/26/3306/b/11.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602/rulespec-us/statutes/26/3306/b/11.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602/rulespec-us/statutes/26/3306/b/11.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b11-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
