### PR TITLE
Refresh generated section 3306(b)(17) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/17.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/17.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/17.yaml",
-      "sha256": "8ca0b9b286151e74aec8bfede9e1f1e83c68630d311515ea0bc537972a7face2"
+      "sha256": "e2e508f99228ca653c2472d96142276ff6259cbe9e44c23d669bfe830566194b"
     },
     {
       "path": "statutes/26/3306/b/17.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "f41679ff2e53d0d9bd650b1e4ca27b244706c5ab",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.235",
-    "version_commit": "f41679ff2e53d0d9bd650b1e4ca27b244706c5ab"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.235",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(17)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-17/workspace/context-manifest.json",
-  "context_manifest_sha256": "6d410441ceb5e3a4cfa9b414e8ab2543b1aa8834772743b49c94ad00b81cc24f",
-  "generated_at": "2026-05-25T19:20:19.056615+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/17.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-17-regen-20260525",
-  "generated_output_sha256": "8ca0b9b286151e74aec8bfede9e1f1e83c68630d311515ea0bc537972a7face2",
-  "generation_prompt_sha256": "9556a3b064e69916a32296e4d2803e6c563b531d24850e8f9b0c5a57b0b90f0e",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-17/workspace/context-manifest.json",
+  "context_manifest_sha256": "f7bedf46b8deede69c0888ed766ac916fbc387bd2fa916683d607d68ac9c3e9d",
+  "generated_at": "2026-06-02T08:21:28.203785+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/17.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "e2e508f99228ca653c2472d96142276ff6259cbe9e44c23d669bfe830566194b",
+  "generation_prompt_sha256": "37aa096ddafda636a03f663394ccb090ef5598785e8c5cbf7a342f3b5b5f10ea",
   "model": "gpt-5.5",
-  "run_id": "ef3fcead",
-  "runner": "codex-gpt-5.5",
+  "run_id": "3f045939",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "acb7f849280ef52c0c963feb8ce0bbe2232c5d3ebe86267594c29841c2594b56"
+    "value": "045e9c3903e5640df8743e34d922065fa2df13dd9a86019b56a81e9895aefc1a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-17-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-17.json",
-  "trace_sha256": "9115c30d3b68ddac56c938dafc5598f0a116e80b8f19b7dbe04df9a4e1ed537c"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-17.json",
+  "trace_sha256": "bd540c15368880d1d7b03e07cddee977f8ea46335ef88c6f008855c45b7d2809"
 }

--- a/statutes/26/3306/b/17.yaml
+++ b/statutes/26/3306/b/17.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (17) any payment made to or for the benefit of an employee if at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(b);
+    any payment made to or for the benefit of an employee if, at the time of payment, it is reasonable to believe the employee can exclude it from income under section 106(b)
 rules:
   - name: payment_made_to_employee_with_expected_section_106_b_income_exclusion
     kind: derived
@@ -25,7 +25,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(b)
+              excerpt: at the time of such payment it is reasonable to believe
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: exclude such payment from income under section 106(b)
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3306(b)(17) with axiom-encode 0.2.532 and gpt-5.5
- preserve the section 106(b) reasonable-belief helper and payment exclusion amount while refreshing proof atoms and generated provenance
- keep the change scoped to generated RuleSpec artifacts only

## PolicyEngine oracle coverage
- `us:statutes/26/3306/b/17#payment_excluded_from_wages_due_to_expected_section_106_b_income_exclusion`: known_not_comparable, tested
- `us:statutes/26/3306/b/17#payment_made_to_employee_with_expected_section_106_b_income_exclusion`: known_not_comparable, tested
- rationale: PolicyEngine exposes final FUTA taxable earnings rather than these narrow exclusion/predicate surfaces separately

## Validation
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602/rulespec-us/statutes/26/3306/b/17.yaml --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602/rulespec-us/statutes/26/3306/b/17.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602/rulespec-us/statutes/26/3306/b/17.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306b17-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
