### PR TITLE
Refresh generated section 3306(c)(10) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/10.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/10.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/10.yaml",
-      "sha256": "150c11da957f11f0f172f6b55dd11e8c35e41423d09c8d71e62ed30d28b01780"
+      "sha256": "850259ee6a14558f19e21db8465804bac8f2d37030c80397769c0e9cef2284d1"
     },
     {
       "path": "statutes/26/3306/c/10.test.yaml",
-      "sha256": "ac08e8a053a85e795132afaf6bbf4c19bd872772fc168264e78d0a5b7ecfe166"
+      "sha256": "2064c7bee2762877ec68147a5eff06339574538bfe121183f32fc909bdf64925"
     }
   ],
   "axiom_encode_git": {
-    "commit": "32ffae581f50a18f3196f2e9e0c069f297babc83",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.249",
-    "version_commit": "32ffae581f50a18f3196f2e9e0c069f297babc83"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.249",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(10)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-10-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-10/workspace/context-manifest.json",
-  "context_manifest_sha256": "53c694010ce5420463170bda31f237ea3325da982bbfe1b948a54ff6c1634c02",
-  "generated_at": "2026-05-26T00:43:30.695544+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-10-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/10.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-10-rerun-20260525",
-  "generated_output_sha256": "150c11da957f11f0f172f6b55dd11e8c35e41423d09c8d71e62ed30d28b01780",
-  "generation_prompt_sha256": "b9076c689160a2718f9e3963cd214199949b6f583c9cc2d5e74879d6e7b2bac1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "fa6ac861428853869960156d164f4530a399044af07b0a3fea3ead12665fa2eb",
+  "generated_at": "2026-06-02T09:33:08.462633+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/10.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "850259ee6a14558f19e21db8465804bac8f2d37030c80397769c0e9cef2284d1",
+  "generation_prompt_sha256": "34f0440e311d63868b24e813707cbb9ca13e38d4b304249c43ec3badfc4713e7",
   "model": "gpt-5.5",
-  "run_id": "e3267240",
-  "runner": "codex-gpt-5.5",
+  "run_id": "9d7086ee",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "44d8e50833d328c75bdb729374255cdfc581b2e5070d80ecf247447d2fef2492"
+    "value": "10725a0882244f3002e44fc6189425028f79f9cfc19b69d8012bdf42061322dc"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-10-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-10.json",
-  "trace_sha256": "bdf9e06f7b398016b658745959c84901e0bae3d9da3660283ece56dd27422289"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-10.json",
+  "trace_sha256": "2312c5f2d410613581da0c08cf4417c2ed4c77c7e23b1202332301f3012b3ad8"
 }

--- a/statutes/26/3306/c/10.test.yaml
+++ b/statutes/26/3306/c/10.test.yaml
@@ -1,7 +1,6 @@
 - name: all_independent_branches_hold
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -42,8 +41,7 @@
     us:statutes/26/3306/c/10#educational_health_and_exempt_organization_service_excepted_from_employment: holds
 - name: section_401_a_organization_blocks_501_a_exempt_organization_path
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -72,21 +70,26 @@
     us:statutes/26/3306/c/10#input.service_performed_in_employ_of_hospital: true
     us:statutes/26/3306/c/10#input.service_performed_by_patient_of_hospital: true
   output:
+    us:statutes/26/3306/c/10#exempt_organization_service_remuneration_below_threshold: holds
     us:statutes/26/3306/c/10#service_in_employ_of_qualifying_exempt_organization: not_holds
     us:statutes/26/3306/c/10#exempt_organization_low_remuneration_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/10#student_school_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#student_spouse_school_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#school_student_or_spouse_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#work_experience_education_program_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#hospital_patient_service_excepted_from_employment: holds
     us:statutes/26/3306/c/10#educational_health_and_exempt_organization_service_excepted_from_employment: holds
 - name: employer_established_work_experience_program_is_excluded
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
     us:statutes/26/3306/c/10#input.remuneration_for_service_in_calendar_quarter: 49
     us:statutes/26/3306/c/10#input.service_performed_in_employ_of_organization: true
-    us:statutes/26/3306/c/10#input.employer_is_section_501_a_income_tax_exempt_organization: true
+    us:statutes/26/3306/c/10#input.employer_is_section_501_a_income_tax_exempt_organization: false
     us:statutes/26/3306/c/10#input.employer_is_section_401_a_organization: false
-    us:statutes/26/3306/c/10#input.employer_is_section_521_income_tax_exempt_organization: false
+    us:statutes/26/3306/c/10#input.employer_is_section_521_income_tax_exempt_organization: true
     us:statutes/26/3306/c/10#input.service_performed_in_employ_of_school_college_or_university: true
     ? us:statutes/26/3306/c/10#input.service_performed_by_student_enrolled_and_regularly_attending_classes_at_employing_school_college_or_university
     : true
@@ -107,12 +110,18 @@
     us:statutes/26/3306/c/10#input.service_performed_in_employ_of_hospital: true
     us:statutes/26/3306/c/10#input.service_performed_by_patient_of_hospital: true
   output:
+    us:statutes/26/3306/c/10#exempt_organization_service_remuneration_below_threshold: holds
+    us:statutes/26/3306/c/10#service_in_employ_of_qualifying_exempt_organization: holds
+    us:statutes/26/3306/c/10#exempt_organization_low_remuneration_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#student_school_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#student_spouse_school_service_excepted_from_employment: holds
+    us:statutes/26/3306/c/10#school_student_or_spouse_service_excepted_from_employment: holds
     us:statutes/26/3306/c/10#work_experience_education_program_service_excepted_from_employment: not_holds
+    us:statutes/26/3306/c/10#hospital_patient_service_excepted_from_employment: holds
     us:statutes/26/3306/c/10#educational_health_and_exempt_organization_service_excepted_from_employment: holds
 - name: remuneration_at_threshold_and_no_other_branch_is_not_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -141,6 +150,7 @@
     us:statutes/26/3306/c/10#input.service_performed_in_employ_of_hospital: false
     us:statutes/26/3306/c/10#input.service_performed_by_patient_of_hospital: false
   output:
+    us:statutes/26/3306/c/10#exempt_organization_service_remuneration_quarter_threshold: 50
     us:statutes/26/3306/c/10#exempt_organization_service_remuneration_below_threshold: not_holds
     us:statutes/26/3306/c/10#service_in_employ_of_qualifying_exempt_organization: holds
     us:statutes/26/3306/c/10#exempt_organization_low_remuneration_service_excepted_from_employment: not_holds

--- a/statutes/26/3306/c/10.yaml
+++ b/statutes/26/3306/c/10.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    26 USC 3306(c)(10) covers service for certain exempt organizations when remuneration is less than $50; school, college, or university service by students and advised student spouses; full-time credit work-experience program service at nonprofit or public educational institutions, except employer-established programs; and hospital service by patients.
+    26 USC 3306(c)(10) excepts specified services: certain low-remuneration service for organizations exempt under section 501(a) or 521; school, college, or university service by students or advised student spouses; full-time credit work-experience program service at qualifying nonprofit or public educational institutions, except employer-established programs; and hospital service by patients.
 rules:
   - name: exempt_organization_service_remuneration_quarter_threshold
     kind: parameter
@@ -57,11 +57,17 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "in the employ of any organization exempt from income tax under section 501(a)"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "other than an organization described in section 401(a)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "or under section 521"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -84,9 +90,17 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3306
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#service_in_employ_of_qualifying_exempt_organization
+              output: service_in_employ_of_qualifying_exempt_organization
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#exempt_organization_service_remuneration_below_threshold
+              output: exempt_organization_service_remuneration_below_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -106,6 +120,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed in the employ of a school, college, or university"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "by a student who is enrolled and is regularly attending classes at such school, college, or university"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -125,6 +145,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "by the spouse of such a student"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "advised, at the time such spouse commences to perform such service"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -143,9 +169,17 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3306
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#student_school_service_excepted_from_employment
+              output: student_school_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#student_spouse_school_service_excepted_from_employment
+              output: student_spouse_school_service_excepted_from_employment
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -165,11 +199,27 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "enrolled at a nonprofit or public educational institution"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "full-time program, taken for credit"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "combines academic instruction with work experience"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "such service is an integral part of such program"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "program established for or on behalf of an employer"
+              excerpt: "shall not apply to service performed in a program established for or on behalf of an employer"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -194,6 +244,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed in the employ of a hospital"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "performed by a patient of such hospital"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -210,9 +266,29 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3306
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#exempt_organization_low_remuneration_service_excepted_from_employment
+              output: exempt_organization_low_remuneration_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#school_student_or_spouse_service_excepted_from_employment
+              output: school_student_or_spouse_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#work_experience_education_program_service_excepted_from_employment
+              output: work_experience_education_program_service_excepted_from_employment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/10#hospital_patient_service_excepted_from_employment
+              output: hospital_patient_service_excepted_from_employment
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
Generated refresh for 26 USC 3306(c)(10), using `axiom-encode --apply` from encoder `0.2.532` / accepted run `9d7086ee`.

This keeps the executable exempt-organization low-remuneration branch, school student and advised-spouse branches, work-experience-program branch, hospital-patient branch, and aggregate output while refreshing proofs, tests, and the signed apply manifest.

Notes:

- A first generated attempt (`dbe0fd6c`) was rejected because it deferred and removed the executable exempt-organization branch, renamed the aggregate output, and dropped existing 401(a)/threshold aggregate coverage.
- The accepted run used `/tmp/axiom-3306c10-preserve-context.txt` via `--allow-context` to preserve the executable local predicates for the 501(a), 401(a), and 521 classifications and the existing branch coverage.
- The accepted run reported standalone CI failure from the generated workspace, but the applied repo output passed the full local validation stack below.
- No generated RuleSpec files were edited by hand.

Validation:

- `uv run axiom-encode validate .../statutes/26/3306/c/10.yaml --skip-reviewers`
- `uv run axiom-encode test .../statutes/26/3306/c/10.test.yaml --root .../rulespec-us --axiom-rules-engine-path .../axiom-rules-engine`
- `uv run axiom-encode proof-validate .../statutes/26/3306/c/10.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo .../rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `git diff --check origin/main`
- `uv run axiom-encode oracle-coverage --root .../payroll-3306c10-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage summary:

- total tax outputs: 1,582
- comparable: 227
- known not comparable: 1,355
- untested comparable: 0
- c10 outputs: known-not-comparable to PE's final FUTA taxable earnings surface, with local tests present
