### PR TITLE
Add generated 3306(j) payroll rules

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3306/j.json
+++ b/.axiom/encoding-manifests/statutes/26/3306/j.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/3306/j.yaml",
+      "sha256": "8983c31af9bc9a4d625b364f5a3c88e3bb6c28e745d704e0082f4bad050505ae"
+    },
+    {
+      "path": "statutes/26/3306/j.test.yaml",
+      "sha256": "53c672531c8870d1208596ff5079ad8d656d3693c38c2bd2e7981681acf054d6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f7d10ae65015e5de55ce08235c4312c6fe918ec1",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602/axiom-encode",
+    "version": "0.2.534",
+    "version_commit": "6dc692909f258e6108ca237148cd7a0fc167dfb9"
+  },
+  "axiom_encode_version": "0.2.534",
+  "backend": "openai",
+  "citation": "26 USC 3306(j)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3306-j/workspace/context-manifest.json",
+  "context_manifest_sha256": "40149ddfda4e01076fb6b7bcaf2dff1abd50884e77fceb3a4b5ed2ca8d5cd175",
+  "generated_at": "2026-06-02T12:42:22.060847+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3306/j.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a120b3f016eb4f81b40e38b45a9b45486044c8cdd7e7f5f1a095121e70eafc70",
+  "generation_prompt_sha256": "2962d9a74de4ff612350984e07b07e85d354d2dd2a3e52685e6fbf21738f6967",
+  "model": "gpt-5.5",
+  "run_id": "24691ea1",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9dc589acd927b66d2393a1e63ea244d67642f986f9c72cb2b8a62601b153cb7a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3306-j.json",
+  "trace_sha256": "45d00d76a47e835eda367a51d0e6abb74a757cc225d9a5178a993c14a0072ffd"
+}

--- a/statutes/26/3306/j.test.yaml
+++ b/statutes/26/3306/j.test.yaml
@@ -1,0 +1,52 @@
+- name: individual_resident_employer_is_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/j#input.individual_employer_is_resident_of_united_states: true
+    us:statutes/26/3306/j#input.employer_is_partnership: false
+    us:statutes/26/3306/j#input.partnership_partners_resident_of_united_states_fraction: 0
+    us:statutes/26/3306/j#input.employer_is_trust: false
+    us:statutes/26/3306/j#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3306/j#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3306/j#local_american_employer: holds
+- name: partnership_at_two_thirds_resident_partner_threshold_is_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/j#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3306/j#input.employer_is_partnership: true
+    us:statutes/26/3306/j#input.partnership_partners_resident_of_united_states_fraction: 0.6666666667
+    us:statutes/26/3306/j#input.employer_is_trust: false
+    us:statutes/26/3306/j#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3306/j#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3306/j#local_american_employer: holds
+- name: employer_with_no_qualifying_branch_is_not_american_employer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/j#input.individual_employer_is_resident_of_united_states: false
+    us:statutes/26/3306/j#input.employer_is_partnership: true
+    us:statutes/26/3306/j#input.partnership_partners_resident_of_united_states_fraction: 0.5
+    us:statutes/26/3306/j#input.employer_is_trust: true
+    us:statutes/26/3306/j#input.all_trustees_are_residents_of_united_states: false
+    us:statutes/26/3306/j#input.corporation_employer_organized_under_laws_of_united_states_or_state: false
+  output:
+    us:statutes/26/3306/j#local_american_employer: not_holds
+- name: puerto_rico_or_virgin_islands_citizen_not_otherwise_us_citizen_considered_us_citizen_for_section
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/j#input.individual_is_citizen_of_puerto_rico_or_virgin_islands: true
+    us:statutes/26/3306/j#input.individual_is_otherwise_citizen_of_united_states: false
+  output:
+    us:statutes/26/3306/j#puerto_rico_or_virgin_islands_citizen_considered_united_states_citizen_for_section: holds

--- a/statutes/26/3306/j.yaml
+++ b/statutes/26/3306/j.yaml
@@ -1,0 +1,97 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: "For purposes of this chapter, \u201CState\u201D includes the District\
+    \ of Columbia, Puerto Rico, and the Virgin Islands; \u201CUnited States\u201D\
+    \ geographically includes the States and those jurisdictions; \u201CAmerican employer\u201D\
+    \ means specified resident individuals, resident-partner partnerships, resident-trustee\
+    \ trusts, and U.S.- or State-organized corporations."
+  deferred_outputs:
+  - output: us:statutes/26/3306/j#state
+    source: 26 USC 3306(j)(1)
+    reason: The source defines the term "State" by including named jurisdictions.
+      The supported RuleSpec schema has no State or jurisdiction entity or enum suitable
+      for faithfully exposing this definitional inclusion as an executable output.
+  - output: us:statutes/26/3306/j#united_states_geographical_sense
+    source: 26 USC 3306(j)(2)
+    reason: The source defines the term "United States" when used in a geographical
+      sense by including the States, the District of Columbia, Puerto Rico, and the
+      Virgin Islands. The supported RuleSpec schema has no geographic-area entity
+      or jurisdiction membership relation suitable for faithfully exposing this definition
+      as an executable output.
+rules:
+- name: local_american_employer
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: "26 USC 3306(j): State, United States, and American employer For purposes\
+    \ of this chapter\u2014 (1) State The term \u201CSta..."
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: an individual who is a resident of the United States
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: a partnership, if two-thirds or more of the partners are residents
+            of the United States
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: a trust, if all of the trustees are residents of the United States
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: a corporation organized under the laws of the United States or
+            of any State
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3121/h#partnership_resident_partner_fraction_threshold
+          output: partnership_resident_partner_fraction_threshold
+          hash: sha256:7fe5e86e5ea35041490b0a4c90cbb4d96badfd74b5da2fd235863b6c820b277e
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "individual_employer_is_resident_of_united_states\nor (\n  employer_is_partnership\n\
+      \  and partnership_partners_resident_of_united_states_fraction >= partnership_resident_partner_fraction_threshold\n\
+      )\nor (\n  employer_is_trust\n  and all_trustees_are_residents_of_united_states\n\
+      )\nor corporation_employer_organized_under_laws_of_united_states_or_state"
+- name: puerto_rico_or_virgin_islands_citizen_considered_united_states_citizen_for_section
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 3306(j), final sentence
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: citizen of the Commonwealth of Puerto Rico or the Virgin Islands
+            (but not otherwise a citizen of the United States)
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/3306
+          excerpt: considered, for purposes of this section, as a citizen of the United
+            States
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'individual_is_citizen_of_puerto_rico_or_virgin_islands
+
+      and not individual_is_otherwise_citizen_of_united_states'
+imports:
+- us:statutes/26/3121/h#partnership_resident_partner_fraction_threshold


### PR DESCRIPTION
## Summary
- add generated RuleSpec and companion tests for 26 USC 3306(j), chapter 23 State/United States/American-employer definitions
- include signed axiom-encode apply manifest

## Provenance
- generated with axiom-encode 0.2.534 at commit f7d10ae65015e5de55ce08235c4312c6fe918ec1
- backend/model: openai gpt-5.5
- run_id: 24691ea1
- encoder oracle coverage update merged separately in TheAxiomFoundation/axiom-encode#499

## Verification
- uv run axiom-encode test statutes/26/3306/j.test.yaml --root /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602/rulespec-us --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine
- uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602/rulespec-us/statutes/26/3306/j.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602/rulespec-us/statutes/26/3306/j.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602/rulespec-us --base-ref origin/main --head-ref HEAD --roots "statutes regulations policies"
- uvx --refresh --from git+https://github.com/TheAxiomFoundation/axiom-encode.git@main axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json

Oracle coverage after #499: 227 comparable, 1360 known_not_comparable, 0 unmapped, 0 untested comparable.