### PR TITLE
Refresh generated section 3306(c)(12) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/12.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/12.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/12.yaml",
-      "sha256": "1ecf23c5f9510dac494b97967fe2ebc4a5bdf68dd7f6803dc05791598f023afb"
+      "sha256": "fbf02d3e7c4e9716e6c2cba464883945b447283d7bb4bf89df482284a0b4b997"
     },
     {
       "path": "statutes/26/3306/c/12.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "d3b7f89ffe7d5c81b9f6b5f6f03001795e63948a",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.251",
-    "version_commit": "d3b7f89ffe7d5c81b9f6b5f6f03001795e63948a"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.251",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(12)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-12/workspace/context-manifest.json",
-  "context_manifest_sha256": "437b37dbe9e3825dcf8337fb19ce9ae5aef66816873f426adffb7e843405061e",
-  "generated_at": "2026-05-26T01:17:15.881727+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/12.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525",
-  "generated_output_sha256": "1ecf23c5f9510dac494b97967fe2ebc4a5bdf68dd7f6803dc05791598f023afb",
-  "generation_prompt_sha256": "3aedde505913df0479daeb69303d6f5b0299af89be26bf5b04002b97b32eb003",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "83f55d9087048ec8361f9591be7c9de7a12c67daaedec24d61cbb7eb38d14a92",
+  "generated_at": "2026-06-02T09:42:58.981567+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/12.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "fbf02d3e7c4e9716e6c2cba464883945b447283d7bb4bf89df482284a0b4b997",
+  "generation_prompt_sha256": "5ee5ca2215ad249ee1b2968c24831ce61c1c0fb1d2a10b1ef07b44ffc34831ec",
   "model": "gpt-5.5",
-  "run_id": "1172788f",
-  "runner": "codex-gpt-5.5",
+  "run_id": "e40f22fe",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7734954800edafa60b2b46903f1f4927f91cc00347ebf1c8a6e93f60f76175b6"
+    "value": "86703adf2bd55aa6db025726a54c39cdb4b788ed6ea9bf2151cd05b0ff03cf8f"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-12-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-12.json",
-  "trace_sha256": "13d1ed9d0cfb63f97a5edef63be90d3c3d6561091e25b4bc4c695e7f4aa4e011"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-12.json",
+  "trace_sha256": "d834dcd761a3e9f3e1bf8996601041d30abc652fafa2eee77c3ce65d2be0ec18"
 }

--- a/statutes/26/3306/c/12.yaml
+++ b/statutes/26/3306/c/12.yaml
@@ -5,14 +5,14 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    service performed in the employ of an instrumentality wholly owned by a foreign government, if the service is similar to foreign-country service by United States Government or instrumentality employees and the Secretary of State certifies reciprocal exemption.
+    service performed in the employ of an instrumentality wholly owned by a foreign government, if similar to foreign-country United States Government service and reciprocal exemption is certified by the Secretary of State.
 rules:
   - name: foreign_government_wholly_owned_instrumentality_service_excepted_from_employment
     kind: derived
     entity: Person
     dtype: Judgment
     period: Year
-    source: 26 U.S.C. 3306(c)(12)
+    source: 26 USC 3306(c)(12)
     metadata:
       proof:
         atoms:


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(12).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Preserve the existing three-condition foreign-government-instrumentality service exception and four companion tests.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/12.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/12.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/12.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(12) output is classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
