### PR TITLE
Refresh generated section 3306(c)(15) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/15.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/15.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/15.yaml",
-      "sha256": "7d7b6cb3237062c4d783a189a71a7ded2d51c486076a59218e4a5ac8ae726c49"
+      "sha256": "0f245ca6e20b09097d4cfaf8da98d349788f516556cfc5980c920cafa9a98560"
     },
     {
       "path": "statutes/26/3306/c/15.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "0574321c2bb437c6bc5d1fdbd5fee73910968e6f",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.254",
-    "version_commit": "0574321c2bb437c6bc5d1fdbd5fee73910968e6f"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.254",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(15)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-15/workspace/context-manifest.json",
-  "context_manifest_sha256": "6e1992ffd27ce1fc75844aa75600fa02bd4c8d5db9c15f416b8efee30c709528",
-  "generated_at": "2026-05-26T02:15:39.618675+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/15.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526",
-  "generated_output_sha256": "7d7b6cb3237062c4d783a189a71a7ded2d51c486076a59218e4a5ac8ae726c49",
-  "generation_prompt_sha256": "12594ddcbf9c22ba093a7f03cd31f80d6534bffd87a07cc54c3db937221db120",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "e12ec180109eb652836787c1c4ddb15e7c2c2cca63f044aae72a92c2682ea15d",
+  "generated_at": "2026-06-02T10:03:54.265981+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/15.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "0f245ca6e20b09097d4cfaf8da98d349788f516556cfc5980c920cafa9a98560",
+  "generation_prompt_sha256": "8f97dd8583f916222d719d5c69126df50b3071bb5c6725e35c9e135ca871a9b2",
   "model": "gpt-5.5",
-  "run_id": "0251aa07",
-  "runner": "codex-gpt-5.5",
+  "run_id": "0ec3a39f",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "049cd1e6a8254dd19700dccc90cbb1287c40efa28b2f6fb808f56724af9678f7"
+    "value": "86369e84a24e4fc19c9c7ca01f10cfdef931f5420cc2488c74c306fd09cc2fa2"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-15-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-15.json",
-  "trace_sha256": "40b8f50c9e93004346d8763a69cd84b71b481cccce8d791d22bf22d0270b11fd"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-15.json",
+  "trace_sha256": "889b5e3099c64c9608baec97e38f7afcd2b84d077e1e3e8ddee87878e7fbe492"
 }

--- a/statutes/26/3306/c/15.yaml
+++ b/statutes/26/3306/c/15.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    service performed by an individual under the age of 18 in the delivery or distribution of newspapers or shopping news, not including delivery or distribution to any point for subsequent delivery or distribution; service performed by an individual in, and at the time of, the sale of newspapers or magazines to ultimate consumers
+    service performed by an individual under the age of 18 in delivery or distribution of newspapers or shopping news, excluding delivery to a point for subsequent delivery or distribution; and service performed in and at the time of sale of newspapers or magazines to ultimate consumers under a fixed-price excess-retention compensation arrangement.
 rules:
   - name: newspaper_delivery_distribution_service_excepted_from_employment
     kind: derived
@@ -32,6 +32,7 @@ rules:
           individual_under_age_18
           and service_performed_in_delivery_or_distribution_of_newspapers_or_shopping_news
           and not service_performed_in_delivery_or_distribution_to_point_for_subsequent_delivery_or_distribution
+
   - name: ultimate_consumer_newspaper_or_magazine_sale_service_excepted_from_employment
     kind: derived
     entity: Person
@@ -62,6 +63,7 @@ rules:
           service_performed_in_and_at_time_of_sale_of_newspapers_or_magazines_to_ultimate_consumers
           and newspapers_or_magazines_to_be_sold_by_individual_at_fixed_price
           and compensation_based_on_retention_of_excess_of_fixed_price_over_amount_charged_to_individual
+
   - name: newspaper_delivery_or_sales_service_excepted_from_employment
     kind: derived
     entity: Person


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(15).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Preserve both newspaper delivery/distribution and ultimate-consumer sales exception branches with all five companion test cases.

## Generation notes

- Rejected generated run `2a5c7c65` because it reported standalone CI failure and removed the `sale_without_excess_retention_compensation_is_not_excepted` companion test.
- Accepted generated run `0ec3a39f` after adding context to preserve branch and test coverage. That run also reported standalone CI failure, but the applied files passed the local validation stack below.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/15.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/15.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/15.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(15) outputs are classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
