### PR TITLE
Refresh generated section 3306(c)(3) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/3.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/3.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/3.yaml",
-      "sha256": "d67d7847d76e6b5f8f3b65a6f48c54da77faa1736d50e38260c12da195a798a8"
+      "sha256": "d52f00d0933f3c984bfe04d0cc1eb9ee0b3f10ece729e71e20f4a082ed484fe0"
     },
     {
       "path": "statutes/26/3306/c/3.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "f703db88832d3793ead829eab582441180fb5218",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.242",
-    "version_commit": "f703db88832d3793ead829eab582441180fb5218"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.242",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(3)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-3/workspace/context-manifest.json",
-  "context_manifest_sha256": "dd4e04b01d2944db0d6b3aef76bd540f9d0afeb88422cd3675306e1bfddb9e09",
-  "generated_at": "2026-05-25T22:00:38.546109+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/3.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525",
-  "generated_output_sha256": "d67d7847d76e6b5f8f3b65a6f48c54da77faa1736d50e38260c12da195a798a8",
-  "generation_prompt_sha256": "059948936c2800f8f72e874558fb7bcd0d267ec4918b812b8474119cba1898ea",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "4f041706089cc143252be47c3da27d1287db0ca46c4a65cf9739f6b89201e6d9",
+  "generated_at": "2026-06-02T08:54:08.471382+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/3.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d52f00d0933f3c984bfe04d0cc1eb9ee0b3f10ece729e71e20f4a082ed484fe0",
+  "generation_prompt_sha256": "9e4e275aa53f12fcbdd07df81374c9ad8cbb89373815acc6145b80e2421ec6a2",
   "model": "gpt-5.5",
-  "run_id": "75b8aeb5",
-  "runner": "codex-gpt-5.5",
+  "run_id": "0fc9caea",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "710beb9ce89b4c23294e451ff3c803f59800a6c1379b6121bfa1afd1f3f12054"
+    "value": "ca24b236971992593d49e8090398260bafa071693246ac1b7737ea74c1ef8e6e"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-3-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-3.json",
-  "trace_sha256": "d30edf8dadd07e4c21d5692f8be124b19bac6eb98b1855e8bee0783da8211754"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-3.json",
+  "trace_sha256": "2062c598463750d6fd02051c9d0dae38aceee2c07aa96331b93fad35d079a302"
 }

--- a/statutes/26/3306/c/3.yaml
+++ b/statutes/26/3306/c/3.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (3) service not in the course of the employer’s trade or business performed in any calendar quarter by an employee, unless the cash remuneration paid for such service is $50 or more and such service is performed by an individual who is regularly employed by such employer to perform such service. For purposes of this paragraph, an individual shall be deemed to be regularly employed by an employer during a calendar quarter only if— (A) on each of some 24 days during such quarter such individual performs for such employer for some portion of the day service not in the course of the employer’s trade or business, or (B) such individual was regularly employed (as determined under subparagraph (A)) by such employer in the performance of such service during the preceding calendar quarter;
+    service not in the course of the employer’s trade or business performed in any calendar quarter by an employee, unless the cash remuneration paid for such service is $50 or more and such service is performed by an individual who is regularly employed by such employer to perform such service
 rules:
   - name: nonbusiness_service_cash_remuneration_quarter_threshold
     kind: parameter
@@ -56,6 +56,12 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "cash remuneration paid for such service is $50 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_quarter_threshold
+              output: nonbusiness_service_cash_remuneration_quarter_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -75,6 +81,12 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "on each of some 24 days during such quarter such individual performs"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_days_threshold
+              output: nonbusiness_service_regular_employment_days_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -99,6 +111,12 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "during the preceding calendar quarter"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/3#nonbusiness_service_current_quarter_regular_employment_test_satisfied
+              output: nonbusiness_service_current_quarter_regular_employment_test_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -124,6 +142,18 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "unless the cash remuneration paid for such service is $50 or more and such service is performed by an individual who is regularly employed"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/3#nonbusiness_service_cash_remuneration_test_satisfied
+              output: nonbusiness_service_cash_remuneration_test_satisfied
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/3#nonbusiness_service_regular_employment_test_satisfied
+              output: nonbusiness_service_regular_employment_test_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
Summary:
- Refresh the generated section 3306(c)(3) payroll RuleSpec using axiom-encode 0.2.532 / openai:gpt-5.5.
- Add generated proof import atoms while preserving the existing executable rule surface and all five companion-test scenarios.
- Rejected two generated attempts that narrowed companion-test coverage; final run used narrow context to preserve the nonbusiness-category negative case, the cash-threshold-but-not-regularly-employed case, and statutory parameter assertions.

PolicyEngine oracle coverage:
- All six `3306(c)(3)` outputs are known_not_comparable and tested.
- Rationale: PE exposes final `taxable_earnings_for_federal_unemployment_tax`, not nonbusiness-service eligibility thresholds/predicates separately.
- Full tax oracle coverage: 1,582 outputs, 227 comparable, 1,355 known_not_comparable, 0 untested comparable.

Validation:
- `uv run axiom-encode validate statutes/26/3306/c/3.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/3.test.yaml --root ... --axiom-rules-engine-path ...`
- `uv run axiom-encode proof-validate statutes/26/3306/c/3.yaml`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root ... --oracle policyengine --program tax --fail-on-untested-comparable --json`
- `git diff --check origin/main`
