### PR TITLE
Refresh generated section 3306(c)(1) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/1.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/1.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/1.yaml",
-      "sha256": "038e33ba094e5168862ef95fb93d91abfbf30f4ea2b66b1e3ab9009687a652aa"
+      "sha256": "9b40a0005a1b1b3f13468a97a81f907db1ec3cea4b7f0c1a0b5a2eb2245c7bda"
     },
     {
       "path": "statutes/26/3306/c/1.test.yaml",
-      "sha256": "751dc9b61d9646798fdcecf2e0e40d443bc5049917023b3c462ad284c4c52817"
+      "sha256": "fd2e8bd32e2dbdd4e65c41f0a431fb125a1cdfc7543d6948efe60733b4dcf645"
     }
   ],
   "axiom_encode_git": {
-    "commit": "e0b7b2b6789aa0dcea6700379605ded7607cb85b",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.240",
-    "version_commit": "e0b7b2b6789aa0dcea6700379605ded7607cb85b"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.240",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(1)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "670729fbe738ef04e5576e44eeeb3f45787daa83a3863a64160c1f3fda7f67c9",
-  "generated_at": "2026-05-25T21:19:17.480578+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/codex-gpt-5.5/statutes/26/3306/c/1.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-1-regen-20260525",
-  "generated_output_sha256": "038e33ba094e5168862ef95fb93d91abfbf30f4ea2b66b1e3ab9009687a652aa",
-  "generation_prompt_sha256": "83def7e5101a2b2779d7eee01c11218eba36d3c54fc66c4576cb4af4f48177a4",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "cc08d098cf9b634ef02f3ab11fa9859213e5338193baa335bd6a213463be4f6f",
+  "generated_at": "2026-06-02T08:41:56.766071+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9b40a0005a1b1b3f13468a97a81f907db1ec3cea4b7f0c1a0b5a2eb2245c7bda",
+  "generation_prompt_sha256": "89c057ecf67c0f65262c8295ca021974c1cbfb4b3fff320f8c5abe01a9444cd1",
   "model": "gpt-5.5",
-  "run_id": "a497e548",
-  "runner": "codex-gpt-5.5",
+  "run_id": "7e2c27c3",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "1d91af26b27341941a08d950fcdb14465bae6e317ef92df351311b5d86e2d57b"
+    "value": "6280a3b4002c597ec6c033a602933c3930c8ea45c2b2ee1ccaeaf1e9027cfae3"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-1-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-c-1.json",
-  "trace_sha256": "4deec1797bedafda70ca8a7c2b56c7c001f423271259942db8d6029f93c05604"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-1.json",
+  "trace_sha256": "b26dce7c4f1b8598de13fa77f51e15242bf02d79fa5d7a29b9e07a32d21243b1"
 }

--- a/statutes/26/3306/c/1.test.yaml
+++ b/statutes/26/3306/c/1.test.yaml
@@ -1,7 +1,6 @@
 - name: cash threshold met and non-alien agricultural labor is not excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -22,8 +21,7 @@
     us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: not_holds
 - name: same employer facts but admitted alien agricultural labor remains excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -41,8 +39,7 @@
     us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: holds
 - name: neither cash nor day threshold met so agricultural labor is excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -58,10 +55,10 @@
     us:statutes/26/3306/c/1#agricultural_labor_day_count_test_satisfied: not_holds
     us:statutes/26/3306/c/1#agricultural_labor_employer_test_satisfied: not_holds
     us:statutes/26/3306/c/1#agricultural_labor_excepted_from_employment: holds
-- name: day count threshold met but non-agricultural labor is outside the exception
+- name: day count threshold met but non-agricultural labor is outside the agricultural
+    labor exception
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/1.yaml
+++ b/statutes/26/3306/c/1.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    Agricultural labor is excepted unless the employer meets the cash-remuneration or day-count test and the labor is not performed by the specified admitted alien worker.
+    Agricultural labor is excepted from employment unless the employer meets either the $20,000 cash-remuneration-quarter test or the 20-days/10-individuals agricultural-labor test, and the labor is not performed by an alien admitted to perform agricultural labor under the cited Immigration and Nationality Act provisions.
 rules:
   - name: agricultural_labor_cash_remuneration_quarter_threshold
     kind: parameter
@@ -72,6 +72,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: during any calendar quarter in the calendar year or the preceding calendar year paid remuneration in cash of $20,000 or more
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -90,6 +91,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: on each of some 20 days ... each day being in a different calendar week ... 10 or more individuals
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -109,6 +111,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: who— (i) ... or (ii) ...
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -128,6 +131,7 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: agricultural labor ... unless ... and ... such labor is not agricultural labor performed by an individual who is an alien admitted to the United States to perform agricultural labor
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
Summary:
- Refresh the generated section 3306(c)(1) payroll RuleSpec using axiom-encode 0.2.532 / openai:gpt-5.5.
- Add generated source excerpts for the agricultural-labor cash-remuneration, day-count, employer-test, and admitted-alien carve-out predicates.
- Preserve the executable `agricultural_labor_excepted_from_employment` output and its admitted-alien carve-out tests.
- Rejected an initial generated attempt that over-deferred the final exception due to unavailable INA RuleSpec targets; reran with narrow source-faithfulness context so the subsection's own text remains executable.

PolicyEngine oracle coverage:
- All seven `3306(c)(1)` outputs are known_not_comparable and tested.
- Rationale: PE exposes final `taxable_earnings_for_federal_unemployment_tax`, not agricultural-employment eligibility thresholds/predicates separately.
- Full tax oracle coverage: 1,582 outputs, 227 comparable, 1,355 known_not_comparable, 0 untested comparable.

Validation:
- `uv run axiom-encode validate statutes/26/3306/c/1.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/1.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/c/1.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
