### PR TITLE
Refresh generated 3306(c)(20) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/c/20.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/c/20.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/c/20.yaml",
-      "sha256": "4086eec327a704021d277cd555a1d705d608f4549afd4f874bb6aa7d70862744"
+      "sha256": "595f154489566994666a82160b987e4776aabbc40a69348be8e2217e92ddeb29"
     },
     {
       "path": "statutes/26/3306/c/20.test.yaml",
-      "sha256": "b2a7a3c4f215e7056471714db50aaec2652bbde430d9aab7761ee2cc1af3a92a"
+      "sha256": "87fba386730e35cc07f4a4cecf889897687cbe8b02203577cd1c41bdb0e6cbff"
     }
   ],
   "axiom_encode_git": {
-    "commit": "f1fd5ad02e858f854213aad43ea4db5a7baa61b7",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.261",
-    "version_commit": "f1fd5ad02e858f854213aad43ea4db5a7baa61b7"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.261",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(c)(20)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-c-20/workspace/context-manifest.json",
-  "context_manifest_sha256": "602de2acd4c64a73b6b9ebb74243a6c42925c146cb74f79fca93407ba9380338",
-  "generated_at": "2026-05-26T05:27:37.295792+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/codex-gpt-5.5/statutes/26/3306/c/20.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-c-20-final-20260526",
-  "generated_output_sha256": "4086eec327a704021d277cd555a1d705d608f4549afd4f874bb6aa7d70862744",
-  "generation_prompt_sha256": "f67b3ee34e7bc033e9e9ea331c9ccb597709b58b26c76c021a7ae5bf40fec28c",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-c-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "62a9ede86da4d82c805fe3f90df7019b6d1396aef3a06895d65fa41cc4886a52",
+  "generated_at": "2026-06-02T10:44:50.163385+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/c/20.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "595f154489566994666a82160b987e4776aabbc40a69348be8e2217e92ddeb29",
+  "generation_prompt_sha256": "3c969fc011e6448701a8635958dae0e631e0be9381f84d0ce01de80b021cac38",
   "model": "gpt-5.5",
-  "run_id": "3ee1d0c2",
-  "runner": "codex-gpt-5.5",
+  "run_id": "f69d0029",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b9d83cc1a2ae96637a0dc4d7884a32f89fd0b8b2fdcbac9f0efd40679df5fef4"
+    "value": "64708d85d6ef2da465c309249389a353890a3df79395976b1bd8c338d0385048"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-c-20-final-20260526/traces/codex-gpt-5.5/26-USC-3306-c-20.json",
-  "trace_sha256": "d2d784c565642437050590bd1153ddff3759726b63f337087168f7751c0bd0dd"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-c-20.json",
+  "trace_sha256": "57ae32b1b87e2fca41c0b5170b3548907f15fbc1a771a1a45cfd7fe677b72958"
 }

--- a/statutes/26/3306/c/20.test.yaml
+++ b/statutes/26/3306/c/20.test.yaml
@@ -1,7 +1,6 @@
 - name: organized camp student service qualifies under short operating season test
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -20,10 +19,9 @@
     us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
     us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: holds
     us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: holds
-- name: organized camp student service qualifies under short operating season test_scalar_outputs
+- name: organized camp student service scalar outputs
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -43,8 +41,7 @@
 - name: organized camp student service qualifies under gross receipts seasonality
     test
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -66,8 +63,7 @@
 - name: organized camp student service does not qualify when neither camp test is
     met
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -88,8 +84,7 @@
     us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: not_holds
 - name: organized camp student service does not qualify at thirteen calendar weeks
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
@@ -98,20 +93,19 @@
     us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_calendar_year: 7
     us:statutes/26/3306/c/20#input.employing_organized_camp_operated_months_in_preceding_calendar_year: 7
     ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_candidate_six_month_period_in_preceding_calendar_year
-    : 900
+    : 600
     ? us:statutes/26/3306/c/20#input.employing_organized_camp_gross_receipts_for_other_six_month_period_in_preceding_calendar_year
     : 2400
     us:statutes/26/3306/c/20#input.calendar_weeks_full_time_student_performed_services_in_employ_of_organized_camp: 13
   output:
     us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied: holds
-    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: not_holds
+    us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied: holds
     us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception: holds
     us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit: not_holds
     us:statutes/26/3306/c/20#organized_camp_full_time_student_service_excepted_from_employment: not_holds
 - name: service outside full time student organized camp category is not excepted
   period:
-    period_kind: custom
-    name: calendar_year
+    period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:

--- a/statutes/26/3306/c/20.yaml
+++ b/statutes/26/3306/c/20.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    Service performed by a full time student in the employ of an organized camp, if the camp satisfies the 7-month operating test or the 33⅓ percent gross receipts test, and the student served for less than 13 calendar weeks.
+    Service performed by a full time student in the employ of an organized camp is excepted if the camp satisfies either the 7-month operating test or the 33⅓ percent gross-receipts seasonality test, and the student performed services for less than 13 calendar weeks in the calendar year.
 rules:
   - name: organized_camp_operation_month_limit
     kind: parameter
@@ -88,6 +88,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "did not operate for more than 7 months in the calendar year and ... preceding calendar year"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -107,6 +108,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "average gross receipts for any 6 months ... not more than 33⅓ percent ... other 6 months"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -122,9 +124,17 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/26/3306
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/20#employing_organized_camp_short_operating_season_test_satisfied
+              output: employing_organized_camp_short_operating_season_test_satisfied
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/20#employing_organized_camp_gross_receipts_seasonality_test_satisfied
+              output: employing_organized_camp_gross_receipts_seasonality_test_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -144,6 +154,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "performed services in the employ of such camp for less than 13 calendar weeks"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
@@ -159,9 +170,22 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: exception
+            kind: condition
             source:
               corpus_citation_path: us/statute/26/3306
+              excerpt: "service performed by a full time student ... in the employ of an organized camp"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/20#employing_organized_camp_qualifies_for_student_service_exception
+              output: employing_organized_camp_qualifies_for_student_service_exception
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3306/c/20#full_time_student_organized_camp_service_weeks_below_limit
+              output: full_time_student_organized_camp_service_weeks_below_limit
+              hash: sha256:local
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- Refresh generated RuleSpec output for `26 USC 3306(c)(20)`.
- Regenerate the signed encoder apply manifest with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.
- Preserve six distinct organized-camp full-time-student tests while normalizing their periods to `tax_year`.
- Add more specific proof atoms for the operating-month test, gross-receipts seasonality test, week limit, and composed exception predicates.

## Notes
- Rejected generated runs `904db70a` and `f053ab0b` because they merged the 13-week boundary negative and outside-category negative into a single case, weakening test coverage.
- Accepted generated run `f69d0029`, which keeps those as separate tests.
- The standalone generation run still reported CI failure before apply, but the applied files passed the local validator/test/proof stack below.

## Validation
- `uv run axiom-encode validate statutes/26/3306/c/20.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/c/20.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306c20-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/c/20.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306c20-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306c20-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports zero untested comparable tax outputs. These rules remain `known_not_comparable` to PolicyEngine because they model organized-camp FUTA employment exception predicates and thresholds, while PolicyEngine exposes final FUTA taxable earnings rather than these predicates separately.
