### PR TITLE
Refresh generated section 3306(b)(15) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/15.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/15.yaml",
-      "sha256": "85e1229992584b64a7bd943019130f112250a5f6050b258960d8fa1628a1e80b"
+      "sha256": "ab2989bbd0d94b69400693a1a575505b11112d6d5e1c1b82f2a7e2723b280539"
     },
     {
       "path": "statutes/26/3306/b/15.test.yaml",
-      "sha256": "c76e3bfcca3cbfc1ff1e013bcdc66733ae63567fb829e0ad047b64c988f5136e"
+      "sha256": "83814038482df397a74faa602da5fdf880c4394f2aad8757d536f95337f7b26b"
     }
   ],
   "axiom_encode_git": {
-    "commit": "24e74430eef0bd49626ae3e2f5591b3560efa5a4",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.233",
-    "version_commit": "24e74430eef0bd49626ae3e2f5591b3560efa5a4"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.233",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(15)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-15/workspace/context-manifest.json",
-  "context_manifest_sha256": "06d44d5eb9405e918c4300cdb6a04eb5d39795d12dc5cc5ae4a5384928578bf7",
-  "generated_at": "2026-05-25T17:00:23.234543+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/15.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-15-regen-20260525",
-  "generated_output_sha256": "85e1229992584b64a7bd943019130f112250a5f6050b258960d8fa1628a1e80b",
-  "generation_prompt_sha256": "c1e4e36d5e667024f8b9178026a331d8b2b8028ec039cf53f26f5cf551288e53",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "4d48426d03942db63606028be0a138487ff3c018890cd19cf0fe2afa7f0c9969",
+  "generated_at": "2026-06-02T08:11:09.703462+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/15.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "ab2989bbd0d94b69400693a1a575505b11112d6d5e1c1b82f2a7e2723b280539",
+  "generation_prompt_sha256": "fa1c57cce491ef1b27f35acd4b3546eafc5788bacc76548a66d48e6b2d77aa97",
   "model": "gpt-5.5",
-  "run_id": "5b364246",
-  "runner": "codex-gpt-5.5",
+  "run_id": "69bdc0ea",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "fa5ede9e56f46bacedea63673189f3bf6cebae6071ae7432c651f09cef746d8f"
+    "value": "cb8266dda737cafe49cf3fa2f06f7fd1be9dde5c8225e64cccff4ec7b1ec285a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-15-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-15.json",
-  "trace_sha256": "eb7f4d0f55acf1d500a8a7c7fc64dadf1c0cb261e6b162608d4086a88656d81b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-15.json",
+  "trace_sha256": "127188396ede0e0e83307ab779fc4fd03712289ae774f992636e4156ce762ef9"
 }

--- a/statutes/26/3306/b/15.test.yaml
+++ b/statutes/26/3306/b/15.test.yaml
@@ -4,49 +4,61 @@
     name: calendar_year
     start: '2026-01-01'
     end: '2026-12-31'
-  input:
-    us:statutes/26/3306/b/15#input.payment_amount: 1200
-    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/15#input.payment_amount: 1200
+      us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
   output:
-    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 1200
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages:
+    - 1200
 - name: estate_payment_after_death_year_excluded
   period:
     period_kind: custom
     name: calendar_year
     start: '2026-01-01'
     end: '2026-12-31'
-  input:
-    us:statutes/26/3306/b/15#input.payment_amount: 800
-    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: true
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/15#input.payment_amount: 800
+      us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: true
   output:
-    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 800
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages:
+    - 800
 - name: survivor_payment_not_after_death_year_not_excluded
   period:
     period_kind: custom
     name: calendar_year
     start: '2026-01-01'
     end: '2026-12-31'
-  input:
-    us:statutes/26/3306/b/15#input.payment_amount: 1200
-    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: false
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/15#input.payment_amount: 1200
+      us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: false
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: true
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
   output:
-    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 0
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages:
+    - 0
 - name: payment_after_death_year_to_neither_survivor_nor_estate_not_excluded
   period:
     period_kind: custom
     name: calendar_year
     start: '2026-01-01'
     end: '2026-12-31'
-  input:
-    us:statutes/26/3306/b/15#input.payment_amount: 1200
-    us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
-    us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/b/15#input.payment_amount: 1200
+      us:statutes/26/3306/b/15#input.payment_made_after_calendar_year_in_which_former_employee_died: true
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_survivor_of_former_employee: false
+      us:statutes/26/3306/b/15#input.payment_made_by_employer_to_estate_of_former_employee: false
   output:
-    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages: 0
+    us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages:
+    - 0

--- a/statutes/26/3306/b/15.yaml
+++ b/statutes/26/3306/b/15.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    Any payment made by an employer to a survivor or the estate of a former employee after the calendar year in which such employee died.
+    any payment made by an employer to a survivor or the estate of a former employee after the calendar year in which such employee died
 rules:
   - name: survivor_or_estate_payment_after_employee_death_year_excluded_from_wages
     kind: derived
@@ -18,10 +18,24 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "payment made by an employer to a survivor or the estate of a former employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "after the calendar year in which such employee died"
+          - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3306
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          if payment_made_after_calendar_year_in_which_former_employee_died and (payment_made_by_employer_to_survivor_of_former_employee or payment_made_by_employer_to_estate_of_former_employee): payment_amount else: 0
+          if payment_made_after_calendar_year_in_which_former_employee_died
+            and (
+              payment_made_by_employer_to_survivor_of_former_employee
+              or payment_made_by_employer_to_estate_of_former_employee
+            ): payment_amount else: 0


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(15) with axiom-encode 0.2.532 and gpt-5.5
- preserve the survivor-or-estate post-death-year exclusion amount while improving proof atoms and converting companion cases to Payment-table shape
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than this narrow survivor-or-estate exclusion amount separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602/rulespec-us/statutes/26/3306/b/15.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602/rulespec-us/statutes/26/3306/b/15.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602/rulespec-us/statutes/26/3306/b/15.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b15-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
