### PR TITLE
Refresh generated section 3306(c)(14) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/14.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/14.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/14.yaml",
-      "sha256": "c5b47668cc92e26437c334862d4d59b8907ab374e6e6397bcd420bc9a7c6890e"
+      "sha256": "992532dbdd36ccf107a56da40e1bb11cab947837b6d9eedcdcf6d6aa323cc331"
     },
     {
       "path": "statutes/26/3306/c/14.test.yaml",
-      "sha256": "cfdfc1ba2a50c2db65b29e0300fac33d30d60405ef8b7371a5a28ec447db3d99"
+      "sha256": "2fa6c37896329b4d9c49fa5f96412ee4b8b0a441298308aa87fa12e0e6130922"
     }
   ],
   "axiom_encode_git": {
-    "commit": "a565d6a911285c4bfc37bdf1ffba922435bf6cda",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.253",
-    "version_commit": "a565d6a911285c4bfc37bdf1ffba922435bf6cda"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.253",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(14)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-14/workspace/context-manifest.json",
-  "context_manifest_sha256": "5cfcc9d3afd878d3d39e5aa4bd833db767400a80e39db48c5e9510ecbc232d91",
-  "generated_at": "2026-05-26T01:56:06.254322+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/14.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526",
-  "generated_output_sha256": "c5b47668cc92e26437c334862d4d59b8907ab374e6e6397bcd420bc9a7c6890e",
-  "generation_prompt_sha256": "0fa6b7e3d264b81c84ad43f093b2af01758e35074fc760d2b6d6787cb181b38b",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "e367dd8a67256d57b6c04c7065dac9b1b9426bdc9f1a6ae1d7b72382360cf659",
+  "generated_at": "2026-06-02T09:54:50.717849+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/14.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "992532dbdd36ccf107a56da40e1bb11cab947837b6d9eedcdcf6d6aa323cc331",
+  "generation_prompt_sha256": "78095da0bca721328875cd9341b3b0e712f44cd479d50752e0ac942754307c33",
   "model": "gpt-5.5",
-  "run_id": "420fc69b",
-  "runner": "codex-gpt-5.5",
+  "run_id": "29c7a8d6",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "57fa434fc4b8b05a4276a607964035414896642465337cb6b5005c764c5a3d2d"
+    "value": "c058c3f6beb0fe1455c955983cf9e9d6b4ae3e0131c1efa1691fad925900634d"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-14-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-14.json",
-  "trace_sha256": "1ac44ca8be887b6ce57754620ad6324fdf81c6b8ab5a0243b430a46a740c571c"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-14.json",
+  "trace_sha256": "fed0e214c1fb00bfc8eb991f60196765211379fe083e49dc29900479425d3a4b"
 }

--- a/statutes/26/3306/c/14.test.yaml
+++ b/statutes/26/3306/c/14.test.yaml
@@ -1,7 +1,6 @@
 - name: insurance_agent_or_solicitor_commission_service_is_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -11,8 +10,7 @@
     us:statutes/26/3306/c/14#insurance_agent_or_solicitor_commission_service_excepted_from_employment: holds
 - name: non_insurance_agent_or_solicitor_service_is_not_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -22,8 +20,7 @@
     us:statutes/26/3306/c/14#insurance_agent_or_solicitor_commission_service_excepted_from_employment: not_holds
 - name: non_commission_service_is_not_excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/14.yaml
+++ b/statutes/26/3306/c/14.yaml
@@ -20,6 +20,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: service performed by an individual for a person as an insurance agent or as an insurance solicitor
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: all such service performed by such individual for such person is performed for remuneration solely by way of commission
           - path: versions[0].formula
             kind: exception
             source:


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(14).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Add proof excerpts and normalize companion test periods to `tax_year`.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/14.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/14.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/14.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(14) output is classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
