### PR TITLE
Bump rules engine for source-relation sets validation

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -3,7 +3,7 @@
 # file trigger full-repository revalidation.
 [toolchain]
 axiom_encode_version = "0.2.655"
-axiom_rules_engine_ref = "07009cec136a3e665fa200d4e5596c6eeaac06f7"
+axiom_rules_engine_ref = "198a401f8aa3049fbd032dfc46c03c7338c76e70"
 axiom_encode_ref = "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
 axiom_corpus_ref = "f880b1758701cfb85472a50597d5253495e8476e"
 # Canonical-targets checkout for cross-repo validation; bump to the


### PR DESCRIPTION
## Summary
- Bump the pinned axiom-rules-engine ref to the merge commit that validates executable `source_relation.type: sets` bindings.
- Leave existing NY SNAP utility allowance `sets` records unchanged: their `value` outputs are derived allowances, not parameters, so they remain metadata-only under the new parameter-binding semantics and compile cleanly.

## Validation
- `cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml --output /tmp/ny-a.compiled.json`
- `cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml --output /tmp/ny-b.compiled.json`
- `cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml --output /tmp/ny-c.compiled.json`
- `uv run --with pytest --with pyyaml pytest tests/test_repository_layout.py`
- `git diff --check`