### PR TITLE
Repair SNAP income eligibility backbone

### DIFF
--- a/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
+++ b/.axiom/encoding-manifests/regulations/7-cfr/273/10.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "regulations/7-cfr/273/10.yaml",
-      "sha256": "67388c5f860019f9561b05b64a4dda57a6e9d1155c98822067f3e9ec0ba57fc4"
+      "sha256": "1920fcef44cef1a5d4c1a2df49e3680ff00fdc80ed0f07109e6e047dcc475945"
     },
     {
       "path": "regulations/7-cfr/273/10.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "566818951a7216be979aa6bb68e566493fe6aced",
+    "commit": "74e496d9b49833ad54aefa6e8388dd77d1d9b7ab",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode",
-    "version": "0.2.503",
-    "version_commit": "566818951a7216be979aa6bb68e566493fe6aced"
+    "root": "/Users/maxghenis/_axiom-worktrees/axiom-encode-runner-main-20260608",
+    "version": "0.2.623",
+    "version_commit": "5aff74c77e750fae6d3256bb41915b2f481dc87f"
   },
-  "axiom_encode_version": "0.2.503",
+  "axiom_encode_version": "0.2.623",
   "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-31T22:54:59.752044+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzlzkgm_1/deterministic-repair/regulations/7-cfr/273/10.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzlzkgm_1",
-  "generated_output_sha256": "67388c5f860019f9561b05b64a4dda57a6e9d1155c98822067f3e9ec0ba57fc4",
+  "generated_at": "2026-06-08T03:58:46.841996+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0k3y3mx2/deterministic-repair/regulations/7-cfr/273/10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0k3y3mx2",
+  "generated_output_sha256": "1920fcef44cef1a5d4c1a2df49e3680ff00fdc80ed0f07109e6e047dcc475945",
   "generation_prompt_sha256": null,
-  "model": "snap-273-10-allotment-v1",
+  "model": "proof-import-hash-v1",
   "run_id": "deterministic-repair",
   "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "76862b5a758f5898718390966e1e334147cdebeeb26c87f73b5b4e739bab918e"
+    "value": "542891a177c02eaa51e14f9746ea4923ad3eaddbc8ac0b97f5541e89ee95b68b"
   },
-  "tool": "axiom-encode repair-snap-273-10-allotment",
+  "tool": "axiom-encode repair-proof-import-hashes",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/regulations/7-cfr/273/9.json
+++ b/.axiom/encoding-manifests/regulations/7-cfr/273/9.json
@@ -2,38 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/7-cfr/273/9.yaml",
-      "sha256": "db0ac2f2f3e3f2a8f7c96386013e8449c47f00ea9f3f4d8454d49c3e60c06664"
+      "sha256": "8cbec1c7dde89258a0e43adefc9340d504e59d3da6a417ce3c6becb2ce742524"
     },
     {
       "path": "regulations/7-cfr/273/9.test.yaml",
-      "sha256": "f0c2445ade4af1bc03a9f0de821fca3350e9e2446c7b6623faac76a7f5aab12f"
+      "sha256": "dd17dbb3420be6ddef782ff555341f30a49c1bf845dca720eb5a2d457e414f78"
     }
   ],
   "axiom_encode_git": {
-    "commit": "6efd6266b2d26956b741c21bb150b4f1bd728530",
+    "commit": "03fd993c0d7e4bac7286c608ac6689866d959953",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
+    "root": "/Users/maxghenis/_axiom-worktrees/axiom-encode-runner-main-20260608",
+    "version": "0.2.624",
+    "version_commit": "03fd993c0d7e4bac7286c608ac6689866d959953"
   },
-  "axiom_encode_version": "0.2.93",
+  "axiom_encode_version": "0.2.624",
   "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/9",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-05-22T09:17:53.569619+00:00",
-  "generated_output_file": null,
-  "generated_output_root": null,
-  "generated_output_sha256": null,
+  "generated_at": "2026-06-08T04:25:13.687137+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3_swa3ci/deterministic-repair/regulations/7-cfr/273/9.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3_swa3ci",
+  "generated_output_sha256": "8cbec1c7dde89258a0e43adefc9340d504e59d3da6a417ce3c6becb2ce742524",
   "generation_prompt_sha256": null,
-  "model": "manual-repair-v1",
+  "model": "snap-273-9-income-eligibility-v1",
   "run_id": "deterministic-repair",
   "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bc570613e80f867d5728bca758938f730f63372b867223c6f78bdefb713c45bd"
+    "value": "41779afd98077f0cbdb04a682e78cc5749f4ac66602bfd48ac795d17ff15b353"
   },
-  "tool": "axiom-encode deterministic/manual repair",
+  "tool": "axiom-encode repair-snap-273-9-income-eligibility",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/regulations/7-cfr/273/9.json
+++ b/.axiom/encoding-manifests/regulations/7-cfr/273/9.json
@@ -10,20 +10,20 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "03fd993c0d7e4bac7286c608ac6689866d959953",
+    "commit": "d493687b8d73ab677f92efb38668725f40fd95e2",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/_axiom-worktrees/axiom-encode-runner-main-20260608",
-    "version": "0.2.624",
-    "version_commit": "03fd993c0d7e4bac7286c608ac6689866d959953"
+    "version": "0.2.628",
+    "version_commit": "d493687b8d73ab677f92efb38668725f40fd95e2"
   },
-  "axiom_encode_version": "0.2.624",
+  "axiom_encode_version": "0.2.628",
   "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/9",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-08T04:25:13.687137+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3_swa3ci/deterministic-repair/regulations/7-cfr/273/9.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3_swa3ci",
+  "generated_at": "2026-06-08T14:00:03.641262+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1qbw4cfl/deterministic-repair/regulations/7-cfr/273/9.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1qbw4cfl",
   "generated_output_sha256": "8cbec1c7dde89258a0e43adefc9340d504e59d3da6a417ce3c6becb2ce742524",
   "generation_prompt_sha256": null,
   "model": "snap-273-9-income-eligibility-v1",
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "41779afd98077f0cbdb04a682e78cc5749f4ac66602bfd48ac795d17ff15b353"
+    "value": "be08509cf183e69996ba1ebe1568846456de05fa03e78870d023e3364696e7d2"
   },
   "tool": "axiom-encode repair-snap-273-9-income-eligibility",
   "trace_file": null,

--- a/regulations/7-cfr/273/10.yaml
+++ b/regulations/7-cfr/273/10.yaml
@@ -55,7 +55,7 @@ module:
 imports:
   - us:policies/usda/snap/fy-2026-cola/deductions
   - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:regulations/7-cfr/273/9
+  - us:statutes/7/2012/j
 rules:
   - name: snap_earned_income_deduction_rate_for_net_income
     kind: parameter
@@ -355,9 +355,9 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
-              output: snap_full_excess_shelter_deduction_applies
-              hash: sha256:db0ac2f2f3e3f2a8f7c96386013e8449c47f00ea9f3f4d8454d49c3e60c06664
+              target: us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member
+              output: snap_household_has_elderly_or_disabled_member
+              hash: sha256:008f221da22fd95306625126232ca22ff7a4c8b622216bc7e8c092532e4e1bb9
           - path: versions[0].formula
             kind: import
             import:
@@ -367,7 +367,7 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          if snap_full_excess_shelter_deduction_applies: snap_excess_shelter_cost else: min(snap_excess_shelter_cost, snap_maximum_excess_shelter_deduction_48_states_dc)
+          if snap_household_has_elderly_or_disabled_member: snap_excess_shelter_cost else: min(snap_excess_shelter_cost, snap_maximum_excess_shelter_deduction_48_states_dc)
 
   - name: snap_net_monthly_income
     kind: derived

--- a/regulations/7-cfr/273/9.test.yaml
+++ b/regulations/7-cfr/273/9.test.yaml
@@ -2,8 +2,16 @@
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/9#input.snap_gross_monthly_income: 1696
-    us:regulations/7-cfr/273/9#input.snap_net_income: 1305
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 1696
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 925.5
   output:
     us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member: not_holds
     us:regulations/7-cfr/273/9#snap_standard_gross_income_eligible: holds
@@ -14,8 +22,16 @@
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/9#input.snap_gross_monthly_income: 1697
-    us:regulations/7-cfr/273/9#input.snap_net_income: 1305
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 1697
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 927
   output:
     us:regulations/7-cfr/273/9#snap_standard_gross_income_eligible: not_holds
     us:regulations/7-cfr/273/9#snap_standard_net_income_eligible: holds
@@ -24,10 +40,18 @@
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
-    us:regulations/7-cfr/273/9#input.snap_gross_monthly_income: 10000
-    us:regulations/7-cfr/273/9#input.snap_net_income: 1305
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 10000
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 13391.5
   output:
     us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member: holds
     us:regulations/7-cfr/273/9#snap_standard_gross_income_eligible: holds
@@ -38,8 +62,16 @@
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/9#input.snap_gross_monthly_income: 1000
-    us:regulations/7-cfr/273/9#input.snap_net_income: 1306
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 1696
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
   output:
     us:regulations/7-cfr/273/9#snap_standard_gross_income_eligible: holds
     us:regulations/7-cfr/273/9#snap_standard_net_income_eligible: not_holds

--- a/regulations/7-cfr/273/9.yaml
+++ b/regulations/7-cfr/273/9.yaml
@@ -28,6 +28,7 @@ module:
     corpus_citation_path: us/regulation/7/273/9
 imports:
   - us:statutes/7/2012/j
+  - us:regulations/7-cfr/273/10
   - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
 rules:
   - name: snap_standard_gross_income_eligible
@@ -40,7 +41,7 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           snap_household_has_elderly_or_disabled_member
-          or snap_gross_monthly_income <= snap_gross_income_limit_130_percent_fpl_48_states_dc
+          or snap_total_gross_income <= snap_gross_income_limit_130_percent_fpl_48_states_dc
   - name: snap_standard_net_income_eligible
     kind: derived
     entity: Household
@@ -49,7 +50,7 @@ rules:
     source: 7 CFR 273.9(a)(2)
     versions:
       - effective_from: '2025-10-01'
-        formula: snap_net_income <= snap_net_income_limit_100_percent_fpl_48_states_dc
+        formula: snap_net_monthly_income <= snap_net_income_limit_100_percent_fpl_48_states_dc
   - name: snap_standard_income_eligible
     kind: derived
     entity: Household


### PR DESCRIPTION
## Summary
- Refactor 7 CFR 273.10 to import the elderly/disabled household fact directly from 7 USC 2012(j), removing the 273.10 -> 273.9 dependency edge.
- Refactor 7 CFR 273.9 income eligibility to consume the canonical 273.10 gross and net income calculation outputs instead of stale free gross/net input leaves.
- Update the 273.9 companion tests to seed the 273.10 calculation inputs and refresh the signed applied-encoding manifests for 273.9 and 273.10.

## Dependency
- Uses the deterministic repair/version commit from TheAxiomFoundation/axiom-encode#579 for the 273.9 applied manifest.

## Validation
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode repair-snap-273-9-income-eligibility --repo /Users/maxghenis/_axiom-worktrees/rulespec-us-snap-backbone-20260608 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `uv run axiom-encode test --root /Users/maxghenis/_axiom-worktrees/rulespec-us-snap-backbone-20260608 regulations/7-cfr/273/9.test.yaml regulations/7-cfr/273/10.test.yaml statutes/7/2014/e/6/A.test.yaml`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/rulespec-us-snap-backbone-20260608/regulations/7-cfr/273/9.yaml --skip-reviewers --json`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/rulespec-us-snap-backbone-20260608/regulations/7-cfr/273/10.yaml --skip-reviewers --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/rulespec-us-snap-backbone-20260608 --json`
