### PR TITLE
Refresh generated section 3306(c)(5) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/5.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/5.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/5.yaml",
-      "sha256": "77f80fe420be476f7825dd67ea40440533970e5eaee72a0fe3738bfc3533bad1"
+      "sha256": "7122ae2d3d87aa5f5eb17d5f0c79d7bb2a15fb7059a72154a40c4fe59b3d870e"
     },
     {
       "path": "statutes/26/3306/c/5.test.yaml",
-      "sha256": "cbd5c4a286086b5e5666ce4f7f55fac16423ac5345dbb2b3acaa2860da75b216"
+      "sha256": "7f3dd01c6cc7df06c9506737253c5f71f8219b6bc9919ac742310400e5e1072d"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3ef9acd31e42e4f15630f76c9b4bd46207fb0f47",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.244",
-    "version_commit": "3ef9acd31e42e4f15630f76c9b4bd46207fb0f47"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.244",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(5)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-5/workspace/context-manifest.json",
-  "context_manifest_sha256": "3d7cb364ea893b162cb621a1d49a3f7461dc771bf315269ef01768b1fb6b3c1d",
-  "generated_at": "2026-05-25T22:44:53.100718+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/5.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525",
-  "generated_output_sha256": "77f80fe420be476f7825dd67ea40440533970e5eaee72a0fe3738bfc3533bad1",
-  "generation_prompt_sha256": "94f8269d0a54cc11d6ec914f0a1041c46dd31af67c1bfd6ca4420eeb099c8c07",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "224b0fce207ef4d8c372f1041a72567aa74def9ba1f1c14dfafc21e1e5880151",
+  "generated_at": "2026-06-02T09:07:34.377493+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/5.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7122ae2d3d87aa5f5eb17d5f0c79d7bb2a15fb7059a72154a40c4fe59b3d870e",
+  "generation_prompt_sha256": "d6e545f9a11ab1ab958436d442d767af296a18027677cce85aa616adc1c2cd46",
   "model": "gpt-5.5",
-  "run_id": "4c10bf81",
-  "runner": "codex-gpt-5.5",
+  "run_id": "407130fb",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "37d0d4880cfd1bc864cd14bcf6f452b1c8d6f4d44df8fcad2f7a855a5014d680"
+    "value": "359d177528f6473661ec45c6429f2f0718d87ae3525c445843d69bb6680f1279"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-5-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-5.json",
-  "trace_sha256": "f2e76a9c7ece0f5314f8ac1ef466bb78754ffcd8bf15afcd66918f700192e8eb"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-5.json",
+  "trace_sha256": "30191bbecbc976f35d0b9cfe169f00af31c79a052bd86071bfc4732e9d67bc8d"
 }

--- a/statutes/26/3306/c/5.test.yaml
+++ b/statutes/26/3306/c/5.test.yaml
@@ -50,7 +50,7 @@
     - holds
     - holds
     - holds
-- name: parent_employment_requires_child_under_age_limit
+- name: parent_employment_requires_child_under_age_limit_and_parent_relationship
   period:
     period_kind: tax_year
     start: '2026-01-01'

--- a/statutes/26/3306/c/5.yaml
+++ b/statutes/26/3306/c/5.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (5) service performed by an individual in the employ of his son, daughter, or spouse, and service performed by a child under the age of 21 in the employ of his father or mother;
+    Service performed by an individual in the employ of the individual's son, daughter, or spouse; and service performed by a child under the age of 21 in the employ of the child's father or mother.
 rules:
   - name: family_employment_child_age_limit
     kind: parameter


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(5), using `axiom-encode --apply` from encoder `0.2.532` / run `407130fb`.

This keeps the existing RuleSpec behavior for the FUTA family-employment exception while refreshing the signed apply manifest and generated companion tests.

Notes:

- The first generated attempt (`f6f96520`) was rejected because it narrowed test coverage: it combined daughter and spouse into one row, dropped the under-age child-in-employ-of-mother positive case, and dropped the under-age/no-parent negative case.
- The accepted run used `/tmp/axiom-3306c5-repair-context.txt` via `--allow-context` to preserve the existing family-relationship and age-boundary coverage.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/5.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/5.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/5.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c5-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c5 outputs: known-not-comparable to PE's final FUTA taxable earnings surface, with local tests present
