### PR TITLE
Refresh generated section 3306(c)(13) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/13.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/13.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/13.yaml",
-      "sha256": "803bb30103b84d63975fdafa081e8a4ba0cbeba403ee192832e0b8704b45ab3c"
+      "sha256": "6cc989b80ce844f4ffc2029e54ecfd73a4b6e5ff488ab892c45457ea969fab36"
     },
     {
       "path": "statutes/26/3306/c/13.test.yaml",
-      "sha256": "e593077af1e72f2c0549d9b1905f90387ec30ed7cc749c0f2cd7c2d5f8e5330a"
+      "sha256": "81b0d2043596e4d3386dc703055c7889c17ec6de122975572deaa74019955530"
     }
   ],
   "axiom_encode_git": {
-    "commit": "0efd213656d94fe064a52413ed2f3b8699fcb99c",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.252",
-    "version_commit": "0efd213656d94fe064a52413ed2f3b8699fcb99c"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.252",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(13)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-13/workspace/context-manifest.json",
-  "context_manifest_sha256": "8110b0bc42ab9fe78744149bfdb3db3ad8422afba3fec0df687ebbc4551d854f",
-  "generated_at": "2026-05-26T01:39:34.337457+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/codex-gpt-5.5/statutes/26/3306/c/13.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525",
-  "generated_output_sha256": "803bb30103b84d63975fdafa081e8a4ba0cbeba403ee192832e0b8704b45ab3c",
-  "generation_prompt_sha256": "11cb6309fb0175ea1cbca49a8423f53539aa3e3716f4b291108df47012afa2ee",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-13/workspace/context-manifest.json",
+  "context_manifest_sha256": "738da9472c8352726e2c0c356ff18d24d5d69801f97f28f3a05727f862438a54",
+  "generated_at": "2026-06-02T09:49:00.579462+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/13.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6cc989b80ce844f4ffc2029e54ecfd73a4b6e5ff488ab892c45457ea969fab36",
+  "generation_prompt_sha256": "40de34e63cf665b4b923a9d66f6328145685a1a5f34d634c3489ed1bb5f33122",
   "model": "gpt-5.5",
-  "run_id": "2e67116a",
-  "runner": "codex-gpt-5.5",
+  "run_id": "4c451bd1",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8a27d16f16f2ac83c421bfead5e9e9b5d53f6bee845892a5ddc020d7ab9474c6"
+    "value": "0f4181d6587b685a93081529f6d8ece53352e4b85da092e4c46771974c1e0573"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-13-rerun-20260525/traces/codex-gpt-5.5/26-USC-3306-c-13.json",
-  "trace_sha256": "ce6e2dac048fd42315e6cfcca68c245b129c112360bf1a4e32ecdd36912a71aa"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-13.json",
+  "trace_sha256": "283b04ee114a7e330fd90b2a17f17bd5d40a4bdff7218778ac10075d6534a928"
 }

--- a/statutes/26/3306/c/13.test.yaml
+++ b/statutes/26/3306/c/13.test.yaml
@@ -17,7 +17,7 @@
     us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: holds
     us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: not_holds
     us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: holds
-- name: student_nurse_in_training_school_qualifies
+- name: student_nurse_in_nurses_training_school_qualifies
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -52,6 +52,7 @@
     us:statutes/26/3306/c/13#input.individual_completed_four_year_course_in_medical_school: true
     us:statutes/26/3306/c/13#input.medical_school_chartered_or_approved_pursuant_to_state_law: true
   output:
+    us:statutes/26/3306/c/13#medical_school_course_years_required_for_hospital_intern_service: 4
     us:statutes/26/3306/c/13#student_nurse_service_excepted_from_employment: not_holds
     us:statutes/26/3306/c/13#hospital_intern_service_excepted_from_employment: holds
     us:statutes/26/3306/c/13#student_nurse_or_hospital_intern_service_excepted_from_employment: holds

--- a/statutes/26/3306/c/13.yaml
+++ b/statutes/26/3306/c/13.yaml
@@ -7,6 +7,23 @@ module:
   summary: |-
     service performed as a student nurse in the employ of a hospital or a nurses' training school ...; and service performed as an intern in the employ of a hospital ...
 rules:
+  - name: medical_school_course_years_required_for_hospital_intern_service
+    kind: parameter
+    dtype: Count
+    source: 26 USC 3306(c)(13), intern clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: completed a 4 years' course in a medical school
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4
+
   - name: student_nurse_service_excepted_from_employment
     kind: derived
     entity: Person
@@ -21,6 +38,11 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: service performed as a student nurse in the employ of a hospital or a nurses' training school
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: enrolled and is regularly attending classes in a nurses' training school chartered or approved pursuant to State law
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -32,6 +54,7 @@ rules:
           and individual_enrolled_in_nurses_training_school
           and individual_regularly_attending_classes_in_nurses_training_school
           and nurses_training_school_chartered_or_approved_pursuant_to_state_law
+
   - name: hospital_intern_service_excepted_from_employment
     kind: derived
     entity: Person
@@ -45,7 +68,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: service performed as an intern in the employ of a hospital by an individual who has completed a 4 years' course
+              excerpt: service performed as an intern in the employ of a hospital
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: completed a 4 years' course in a medical school chartered or approved pursuant to State law
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -53,6 +81,7 @@ rules:
           and service_performed_in_employ_of_hospital
           and individual_completed_four_year_course_in_medical_school
           and medical_school_chartered_or_approved_pursuant_to_state_law
+
   - name: student_nurse_or_hospital_intern_service_excepted_from_employment
     kind: derived
     entity: Person


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(13).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Preserve student-nurse, hospital-intern, and aggregate exception outputs with all nine companion test cases.
- Add a generated parameter for the four-year medical-school course requirement.

## Generation notes

- Rejected generated run `dd85cd7a` because it removed five negative companion tests.
- Accepted generated run `4c451bd1` after adding context to preserve branch and test coverage.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/13.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/13.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/13.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(13) outputs are classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
