### PR TITLE
Refresh generated section 3306(b)(16) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/16.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/16.yaml",
-      "sha256": "de7e3ab5f7db97f7f89f66e78b4ebe524209584af75b5e1c301a50d0b0b76b84"
+      "sha256": "f8e812cc41b6f13c72b076b2e9bb1795ccd0092720bda93d4c372f81df37db5f"
     },
     {
       "path": "statutes/26/3306/b/16.test.yaml",
-      "sha256": "0fa74a72296ad4765b63aeb4b10241474817d8199c94dcd91deda2e414fe0a5b"
+      "sha256": "04fb05dcd8177e10a50970326d648db084fb1b983522fdcb554d3e5b738a3688"
     }
   ],
   "axiom_encode_git": {
-    "commit": "91c5f2ba443a70c0460950e287adb9e84e65aeaf",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.234",
-    "version_commit": "91c5f2ba443a70c0460950e287adb9e84e65aeaf"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.234",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(16)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-16/workspace/context-manifest.json",
-  "context_manifest_sha256": "3dbd66c9e4e33805b9726ab89fe25837ee0050e9ad5ce5ae9874fa7594b42ef6",
-  "generated_at": "2026-05-25T18:48:29.378785+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/16.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-16-regen-20260525",
-  "generated_output_sha256": "de7e3ab5f7db97f7f89f66e78b4ebe524209584af75b5e1c301a50d0b0b76b84",
-  "generation_prompt_sha256": "14bd52ee9a036097ea21e178a4342820267574ec4d22720887ddea4812cade66",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "eea4406c0b44f2237c680b44f33364f0053a6a4379c9776ed3a1c5bf412af0d7",
+  "generated_at": "2026-06-02T08:17:04.677147+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/16.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f8e812cc41b6f13c72b076b2e9bb1795ccd0092720bda93d4c372f81df37db5f",
+  "generation_prompt_sha256": "c327cd240ac9d88e01813f82e8030d7c09b4e0601ba902c2d4144c2f7fe3f973",
   "model": "gpt-5.5",
-  "run_id": "2fe01b0f",
-  "runner": "codex-gpt-5.5",
+  "run_id": "72b84978",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "19ca03eb66b3b0fc683baa560200215502bce1c9274679916a2ed26438030ae2"
+    "value": "0ba343a51e4633371120d49f0ed2a353643d915e5b0bb697aaba931944cf4489"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-16-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-16.json",
-  "trace_sha256": "e00021fff180fd3f879c999ce25496adfd96ba034cc8e606fe0941ea2796444e"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-16.json",
+  "trace_sha256": "fd90f4af2299324a127b6d39f86ae0d63300ea4d3cdbeb55ca5981d51eee035b"
 }

--- a/statutes/26/3306/b/16.test.yaml
+++ b/statutes/26/3306/b/16.test.yaml
@@ -1,8 +1,7 @@
 - name: benefit excluded when provided to employee and section 74 c exclusion reasonably
     expected
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -19,10 +18,9 @@
   output:
     us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: holds
     us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 1200
-- name: benefit not excluded when benefit is not provided to or on behalf of employee
+- name: benefit not excluded when not provided to or on behalf of employee
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -39,10 +37,9 @@
   output:
     us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: holds
     us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 0
-- name: benefit not excluded when no cited income exclusion is reasonably expected
+- name: benefit not excluded when no cited income exclusion reasonably expected
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -59,3 +56,23 @@
   output:
     us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: not_holds
     us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 0
+- name: benefit excluded when provided to employee and section 132 exclusion reasonably
+    expected
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/16#input.benefit_amount: 900
+    us:statutes/26/3306/b/16#input.benefit_provided_to_or_on_behalf_of_employee: true
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+    : false
+    ? us:statutes/26/3306/b/16#input.reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+    : true
+  output:
+    us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections: holds
+    us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion: 900

--- a/statutes/26/3306/b/16.yaml
+++ b/statutes/26/3306/b/16.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    any benefit provided to or on behalf of an employee if, when provided, it is reasonable to believe the employee can exclude it from income under section 74(c), 108(f)(4), 117, or 132.
+    any benefit provided to or on behalf of an employee if, when provided, it is reasonable to believe the employee can exclude it from income under section 74(c), 108(f)(4), 117, or 132
 rules:
   - name: benefit_income_exclusion_reasonably_expected_under_cited_sections
     kind: derived
@@ -28,6 +28,7 @@ rules:
           or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
           or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
           or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+
   - name: benefit_excluded_from_wages_due_to_expected_income_exclusion
     kind: derived
     entity: Payment


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(16) with axiom-encode 0.2.532 and gpt-5.5
- preserve the cited-section reasonable-belief helper and benefit exclusion amount while refreshing generated provenance and companion coverage
- keep the change scoped to generated RuleSpec artifacts only

## Notes
- rejected an initial generated attempt that added an unsupported `max(0, benefit_amount)` clamp
- reran generation with repair context to preserve the source-faithful benefit amount surface without hand-editing RuleSpec files

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion`: known_not_comparable, tested
- `us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than these narrow exclusion/predicate surfaces separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602/rulespec-us/statutes/26/3306/b/16.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602/rulespec-us/statutes/26/3306/b/16.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602/rulespec-us/statutes/26/3306/b/16.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b16-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
