### PR TITLE
Add generated 3306(h) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/h.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/h.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/h.yaml",
+      "sha256": "704a8e9704df1e08cf6f26ef4e650f265e47c4da5208d1d84854bb78a2aa84a7"
+    },
+    {
+      "path": "statutes/26/3306/h.test.yaml",
+      "sha256": "1f2c1c17951ac461d30045a33ac23b09608bdbeabe1c451d4e53875ffc4bd37d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a470e6022470b5587c81806f1d25d404abdf4dbf",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
+    "version": "0.2.532",
+    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
+  },
+  "axiom_encode_version": "0.2.532",
+  "backend": "openai",
+  "citation": "26 USC 3306(h)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-h/workspace/context-manifest.json",
+  "context_manifest_sha256": "cb248537b0f149b6fbcae685cda26620fabf36bc54fd7256408e907dfb88b5ca",
+  "generated_at": "2026-06-02T11:11:27.130964+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/h.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "704a8e9704df1e08cf6f26ef4e650f265e47c4da5208d1d84854bb78a2aa84a7",
+  "generation_prompt_sha256": "59ddabe098a2222e4257c914595ad410ae650b51e3094332ee17c70af602ba91",
+  "model": "gpt-5.5",
+  "run_id": "169aaaa5",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e86fbcafd0bfff7a43d63e7dd20205c5a867e3901b3c9b40c1ac6d8b6924d6d9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-h.json",
+  "trace_sha256": "9cc6ea6b76f3f7a5dcbb447767f217b833a6d7b5463b8d94cf01dae615417143"
+}

--- a/statutes/26/3306/h.test.yaml
+++ b/statutes/26/3306/h.test.yaml
@@ -1,0 +1,56 @@
+- name: cash_benefit_payable_to_individual_for_unemployment_is_compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/h#input.payment_is_cash_benefit: true
+      us:statutes/26/3306/h#input.payment_payable_to_individual: true
+      us:statutes/26/3306/h#input.payment_payable_with_respect_to_individual_unemployment: true
+  output:
+    us:statutes/26/3306/h#compensation:
+    - holds
+- name: non_cash_benefit_is_not_compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/h#input.payment_is_cash_benefit: false
+      us:statutes/26/3306/h#input.payment_payable_to_individual: true
+      us:statutes/26/3306/h#input.payment_payable_with_respect_to_individual_unemployment: true
+  output:
+    us:statutes/26/3306/h#compensation:
+    - not_holds
+- name: cash_benefit_not_payable_to_individual_is_not_compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/h#input.payment_is_cash_benefit: true
+      us:statutes/26/3306/h#input.payment_payable_to_individual: false
+      us:statutes/26/3306/h#input.payment_payable_with_respect_to_individual_unemployment: true
+  output:
+    us:statutes/26/3306/h#compensation:
+    - not_holds
+- name: cash_benefit_not_with_respect_to_unemployment_is_not_compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3306/h#input.payment_is_cash_benefit: true
+      us:statutes/26/3306/h#input.payment_payable_to_individual: true
+      us:statutes/26/3306/h#input.payment_payable_with_respect_to_individual_unemployment: false
+  output:
+    us:statutes/26/3306/h#compensation:
+    - not_holds

--- a/statutes/26/3306/h.yaml
+++ b/statutes/26/3306/h.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    “compensation” means cash benefits payable to individuals with respect to their unemployment.
+rules:
+  - name: compensation
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_is_cash_benefit
+          and payment_payable_to_individual
+          and payment_payable_with_respect_to_individual_unemployment


### PR DESCRIPTION
## Summary
- Add generated RuleSpec output for `26 USC 3306(h)`.
- Define `compensation` as a Payment-level predicate for cash benefits payable to individuals with respect to unemployment.
- Add four companion tests covering the positive case and each missing statutory condition.
- Add the signed encoder apply manifest generated with `axiom-encode 0.2.532`, `openai`, `gpt-5.5`.

## Validation
- `uv run axiom-encode validate statutes/26/3306/h.yaml --skip-reviewers`
- `uv run axiom-encode test statutes/26/3306/h.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306h-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `uv run axiom-encode proof-validate statutes/26/3306/h.yaml`
- `git diff --check origin/main`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306h-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"`
- `uvx --from git+https://github.com/TheAxiomFoundation/axiom-encode.git@main axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306h-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json`

Oracle coverage reports `227` comparable tax outputs, `1357` known-not-comparable outputs, zero unmapped outputs, and zero untested comparable outputs. The new `3306(h)#compensation` predicate is classified as known-not-comparable because it is a payment-level chapter 23 unemployment-compensation predicate rather than a PolicyEngine final FUTA output.