### PR TITLE
Refresh generated section 3306(b)(14) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/14.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "statutes/26/3306/b/14.test.yaml",
-      "sha256": "448a90df26d07fdab4fdc368f5c33838e17901af412110accaec74ae982b310b"
+      "sha256": "ec15df3f75a369d07b6f7d578e4d7d781c8897b76f00fd55ae52a3d933eb638d"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d77a349253e4d14277acac666c3e64c0344ea2f7",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.232",
-    "version_commit": "d77a349253e4d14277acac666c3e64c0344ea2f7"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.232",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(14)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-14/workspace/context-manifest.json",
-  "context_manifest_sha256": "f99f99550111f65c1bfbcd731f1e6e8037971f9368a2067bbca59f4e94469b8d",
-  "generated_at": "2026-05-25T16:42:23.679934+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/14.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-14-regen-20260525",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "83447be5bdac690e52ffb7dd44f75e880f5c8267ff3ed107016444ac1b04d363",
+  "generated_at": "2026-06-02T08:07:06.369959+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/14.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "708c712a63f0ed9a38fd0240b09daa9da62eae0cbfc3a96ca5dbe739358aff5a",
-  "generation_prompt_sha256": "e69d75023784e8f427bb4dc022f8cf8fb960865be312866f538bc907ec302c7f",
+  "generation_prompt_sha256": "5c46376d5bf89c4a8633d468351267c3af570c5e702ad83a48b506742d57a232",
   "model": "gpt-5.5",
-  "run_id": "93a717ed",
-  "runner": "codex-gpt-5.5",
+  "run_id": "3b35f34c",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "281d2070aaa3991bc6b770e67c1741ac94cbe80a5e920904b1e58a4971ff8996"
+    "value": "aac24e681c97ff0c9deeea522e476f57751925b4cd4e112a975e06426b1a530a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-14-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-14.json",
-  "trace_sha256": "cd60324e2b1100e6173eb11575352fea13db0d46555fd0568faf311e0bd83547"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-14.json",
+  "trace_sha256": "e069d676ec92d5bd7254c454649b8f76230241fb387462306f84ea4c0517b84d"
 }

--- a/statutes/26/3306/b/14.test.yaml
+++ b/statutes/26/3306/b/14.test.yaml
@@ -25,7 +25,7 @@
   output:
     us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing: not_holds
     us:statutes/26/3306/b/14#meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion: 0
-- name: no reasonable belief of section 119 exclusion at furnishing
+- name: no reasonable belief of section 119 exclusion at time of furnishing
   period:
     period_kind: tax_year
     start: '2026-01-01'


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(14) with axiom-encode 0.2.532 and gpt-5.5
- preserve the section 119 meals-or-lodging reasonable-belief gate and exclusion amount rule while refreshing generated provenance and a companion test name
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/14#meals_or_lodging_section_119_income_exclusion_reasonably_expected_at_furnishing`: known_not_comparable, tested
- `us:statutes/26/3306/b/14#meals_or_lodging_value_excluded_from_wages_due_to_expected_section_119_income_exclusion`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than these narrow exclusion/predicate surfaces separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602/rulespec-us/statutes/26/3306/b/14.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602/rulespec-us/statutes/26/3306/b/14.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602/rulespec-us/statutes/26/3306/b/14.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b14-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
