### PR TITLE
Refresh generated section 3306(c)(9) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/9.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/9.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/9.yaml",
-      "sha256": "25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525"
+      "sha256": "40d9b7ffd165ef105f569a2588e2d7fd312a3111fccfc1e9485d7e1e6223e4ff"
     },
     {
       "path": "statutes/26/3306/c/9.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "dae05b0017be0420e8c2d7389d5032877b7a6733",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.248",
-    "version_commit": "dae05b0017be0420e8c2d7389d5032877b7a6733"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.248",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(9)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-9/workspace/context-manifest.json",
-  "context_manifest_sha256": "3de2b5c86024857c553acc7b863de8935e6feffa4c48a99d2c2d2a1f61d83a3c",
-  "generated_at": "2026-05-25T23:58:40.410722+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/9.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525",
-  "generated_output_sha256": "25f445e01427b772959fbf93fbb2e99f56b79fa6427bfc69716635c9a34a6525",
-  "generation_prompt_sha256": "6d6685bb06fcb8a47d18dbbb84906a18c2aba49de744676649e2669bde05407a",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "b65e49913c1fa1f9cc9c1a92bfe6c23fce156a1ce4b53b1f35995162f6b6a51a",
+  "generated_at": "2026-06-02T09:25:59.188245+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/9.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "40d9b7ffd165ef105f569a2588e2d7fd312a3111fccfc1e9485d7e1e6223e4ff",
+  "generation_prompt_sha256": "91110b7a6e9e6bd221a745db526d1a8057976201c6590d4b6c069b46148082f6",
   "model": "gpt-5.5",
-  "run_id": "960cbae4",
-  "runner": "codex-gpt-5.5",
+  "run_id": "27aa9b2c",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "df6ac8a032bdc7512f59a7c868a0246454527499924524710f38fc9a2289f473"
+    "value": "ae5b8858e623f57ba8246c228b1f98248812fc9e302d04649c33e437d9a830fb"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-9-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-9.json",
-  "trace_sha256": "b9c69d54f5c3996db87ff01710c59f156979410dbf325ce046f00b2939e6100e"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-9.json",
+  "trace_sha256": "8161af6ef626711596405642f45dd77262a5922abaee8b6bf9e5bead49e838c7"
 }

--- a/statutes/26/3306/c/9.yaml
+++ b/statutes/26/3306/c/9.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (9) service performed by an individual as an employee or employee representative as defined in section 1 of the Railroad Unemployment Insurance Act (45 U.S.C. 351)
+    service performed by an individual as an employee or employee representative as defined in section 1 of the Railroad Unemployment Insurance Act
 rules:
   - name: railroad_employee_or_employee_representative_service_excepted_from_employment
     kind: derived


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(9), using `axiom-encode --apply` from encoder `0.2.532` / run `27aa9b2c`.

This keeps the existing RuleSpec formula and companion tests for the railroad employee / employee representative FUTA employment exception, while refreshing the signed apply manifest.

Notes:

- The generated test file was unchanged, preserving employee, employee-representative, and neither cases.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/9.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/9.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/9.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c9-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c9 output: known-not-comparable to PE's final FUTA taxable earnings surface, with 3 tested local outputs
