### PR TITLE
Refresh generated section 3306(c)(11) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/11.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/11.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/11.yaml",
-      "sha256": "9da1fbaaed0b620f3739b4548d3ae75c019dc76cd841fbfe108a41a56c3f1ca9"
+      "sha256": "1aaa5802c1f3d0cf15be43a13de565e585c9bb0500c7b84e48f74d6772aa86fa"
     },
     {
       "path": "statutes/26/3306/c/11.test.yaml",
-      "sha256": "2c2b73fc498bb288e13b214ca20b63e1fc55120d390f7eaf7f2070bc08509601"
+      "sha256": "4d355c91470796086bbe1473aa4379ce00a266f96e297663cb7f6359ef369fe0"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d192631eecd0885f49c87d3ea433bcfea7db6cca",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.250",
-    "version_commit": "d192631eecd0885f49c87d3ea433bcfea7db6cca"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.250",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(11)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-11/workspace/context-manifest.json",
-  "context_manifest_sha256": "87dd8e83bfe704bccf43cee04d01edbdb402787eba8b5698b44c3a5543444e6a",
-  "generated_at": "2026-05-26T00:59:41.025411+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/11.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525",
-  "generated_output_sha256": "9da1fbaaed0b620f3739b4548d3ae75c019dc76cd841fbfe108a41a56c3f1ca9",
-  "generation_prompt_sha256": "67117bac63b644a91f9233d6f276df4bb06f9f12ce82e62ef2aedf1c9e662607",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-11/workspace/context-manifest.json",
+  "context_manifest_sha256": "35bf9a8d18e49a6964a1c4a49e784a6f76330179b118162837b82aa82113e253",
+  "generated_at": "2026-06-02T09:38:59.605055+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/11.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1aaa5802c1f3d0cf15be43a13de565e585c9bb0500c7b84e48f74d6772aa86fa",
+  "generation_prompt_sha256": "6955463e13ad83b52a3fb108a2074b1bd17589823b37189a839668ffd714462d",
   "model": "gpt-5.5",
-  "run_id": "8e15e032",
-  "runner": "codex-gpt-5.5",
+  "run_id": "6ff97620",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "d02f4bb338b0d8f861b4ae4e5f8c02b6ca821d74191ddd724971c86220763458"
+    "value": "a2079f8b3807f40df14187759828bed8a9d4debb9df15e14bcecdee021f30285"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-11-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-11.json",
-  "trace_sha256": "bb789f15f8ac6902ff7710a3428d2d29a4c9a491e4c5ebdda687f9cc8e588ab1"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-11.json",
+  "trace_sha256": "eb2bb1476661b50a19ecfc2979983fda266245c4b2f8b19d2859bd5c6f2ec4de"
 }

--- a/statutes/26/3306/c/11.test.yaml
+++ b/statutes/26/3306/c/11.test.yaml
@@ -1,7 +1,6 @@
 - name: service_in_employ_of_foreign_government_is_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -12,8 +11,7 @@
     us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
 - name: consular_or_other_officer_or_employee_service_is_included
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -24,8 +22,7 @@
     us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
 - name: nondiplomatic_representative_service_is_included
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -36,8 +33,7 @@
     us:statutes/26/3306/c/11#foreign_government_service_excepted_from_employment: holds
 - name: non_foreign_government_service_is_not_excepted_by_this_paragraph
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/11.yaml
+++ b/statutes/26/3306/c/11.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    service performed in the employ of a foreign government, including consular or other officers or employees and nondiplomatic representatives
+    service performed in the employ of a foreign government, including service as a consular or other officer or employee or a nondiplomatic representative
 rules:
   - name: foreign_government_service_excepted_from_employment
     kind: derived


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(11).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Normalize companion test periods to `tax_year`; preserve the four existing positive/negative service-exception cases.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/11.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/11.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/11.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(11) output is classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
