### PR TITLE
Encode Medicaid MAGI eligibility groups

### DIFF
--- a/.axiom/encoding-manifests/regulations/42-cfr/435/110.json
+++ b/.axiom/encoding-manifests/regulations/42-cfr/435/110.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/110.yaml",
+      "sha256": "e75602f427450e0c901f86624cdf8722311a12fddef730325a649d5f4e6d843f"
+    },
+    {
+      "path": "regulations/42-cfr/435/110.test.yaml",
+      "sha256": "63119ebf4adc8a0a525c6e2974bfb4f3bce1af3514335af29b6b720ee05643d9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode-nyc-cardinal-fix",
+    "version": "0.2.602",
+    "version_commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f"
+  },
+  "axiom_encode_version": "0.2.602",
+  "backend": "claude",
+  "citation": "us/regulation/42/435/110",
+  "context_manifest_file": "/tmp/axiom-encode-medicaid-magi-110-v5/_eval_workspaces/claude-opus/us-regulation-42-435-110/workspace/context-manifest.json",
+  "context_manifest_sha256": "09ac8492db54061f1e176f5bd7dd3f46bbe5481ce54b279aefe354bbc88cc622",
+  "generated_at": "2026-06-05T22:43:24.241771+00:00",
+  "generated_output_file": "/tmp/axiom-encode-medicaid-magi-110-v5/claude-opus/regulations/42-cfr/435/110.yaml",
+  "generated_output_root": "/tmp/axiom-encode-medicaid-magi-110-v5",
+  "generated_output_sha256": "e75602f427450e0c901f86624cdf8722311a12fddef730325a649d5f4e6d843f",
+  "generation_prompt_sha256": "5580b3d8c0069684c5a4e3b8da8b629ee291e4b7835f21084072f3def196e0ea",
+  "model": "opus",
+  "run_id": "58bee239",
+  "runner": "claude-opus",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7170008915f99333d78051900bc157fab9c1402033fedaa687c5306e3eaab494"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-medicaid-magi-110-v5/traces/claude-opus/us-regulation-42-435-110.json",
+  "trace_sha256": "6e9f2fc77842dbd5836797d0c373f5df1a5d34be4b1e825e922d39a0f8abec0d"
+}

--- a/.axiom/encoding-manifests/regulations/42-cfr/435/116.json
+++ b/.axiom/encoding-manifests/regulations/42-cfr/435/116.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/116.yaml",
+      "sha256": "279df515adff9b1ea0aed1f926e1f7f2413f6130a35fcd04067cd606cf508314"
+    },
+    {
+      "path": "regulations/42-cfr/435/116.test.yaml",
+      "sha256": "c1c462d7ff6091bb9b5fae854e291bf0b9bff391f8d172929d49c002cab7f0a1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode-nyc-cardinal-fix",
+    "version": "0.2.602",
+    "version_commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f"
+  },
+  "axiom_encode_version": "0.2.602",
+  "backend": "claude",
+  "citation": "us/regulation/42/435/116",
+  "context_manifest_file": "/tmp/axiom-encode-medicaid-magi-116-v1/_eval_workspaces/claude-opus/us-regulation-42-435-116/workspace/context-manifest.json",
+  "context_manifest_sha256": "74d9838d7150e612a01e3f4658b6d33a1a666a3c6ed70411a88a8d11db83e36b",
+  "generated_at": "2026-06-05T22:45:12.997524+00:00",
+  "generated_output_file": "/tmp/axiom-encode-medicaid-magi-116-v1/claude-opus/regulations/42-cfr/435/116.yaml",
+  "generated_output_root": "/tmp/axiom-encode-medicaid-magi-116-v1",
+  "generated_output_sha256": "279df515adff9b1ea0aed1f926e1f7f2413f6130a35fcd04067cd606cf508314",
+  "generation_prompt_sha256": "d4ba2f4229a2aa1ef2a477b9cfd2c5a58e170c2e3ee7a62bed60b151eec50358",
+  "model": "opus",
+  "run_id": "f35a2320",
+  "runner": "claude-opus",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9940e995bed6d404b3b23e99dc5e39c4759649d00209f9198e27fb587178b7a3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-medicaid-magi-116-v1/traces/claude-opus/us-regulation-42-435-116.json",
+  "trace_sha256": "d6246c0f170f5f08d562055b97d7dba6ef1a02e9260d3b9433cbed3ad1bfea91"
+}

--- a/.axiom/encoding-manifests/regulations/42-cfr/435/118.json
+++ b/.axiom/encoding-manifests/regulations/42-cfr/435/118.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/118.yaml",
+      "sha256": "d25d698a533bec85bd82b5dcb1f1a35447a67abcc7e53f2463bf9da0addfd809"
+    },
+    {
+      "path": "regulations/42-cfr/435/118.test.yaml",
+      "sha256": "1a2c97684c55dc56529fbbe575234289ce667e8a85e27abc78f799e63d937ad7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode-nyc-cardinal-fix",
+    "version": "0.2.602",
+    "version_commit": "71f1a886c4ccdd270ee08ec0643dd831cd817c0f"
+  },
+  "axiom_encode_version": "0.2.602",
+  "backend": "claude",
+  "citation": "us/regulation/42/435/118",
+  "context_manifest_file": "/tmp/axiom-encode-medicaid-magi-118-v1/_eval_workspaces/claude-opus/us-regulation-42-435-118/workspace/context-manifest.json",
+  "context_manifest_sha256": "f0ef440e9c525dfe8adaab268c74fb44ab8cc1187748eb7cb6370ee3d757a118",
+  "generated_at": "2026-06-05T22:51:50.257831+00:00",
+  "generated_output_file": "/tmp/axiom-encode-medicaid-magi-118-v1/claude-opus/regulations/42-cfr/435/118.yaml",
+  "generated_output_root": "/tmp/axiom-encode-medicaid-magi-118-v1",
+  "generated_output_sha256": "d25d698a533bec85bd82b5dcb1f1a35447a67abcc7e53f2463bf9da0addfd809",
+  "generation_prompt_sha256": "eca9e99e064d3b121005e0e423b582e2dd6128d32a7197ec70f89d749bd1a3ae",
+  "model": "opus",
+  "run_id": "cfa2a28d",
+  "runner": "claude-opus",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "70a651e9e54451fa5fee177c8756ae159dbb5e9c6feda0fadb7486775333fb45"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-medicaid-magi-118-v1/traces/claude-opus/us-regulation-42-435-118.json",
+  "trace_sha256": "6f98feaa0434e00c5dcc0628b6f4f5371507919294808fba964e5acc323c1eaf"
+}

--- a/.axiom/encoding-manifests/regulations/42-cfr/435/119.json
+++ b/.axiom/encoding-manifests/regulations/42-cfr/435/119.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/119.yaml",
+      "sha256": "0c9a76599b5604b754e25929deb339f6567f54634acc0acb8a2c60fd31736254"
+    },
+    {
+      "path": "regulations/42-cfr/435/119.test.yaml",
+      "sha256": "075a0064170be51cbf164302fa97d260cf9697e836867a5e987e6ffc58e847aa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "96549fdb23109c9340030980be2d17a88a58addf",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode-nyc-cardinal-fix",
+    "version": "0.2.602",
+    "version_commit": "96549fdb23109c9340030980be2d17a88a58addf"
+  },
+  "axiom_encode_version": "0.2.602",
+  "backend": "claude",
+  "citation": "us/regulation/42/435/119",
+  "context_manifest_file": "/tmp/axiom-encode-medicaid-magi-119-v2/_eval_workspaces/claude-opus/us-regulation-42-435-119/workspace/context-manifest.json",
+  "context_manifest_sha256": "d3bae961c4ebd2d41679da1896b30db83f673fc201e6b7b0cec0c4f527ced652",
+  "generated_at": "2026-06-05T22:28:18.236681+00:00",
+  "generated_output_file": "/tmp/axiom-encode-medicaid-magi-119-v2/claude-opus/regulations/42-cfr/435/119.yaml",
+  "generated_output_root": "/tmp/axiom-encode-medicaid-magi-119-v2",
+  "generated_output_sha256": "0c9a76599b5604b754e25929deb339f6567f54634acc0acb8a2c60fd31736254",
+  "generation_prompt_sha256": "dd4e8573a20194f42a4962c465aa6d02c44487a08a686ba5e687b1badd8c8adf",
+  "model": "opus",
+  "run_id": "33c1be8d",
+  "runner": "claude-opus",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "992bdcd59923a2ef27d7be7f7b356c0c7205fb02e777587e06ea6776da1bb742"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-medicaid-magi-119-v2/traces/claude-opus/us-regulation-42-435-119.json",
+  "trace_sha256": "b7406d33b187e7c0cf701547139b6e4e2b76f7b002bf520ff75940481847c809"
+}

--- a/regulations/42-cfr/435/110.test.yaml
+++ b/regulations/42-cfr/435/110.test.yaml
@@ -1,0 +1,32 @@
+- name: parent_with_income_below_state_standard_is_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them: false
+    us:regulations/42-cfr/435/110#input.household_income_at_or_below_state_plan_income_standard: true
+  output:
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible: holds
+- name: spouse_living_with_caretaker_relative_below_standard_is_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them: true
+    us:regulations/42-cfr/435/110#input.household_income_at_or_below_state_plan_income_standard: true
+  output:
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible: holds
+- name: parent_with_income_above_state_standard_is_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them: false
+    us:regulations/42-cfr/435/110#input.household_income_at_or_below_state_plan_income_standard: false
+  output:
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible: not_holds
+- name: non_parent_non_spouse_is_not_eligible_even_below_standard
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them: false
+    us:regulations/42-cfr/435/110#input.household_income_at_or_below_state_plan_income_standard: true
+  output:
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible: not_holds

--- a/regulations/42-cfr/435/110.yaml
+++ b/regulations/42-cfr/435/110.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+  summary: "The agency must provide Medicaid to parents and other caretaker relatives,\
+    \ as defined in \xA7 435.4, and, if living with such parent or other caretaker\
+    \ relative, his or her spouse, whose household income is at or below the income\
+    \ standard established by the agency in the State plan. The agency must establish\
+    \ the income standard subject to: (1) a minimum equal to the State's AFDC income\
+    \ standard in effect as of May 1, 1988 for the applicable family size converted\
+    \ to a MAGI-equivalent standard; and (2) a maximum equal to the higher of (i)\
+    \ the effective income level for section 1931 low-income families under the Medicaid\
+    \ State plan or waiver as of March 23, 2010 or December 31, 2013, if higher, converted\
+    \ to a MAGI-equivalent standard; or (ii) the State's AFDC income standard in effect\
+    \ as of July 16, 1996 for the applicable family size, increased by no more than\
+    \ the percentage increase in the CPI for all urban consumers between July 16,\
+    \ 1996 and the effective date of the increase."
+rules:
+- name: parent_or_caretaker_relative_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.110(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/110
+          excerpt: "The agency must provide Medicaid to parents and other caretaker\
+            \ relatives, as defined in \xA7 435.4, and, if living with such parent\
+            \ or other caretaker relative, his or her spouse, whose household income\
+            \ is at or below the income standard established by the agency in the\
+            \ State plan"
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '(person_is_parent_or_caretaker_relative or person_is_spouse_of_parent_or_caretaker_relative_living_with_them)
+
+      and household_income_at_or_below_state_plan_income_standard'

--- a/regulations/42-cfr/435/116.test.yaml
+++ b/regulations/42-cfr/435/116.test.yaml
@@ -1,0 +1,50 @@
+- name: pregnant_woman_low_income_full_medicaid
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/116#input.person_is_pregnant: true
+    us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/116#input.state_plan_pregnant_women_income_standard_fpl_ratio: 1.5
+    us:regulations/42-cfr/435/116#input.state_plan_full_medicaid_applicable_income_limit_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/116#minimum_income_standard_floor_fpl_ratio: 1.33
+    us:regulations/42-cfr/435/116#minimum_income_standard_ceiling_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/116#maximum_income_standard_floor_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/116#pregnant_woman_eligible: holds
+    us:regulations/42-cfr/435/116#pregnant_woman_income_within_full_medicaid_applicable_income_limit: holds
+    us:regulations/42-cfr/435/116#pregnant_woman_full_medicaid_coverage: holds
+    us:regulations/42-cfr/435/116#pregnant_woman_pregnancy_related_services_only: not_holds
+- name: pregnant_woman_above_applicable_limit_pregnancy_related_only
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/116#input.person_is_pregnant: true
+    us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl: 1.5
+    us:regulations/42-cfr/435/116#input.state_plan_pregnant_women_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/116#input.state_plan_full_medicaid_applicable_income_limit_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/116#pregnant_woman_eligible: holds
+    us:regulations/42-cfr/435/116#pregnant_woman_income_within_full_medicaid_applicable_income_limit: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_full_medicaid_coverage: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_pregnancy_related_services_only: holds
+- name: pregnant_woman_above_state_plan_standard_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/116#input.person_is_pregnant: true
+    us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl: 2.0
+    us:regulations/42-cfr/435/116#input.state_plan_pregnant_women_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/116#input.state_plan_full_medicaid_applicable_income_limit_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/116#pregnant_woman_eligible: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_income_within_full_medicaid_applicable_income_limit: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_full_medicaid_coverage: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_pregnancy_related_services_only: not_holds
+- name: not_pregnant_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/116#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl: 0.5
+    us:regulations/42-cfr/435/116#input.state_plan_pregnant_women_income_standard_fpl_ratio: 1.5
+    us:regulations/42-cfr/435/116#input.state_plan_full_medicaid_applicable_income_limit_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/116#pregnant_woman_eligible: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_full_medicaid_coverage: not_holds
+    us:regulations/42-cfr/435/116#pregnant_woman_pregnancy_related_services_only: not_holds

--- a/regulations/42-cfr/435/116.yaml
+++ b/regulations/42-cfr/435/116.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/116
+  summary: 'The agency must provide Medicaid to pregnant women whose household income
+
+    is at or below the income standard established by the agency in its State
+
+    plan. The minimum income standard is the higher of 133 percent FPL or such
+
+    higher standard up to 185 percent FPL as the State had established as of
+
+    December 19, 1989 (or had authorizing legislation as of July 1, 1989). The
+
+    maximum income standard is the higher of the highest effective income
+
+    level in effect as of March 23, 2010 or December 31, 2013 (converted to a
+
+    MAGI-equivalent standard), or 185 percent FPL. Pregnant women are covered
+
+    for full Medicaid coverage except that the agency may provide only
+
+    pregnancy-related services when household income exceeds the applicable
+
+    income limit for full coverage established by the agency in its State
+
+    plan.'
+rules:
+- name: minimum_income_standard_floor_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.116(c)(1)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: 133 percent FPL for the applicable family size
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.33'
+- name: minimum_income_standard_ceiling_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.116(c)(1)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: Such higher income standard up to 185 percent FPL
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.85'
+- name: maximum_income_standard_floor_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.116(c)(2)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: 185 percent FPL
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.85'
+- name: pregnant_woman_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.116(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: The agency must provide Medicaid to pregnant women whose household
+            income is at or below the income standard
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'person_is_pregnant
+
+      and (household_income_as_fraction_of_fpl <= state_plan_pregnant_women_income_standard_fpl_ratio)'
+- name: pregnant_woman_income_within_full_medicaid_applicable_income_limit
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.116(d)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: the agency may provide only pregnancy-related services ... for
+            pregnant women whose income exceeds the applicable income limit
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_as_fraction_of_fpl <= state_plan_full_medicaid_applicable_income_limit_fpl_ratio
+- name: pregnant_woman_full_medicaid_coverage
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.116(d)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: Pregnant women are covered under this section for the full Medicaid
+            coverage
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'pregnant_woman_eligible
+
+      and pregnant_woman_income_within_full_medicaid_applicable_income_limit'
+- name: pregnant_woman_pregnancy_related_services_only
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.116(d)(1), (d)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/116
+          excerpt: the agency may provide only pregnancy-related services ... for
+            pregnant women whose income exceeds the applicable income limit established
+            by the agency in its State plan
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'pregnant_woman_eligible
+
+      and not pregnant_woman_income_within_full_medicaid_applicable_income_limit'

--- a/regulations/42-cfr/435/118.test.yaml
+++ b/regulations/42-cfr/435/118.test.yaml
@@ -1,0 +1,115 @@
+- name: eligible_infant_at_state_standard
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 0
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/118#child_under_age_19: holds
+    us:regulations/42-cfr/435/118#child_is_infant: holds
+    us:regulations/42-cfr/435/118#child_is_in_young_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_older_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: holds
+- name: eligible_young_child
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 5
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/118#child_under_age_19: holds
+    us:regulations/42-cfr/435/118#child_is_infant: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_young_child_age_group: holds
+    us:regulations/42-cfr/435/118#child_is_in_older_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: holds
+- name: eligible_older_child_age_18
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 18
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/118#child_under_age_19: holds
+    us:regulations/42-cfr/435/118#child_is_infant: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_young_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_older_child_age_group: holds
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: holds
+- name: ineligible_age_19_or_older
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 19
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 0.5
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/118#child_under_age_19: not_holds
+    us:regulations/42-cfr/435/118#child_is_infant: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_young_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_older_child_age_group: not_holds
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: not_holds
+- name: ineligible_income_above_state_standard
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 10
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 2.0
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.33
+  output:
+    us:regulations/42-cfr/435/118#child_under_age_19: holds
+    us:regulations/42-cfr/435/118#child_is_infant: not_holds
+    us:regulations/42-cfr/435/118#child_is_in_older_child_age_group: holds
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: not_holds
+- name: infant_minimum_and_maximum_standards_with_state_authorization
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 0
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 1.5
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/118#input.state_had_authorizing_legislation_for_higher_infant_income_standard: true
+    us:regulations/42-cfr/435/118#input.state_plan_authorized_infant_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/118#input.state_plan_age_group_grandfathered_income_standard_fpl_ratio: 1.85
+  output:
+    us:regulations/42-cfr/435/118#child_is_infant: holds
+    us:regulations/42-cfr/435/118#minimum_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/118#maximum_income_standard_fpl_ratio: 1.85
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: holds
+- name: non_infant_maximum_standard_uses_grandfathered_level
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/118#input.person_age: 10
+    us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio: 1.5
+    us:regulations/42-cfr/435/118#input.state_had_authorizing_legislation_for_higher_infant_income_standard: false
+    us:regulations/42-cfr/435/118#input.state_plan_authorized_infant_income_standard_fpl_ratio: 1.33
+    us:regulations/42-cfr/435/118#input.state_plan_age_group_grandfathered_income_standard_fpl_ratio: 1.5
+  output:
+    us:regulations/42-cfr/435/118#child_is_infant: not_holds
+    us:regulations/42-cfr/435/118#minimum_income_standard_fpl_ratio: 1.33
+    us:regulations/42-cfr/435/118#maximum_income_standard_fpl_ratio: 1.5
+    us:regulations/42-cfr/435/118#infants_and_children_eligible: holds

--- a/regulations/42-cfr/435/118.yaml
+++ b/regulations/42-cfr/435/118.yaml
@@ -1,0 +1,309 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/118
+  summary: 'The agency must provide Medicaid to children under age 19 whose household
+
+    income is at or below the income standard established by the agency in its
+
+    State plan. The minimum income standard is the higher of 133 percent FPL
+
+    for the applicable family size, or, for infants under age 1, such higher
+
+    income standard up to 185 percent FPL as the State had established as of
+
+    December 19, 1989 or had authorizing legislation to do so as of July 1,
+
+    1989. The maximum income standard for each age group (infants under 1,
+
+    children 1 through 5, children 6 through 18) is the higher of 133 percent
+
+    FPL, the highest effective income level for the age group under the State
+
+    plan as of March 23, 2010 or December 31, 2013 if higher, MAGI-converted,
+
+    or, for infants under age 1, 185 percent FPL.'
+rules:
+- name: child_maximum_age_exclusive
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children under age 19
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '19'
+- name: infant_maximum_age_exclusive
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(c)(1)(ii), (c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: infants under age 1
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1'
+- name: young_child_age_group_minimum_age
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 1 through age 5
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1'
+- name: young_child_age_group_maximum_age_inclusive
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 1 through age 5
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '5'
+- name: older_child_age_group_minimum_age
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 6 through age 18
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '6'
+- name: older_child_age_group_maximum_age_inclusive
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 6 through age 18
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '18'
+- name: child_minimum_income_standard_floor_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.118(c)(1)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: 133 percent FPL for the applicable family size
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.33'
+- name: child_maximum_income_standard_floor_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.118(c)(2)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: 133 percent FPL
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.33'
+- name: infant_minimum_income_standard_ceiling_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.118(c)(1)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: such higher income standard up to 185 percent FPL
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.85'
+- name: infant_maximum_income_standard_floor_fpl_ratio
+  kind: parameter
+  dtype: Rate
+  source: 42 CFR 435.118(c)(2)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: For infants under age 1, 185 percent FPL
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '1.85'
+- name: child_under_age_19
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.118(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children under age 19
+  versions:
+  - effective_from: '2014-01-01'
+    formula: person_age < child_maximum_age_exclusive
+- name: child_is_infant
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.118(c)(1)(ii), (c)(2)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: infants under age 1
+  versions:
+  - effective_from: '2014-01-01'
+    formula: person_age < infant_maximum_age_exclusive
+- name: child_is_in_young_child_age_group
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 1 through age 5
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'person_age >= young_child_age_group_minimum_age
+
+      and person_age <= young_child_age_group_maximum_age_inclusive'
+- name: child_is_in_older_child_age_group
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: children age 6 through age 18
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'person_age >= older_child_age_group_minimum_age
+
+      and person_age <= older_child_age_group_maximum_age_inclusive'
+- name: minimum_income_standard_fpl_ratio
+  kind: derived
+  entity: Person
+  dtype: Rate
+  period: Year
+  source: 42 CFR 435.118(c)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: The minimum income standard is the higher of
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'if child_is_infant and state_had_authorizing_legislation_for_higher_infant_income_standard:
+      max(child_minimum_income_standard_floor_fpl_ratio, min(state_plan_authorized_infant_income_standard_fpl_ratio,
+      infant_minimum_income_standard_ceiling_fpl_ratio)) else: child_minimum_income_standard_floor_fpl_ratio'
+- name: maximum_income_standard_fpl_ratio
+  kind: derived
+  entity: Person
+  dtype: Rate
+  period: Year
+  source: 42 CFR 435.118(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: The maximum income standard for each of the age groups
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'if child_is_infant: max(infant_maximum_income_standard_floor_fpl_ratio,
+      state_plan_age_group_grandfathered_income_standard_fpl_ratio) else: max(child_maximum_income_standard_floor_fpl_ratio,
+      state_plan_age_group_grandfathered_income_standard_fpl_ratio)'
+- name: infants_and_children_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.118(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/118
+          excerpt: The agency must provide Medicaid to children under age 19 whose
+            household income is at or below the income standard established by the
+            agency in its State plan
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'child_under_age_19
+
+      and (household_income_as_fraction_of_fpl <= state_plan_child_income_standard_fpl_ratio)'

--- a/regulations/42-cfr/435/119.test.yaml
+++ b/regulations/42-cfr/435/119.test.yaml
@@ -1,0 +1,206 @@
+- name: adult_age_30_meets_all_requirements_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_age_eligible: holds
+    us:regulations/42-cfr/435/119#parent_or_caretaker_relative_blocked_by_dependent_child: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: holds
+- name: age_18_below_minimum_not_age_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 18
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_age_eligible: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: age_65_at_max_not_age_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 65
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_age_eligible: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: pregnant_individual_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: true
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: enrolled_medicare_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: true
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: enrolled_mandatory_subpart_b_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: true
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: income_above_133_fpl_not_eligible
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.5
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: parent_with_uncovered_dependent_child_blocked
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: true
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#parent_or_caretaker_relative_blocked_by_dependent_child: holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: not_holds
+- name: parent_with_child_on_medicaid_not_blocked
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: true
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: true
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#parent_or_caretaker_relative_blocked_by_dependent_child: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: holds
+- name: parent_with_child_on_chip_not_blocked
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: true
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: true
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#parent_or_caretaker_relative_blocked_by_dependent_child: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: holds
+- name: parent_with_child_in_mec_not_blocked
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 30
+    us:regulations/42-cfr/435/119#input.person_is_pregnant: false
+    us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b: false
+    us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b: false
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative: true
+    us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold: true
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid: false
+    us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip: false
+    us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage: true
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: false
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 19
+  output:
+    us:regulations/42-cfr/435/119#parent_or_caretaker_relative_blocked_by_dependent_child: not_holds
+    us:regulations/42-cfr/435/119#adult_group_eligible: holds
+- name: state_higher_age_election_threshold
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age_as_of_march_23_2010: true
+    us:regulations/42-cfr/435/119#input.state_elected_435_222_higher_age: 21
+  output:
+    us:regulations/42-cfr/435/119#dependent_child_age_threshold: 21

--- a/regulations/42-cfr/435/119.yaml
+++ b/regulations/42-cfr/435/119.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to individuals who: are age 19 or older and under age 65; are not pregnant; are not entitled to or enrolled for Medicare benefits under part A or B of title XVIII; are not otherwise eligible for and enrolled for mandatory coverage under a State's Medicaid State plan under subpart B; and have household income at or below 133 percent FPL for the applicable family size. A State may not provide Medicaid under this section to a parent or other caretaker relative living with a dependent child if the child is under the specified age (under age 19, unless the State had elected as of March 23, 2010 to cover individuals under age 20 or 21 under § 435.222, in which case the higher age applies) unless such child is receiving Medicaid, CHIP, or otherwise enrolled in minimum essential coverage.
+rules:
+  - name: adult_group_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: 42 CFR 435.119(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Are age 19 or older and under age 65"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          19
+  - name: adult_group_maximum_age
+    kind: parameter
+    dtype: Integer
+    source: 42 CFR 435.119(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Are age 19 or older and under age 65"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          65
+  - name: adult_group_income_limit_fpl_ratio
+    kind: parameter
+    dtype: Rate
+    source: 42 CFR 435.119(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Have household income that is at or below 133 percent FPL for the applicable family size"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          1.33
+  - name: dependent_child_default_age_threshold
+    kind: parameter
+    dtype: Integer
+    source: 42 CFR 435.119(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "the age specified is under age 19"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          19
+  - name: dependent_child_age_threshold
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: 42 CFR 435.119(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "unless the State had elected as of March 23, 2010 to provide Medicaid to individuals under age 20 or 21 under § 435.222 of this part, in which case the age specified is such higher age"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          if state_elected_435_222_higher_age_as_of_march_23_2010: state_elected_435_222_higher_age else: dependent_child_default_age_threshold
+  - name: adult_group_age_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.119(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Are age 19 or older and under age 65"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          person_age >= adult_group_minimum_age and person_age < adult_group_maximum_age
+  - name: parent_or_caretaker_relative_blocked_by_dependent_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.119(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "A State may not provide Medicaid under this section to a parent or other caretaker relative living with a dependent child if the child is under the age specified in paragraph (c)(2) of this section, unless such child is receiving benefits under Medicaid, the Children's Health Insurance Program under subchapter D of this chapter, or otherwise is enrolled in minimum essential coverage as defined in § 435.4 of this part."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          person_is_parent_or_caretaker_relative
+          and person_lives_with_dependent_child_under_age_threshold
+          and not dependent_child_receiving_medicaid
+          and not dependent_child_receiving_chip
+          and not dependent_child_enrolled_in_minimum_essential_coverage
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Effective January 1, 2014, the agency must provide Medicaid to individuals who: (1) Are age 19 or older and under age 65; (2) Are not pregnant; (3) Are not entitled to or enrolled for Medicare benefits under part A or B of title XVIII of the Act; (4) Are not otherwise eligible for and enrolled for mandatory coverage under a State's Medicaid State plan in accordance with subpart B of this part; and (5) Have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          adult_group_age_eligible
+          and not person_is_pregnant
+          and not person_entitled_to_or_enrolled_in_medicare_part_a_or_b
+          and not person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b
+          and household_income_as_fraction_of_fpl <= adult_group_income_limit_fpl_ratio
+          and not parent_or_caretaker_relative_blocked_by_dependent_child


### PR DESCRIPTION
## Summary
- Encodes federal Medicaid MAGI eligibility groups at 42 CFR 435.110, 435.116, 435.118, and 435.119.
- Adds companion tests for parent/caretaker relatives, pregnant women, infants/children, and adult group eligibility.
- Includes encoder apply manifests for all four sections.

## Validation
- axiom-encode validate regulations/42-cfr/435/110.yaml --skip-reviewers
- axiom-encode validate regulations/42-cfr/435/116.yaml --skip-reviewers
- axiom-encode validate regulations/42-cfr/435/118.yaml --skip-reviewers
- axiom-encode validate regulations/42-cfr/435/119.yaml --skip-reviewers
- axiom-encode test regulations/42-cfr/435/110.test.yaml regulations/42-cfr/435/116.test.yaml regulations/42-cfr/435/118.test.yaml regulations/42-cfr/435/119.test.yaml

All listed validations passed locally after TheAxiomFoundation/axiom-encode#560 merged.