### PR TITLE
Refresh generated section 3306(b)(19) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/19.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/19.yaml",
-      "sha256": "ded4aa69aaa64ed4da51bb81651a2fd8f62d59b4b4cd39d24607914984d576bd"
+      "sha256": "3f4d0beae6dcf4629cd47c163787afeec00ba80529863bc7e9b6b76f404e18e8"
     },
     {
       "path": "statutes/26/3306/b/19.test.yaml",
-      "sha256": "59a7eb034e89f0fa7dd310d4f5e8edcd6f49b8db23b09cf3c345d1c0cf28bb51"
+      "sha256": "1e57cc4d43c1ca89377f3188be375ad72144cdba223e0e1dafb40061d3aa4712"
     }
   ],
   "axiom_encode_git": {
-    "commit": "5dfedf1829f9cf17bcbf22d719a57f991662ff64",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.237",
-    "version_commit": "5dfedf1829f9cf17bcbf22d719a57f991662ff64"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.237",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(19)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-19/workspace/context-manifest.json",
-  "context_manifest_sha256": "32042d1866e671bf9abcbe70d1a0a31ab70fbb7ca0b1e05a9a203f4fef266fb4",
-  "generated_at": "2026-05-25T20:05:32.361176+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/19.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-19-regen-20260525",
-  "generated_output_sha256": "ded4aa69aaa64ed4da51bb81651a2fd8f62d59b4b4cd39d24607914984d576bd",
-  "generation_prompt_sha256": "de6c6faa36dcd5609cee1136e268011b53f0c69f77840bb56afa21a1352b30f9",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "f490a6050c8666f0561d92af9aaee28fa2aec72b05c56a392e920ad01c084402",
+  "generated_at": "2026-06-02T08:31:22.534378+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/19.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "3f4d0beae6dcf4629cd47c163787afeec00ba80529863bc7e9b6b76f404e18e8",
+  "generation_prompt_sha256": "920278d4aed095c902ae488b18a56d9a09d69d615991dc0328ba6fcd7f5a836c",
   "model": "gpt-5.5",
-  "run_id": "820ee886",
-  "runner": "codex-gpt-5.5",
+  "run_id": "e6438191",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "80f43ff62bc752b81905e9e1be0809e51b8149ffbe4c592b5b2b3d57ce280114"
+    "value": "5ee3abcc71da84a318bd6fbc716460d6ccd177cace3712e870ad9ebdeba3860a"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-19-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-19.json",
-  "trace_sha256": "f7ed970fc0790b2160fcd3027ed9dc27cc25b8536ede2771370f6e80641ce3ff"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-19.json",
+  "trace_sha256": "cd63e9c80c80d3323b35e47435b50b473c1a5932f74733932eda2babf644f2c4"
 }

--- a/statutes/26/3306/b/19.test.yaml
+++ b/statutes/26/3306/b/19.test.yaml
@@ -1,4 +1,4 @@
-- name: stock option and employee stock purchase plan remuneration exclusions
+- name: incentive_stock_option_transfer_remuneration_excluded
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -12,40 +12,65 @@
       us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
       ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
       : false
+  output:
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages:
+    - 1000
+- name: employee_stock_purchase_plan_transfer_remuneration_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
     - us:statutes/26/3306/b/19#input.remuneration_amount: 800
       us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
       us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
       us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: true
       ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
       : false
+  output:
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages:
+    - 800
+- name: disposition_by_individual_of_such_stock_remuneration_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
     - us:statutes/26/3306/b/19#input.remuneration_amount: 600
       us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
       us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
       us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
       ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
       : true
+  output:
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies:
+    - holds
+    us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages:
+    - 600
+- name: stock_transfer_without_cited_option_or_plan_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
     - us:statutes/26/3306/b/19#input.remuneration_amount: 400
       us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: true
       us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: false
       us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
       ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
       : false
-    - us:statutes/26/3306/b/19#input.remuneration_amount: 500
-      us:statutes/26/3306/b/19#input.remuneration_on_account_of_transfer_of_share_of_stock_to_individual: false
-      us:statutes/26/3306/b/19#input.stock_transfer_pursuant_to_exercise_of_incentive_stock_option_as_defined_in_section_422_b: true
-      us:statutes/26/3306/b/19#input.stock_transfer_under_employee_stock_purchase_plan_as_defined_in_section_423_b: false
-      ? us:statutes/26/3306/b/19#input.remuneration_on_account_of_disposition_by_individual_of_stock_transferred_pursuant_to_exercise_of_incentive_stock_option_or_under_employee_stock_purchase_plan
-      : false
   output:
     us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies:
-    - holds
-    - holds
-    - holds
-    - not_holds
     - not_holds
     us:statutes/26/3306/b/19#stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages:
-    - 1000
-    - 800
-    - 600
-    - 0
     - 0

--- a/statutes/26/3306/b/19.yaml
+++ b/statutes/26/3306/b/19.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    "remuneration on account of" a cited stock transfer or "any disposition by the individual of such stock"
+    "remuneration on account of" a transfer of stock pursuant to an incentive stock option or employee stock purchase plan, or "any disposition by the individual of such stock"
 rules:
   - name: stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies
     kind: derived
@@ -25,12 +25,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "pursuant to an exercise of an incentive stock option (as defined in section 422(b))"
+              excerpt: "pursuant to an exercise of an incentive stock option"
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "under an employee stock purchase plan (as defined in section 423(b))"
+              excerpt: "under an employee stock purchase plan"
           - path: versions[0].formula
             kind: condition
             source:


### PR DESCRIPTION
Summary:
- Refresh the generated section 3306(b)(19) payroll RuleSpec using axiom-encode 0.2.532 / openai:gpt-5.5.
- Split the generated companion tests into four single-scenario cases for qualifying ISO transfer, qualifying employee stock purchase plan transfer, qualifying disposition, and non-qualifying stock transfer.
- Update the generated apply manifest/provenance for the current encoder run.

PolicyEngine oracle coverage:
- `stock_option_or_employee_stock_purchase_plan_stock_remuneration_excluded_from_wages`: known_not_comparable, tested (PE exposes final `taxable_earnings_for_federal_unemployment_tax`, not this narrow FUTA wage exclusion amount separately).
- `stock_option_or_employee_stock_purchase_plan_stock_remuneration_exclusion_applies`: known_not_comparable, tested (PE exposes final FUTA taxable earnings, not this statutory predicate separately).
- Full tax oracle coverage: 1,582 outputs, 227 comparable, 1,355 known_not_comparable, 0 untested comparable.

Validation:
- `uv run axiom-encode validate statutes/26/3306/b/19.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/b/19.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/b/19.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
