### PR TITLE
Refresh generated section 3306(b)(20) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/b/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/b/20.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/b/20.yaml",
-      "sha256": "e091a58d4018e9f208b9a8687772d23eb3f6529dd76b52c204a4816cde0d9a12"
+      "sha256": "841807e21ba05ba6823992ccbe6c7ef34c2a3a46ced369df05a111988da80bd4"
     },
     {
       "path": "statutes/26/3306/b/20.test.yaml",
-      "sha256": "59ff3a13e0b8f86f1a14859d938781cbfe638f4cc5cfaa96ed842ea59f17427a"
+      "sha256": "cd3d2d9ec4e3d8bc931e0576f5f0239d33f4b2dd65203f92a3a7d1adf4c3b971"
     }
   ],
   "axiom_encode_git": {
-    "commit": "cb644c60240544125495a0576c30a28d48c259ee",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.238",
-    "version_commit": "cb644c60240544125495a0576c30a28d48c259ee"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.238",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(b)(20)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-b-20/workspace/context-manifest.json",
-  "context_manifest_sha256": "3cbe6d4fa97de3ba85281fc4ec724e0a307d8e0fa5cfa1e446331a7c701d74ae",
-  "generated_at": "2026-05-25T20:27:48.386166+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/codex-gpt-5.5/statutes/26/3306/b/20.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-b-20-regen-20260525",
-  "generated_output_sha256": "e091a58d4018e9f208b9a8687772d23eb3f6529dd76b52c204a4816cde0d9a12",
-  "generation_prompt_sha256": "d60876648d590fde61a1d156b1170d2e6b76fd25720ef066ae05987659e245b0",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-b-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "4882959c862f0d1d6c68de022d8dd92d852c4652b8e5f14aa911364242fdece2",
+  "generated_at": "2026-06-02T08:35:47.163161+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/b/20.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "841807e21ba05ba6823992ccbe6c7ef34c2a3a46ced369df05a111988da80bd4",
+  "generation_prompt_sha256": "c86544e3128a45a6f8b3aff51f98d860d04243e6a434cd6f939b17e866504af6",
   "model": "gpt-5.5",
-  "run_id": "d9ec6919",
-  "runner": "codex-gpt-5.5",
+  "run_id": "52e17153",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "509746f57e63a011acaf3f7d2c142b363ef18fa5a94f0a0f0169cd7b1930605b"
+    "value": "525916da5570e2dfd08f6a772a841b3eb6f12495f17a5d081ea2d0b7b2f53fb8"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-b-20-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-b-20.json",
-  "trace_sha256": "98091bd87f6819fef64a4172a50524f2b2bd602256790725c2645a0cfccf5043"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-b-20.json",
+  "trace_sha256": "e88b524e47a9cff78e155120ca67d06d70cc656e7fd6e8a323e72f97a0b03e77"
 }

--- a/statutes/26/3306/b/20.test.yaml
+++ b/statutes/26/3306/b/20.test.yaml
@@ -10,6 +10,18 @@
     us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: false
   output:
     us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: holds
+- name: no_treatment_when_secretary_regulations_provide_otherwise
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/b/20#input.third_party_makes_payment: true
+    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+    : true
+    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: true
+  output:
+    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds
 - name: no_treatment_when_third_party_does_not_make_payment
   period:
     period_kind: tax_year
@@ -32,17 +44,5 @@
     ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
     : false
     us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: false
-  output:
-    us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds
-- name: no_treatment_when_secretary_regulations_provide_otherwise
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us:statutes/26/3306/b/20#input.third_party_makes_payment: true
-    ? us:statutes/26/3306/b/20#input.payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
-    : true
-    us:statutes/26/3306/b/20#input.regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment: true
   output:
     us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages: not_holds

--- a/statutes/26/3306/b/20.yaml
+++ b/statutes/26/3306/b/20.yaml
@@ -5,10 +5,10 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    "any benefit or payment which is excludable from the gross income of the employee under section 139B(b)" and, except as Secretarial regulations otherwise provide, third-party payments described by paragraph (2)(A)'s parenthetical are treated as employer wages for this chapter and chapter 22.
+    "any benefit or payment which is excludable from the gross income of the employee under section 139B(b)" and, except as Secretarial regulations otherwise provide, a third party making a paragraph (2)(A) parenthetical wage payment is treated as the employer for this chapter and chapter 22.
   deferred_outputs:
     - output: us:statutes/26/3306/b/20#benefit_or_payment_excluded_from_wages_due_to_employee_gross_income_exclusion
-      reason: Requires determining whether the benefit or payment is excludable from employee gross income under 26 U.S.C. 139B(b), but no copied RuleSpec target for that subsection is available.
+      reason: Requires determining whether the benefit or payment is excludable from employee gross income under section 139B(b), but no copied RuleSpec target for section 139B(b) is available.
 rules:
   - name: third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages
     kind: derived
@@ -23,14 +23,22 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "any third party which makes a payment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "included in wages solely by reason of the parenthetical matter contained in subparagraph (A) of paragraph (2)"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "Except as otherwise provided in regulations prescribed by the Secretary"
           - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "shall be treated for purposes of this chapter and chapter 22 as the employer with respect to such wages"
     versions:
       - effective_from: '2026-01-01'
         formula: |-


### PR DESCRIPTION
Summary:
- Refresh the generated section 3306(b)(20) payroll RuleSpec using axiom-encode 0.2.532 / openai:gpt-5.5.
- Preserve the deferred 139B(b) exclusion output because no copied RuleSpec target for section 139B(b) is available.
- Add generated source excerpts for the third-party employer treatment rule and refresh generated tests/manifest provenance.

PolicyEngine oracle coverage:
- `third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages`: known_not_comparable, tested (PE does not expose employer-identity treatment predicates separately).
- Full tax oracle coverage: 1,582 outputs, 227 comparable, 1,355 known_not_comparable, 0 untested comparable.

Validation:
- `uv run axiom-encode validate statutes/26/3306/b/20.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/b/20.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/b/20.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
