### PR TITLE
Add Georgia Medicaid CMS eligibility levels

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
+++ b/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+      "sha256": "0761792be59b8afa4b506b9bd5feeab13479a5b54b0030a6bb422ac895ce8f59"
+    },
+    {
+      "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
+      "sha256": "8ae43d7f6a699f15520c45020bb744537cf9cac7ea674f70a408fb63a022b8ad"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e9bf1159c4e6bc8fe748739970e5fc2e4829953b",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-main-1781454308",
+    "version": "0.2.658",
+    "version_commit": "e9bf1159c4e6bc8fe748739970e5fc2e4829953b"
+  },
+  "axiom_encode_version": "0.2.658",
+  "backend": "codex",
+  "citation": "us-ga/form/cms/georgia-medicaid-chip-bhp-eligibility-levels",
+  "context_manifest_file": "/tmp/axiom-encode-ga-medicaid-cms-apply-target-1781454664/_eval_workspaces/codex-gpt-5.5/us-ga-form-cms-georgia-medicaid-chip-bhp-eligibility-levels/workspace/context-manifest.json",
+  "context_manifest_sha256": "f5ca6f8c7046b0d24b90c685db1820f898dfa95c5150d91880878a687676105c",
+  "generated_at": "2026-06-14T16:45:07.340398+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ga-medicaid-cms-monorepo-apply-1781454664/codex-gpt-5.5/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ga-medicaid-cms-monorepo-apply-1781454664",
+  "generated_output_sha256": "0761792be59b8afa4b506b9bd5feeab13479a5b54b0030a6bb422ac895ce8f59",
+  "generation_prompt_sha256": null,
+  "model": "gpt-5.5",
+  "run_id": "manual-monorepo-apply-period-anchor-repair-1781454664",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2c6d024a0063a360bb71434f8a30c83c27e5dbd16dbe44f9b033125c2a8de33b"
+  },
+  "tool": "axiom-encode encode --backend codex --model gpt-5.5 --apply --apply-target-only",
+  "trace_file": "/tmp/axiom-encode-ga-medicaid-cms-apply-target-1781454664/traces/codex-gpt-5.5/us-ga-form-cms-georgia-medicaid-chip-bhp-eligibility-levels.json",
+  "trace_sha256": "385740aac709c72f44e110ab0ef9c1364a8cfa828436d030f6e4783031a7e9dc"
+}

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -402,6 +402,8 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   - us-co/policies/cdhs/colorado-works/basic-cash-assistance.yaml
   - us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml
   - us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml
+  # Monorepo companion anchor mismatch: https://github.com/TheAxiomFoundation/axiom-encode/issues/612
+  - us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
   - us-co/regulations/10-ccr-2506-1/4.207.2.yaml
   - us-co/regulations/10-ccr-2506-1/4.401.1.yaml
   - us-co/regulations/10-ccr-2506-1/4.401.2.yaml

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
@@ -1,0 +1,15 @@
+- name: georgia_magi_income_standards_as_of_december_2023
+  period:
+    period_kind: custom
+    name: day
+    start: '2023-12-01'
+    end: '2023-12-01'
+  input: {}
+  output:
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#children_medicaid_ages_0_1_income_standard: 2.05
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#children_medicaid_ages_1_5_income_standard: 1.49
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#children_medicaid_ages_6_18_income_standard: 1.33
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#children_separate_chip_income_standard: 2.47
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#pregnant_women_medicaid_income_standard: 2.2
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#parent_caretaker_medicaid_income_standard: 0.28
+    us:us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard: 0.05

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
@@ -1,0 +1,145 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+  summary: |-
+    The table provides eligibility levels in each state for selected MAGI coverage groups as of December 1, 2023. For Georgia: Children Medicaid Ages 0-1 205%; Ages 1-5 149%; Ages 6-18 133%; Children Separate CHIP 247%; Pregnant Women Medicaid 220%; Pregnant Women CHIP N/A; Adults Parent/Caretaker 28%($); Adults Expansion to Adults No.
+rules:
+  - name: children_medicaid_ages_0_1_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Children Medicaid Ages 0-1 column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Children Medicaid Ages 0-1
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.05
+  - name: children_medicaid_ages_1_5_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Children Medicaid Ages 1-5 column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Children Medicaid Ages 1-5
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.49
+  - name: children_medicaid_ages_6_18_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Children Medicaid Ages 6-18 column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Children Medicaid Ages 6-18
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.33
+  - name: children_separate_chip_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Children Separate CHIP column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Children Separate CHIP
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.47
+  - name: pregnant_women_medicaid_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Pregnant Women Medicaid column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Pregnant Women Medicaid
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.20
+  - name: parent_caretaker_medicaid_income_standard
+    kind: parameter
+    dtype: Rate
+    source: CMS State Medicaid, CHIP and BHP Income Eligibility Standards table, Georgia row, Adults Medicaid Parent/Caretaker column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "Georgia 205% 149% 133% 247% 220% N/A 28%($) No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Adults (Medicaid) Parent/Caretaker
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.28
+  - name: magi_fpl_disregard
+    kind: parameter
+    dtype: Rate
+    source: CMS table introductory note, MAGI-based rules
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
+              excerpt: "MAGI-based rules generally include adjusting an individual's income by an amount equivalent to a 5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.05


### PR DESCRIPTION
## Summary

- Adds Georgia CMS Medicaid/CHIP/BHP MAGI eligibility level parameters from the CMS state eligibility levels table.
- Adds a companion test for the December 1, 2023 Georgia row values.
- Adds the signed generated-apply manifest for the new RuleSpec files.
- Adds a temporary `known-validation-gaps.yaml` entry for the current country-monorepo companion-anchor mismatch, tracked in TheAxiomFoundation/axiom-encode#612.

## Validation

- `uv run --with pytest --with pyyaml python -m pytest -q tests` (`12 passed`)
- pinned toolchain: `axiom-encode test --root /tmp/rulespec-us-ga-medicaid-1781454308 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine /tmp/rulespec-us-ga-medicaid-1781454308/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml --json` (`success: true`)
- pinned toolchain: `axiom-encode proof-validate /tmp/rulespec-us-ga-medicaid-1781454308/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml --json` (`passed: true`, `atoms_checked: 7`)
- pinned toolchain: `axiom-encode guard-generated --repo /tmp/rulespec-us-ga-medicaid-1781454308 --roots us-ga --all --json` (`passed: true`)
- pinned toolchain changed oracle coverage check: no failures; all new outputs classify as known not comparable.
