### PR TITLE
Refresh generated section 3306(b)(12) payroll manifest

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/12.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/12.json
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "884ecffb54d204ead21abf540c4258a6123cc97b",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.230",
-    "version_commit": "884ecffb54d204ead21abf540c4258a6123cc97b"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.230",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(12)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-12-retry-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-12/workspace/context-manifest.json",
-  "context_manifest_sha256": "6c59c48e9d0f61d83fc0c0d0034e9fd95ec6a07a0fffe4ded66e24de61346573",
-  "generated_at": "2026-05-25T15:59:58.081906+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-12-retry-20260525/codex-gpt-5.5/statutes/26/3306/b/12.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-12-retry-20260525",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "b8f6e6340727845fa6c8f19c3059421e5a6b4e937e6b4bd925fcf0c31d31de24",
+  "generated_at": "2026-06-02T07:57:47.229318+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/12.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "a63452ba98d32785e4e06779bf280b40d09164ae20806b6c7141868e0fa1bc80",
-  "generation_prompt_sha256": "9d972f69ac2f8a335d367128306c90ea9966eb94a2d6450844578d2738890455",
+  "generation_prompt_sha256": "44e6fc1b60535f3dc3353bb1b56b51e78625b828ac0d8e2cd41c1867c548b22c",
   "model": "gpt-5.5",
-  "run_id": "16c98d20",
-  "runner": "codex-gpt-5.5",
+  "run_id": "aa2d53ea",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2b81aedd9cf5950a055aeb3d048042a99fda2623d9b10f1c245a2a06aa762f5e"
+    "value": "1c1dc0e3c77034b90e9225afa998c99740698e0662fe97e0fe61f21ba9062cf0"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-12-retry-20260525/traces/codex-gpt-5.5/26-USC-3306-b-12.json",
-  "trace_sha256": "42902c3e110a57193ebdfb2b954f12f55b75d042b022358140ab2614813dc93b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-12.json",
+  "trace_sha256": "69e5927b1355aa905fef18b8673651e07f7d82d6cccb91102b97d51d04f5a13e"
 }


### PR DESCRIPTION
## Summary
- refresh the generated manifest for repealed 26 USC 3306(b)(12) with axiom-encode 0.2.532 and gpt-5.5
- leave the deferred repealed-section YAML and empty companion test unchanged
- keep the change scoped to generated RuleSpec provenance only

## PolicyEngine oracle coverage
- no changed oracle item for this repealed subsection
- corpus-wide tax oracle coverage still reports zero untested comparable outputs

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b12-20260602/rulespec-us/statutes/26/3306/b/12.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b12-20260602/rulespec-us/statutes/26/3306/b/12.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b12-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b12-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
