### PR TITLE
Refresh generated 3306(e) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/e.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/e.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/e.yaml",
-      "sha256": "1a9f15d2cfe26112cadeae9baa810692521b6ad4b6d81916e8785c1d9cbf9ac5"
+      "sha256": "59b9ca44866f1400ad1a7c3d27d4ae9c7c4de5543f88b207497834e8dff1856f"
     },
     {
       "path": "statutes/26/3306/e.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.266",
-    "version_commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.266",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(e)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-e-final-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-e/workspace/context-manifest.json",
-  "context_manifest_sha256": "e0d93a354b9c79f294141e12acdfbfac7dbfd8087c5a83a3d453e65309b4e12c",
-  "generated_at": "2026-05-26T07:18:43.739857+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-e-final-20260526/codex-gpt-5.5/statutes/26/3306/e.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-e-final-20260526",
-  "generated_output_sha256": "1a9f15d2cfe26112cadeae9baa810692521b6ad4b6d81916e8785c1d9cbf9ac5",
-  "generation_prompt_sha256": "e02ee55497e873aa2f92c9cb52dbb532e7912deaa9eef2dcc9b9204934a7f6de",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-e/workspace/context-manifest.json",
+  "context_manifest_sha256": "a46b0bc62f5874939422984fade7476da1c39ea79d1ab7816bc2f32743d6a005",
+  "generated_at": "2026-06-02T10:51:16.212240+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/e.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "59b9ca44866f1400ad1a7c3d27d4ae9c7c4de5543f88b207497834e8dff1856f",
+  "generation_prompt_sha256": "e4ef36140f438971926dd39fea4c1c207364f3d51253c8fb84710929fd80b75d",
   "model": "gpt-5.5",
-  "run_id": "42d32f97",
-  "runner": "codex-gpt-5.5",
+  "run_id": "9e78619b",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "96ce4d61cd2530ee49a91ad5c6ed4635d35e9e20f69f733fe1831b48fa969e4d"
+    "value": "9d585d1d39937fd3ab3db5114fffda1942a1104d9916ff5b643c61885ec1fe46"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-e-final-20260526/traces/codex-gpt-5.5/26-USC-3306-e.json",
-  "trace_sha256": "97ae57182d062253a4f996693b6e3cc718fa1e8847aa6ca3d5b94898ad491a41"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-e.json",
+  "trace_sha256": "a05f0799eefed442efccaafc0b3f336abdea1e48033d688ffd8e38b2c7a16e09"
 }

--- a/statutes/26/3306/e.yaml
+++ b/statutes/26/3306/e.yaml
@@ -5,11 +5,10 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3306
-  summary: '"State agency" means any State officer, board, or other authority designated
-    under State law to administer the State unemployment fund.'
+  summary: |-
+    For purposes of this chapter, “State agency” means any State officer, board, or other authority designated under State law to administer the unemployment fund in such State.
   deferred_outputs:
-  - output: us:statutes/26/3306/e#state_agency
-    reason: Generated module is marked `entity_not_supported`; the source definition
-      for State agency cannot be encoded as an executable RuleSpec output until the
-      target entity or surface is supported.
+    - output: us:statutes/26/3306/e#state_agency
+      source: 26 USC 3306(e)
+      reason: The source defines an institutional legal status for State officers, boards, or other authorities designated under State law to administer a State unemployment fund. The supported RuleSpec entity set does not include State agencies, officers, boards, authorities, or governmental offices as entities, so the definition cannot be faithfully exposed as an executable output.
 rules: []


### PR DESCRIPTION
## Summary
- Refresh generated RuleSpec output for `26 USC 3306(e)`.
- Regenerate the signed encoder apply manifest with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.
- Keep the State agency definition deferred as unsupported, with a clearer source and reason for why no executable entity output is emitted.

## Validation
- `uv run axiom-encode validate statutes/26/3306/e.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/e.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306e-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/e.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306e-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306e-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports zero untested comparable tax outputs. This section emits no executable RuleSpec rules because the current RuleSpec entity set does not include State agencies, officers, boards, authorities, or governmental offices.
