### PR TITLE
Refresh generated 3306(g) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/g.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/g.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "statutes/26/3306/g.yaml",
-      "sha256": "55093751827eccbd54d1709187f430accd2f79fae362a5a3681736357a313dae"
+      "sha256": "d8b7d86e63f5c40a4e359db8deb8b3e6967877cac55f63a987a53f3000843fb6"
     },
     {
       "path": "statutes/26/3306/g.test.yaml",
-      "sha256": "a2b952569fb6c4fadc154be6d00bb37e61647239e235fcf0e7621a477391f2a5"
+      "sha256": "3fe801152e41584c853ef278024e7310d168b75770890faea700964a7bb873d1"
     }
   ],
   "axiom_encode_git": {
@@ -20,22 +20,22 @@
   "backend": "openai",
   "citation": "26 USC 3306(g)",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-g/workspace/context-manifest.json",
-  "context_manifest_sha256": "d5101b0f20f2b72e2fef1eed9b0f35a4ad7017dd37193ecf7c9f8aa5ad530853",
-  "generated_at": "2026-06-02T07:03:27.670988+00:00",
+  "context_manifest_sha256": "0032330e621821bf97db54d6dd082fd8d84a11288aa62d734fd9b6ff813de8e5",
+  "generated_at": "2026-06-02T11:05:41.153816+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/g.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "55093751827eccbd54d1709187f430accd2f79fae362a5a3681736357a313dae",
-  "generation_prompt_sha256": "86a518e694004068d731ff2d6e4bd5dc85f019bcc4218b40ca94e43324316cd8",
+  "generated_output_sha256": "d8b7d86e63f5c40a4e359db8deb8b3e6967877cac55f63a987a53f3000843fb6",
+  "generation_prompt_sha256": "1d30cb155bbc0dde8873228c18f5d0c9c732ab72f40dbc49803cd5215b86a984",
   "model": "gpt-5.5",
-  "run_id": "18870b63",
+  "run_id": "b60d52ab",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bf548ca51a5e1482222c542de73fe65e633796512dca5811cf244331f148293e"
+    "value": "0c3121a2c49e809bff60b7b357d16971c4c29cc94cca4324c7f7727837042b20"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-g.json",
-  "trace_sha256": "3fe0c53b63cb6dbc89df06479a17a653eb39556030f1472e68709f700665260a"
+  "trace_sha256": "52a963b6b74c5abc1c7fe0939d08cfb61cd2db8807109e764b869e14688463fa"
 }

--- a/statutes/26/3306/g.test.yaml
+++ b/statutes/26/3306/g.test.yaml
@@ -1,4 +1,4 @@
-- name: state_required_employment_payment_to_unemployment_fund_counts_to_extent_not_deducted
+- name: state_required_employment_payment_to_unemployment_fund_counts_to_extent_not_deducted_or_deductible
   period:
     period_kind: tax_year
     start: '2024-01-01'

--- a/statutes/26/3306/g.yaml
+++ b/statutes/26/3306/g.yaml
@@ -4,10 +4,10 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/3306
-  summary: For purposes of this chapter, "contributions" means payments required by
-    State law to be made into an unemployment fund by a person on account of having
-    individuals in employ, to the extent made without being deducted or deductible
-    from employees' remuneration.
+  summary: "\u201Ccontributions\u201D means payments required by a State law to be\
+    \ made into an unemployment fund by any person on account of having individuals\
+    \ in his employ, to the extent made without being deducted or deductible from\
+    \ the remuneration of individuals in his employ."
 imports:
 - us:statutes/26/3306/f#unemployment_fund
 rules:
@@ -39,7 +39,7 @@ rules:
         import:
           target: us:statutes/26/3306/f#unemployment_fund
           output: unemployment_fund
-          hash: sha256:e3244043781cf864afe93edd7bd3f148e93eb23bf29a2bf1a3aecd39ed6fdb2b
+          hash: sha256:d9246d9dad8c2f369b7a6020e4df24cad1ccad831c1dcebe2d84b112a7aba70a
   versions:
   - effective_from: '1990-01-01'
     formula: 'if count_where(payment_destination_fund, unemployment_fund) >= 1 and


### PR DESCRIPTION
## Summary
- Refresh generated RuleSpec output for `26 USC 3306(g)`.
- Regenerate the signed encoder apply manifest with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.
- Update the proof import hash for `us:statutes/26/3306/f#unemployment_fund` after the `3306(f)` refresh.
- Preserve the four contribution tests and the statutory "deducted or deductible" wording.

## Notes
- Rejected generated run `018fe1ce` because it compressed the statutory "deducted or deductible" phrase in the summary.
- Accepted generated run `b60d52ab`, which keeps the phrase and updates the dependency hash to the current `3306(f)` output.

## Validation
- `uv run axiom-encode validate statutes/26/3306/g.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/g.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306g-v2-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/g.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306g-v2-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306g-v2-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports zero untested comparable tax outputs. `contributions` remains `known_not_comparable` to PolicyEngine because PE exposes final employer FUTA tax rather than payment-level State unemployment-fund contribution amounts separately.
