### PR TITLE
Refresh generated section 3306(c)(18) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/18.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/18.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/18.yaml",
-      "sha256": "65007ea958f447bcf489b0b261be98ab2c22574c5e4bc7f434a3a36e09c597c1"
+      "sha256": "322a3090137981d889e949c50d7788aec0ba78ea5907fdb4791fb06ca24b4b3c"
     },
     {
       "path": "statutes/26/3306/c/18.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "8a26d9f26c93544f8ac2f6a7bc8420e0329f1406",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.257",
-    "version_commit": "8a26d9f26c93544f8ac2f6a7bc8420e0329f1406"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.257",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(18)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-18/workspace/context-manifest.json",
-  "context_manifest_sha256": "5a82bbc2382802e0fd7e29e8bd13d38e8afd175e2c77b43dd0666fcfe55bf2e3",
-  "generated_at": "2026-05-26T03:26:23.061790+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/18.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526",
-  "generated_output_sha256": "65007ea958f447bcf489b0b261be98ab2c22574c5e4bc7f434a3a36e09c597c1",
-  "generation_prompt_sha256": "d5c40e87a4f259bdb62e184422b40acb15209a7cb9d9057adc4a8f86614315c7",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-18/workspace/context-manifest.json",
+  "context_manifest_sha256": "56a22f937a195c3916880ebe4ce1632f63779b8beca8637e42b294b7e1649e78",
+  "generated_at": "2026-06-02T10:23:48.984699+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/18.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "322a3090137981d889e949c50d7788aec0ba78ea5907fdb4791fb06ca24b4b3c",
+  "generation_prompt_sha256": "aa508b8c7ff2f25dbb11103b3f5aec5d3cc2b41c6008b877b68c27fc80f736e8",
   "model": "gpt-5.5",
-  "run_id": "ebb60527",
-  "runner": "codex-gpt-5.5",
+  "run_id": "3534afbb",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7058b562298d0043e37c8aad9ffaf5573f8080d08d9cca38c3d48cffffa6a71e"
+    "value": "cd303982d37c3c7d62c8598f8d0c5444ad29a2411bcf99d84a372d0b27981db3"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-18-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-18.json",
-  "trace_sha256": "edffde21f3fe11e9883d25f5a2c205e3081997786a37422e8c375f87083ca83b"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-18.json",
+  "trace_sha256": "e6421a693fc9bfeaf4db1d7fa55d4f9dd685e40601da0ceae71c558df6ef0d92"
 }

--- a/statutes/26/3306/c/18.yaml
+++ b/statutes/26/3306/c/18.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (18) service described in section 3121(b)(20);
+    service described in section 3121(b)(20)
 imports:
   - us:statutes/26/3121/b/20#fishing_boat_service_excluded_from_employment
 rules:
@@ -22,7 +22,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "service described in section 3121(b)(20)"
+              excerpt: service described in section 3121(b)(20)
           - path: versions[0].formula
             kind: import
             import:


### PR DESCRIPTION
## Summary

- Refresh generated RuleSpec output for 26 USC 3306(c)(18).
- Regenerate the signed apply manifest with axiom-encode 0.2.532 / gpt-5.5.
- Preserve the import from 26 USC 3121(b)(20) and the two payment-table companion tests.

## Validation

- `uv run axiom-encode validate statutes/26/3306/c/18.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/18.test.yaml --root <rulespec-us> --axiom-rules-engine-path <axiom-rules-engine>`
- `uv run axiom-encode proof-validate statutes/26/3306/c/18.yaml`
- `git diff --check origin/main`
- `axiom-encode guard-generated --repo <rulespec-us> --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `axiom-encode oracle-coverage --root <worktree-parent> --oracle policyengine --program tax --fail-on-untested-comparable`

Oracle coverage reports zero untested comparable tax outputs. The 3306(c)(18) output is classified as known-not-comparable to PolicyEngine's final FUTA taxable earnings surface.
