### PR TITLE
Refresh generated section 3306(b)(18) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/18.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/18.yaml",
-      "sha256": "8a1438a0d3cf1d17402a74684b70ff7819ba074b5caaaf95f2806136aee6623a"
+      "sha256": "f01fe88ecbd0ff60e950d0aea39f8ef3996581f9005076a251d9f6fcdd18ae4a"
     },
     {
       "path": "statutes/26/3306/b/18.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "3f9f0d717aa0175171f55155aff6dc4ec941df6a",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.236",
-    "version_commit": "3f9f0d717aa0175171f55155aff6dc4ec941df6a"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.236",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(18)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-18/workspace/context-manifest.json",
-  "context_manifest_sha256": "f4e331ac611e580a7cce01ec2a5fcef155ec07096df4e239b0e2e0ad25241e35",
-  "generated_at": "2026-05-25T19:44:19.388505+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/18.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-18-regen-20260525",
-  "generated_output_sha256": "8a1438a0d3cf1d17402a74684b70ff7819ba074b5caaaf95f2806136aee6623a",
-  "generation_prompt_sha256": "eef72fc01b6bc765f4f4850da201627ef7c4206d374ac5a6455fbd4af25627dc",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "52a251f54c5a132e00189173f0bf37776d98ee76a07007fc1d9cb0a9cb58c3b5",
+  "generated_at": "2026-06-02T08:26:33.596863+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/18.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "f01fe88ecbd0ff60e950d0aea39f8ef3996581f9005076a251d9f6fcdd18ae4a",
+  "generation_prompt_sha256": "b8b84cad5384c94cd17a460a161fc0032173b77c667276941fcee87fd1308d23",
   "model": "gpt-5.5",
-  "run_id": "a3b492fb",
-  "runner": "codex-gpt-5.5",
+  "run_id": "d5776e20",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "27e204c6c3672c935f3fdd5ba9e0061d29165286482bf9ee7e3fa182323d8c07"
+    "value": "8006e0afda6c768e515e06072f21a7f744c303b817a69ecc702db74083f1afa2"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-18-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-18.json",
-  "trace_sha256": "9b63af88e3bd0355747d0517773ce0251badcf85f71cced4aad65aed833e778b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-18.json",
+  "trace_sha256": "2d33044c412dc17f0efabeaf8ab666a9385aec81478bf0c5980550dd4ca2e8e1"
 }

--- a/statutes/26/3306/b/18.yaml
+++ b/statutes/26/3306/b/18.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    any payment made to or for the benefit of an employee if at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(d);
+    any payment made to or for the benefit of an employee if at the time of such payment it is reasonable to believe that the employee will be able to exclude such payment from income under section 106(d)
 rules:
   - name: section_106_d_income_exclusion_reasonably_expected_at_payment
     kind: derived


### PR DESCRIPTION
Summary:
- Refresh the generated section 3306(b)(18) payroll RuleSpec using axiom-encode 0.2.532 / openai:gpt-5.5.
- Update the generated apply manifest/provenance for the current encoder run.
- No manual RuleSpec edits; logic is unchanged apart from generated summary punctuation.

PolicyEngine oracle coverage:
- `payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion`: known_not_comparable, tested (PE exposes final `taxable_earnings_for_federal_unemployment_tax`, not this narrow payment-level exclusion amount).
- `section_106_d_income_exclusion_reasonably_expected_at_payment`: known_not_comparable, tested (PE exposes final FUTA taxable earnings, not this statutory predicate separately).

Validation:
- `uv run axiom-encode validate statutes/26/3306/b/18.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/b/18.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/b/18.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
