### PR TITLE
Refresh generated section 3306(b)(13) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/13.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/13.yaml",
-      "sha256": "a82271e2ca7c10303cc4c8193e241aa95a038bb5a2d8ba618df1dbdd0e612580"
+      "sha256": "18bb37fb218a3536ec200251f63399081d49917a6804499bd365b65fe9e7d0bd"
     },
     {
       "path": "statutes/26/3306/b/13.test.yaml",
-      "sha256": "b7e39371e504436e5073df7de230b5cb8ed63cf4427466ce5b8521be7b174130"
+      "sha256": "191a18b9aa76401449fea1e3ee99becebc41f1a65c66920ce382ddf486225318"
     }
   ],
   "axiom_encode_git": {
-    "commit": "b24bef4d4ffe43eb0f8e469ff5de838c38f27270",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.231",
-    "version_commit": "b24bef4d4ffe43eb0f8e469ff5de838c38f27270"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.231",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(13)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-13/workspace/context-manifest.json",
-  "context_manifest_sha256": "d0de64e203e8981336d7123dd8aaeaabbbad393ac1c1126d181df4c270805784",
-  "generated_at": "2026-05-25T16:22:38.665302+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/13.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-13-regen-20260525",
-  "generated_output_sha256": "a82271e2ca7c10303cc4c8193e241aa95a038bb5a2d8ba618df1dbdd0e612580",
-  "generation_prompt_sha256": "50bcf26cca6d27df8d9b347a8654e6a1efc7cfbf346d4a6082f8657706cfc3be",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "9872b788212655e2a10a93cdaf5abc582174c1fce885d907d27301650173e273",
+  "generated_at": "2026-06-02T08:01:53.401454+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/13.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "18bb37fb218a3536ec200251f63399081d49917a6804499bd365b65fe9e7d0bd",
+  "generation_prompt_sha256": "c5acf6dfe6a13e85b7f25de604ff78e58e9d0af795afcac5176c8320ea49888b",
   "model": "gpt-5.5",
-  "run_id": "d16e5559",
-  "runner": "codex-gpt-5.5",
+  "run_id": "d32035cf",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "9ec5d9e86c5de84c1a199b01f3adb085ec108a4e5b4db4b9f154b6902629d33e"
+    "value": "b4bd83938868e1e7c176ecf1423c60f3ecc66d2aa9b5f7306428d12d5d70d8c0"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-13-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-13.json",
-  "trace_sha256": "91d47a2f3624122c301cfb9793aee3f11ec033a4f7df97a90f22064ced40f26e"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-13.json",
+  "trace_sha256": "efff93411cf389187f895f4589d3d918cdf20c4dfabee1f55add6666aecdb257"
 }

--- a/statutes/26/3306/b/13.test.yaml
+++ b/statutes/26/3306/b/13.test.yaml
@@ -1,4 +1,4 @@
-- name: excludes payments for each cited income exclusion belief
+- name: excludes payments for each cited income exclusion reasonable belief
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -49,7 +49,7 @@
     - 700
     - 800
     - 600
-- name: does not exclude payment without cited reasonable belief
+- name: does not exclude payment without any cited reasonable belief
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3306/b/13.yaml
+++ b/statutes/26/3306/b/13.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (13) any payment made, or benefit furnished, to or for the benefit of an employee if at the time of such payment or such furnishing it is reasonable to believe that the employee will be able to exclude such payment or benefit from income under section 127, 129, 134(b)(4), or 134(b)(5);
+    Payment or benefit to or for an employee excluded from wages when reasonably believed excludable from income under section 127, 129, 134(b)(4), or 134(b)(5).
 rules:
   - name: cited_income_exclusion_reasonably_expected
     kind: derived
@@ -44,6 +44,11 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "any payment made, or benefit furnished, to or for the benefit of an employee"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "any payment made, or benefit furnished"
           - path: versions[0].formula
             kind: import
             import:


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(13) with axiom-encode 0.2.532 and gpt-5.5
- preserve the reasonable-belief helper and payment-or-benefit exclusion outputs while refreshing proof text, test names, and generated provenance
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/13#cited_income_exclusion_reasonably_expected`: known_not_comparable, tested
- `us:statutes/26/3306/b/13#payment_or_benefit_excluded_from_wages_due_to_expected_income_exclusion`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than these narrow exclusion/predicate surfaces separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602/rulespec-us/statutes/26/3306/b/13.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602/rulespec-us/statutes/26/3306/b/13.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602/rulespec-us/statutes/26/3306/b/13.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b13-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
