### PR TITLE
Refresh generated section 3306(c)(6) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/6.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/6.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/6.yaml",
-      "sha256": "8a520faf9be8210b4f79e9a7020007830f94686dd474a31acfbafdb1a76f5a9a"
+      "sha256": "abbe6f55b7e6bc426058a847ffbaf376b4e0428a2fbf347fa9c2be0fa3d2e8e8"
     },
     {
       "path": "statutes/26/3306/c/6.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "11c5c68c857f342ad4639e328d9d110538b8b2bf",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.245",
-    "version_commit": "11c5c68c857f342ad4639e328d9d110538b8b2bf"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.245",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(6)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-6/workspace/context-manifest.json",
-  "context_manifest_sha256": "f74d052c6e3d9ce3df8b559fcc8fbc0c65d4615dbe8c1ed957deb63f81c5756a",
-  "generated_at": "2026-05-25T23:05:04.486495+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/6.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525",
-  "generated_output_sha256": "8a520faf9be8210b4f79e9a7020007830f94686dd474a31acfbafdb1a76f5a9a",
-  "generation_prompt_sha256": "4ef4cd329b19f04a479ac5dca2d0fc79c390cf094853df69aafe452373f56276",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "f1e86430ba4e3cd1d0a5bbc9c9b8f22cb0ee49d3821bc253cb6869d0c0c809c2",
+  "generated_at": "2026-06-02T09:12:04.747099+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/6.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "abbe6f55b7e6bc426058a847ffbaf376b4e0428a2fbf347fa9c2be0fa3d2e8e8",
+  "generation_prompt_sha256": "fec7625ff02aef43a8a0195c56612a6577889aeed043fea9b0839887166f6562",
   "model": "gpt-5.5",
-  "run_id": "2136dd7e",
-  "runner": "codex-gpt-5.5",
+  "run_id": "753ef08b",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8d0e50a44ac9deed54fccdd38bb1ffe9fcd09016b6e1f80884600cfc79705144"
+    "value": "e48f1417820f14c543a631ab5cb5168fe233892e5f2fcd4ce4959efc0754f18c"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-6-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-6.json",
-  "trace_sha256": "a912a2bef621d148c0a16f87223979071719a3f8a249764bf8d22c3602188db0"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-6.json",
+  "trace_sha256": "a086b934ccbf926009b0d4f7d6a8ba1eee07def79f0dba58d4e4cc61980b6dd5"
 }

--- a/statutes/26/3306/c/6.yaml
+++ b/statutes/26/3306/c/6.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (6) service performed in the employ of the United States Government or of an instrumentality of the United States which is— (A) wholly or partially owned by the United States, or (B) exempt from the tax imposed by section 3301 by virtue of any provision of law which specifically refers to such section (or the corresponding section of prior law) in granting such exemption;
+    service performed in the employ of the United States Government or of an instrumentality of the United States which is wholly or partially owned by the United States, or exempt from the tax imposed by section 3301 by specific statutory reference
 rules:
   - name: service_in_employ_of_qualifying_united_states_instrumentality
     kind: derived


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(6), using `axiom-encode --apply` from encoder `0.2.532` / run `753ef08b`.

This keeps the existing RuleSpec behavior and companion tests for the FUTA United States Government and qualifying federal-instrumentality service exception, while refreshing the signed apply manifest.

Notes:

- The generated test file was unchanged, preserving the existing government-service, owned-instrumentality, section-3301-exempt-instrumentality, and nonqualifying-instrumentality cases.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/6.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/6.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/6.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c6-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c6 outputs: known-not-comparable to PE's final FUTA taxable earnings surface, with 4 tested local outputs
