### PR TITLE
Regenerate 3241(b) with current encoder

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/3241/b.json
+++ b/.axiom/encoding-manifests/statutes/26/3241/b.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/3241/b.yaml",
-      "sha256": "20b106ec9023aec7cc2342ca8a78d7544fea981e065d21580c0dd6d9b3af7fa4"
+      "sha256": "92e19c92a35668c208e398950a3418b2584b8c66477c71eb5c08e308756ffe79"
     },
     {
       "path": "statutes/26/3241/b.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51",
+    "commit": "f90e47dc94bf808a8bedf33581f405f32434706b",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-encode",
-    "version": "0.2.532",
-    "version_commit": "04f364d8ed3818ee2e3ad1c6e3b5583b1090db51"
+    "root": "/Users/maxghenis/_axiom-worktrees/3241b-20260602/axiom-encode",
+    "version": "0.2.539",
+    "version_commit": "f90e47dc94bf808a8bedf33581f405f32434706b"
   },
-  "axiom_encode_version": "0.2.532",
+  "axiom_encode_version": "0.2.539",
   "backend": "openai",
   "citation": "26 USC 3241(b)",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "3c95aafc3cdbe43b374e29cc10fe2eabe82e174ce7ca53c3cf4823347bbf38db",
-  "generated_at": "2026-06-02T04:37:40.897835+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3241/b.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "20b106ec9023aec7cc2342ca8a78d7544fea981e065d21580c0dd6d9b3af7fa4",
-  "generation_prompt_sha256": "baa7573db732bba781d2ef4a568caa40d0907906e8ca69be1a9d2198b6a4abcc",
+  "context_manifest_file": "/tmp/axiom-encode-3241b-target-EzSrwM/_eval_workspaces/openai-gpt-5.5/26-USC-3241-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "71df0293e0902a7339ebbafd5174e451132e137c59be163ce4b94375215fcf1f",
+  "generated_at": "2026-06-02T17:01:47.099386+00:00",
+  "generated_output_file": "/tmp/axiom-encode-3241b-target-EzSrwM/openai-gpt-5.5/statutes/26/3241/b.yaml",
+  "generated_output_root": "/tmp/axiom-encode-3241b-target-EzSrwM",
+  "generated_output_sha256": "92e19c92a35668c208e398950a3418b2584b8c66477c71eb5c08e308756ffe79",
+  "generation_prompt_sha256": "fa61a57fbcb09ef1e92cc14b8208653864ba534d41c774289b955161981fe229",
   "model": "gpt-5.5",
-  "run_id": "3adc8c5c",
+  "run_id": "0a74505a",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8cf50c95e7f8b81bace7c08ee0016a65afff6579ddd13500cc06c5bdf3496905"
+    "value": "abbded958c6b39da1ca447ba7783f5dcaa4817db0f374ab50c6c36866c820b70"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/26-USC-3241-b.json",
-  "trace_sha256": "864372402b9eccfdffc61764003ab58e6f964d93a7072b50b63612e69ff0fafe"
+  "trace_file": "/tmp/axiom-encode-3241b-target-EzSrwM/traces/openai-gpt-5.5/26-USC-3241-b.json",
+  "trace_sha256": "b90230650a6530645cb93d53b3767434a5291a8eab12c0fcb6a87fa11d800bf9"
 }

--- a/statutes/26/3241/b.yaml
+++ b/statutes/26/3241/b.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3241
   summary: |-
-    Tax rate schedule for average account benefits ratio bands gives applicable percentages for sections 3211(b) and 3221(b), and for section 3201(b).
+    Tax rate schedule: average account benefits ratio bands determine the applicable percentage for sections 3211(b) and 3221(b), and for section 3201(b).
 rules:
   - name: average_account_benefits_ratio_band_lower_bound
     kind: parameter


### PR DESCRIPTION
## Summary
- regenerate 26 USC 3241(b) with axiom-encode 0.2.539 from merged encoder main
- update the signed generated-artifact manifest for the new run
- no hand edits to generated RuleSpec artifacts

## Validation
- `AXIOM_CORPUS_LOCAL_ROOT=/Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-corpus uv run axiom-encode validate statutes/26/3241/b.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate statutes/26/3241/b.yaml`
- `uv run axiom-encode test statutes/26/3241/b.test.yaml --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo . --base-ref origin/main --head-ref HEAD --json`

Note: this used `--apply-target-only` because repo-augmented apply validation currently checks copied context files against the requested citation; I will track that separately in axiom-encode.