### PR TITLE
Refresh generated section 3306(c)(8) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/8.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/8.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/8.yaml",
-      "sha256": "31e1212820f29c341a72698d0d6fc325879b7bee20b3cbeee413ab26ee890f43"
+      "sha256": "2c5ee72c20f70504832cc89062bd756372b26f83830c39ce61a53a0eb3a7488d"
     },
     {
       "path": "statutes/26/3306/c/8.test.yaml",
-      "sha256": "a3d85e4669f4139d17c9687a45f360cf13e00bd1ef9f577be75d662f3bc82e9a"
+      "sha256": "ec73dc20554e36fdc6562b6ac3085de6074a22f604969dd5e402a3bb30fcea35"
     }
   ],
   "axiom_encode_git": {
-    "commit": "9ea986123cf58a6c5dfaf2959ea5c7dbcd14e6ed",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.247",
-    "version_commit": "9ea986123cf58a6c5dfaf2959ea5c7dbcd14e6ed"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.247",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(8)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-8/workspace/context-manifest.json",
-  "context_manifest_sha256": "1613db35c556380088db1c71c834c15914717790364ea40bfb374d21e1304e63",
-  "generated_at": "2026-05-25T23:40:23.714388+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/8.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525",
-  "generated_output_sha256": "31e1212820f29c341a72698d0d6fc325879b7bee20b3cbeee413ab26ee890f43",
-  "generation_prompt_sha256": "e97507c81c57ad54ef80dadefd8731d72bf6d9c0f7a6ec4c4af782c51ab6a792",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "31e2b09298b11a22dd77fbc95803e9272521d2c2a3bf4539c8ab080b987a4634",
+  "generated_at": "2026-06-02T09:21:25.780781+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/8.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "2c5ee72c20f70504832cc89062bd756372b26f83830c39ce61a53a0eb3a7488d",
+  "generation_prompt_sha256": "fe099c7c81be626e1323053297ff52492718510009c2c40ada612dd7bfde5749",
   "model": "gpt-5.5",
-  "run_id": "36d506fb",
-  "runner": "codex-gpt-5.5",
+  "run_id": "64282c44",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8fc773f15e8a6288ad4bb047fe64d5a269b3e216af57d68d2d88ac2a4dbad169"
+    "value": "a4bbb83c5f9c95fddac2914f2967b5c6f0336f8b22736dc6ec55dca7a47cec74"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-8-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-8.json",
-  "trace_sha256": "3c94534e3160db55c7d31bdc24daf17cc840e194344029d0a57e15472e3f417c"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-8.json",
+  "trace_sha256": "33ef43bbd5fb4fcdbaef6ca3babde7e02a5826ad102c6235f57fcbbe363b9eb8"
 }

--- a/statutes/26/3306/c/8.test.yaml
+++ b/statutes/26/3306/c/8.test.yaml
@@ -1,7 +1,6 @@
 - name: service_for_tax_exempt_501_c_3_organization_is_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -12,8 +11,7 @@
     us:statutes/26/3306/c/8#tax_exempt_section_501_c_3_organization_service_excepted_from_employment: holds
 - name: service_not_for_501_c_3_organization_is_not_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -24,8 +22,7 @@
     us:statutes/26/3306/c/8#tax_exempt_section_501_c_3_organization_service_excepted_from_employment: not_holds
 - name: service_for_non_exempt_organization_is_not_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/8.yaml
+++ b/statutes/26/3306/c/8.yaml
@@ -20,10 +20,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: service performed in the employ of a religious, charitable, educational, or other organization described in section 501(c)(3)
           - path: versions[0].formula
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: exempt from income tax under section 501(a)
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(8), using `axiom-encode --apply` from encoder `0.2.532` / run `64282c44`.

This keeps the existing RuleSpec formula for the FUTA tax-exempt section 501(c)(3) organization service exception, adds proof excerpts, normalizes companion-test periods to tax years, and refreshes the signed apply manifest.

Notes:

- The generated tests preserve the positive case and both missing-condition negative cases.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/8.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/8.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/8.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c8-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c8 output: known-not-comparable to PE's final FUTA taxable earnings surface, with 3 tested local outputs
