### PR TITLE
Refresh generated section 3306(c)(2) payroll tests

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/2.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/2.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "statutes/26/3306/c/2.test.yaml",
-      "sha256": "52493f648df811e7304dbf277acb76df26a951e8e86dce8c5dec7d316012feb6"
+      "sha256": "e51ee529c81e570a7c361abecfb84a6ad4333df8642c9534ab435279851d2b0d"
     }
   ],
   "axiom_encode_git": {
-    "commit": "55ace8ec2d2043b6cf66e9ceb70b25f657927e99",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.241",
-    "version_commit": "55ace8ec2d2043b6cf66e9ceb70b25f657927e99"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.241",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(2)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-2/workspace/context-manifest.json",
-  "context_manifest_sha256": "3ef102351cbecb7d19e9c85c1b4aa2a7fbb390969d972cc4a6a91a119a660699",
-  "generated_at": "2026-05-25T21:35:53.053754+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/codex-gpt-5.5/statutes/26/3306/c/2.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-2-regen-20260525",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "9d7649c3804fc0fd070305e878ce313fa47feef4fa533fac985977d905a459d3",
+  "generated_at": "2026-06-02T08:46:26.472337+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "b71de3bd3232a6562d8f4678ae21223db455612aafa5e3a9a62803a8190bd63e",
-  "generation_prompt_sha256": "58535bde1a29ee20dc2984f6acac5a624ffdee8d93803f1edb3e7505214e1247",
+  "generation_prompt_sha256": "83b2100537c3c2989f4d4f35f871e0558d50c706a8fd46affd3ba2ae4238b19e",
   "model": "gpt-5.5",
-  "run_id": "76954e8f",
-  "runner": "codex-gpt-5.5",
+  "run_id": "7cbcfe3c",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "f0695636050130cc1f38b18d1909e9406dc82d9901695b9511d65f1b1c44edf4"
+    "value": "416eda82bb6011dcfaead6922b569099cd2c4cd0ee54532b50a5c2329f3ebd04"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-2-regen-20260525/traces/codex-gpt-5.5/26-USC-3306-c-2.json",
-  "trace_sha256": "ee40fe303642914ab38ea5aea991db45934b886c179fa1298f64f99610be11e1"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-2.json",
+  "trace_sha256": "e63b7e00190729aeb7dbfe912bd67587e080f403433bd5454f940aab2dac26f0"
 }

--- a/statutes/26/3306/c/2.test.yaml
+++ b/statutes/26/3306/c/2.test.yaml
@@ -1,4 +1,4 @@
-- name: domestic service below threshold is excepted
+- name: domestic_service_below_threshold_is_excepted
   period:
     period_kind: custom
     name: calendar_year
@@ -12,7 +12,7 @@
   output:
     us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied: not_holds
     us:statutes/26/3306/c/2#domestic_service_excepted_from_employment: holds
-- name: domestic service at threshold is not excepted
+- name: domestic_service_at_threshold_is_not_excepted
   period:
     period_kind: custom
     name: calendar_year
@@ -24,9 +24,10 @@
     ? us:statutes/26/3306/c/2#input.maximum_cash_remuneration_paid_to_individuals_employed_in_such_domestic_service_in_any_calendar_quarter_during_calendar_year_or_preceding_calendar_year
     : 1000
   output:
+    us:statutes/26/3306/c/2#domestic_service_cash_remuneration_quarter_threshold: 1000
     us:statutes/26/3306/c/2#domestic_service_cash_remuneration_test_satisfied: holds
     us:statutes/26/3306/c/2#domestic_service_excepted_from_employment: not_holds
-- name: non domestic service is not covered by this exception
+- name: non_domestic_service_is_not_covered_by_this_exception
   period:
     period_kind: custom
     name: calendar_year


### PR DESCRIPTION
Summary:
- Refresh generated section 3306(c)(2) companion tests/provenance using axiom-encode 0.2.532 / openai:gpt-5.5.
- Rule YAML is unchanged; generated tests now use normalized names and explicitly assert the domestic-service cash-remuneration threshold in the at-threshold case.

PolicyEngine oracle coverage:
- All three `3306(c)(2)` outputs are known_not_comparable and tested.
- Rationale: PE exposes final `taxable_earnings_for_federal_unemployment_tax`, not domestic-service eligibility thresholds/predicates separately.
- Full tax oracle coverage: 1,582 outputs, 227 comparable, 1,355 known_not_comparable, 0 untested comparable.

Validation:
- `uv run axiom-encode validate statutes/26/3306/c/2.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/2.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/c/2.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
