### PR TITLE
Refresh generated section 3306(c)(17) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/17.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/17.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/17.yaml",
-      "sha256": "b2bcf2f9d9be9f83aa1a9826d8552bba093bad3b453c699a2272e3ce1ff56081"
+      "sha256": "db568b107a13687f07d0293219ff8c7fb3ae01a7758fd4a3ea6052c7ef9c01e8"
     },
     {
       "path": "statutes/26/3306/c/17.test.yaml",
-      "sha256": "dd4f09a1923e7fdffda907989e51e2417459a2b507eebc8948ded0691aae740d"
+      "sha256": "7969f5e5b6287a91b3825ab62dc81a55b5afa22cb150e75aec5d1128b1258152"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d7a00edcf0a8bb0b6293cee94480a1c53e157b43",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.256",
-    "version_commit": "d7a00edcf0a8bb0b6293cee94480a1c53e157b43"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.256",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(17)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-17/workspace/context-manifest.json",
-  "context_manifest_sha256": "437fd063c222656c7fc986455d9526836f15491548d6e207eb115074836df875",
-  "generated_at": "2026-05-26T02:59:35.985697+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/17.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526",
-  "generated_output_sha256": "b2bcf2f9d9be9f83aa1a9826d8552bba093bad3b453c699a2272e3ce1ff56081",
-  "generation_prompt_sha256": "bf225278ed7c3a28717387610ee3c9e5ba7d0aeae5c7ce19dcea13fc260b1b48",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-17/workspace/context-manifest.json",
+  "context_manifest_sha256": "e0412993d08e79abf756f1fe3e9c009b9857faf139f2d24b46a60109439d7862",
+  "generated_at": "2026-06-02T10:17:11.453114+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/17.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "db568b107a13687f07d0293219ff8c7fb3ae01a7758fd4a3ea6052c7ef9c01e8",
+  "generation_prompt_sha256": "f748c5a8b48605fda6838faf94ddf1d607968f2eef0ca92f0de70728d61cb483",
   "model": "gpt-5.5",
-  "run_id": "3f28737d",
-  "runner": "codex-gpt-5.5",
+  "run_id": "26b332b9",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "310560cee5945287f0987e4698e25303dfa027b6635ebc041bbd54518e57a2cd"
+    "value": "fce94cf90e8e7bfe5356bd76f75bad4c022daeb090f62e8f479b017dde7d0f0d"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-17-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-17.json",
-  "trace_sha256": "0b32c545039dab60af0c5a6a5bc3c4590dd561432010f7efb222ac04052c613b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-17.json",
+  "trace_sha256": "1f8f5c563ae97b07f366c81b89fa68531ab7cfbb37a6b278ee0e093da9c008ac"
 }

--- a/statutes/26/3306/c/17.test.yaml
+++ b/statutes/26/3306/c/17.test.yaml
@@ -10,6 +10,7 @@
     us:statutes/26/3306/c/17#input.service_performed_on_or_in_connection_with_vessel: true
     us:statutes/26/3306/c/17#input.vessel_net_tons_determined_under_merchant_vessel_register_tonnage_laws: 10
   output:
+    us:statutes/26/3306/c/17#fishing_service_vessel_net_tonnage_exception_threshold: 10
     us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies: not_holds
     us:statutes/26/3306/c/17#aquatic_life_service_excepted_from_employment: holds
 - name: commercial_salmon_or_halibut_service_is_not_excepted

--- a/statutes/26/3306/c/17.yaml
+++ b/statutes/26/3306/c/17.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    service performed by an individual in ... the catching, taking, harvesting, cultivating, or farming of any kind of fish, shellfish, crustacea, sponges, seaweeds, or other aquatic forms of animal and vegetable life ... except— (A) service performed in connection with the catching or taking of salmon or halibut, for commercial purposes, and (B) service performed on or in connection with a vessel of more than 10 net tons ...
+    service performed by an individual in ... catching, taking, harvesting, cultivating, or farming ... aquatic forms of animal and vegetable life ... except commercial salmon or halibut catching or taking and service on or in connection with a vessel of more than 10 net tons
 rules:
   - name: fishing_service_vessel_net_tonnage_exception_threshold
     kind: parameter
@@ -38,6 +38,12 @@ rules:
             source:
               corpus_citation_path: us/statute/26/3306
               excerpt: "service performed on or in connection with a vessel of more than 10 net tons"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/17#fishing_service_vessel_net_tonnage_exception_threshold
+              output: fishing_service_vessel_net_tonnage_exception_threshold
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -57,17 +63,18 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "service performed by an individual in ... the catching, taking, harvesting, cultivating, or farming"
+              excerpt: "catching, taking, harvesting, cultivating, or farming"
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "service performed in connection with the catching or taking of salmon or halibut, for commercial purposes"
+              excerpt: "catching or taking of salmon or halibut, for commercial purposes"
           - path: versions[0].formula
-            kind: exception
-            source:
-              corpus_citation_path: us/statute/26/3306
-              excerpt: "service performed on or in connection with a vessel of more than 10 net tons"
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/17#large_vessel_aquatic_life_service_exception_applies
+              output: large_vessel_aquatic_life_service_exception_applies
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(17).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Preserve the aquatic-life service exception, commercial salmon/halibut carveout, and >10-net-ton vessel exception with five companion test cases.
- Add generated proof imports and a companion test assertion for the 10-net-ton threshold parameter.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/17.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/17.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/17.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(17) outputs are classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
