### PR TITLE
Add generated 3306(i) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/i.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/i.yaml",
+      "sha256": "e292c10df68f557a3b493af7344eea2be4877dfc029a3639b8d7b263a5d901a7"
+    },
+    {
+      "path": "statutes/26/3306/i.test.yaml",
+      "sha256": "a49967f5554d7a90879f4eaf98431840a1302a705b85d538410a96c53ef784e6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0a59757ac79f183e721ea52b751433206d1a9ec1",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602/axiom-encode",
+    "version": "0.2.533",
+    "version_commit": "0a59757ac79f183e721ea52b751433206d1a9ec1"
+  },
+  "axiom_encode_version": "0.2.533",
+  "backend": "openai",
+  "citation": "26 USC 3306(i)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-i/workspace/context-manifest.json",
+  "context_manifest_sha256": "314ab5e49c5839001cc53462f584f60497be93497a5e8fc263020175f06109ea",
+  "generated_at": "2026-06-02T11:58:35.710307+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/i.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "e292c10df68f557a3b493af7344eea2be4877dfc029a3639b8d7b263a5d901a7",
+  "generation_prompt_sha256": "fb98469591dbd4deb32fe3a3009f8b4bdc54497bee04ed3f1f0d7ccc76b9033a",
+  "model": "gpt-5.5",
+  "run_id": "1dba2cc6",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "308d415991a248b94ef55f896bd824f8072a965ab418a928efa32fc0c5a8827b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-i.json",
+  "trace_sha256": "5389de8793600aec93c260e740a7c2b427ee65c7205587060dbc890c7143a366"
+}

--- a/statutes/26/3306/i.test.yaml
+++ b/statutes/26/3306/i.test.yaml
@@ -1,0 +1,68 @@
+- name: officer_of_corporation_is_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/i#input.officer_of_corporation: true
+    us:statutes/26/3306/i#input.common_law_employee_status: false
+    us:statutes/26/3306/i#input.performs_services_for_remuneration_for_person: false
+    us:statutes/26/3306/i#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: false
+    ? us:statutes/26/3306/i#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3306/i#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: false
+    us:statutes/26/3306/i#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3306/i#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+  output:
+    us:statutes/26/3306/i#employee: holds
+- name: included_statutory_agent_driver_is_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/i#input.officer_of_corporation: false
+    us:statutes/26/3306/i#input.common_law_employee_status: false
+    us:statutes/26/3306/i#input.performs_services_for_remuneration_for_person: true
+    us:statutes/26/3306/i#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: true
+    ? us:statutes/26/3306/i#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3306/i#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: true
+    us:statutes/26/3306/i#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3306/i#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+  output:
+    us:statutes/26/3306/i#employee: holds
+- name: excluded_paragraph_3_b_life_insurance_salesman_alone_is_not_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/i#input.officer_of_corporation: false
+    us:statutes/26/3306/i#input.common_law_employee_status: false
+    us:statutes/26/3306/i#input.performs_services_for_remuneration_for_person: true
+    us:statutes/26/3306/i#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: false
+    ? us:statutes/26/3306/i#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3306/i#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: true
+    us:statutes/26/3306/i#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3306/i#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+  output:
+    us:statutes/26/3306/i#employee: not_holds
+- name: excluded_paragraph_4_social_security_act_agreement_alone_is_not_employee
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/i#input.officer_of_corporation: false
+    us:statutes/26/3306/i#input.common_law_employee_status: false
+    us:statutes/26/3306/i#input.performs_services_for_remuneration_for_person: false
+    us:statutes/26/3306/i#input.agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal: false
+    ? us:statutes/26/3306/i#input.traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+    : false
+    us:statutes/26/3306/i#input.contract_contemplates_substantially_all_services_performed_personally_by_individual: false
+    us:statutes/26/3306/i#input.individual_has_substantial_investment_in_nontransportation_facilities_used_in_services: false
+    us:statutes/26/3306/i#input.services_are_single_transaction_not_part_of_continuing_relationship: false
+  output:
+    us:statutes/26/3306/i#employee: not_holds

--- a/statutes/26/3306/i.yaml
+++ b/statutes/26/3306/i.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    For purposes of this chapter, “employee” has the meaning assigned by section 3121(d), except that paragraph (4) and subparagraphs (B) and (C) of paragraph (3) shall not apply.
+rules:
+  - name: employee
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "the term “employee” has the meaning assigned to such term by section 3121(d)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3306
+              excerpt: "except that paragraph (4) and subparagraphs (B) and (C) of paragraph (3) shall not apply"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          officer_of_corporation
+          or common_law_employee_status
+          or (
+            not officer_of_corporation
+            and not common_law_employee_status
+            and performs_services_for_remuneration_for_person
+            and (
+              agent_driver_or_commission_driver_distributing_listed_products_or_services_for_principal
+              or traveling_or_city_salesman_full_time_soliciting_and_transmitting_orders_to_principal_for_resale_merchandise_or_business_supplies
+            )
+            and contract_contemplates_substantially_all_services_performed_personally_by_individual
+            and not individual_has_substantial_investment_in_nontransportation_facilities_used_in_services
+            and not services_are_single_transaction_not_part_of_continuing_relationship
+          )


### PR DESCRIPTION
## Summary
- add generated RuleSpec and companion tests for 26 USC 3306(i), FUTA employee definition
- include signed axiom-encode apply manifest

## Provenance
- generated with axiom-encode 0.2.533 at commit 0a59757ac79f183e721ea52b751433206d1a9ec1
- backend/model: openai gpt-5.5
- run_id: 1dba2cc6
- encoder oracle coverage update merged separately in TheAxiomFoundation/axiom-encode#498

## Verification
- uv run axiom-encode test statutes/26/3306/i.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602/rulespec-us/statutes/26/3306/i.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602/rulespec-us/statutes/26/3306/i.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- uvx --refresh --from git+https://github.com/TheAxiomFoundation/axiom-encode.git@main axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json

Oracle coverage after #498: 227 comparable, 1358 known_not_comparable, 0 unmapped, 0 untested comparable.