### PR TITLE
Refresh generated 3306(f) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/f.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/f.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/f.yaml",
-      "sha256": "e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b"
+      "sha256": "d9246d9dad8c2f369b7a6020e4df24cad1ccad831c1dcebe2d84b112a7aba70a"
     },
     {
       "path": "statutes/26/3306/f.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce",
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3241b-main-20260524",
-    "version": "0.2.266",
-    "version_commit": "4b6abcb855e8d3e6f76fbae1bfa836e6b34b19ce"
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
   },
-  "axiom_encode_version": "0.2.266",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
   "citation": "26 USC 3306(f)",
-  "context_manifest_file": "/private/tmp/axiom-encode-3306-f-20260526/_eval_workspaces/codex-gpt-5.5/26-USC-3306-f/workspace/context-manifest.json",
-  "context_manifest_sha256": "1f00d45dad6300d5c05986d28d7a8442243c29a34f8f1cf08c78e5f89c866dda",
-  "generated_at": "2026-05-26T07:29:12.746591+00:00",
-  "generated_output_file": "/private/tmp/axiom-encode-3306-f-20260526/codex-gpt-5.5/statutes/26/3306/f.yaml",
-  "generated_output_root": "/private/tmp/axiom-encode-3306-f-20260526",
-  "generated_output_sha256": "e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b",
-  "generation_prompt_sha256": "bb6300aceb11e94ead2f84d858a9170700d846cd88475bcbdadc712a97fe27c2",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "51a8dd83f6e533ff416754e11b2eed6dbbc2c74ac42b78e9676413a7aaca9a4f",
+  "generated_at": "2026-06-02T10:57:01.657834+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/f.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d9246d9dad8c2f369b7a6020e4df24cad1ccad831c1dcebe2d84b112a7aba70a",
+  "generation_prompt_sha256": "b06e88fbd6f4eb13292258758a17ac9dd5448417dac1f7154fa952f5dc9c307e",
   "model": "gpt-5.5",
-  "run_id": "19911e53",
-  "runner": "codex-gpt-5.5",
+  "run_id": "3b9f9650",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0d8eb495830ad9c1a78b0213169e9c572ac30aa4171a2e3eb9ea38b5eaa46ade"
+    "value": "06f5938ce247175906789f96071c6d4d70cb43ad362d649d9d26d04cacc3131d"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/private/tmp/axiom-encode-3306-f-20260526/traces/codex-gpt-5.5/26-USC-3306-f.json",
-  "trace_sha256": "8e0e7c16e3259ae65e88f9825b3ffe339a7b092864277554bb3e1eb9048c29c0"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-f.json",
+  "trace_sha256": "85d59933c7675b5677aff5d2810fe3e8c10b78786559c82d232bcad53589a9d2"
 }

--- a/statutes/26/3306/f.yaml
+++ b/statutes/26/3306/f.yaml
@@ -5,18 +5,21 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
   summary: |-
-    (f) Unemployment fund For purposes of this chapter, the term "unemployment fund" means a special fund, established under a State law and administered by a State agency, for the payment of compensation. ... An unemployment fund shall be deemed to be maintained during a taxable year only if ... no part of the moneys of such fund was expended for any purpose other than [specified permitted purposes and enumerated exceptions].
+    For purposes of this chapter, "unemployment fund" means a special fund, established under a State law and administered by a State agency, for the payment of compensation. Sums in or paid from the Unemployment Trust Fund are deemed part of the State unemployment fund until expended by the State agency. A fund is deemed maintained during a taxable year only if its moneys are expended only for compensation, specified refunds, and enumerated exceptions.
   deferred_outputs:
+    - output: us:statutes/26/3306/f#unemployment_fund_trust_fund_amounts_deemed_part
+      source: 26 USC 3306(f), Unemployment Trust Fund sentence
+      reason: The source deems State-agency account sums in the Unemployment Trust Fund and sums paid out to the State agency to be part of the State unemployment fund until expended. Faithful execution requires representing fund-to-fund account balances, payments out of the federal trust fund, State-agency expenditure status, and same-State fund membership as amount/relation state, which is not available in the current supported schema for this artifact.
     - output: us:statutes/26/3306/f#unemployment_fund_maintained
       source: 26 USC 3306(f), maintained-during-taxable-year sentence and exceptions (1)-(6)
-      reason: Computation of whether an unemployment fund is deemed maintained requires classifying permitted expenditures and exceptions by reference to section 3305(b), Social Security Act sections 903(c)(2), 903(d)(4), and 303(g), and definitions in 26 USC 3306(t) and 26 USC 3306(v), which are not available as copied RuleSpec dependencies for this artifact.
+      reason: Computing whether an unemployment fund is deemed maintained requires classifying all fund expenditures throughout the taxable year, permitted compensation payments, administration-expense exclusions, refunds including section 3305(b), Social Security Act sections 903(c)(2), 903(d)(4), and 303(g), health-insurance and income-tax withholding programs approved by the Secretary of Labor, short-time compensation under 26 USC 3306(v), and self-employment assistance under 26 USC 3306(t). These expenditure classifications and cross-referenced definitions are not available as executable RuleSpec dependencies for this artifact.
 rules:
   - name: unemployment_fund
     kind: derived
     entity: Asset
     dtype: Judgment
     period: Year
-    source: 26 USC 3306(f), first sentence
+    source: 26 USC 3306(f)
     metadata:
       proof:
         atoms:
@@ -24,7 +27,7 @@ rules:
             kind: definition
             source:
               corpus_citation_path: us/statute/26/3306
-              excerpt: "the term unemployment fund means a special fund, established under a State law and administered by a State agency, for the payment of compensation"
+              excerpt: "the term “unemployment fund” means a special fund, established under a State law and administered by a State agency, for the payment of compensation"
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
## Summary
- Refresh generated RuleSpec output for `26 USC 3306(f)`.
- Regenerate the signed encoder apply manifest with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.
- Preserve the executable `unemployment_fund` definition and four Asset-table companion tests.
- Keep the maintained-fund rule deferred, and add an explicit deferred output for Unemployment Trust Fund amounts that require unsupported fund/account state.

## Validation
- `uv run axiom-encode validate statutes/26/3306/f.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/f.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306f-v2-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/f.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306f-v2-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306f-v2-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports zero untested comparable tax outputs. `unemployment_fund` remains `known_not_comparable` to PolicyEngine because PE exposes final FUTA taxable earnings rather than State unemployment-fund entity predicates separately.
