### PR TITLE
Refresh generated section 3306(c)(4) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/4.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/4.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/4.yaml",
-      "sha256": "b3db6d2a97ef7351697caf23ab0dc534bf4886c7ec9b4de18191685bd4f2f09c"
+      "sha256": "b03d26bfb0c4743d12946deea34e7e65386db3c1049a3ff8f47677258a69b30e"
     },
     {
       "path": "statutes/26/3306/c/4.test.yaml",
-      "sha256": "f31b4e5ab3650aa4579eb06624322c90c6cf610f3246878f893011bc04de00bb"
+      "sha256": "cf814cd88b22838d14d52e06ce47328d2fc67ec59c626a74d8bca44eee9b8544"
     }
   ],
   "axiom_encode_git": {
-    "commit": "6a09be5a0d4b4468e57e4a9ad01fd672d05bff79",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.243",
-    "version_commit": "6a09be5a0d4b4468e57e4a9ad01fd672d05bff79"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.243",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(4)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-4/workspace/context-manifest.json",
-  "context_manifest_sha256": "5eb58404b5f4519b7cab71c21986909ae3d84b086fda630607b8efeb19dc4cd0",
-  "generated_at": "2026-05-25T22:21:37.732362+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/4.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525",
-  "generated_output_sha256": "b3db6d2a97ef7351697caf23ab0dc534bf4886c7ec9b4de18191685bd4f2f09c",
-  "generation_prompt_sha256": "19e51d2aa458d8c9bd54bda47d00830c97ac80c05980cf2bf2a849d26af31a1b",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "0590478e6d0b2f184e4a0501f7c1787bf6362303f8e69a300118f48f1dd0818b",
+  "generated_at": "2026-06-02T09:01:02.899808+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/4.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b03d26bfb0c4743d12946deea34e7e65386db3c1049a3ff8f47677258a69b30e",
+  "generation_prompt_sha256": "cb471a190a33b4b0b207c83dfcd4cc219b6917434e69d269f91c504c8b835723",
   "model": "gpt-5.5",
-  "run_id": "1bfd69de",
-  "runner": "codex-gpt-5.5",
+  "run_id": "c41ec0e2",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "9419479f16d09a3b46e882b1bdb26185b2469e4a13b6862893895b042898b541"
+    "value": "a66f98082f1af2d435febe3d78c9c47515b9bf9d5a32a1353459f87776f4e4c9"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-4-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-4.json",
-  "trace_sha256": "8a3b0bc711f5ae700e0248ae46d907ca3b5ee4fceca60a30d8c55b111fe50497"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-4.json",
+  "trace_sha256": "0b476f0bbd36aac814cc3d35a8d45bbc74f4980b9d95b61fa9b11a44be268a3d"
 }

--- a/statutes/26/3306/c/4.test.yaml
+++ b/statutes/26/3306/c/4.test.yaml
@@ -1,4 +1,4 @@
-- name: non_american_vessel_and_aircraft_service_exception_applies
+- name: non_american_vessel_service_exception_applies
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -15,6 +15,17 @@
       ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
       : false
       us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
+    - holds
+- name: non_american_aircraft_service_exception_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Asset:
     - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
       us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: true
       us:statutes/26/3121/f#input.asset_is_vessel: false
@@ -27,8 +38,7 @@
   output:
     us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
     - holds
-    - holds
-- name: service_not_on_or_in_connection_with_vessel_or_aircraft
+- name: required_service_connection_or_outside_united_states_employment_missing
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -45,17 +55,6 @@
       ? us:statutes/26/3121/f#input.vessel_crew_employed_solely_by_united_states_citizens_residents_or_united_states_or_state_corporations
       : false
       us:statutes/26/3121/f#input.aircraft_registered_under_laws_of_united_states: false
-  output:
-    us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
-    - not_holds
-- name: employee_not_employed_on_asset_outside_united_states
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input: {}
-  tables:
-    Asset:
     - us:statutes/26/3306/c/4#input.service_performed_on_or_in_connection_with_vessel_or_aircraft: true
       us:statutes/26/3306/c/4#input.employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states: false
       us:statutes/26/3121/f#input.asset_is_vessel: true
@@ -68,7 +67,8 @@
   output:
     us:statutes/26/3306/c/4#non_american_vessel_or_aircraft_service_excepted_from_employment:
     - not_holds
-- name: american_vessel_or_aircraft_not_excepted
+    - not_holds
+- name: american_vessel_or_american_aircraft_service_not_excepted
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3306/c/4.yaml
+++ b/statutes/26/3306/c/4.yaml
@@ -8,7 +8,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (4) service performed on or in connection with a vessel or aircraft not an American vessel or American aircraft, if the employee is employed on and in connection with such vessel or aircraft when outside the United States;
+    service performed on or in connection with a vessel or aircraft not an American vessel or American aircraft, if the employee is employed on and in connection with such vessel or aircraft when outside the United States
 rules:
   - name: non_american_vessel_or_aircraft_service_excepted_from_employment
     kind: derived
@@ -40,8 +40,5 @@ rules:
         formula: |-
           service_performed_on_or_in_connection_with_vessel_or_aircraft
           and employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states
-          and (
-            not american_vessel
-            and
-            not american_aircraft
-          )
+          and not american_vessel
+          and not american_aircraft


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(4), using `axiom-encode --apply` from encoder `0.2.532` / run `c41ec0e2`.

This keeps the existing RuleSpec behavior for the FUTA employment exception for service on non-American vessels or aircraft, while refreshing the signed apply manifest and companion tests.

Notes:

- The first generated attempt (`77cafe3b`) was rejected because it dropped the positive non-American aircraft test row.
- The accepted run used `/tmp/axiom-3306c4-repair-context.txt` via `--allow-context` to preserve the existing vessel and aircraft coverage.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/4.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/4.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/4.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c4-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c4 output status: known-not-comparable to PE's final FUTA taxable earnings surface, with 4 tested local outputs
