### PR TITLE
Refresh generated 3306(c)(19) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/19.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/19.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/19.yaml",
-      "sha256": "6d978da623271917cef50e57fe4a0a5189e8b4a743b228cdec24e946415b4d3f"
+      "sha256": "3ff8dc4cdaded886a5b864f6664119d9b848750939830e10a30b198494c4428c"
     },
     {
       "path": "statutes/26/3306/c/19.test.yaml",
-      "sha256": "3d4fbb6a62044b031937916c6bb525d6777dcf5e9361dd32ced186ce5fb7f72a"
+      "sha256": "5099df484b3fff54cb25053bd202e83704b94272bf596bff8ebba947ba1a03d8"
     }
   ],
   "axiom_encode_git": {
-    "commit": "60227c07df77433d3c94e8833cb10c8955efde72",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.258",
-    "version_commit": "60227c07df77433d3c94e8833cb10c8955efde72"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.258",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(19)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-19/workspace/context-manifest.json",
-  "context_manifest_sha256": "ced18e9e01b7720fa4f583b312de76fa985dab1e48afea8fee90f02a79daeb6a",
-  "generated_at": "2026-05-26T03:54:37.138999+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/codex-gpt-5.5/statutes/26/3306/c/19.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526",
-  "generated_output_sha256": "6d978da623271917cef50e57fe4a0a5189e8b4a743b228cdec24e946415b4d3f",
-  "generation_prompt_sha256": "042ca7c264087a21e05a82ea528d7f91e8881bbafb8c7e42f21cb5a822fe441f",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "60daad637d4187847a4abc5ac328e98bbeed434d513c10ee57f8c20e683d35a3",
+  "generated_at": "2026-06-02T10:30:03.582479+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/19.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "3ff8dc4cdaded886a5b864f6664119d9b848750939830e10a30b198494c4428c",
+  "generation_prompt_sha256": "dc05a382ec54ac5643374819b1a273b5dcbdb609643b9456fa8d1214a7390c26",
   "model": "gpt-5.5",
-  "run_id": "4da09cb8",
-  "runner": "codex-gpt-5.5",
+  "run_id": "706edff9",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "541063dfa8446028c8be72bec3d6bd1baaf07467648cc460005963a2952a6cd8"
+    "value": "cbfa37d713dd2619a736ee177a6b28db9fc1c09086d7755e0c1185e063527356"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-19-rerun-20260526/traces/codex-gpt-5.5/26-USC-3306-c-19.json",
-  "trace_sha256": "be4314e4bd0387c8623990d20a67908081725a489198b538fbff59b97639a38d"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-19.json",
+  "trace_sha256": "e10f179ba42f6e5ffc1e0a1fa104251b9cfec473d28b9b184f29e43131b216ab"
 }

--- a/statutes/26/3306/c/19.test.yaml
+++ b/statutes/26/3306/c/19.test.yaml
@@ -1,7 +1,6 @@
 - name: qualifying nonresident alien nonimmigrant purpose service is excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -14,8 +13,7 @@
     us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: holds
 - name: resident alien service is not excepted under paragraph 19
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -28,8 +26,7 @@
     us:statutes/26/3306/c/19#nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment: not_holds
 - name: other immigration status service is not excepted under paragraph 19
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -43,8 +40,7 @@
 - name: service outside specified nonimmigrant purpose is not excepted under paragraph
     19
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/19.yaml
+++ b/statutes/26/3306/c/19.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    service performed by a nonresident alien individual while temporarily present in the United States as an F, J, M, or Q nonimmigrant, and performed to carry out the purpose specified in that subparagraph
+    service performed by a nonresident alien individual while temporarily present in the United States as an F, J, M, or Q nonimmigrant, and performed to carry out the purpose specified in the applicable subparagraph
 rules:
   - name: nonresident_alien_nonimmigrant_purpose_service_excepted_from_employment
     kind: derived
@@ -20,10 +20,17 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: service which is performed by a nonresident alien individual
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: temporarily present in the United States as a nonimmigrant under subparagraph (F), (J), (M), or (Q)
           - path: versions[0].formula
             kind: exception
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: performed to carry out the purpose specified in subparagraph (F), (J), (M), or (Q)
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- Refresh generated RuleSpec output for `26 USC 3306(c)(19)`.
- Regenerate the signed encoder apply manifest with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.
- Preserve the four nonresident alien / F, J, M, or Q purpose-service tests and normalize their period kind to `tax_year`.

## Validation
- `uv run axiom-encode validate statutes/26/3306/c/19.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/19.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306c19-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/c/19.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306c19-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306c19-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports zero untested comparable tax outputs. This rule remains `known_not_comparable` to PolicyEngine because it models an immigration-status FUTA employment exception predicate, while PolicyEngine exposes final FUTA taxable earnings rather than this predicate separately.
