### PR TITLE
Refresh generated section 3306(c)(7) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/7.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/7.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/7.yaml",
-      "sha256": "0c4f1c8623e9a0ea23b775bf189318ec38220065d3a78a7abc6dbe81d17df040"
+      "sha256": "9358e9e8fbd28bf29e8c46e5bee87c8ff49a5425506790476c48f5d43103f9c7"
     },
     {
       "path": "statutes/26/3306/c/7.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "63ee2fbd3ea5512ec75597e21c59e7f0ba841487",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
-    "version": "0.2.530",
-    "version_commit": "d743168d9b62b31358fecba5695094e81784dd78"
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.530",
+  "axiom_encode_version": "0.2.532",
   "backend": "openai",
   "citation": "26 USC 3306(c)(7)",
-  "context_manifest_file": "/tmp/axiom-encode-3306-c-7-20260602-rerun/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-7/workspace/context-manifest.json",
-  "context_manifest_sha256": "7232fd1d71c6998794b711322f74ac3ab567d5bb5a934ec4b3525e8a53e31e6d",
-  "generated_at": "2026-06-02T02:19:16.394841+00:00",
-  "generated_output_file": "/tmp/axiom-encode-3306-c-7-20260602-rerun/openai-gpt-5.5/statutes/26/3306/c/7.yaml",
-  "generated_output_root": "/tmp/axiom-encode-3306-c-7-20260602-rerun",
-  "generated_output_sha256": "0c4f1c8623e9a0ea23b775bf189318ec38220065d3a78a7abc6dbe81d17df040",
-  "generation_prompt_sha256": "b1ec8222a3036c056bbf4dc6c1dedf0222b4d7822ef3816354249fcb75d62a27",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "b5ff0541d6990691950583577c97f5eeb1002609476a1a5a520ea274e57563d4",
+  "generated_at": "2026-06-02T09:16:47.124232+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/7.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "9358e9e8fbd28bf29e8c46e5bee87c8ff49a5425506790476c48f5d43103f9c7",
+  "generation_prompt_sha256": "8bbbe9ca1d27cae35262f4b535ca1130ca4dfc876a07343bc30e80ca9267df64",
   "model": "gpt-5.5",
-  "run_id": "63cf0e8e",
+  "run_id": "a525c8ab",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b838f0379493500252a61898ff8ae53c17238dce086fbabda12e38c2b75ed662"
+    "value": "7dad0d7fdc5141b6c5e82adb9799f7094066ffd07af5ecc989ae0101cdd47441"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-3306-c-7-20260602-rerun/traces/openai-gpt-5.5/26-USC-3306-c-7.json",
-  "trace_sha256": "2c9229f87842338ef4bbfcd2d07fe65acc43fc90a52c99f6134d3f4e7848c4d8"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-7.json",
+  "trace_sha256": "58a7a0d868b210bfcd6f31098c5a32fe23dc59fa9b4631c1985185483777ff31"
 }

--- a/statutes/26/3306/c/7.yaml
+++ b/statutes/26/3306/c/7.yaml
@@ -61,7 +61,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "service performed in the employ of any instrumentality of one or more States or political subdivisions to the extent that the instrumentality is, with respect to such service"
+              excerpt: "service performed in the employ of any instrumentality of one or more States or political subdivisions"
           - path: versions[0].formula
             kind: condition
             source:


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(7), using `axiom-encode --apply` from encoder `0.2.532` / run `a525c8ab`.

This keeps the existing RuleSpec formulas and companion tests for the FUTA State, political-subdivision, Indian-tribe, wholly owned instrumentality, and constitutionally immune instrumentality service exceptions, while refreshing the signed apply manifest.

Notes:

- The generated test file was unchanged, preserving all existing branch and nonqualifying-service coverage.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/7.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/7.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/7.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c7-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c7 outputs: known-not-comparable to PE's final FUTA taxable earnings surface, with 4 tested local outputs each
