### PR TITLE
Refresh generated section 3306(c)(16) payroll manifest

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/16.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/16.json
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "6d5e2f3edd7d9a0ee0cdbc379bf2236636001742",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.255",
-    "version_commit": "6d5e2f3edd7d9a0ee0cdbc379bf2236636001742"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.255",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(16)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-16/workspace/context-manifest.json",
-  "context_manifest_sha256": "770a0072b8c3936001472118b207d76bef94147e9067852ee844545fb65ce615",
-  "generated_at": "2026-05-26T02:32:21.139989+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/16.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "252c227bc807b367376c0bd3549007ed72fc463a68963681ebc0b25e06cae8e9",
+  "generated_at": "2026-06-02T10:09:39.079172+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/16.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
   "generated_output_sha256": "41adb628091d449431cb30e3b7d7f551eb954d06c69d147dad0376811af1620d",
-  "generation_prompt_sha256": "cb2cb192dde28add535a3d52fc912730c9b0741bb311273bd92b750077a27c7d",
+  "generation_prompt_sha256": "ed477f23acc3649b8dbba71dd5227aaec857e487892f69b93b2a5dbbe7f2ac66",
   "model": "gpt-5.5",
-  "run_id": "d114cc9f",
-  "runner": "codex-gpt-5.5",
+  "run_id": "205961db",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "79d23579b3ccaa2fb8b6d241aa61c2ba830f447039f28b99c242e1438a0c02e8"
+    "value": "de2abce02f01e9bc372deee71598169f4ec28c3948f33f9ec1c3224a8b8934af"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-16-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-16.json",
-  "trace_sha256": "e4b4384d4fc68c875139b5644c5f642673da6cac3e537cf95c0fd513bcc37c46"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-16.json",
+  "trace_sha256": "508356b579d0f51bf9584ac4b14f11e122821403502db4f3b3965fb60a28659e"
 }


### PR DESCRIPTION
## Summary

- Refresh the generated apply manifest for 26 USC 3306(c)(16) with axiom-encode 0.2.532 / gpt-5.5.
- RuleSpec YAML and companion tests are unchanged; the existing two-case coverage is preserved.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/16.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/16.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/16.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(16) output is classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
