### PR TITLE
Add SNAP utility allowance hook concepts

### DIFF
--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/a.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/a.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml",
+      "sha256": "53ca3d912c6c46c6311fb990e6a96aaf8c1796c44caa83d30ec71435738bfe52"
+    },
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml",
+      "sha256": "99c8ec84077b9e78ffc5350c948b8670b5f53b12538d0e3f49dd0cd8ee883dc8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.655",
+    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+  },
+  "axiom_encode_version": "0.2.655",
+  "backend": "codex",
+  "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/a",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-14T22:15:14.393991+00:00",
+  "generated_output_file": null,
+  "generated_output_root": "/tmp/rulespec-us",
+  "generated_output_sha256": null,
+  "generation_prompt_sha256": null,
+  "model": "gpt-5",
+  "run_id": "snap-utility-hooks-derived-sets-20260614",
+  "runner": "manual",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5ac27a8da0e96a2e655f82593d657257aa768ef7daac8dce854366209af1644f"
+  },
+  "tool": "axiom-encode manual-apply-manifest",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/b.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml",
+      "sha256": "d850e89a2484a4e3283add1af7390b581abe03219531a2513df081c66cf30a0f"
+    },
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml",
+      "sha256": "238095d242a7269ff087c2d67d5b457449f8d02e481a97c0b584e09311313218"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.655",
+    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+  },
+  "axiom_encode_version": "0.2.655",
+  "backend": "codex",
+  "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/b",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-14T22:15:14.393991+00:00",
+  "generated_output_file": null,
+  "generated_output_root": "/tmp/rulespec-us",
+  "generated_output_sha256": null,
+  "generation_prompt_sha256": null,
+  "model": "gpt-5",
+  "run_id": "snap-utility-hooks-derived-sets-20260614",
+  "runner": "manual",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3979786dea7dee84632ff19f28102953b81a4ff7a3fbbf824c065e7136d974a1"
+  },
+  "tool": "axiom-encode manual-apply-manifest",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/c.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/c.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml",
+      "sha256": "7387dcefaff916edf5b127a14180a89ccfe1e9a877954e78614a90dad0e2040e"
+    },
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/c.test.yaml",
+      "sha256": "095208d2b3d26ebf1362e7f2af28371c55237420a6f8c04adc21872931726824"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.655",
+    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+  },
+  "axiom_encode_version": "0.2.655",
+  "backend": "codex",
+  "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/c",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-14T22:15:14.393991+00:00",
+  "generated_output_file": null,
+  "generated_output_root": "/tmp/rulespec-us",
+  "generated_output_sha256": null,
+  "generation_prompt_sha256": null,
+  "model": "gpt-5",
+  "run_id": "snap-utility-hooks-derived-sets-20260614",
+  "runner": "manual",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0d316a0ce7a9f1f20f8e7ccc9ca9163b2e0609faab82ee094d839e5964cb6a3e"
+  },
+  "tool": "axiom-encode manual-apply-manifest",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/9.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/7-cfr/273/9.yaml",
+      "sha256": "76dd530624a00c5199f27bd4ec3ce866cd89e897fd7332b368164cf58f222b9f"
+    },
+    {
+      "path": "us/regulations/7-cfr/273/9.test.yaml",
+      "sha256": "c06c7be9f4b3b488aca3735077603e1ab008cb51815d71ceb1e4b8dcc8d82ac2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.655",
+    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+  },
+  "axiom_encode_version": "0.2.655",
+  "backend": "codex",
+  "citation": "us:regulations/7-cfr/273/9",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-14T22:15:14.393991+00:00",
+  "generated_output_file": null,
+  "generated_output_root": "/tmp/rulespec-us",
+  "generated_output_sha256": null,
+  "generation_prompt_sha256": null,
+  "model": "gpt-5",
+  "run_id": "snap-utility-hooks-derived-sets-20260614",
+  "runner": "manual",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1fc0ea56af983b8050d41aff1c50f1cf2830a1a9bba8f3e29ddcb5399e5f8148"
+  },
+  "tool": "axiom-encode manual-apply-manifest",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -3,7 +3,7 @@
 # file trigger full-repository revalidation.
 [toolchain]
 axiom_encode_version = "0.2.655"
-axiom_rules_engine_ref = "07009cec136a3e665fa200d4e5596c6eeaac06f7"
+axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
 axiom_encode_ref = "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
 axiom_corpus_ref = "f880b1758701cfb85472a50597d5253495e8476e"
 # Canonical-targets checkout for cross-repo validation; bump to the

--- a/known-dangling.yaml
+++ b/known-dangling.yaml
@@ -4,15 +4,6 @@
 # and on listed entries that start resolving (remove them when fixed).
 # Do not add entries without an issue link.
 entries:
-  # 7 CFR 273.9(d)(6)(iii) was never encoded; us/ carries 273.9 at
-  # section granularity only (issue #14).
-  - {spec: programs/us-al/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-ca/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-ma/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-nc/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-ny/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-sc/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
-  - {spec: programs/us-tn/snap/fy-2026.yaml, scope: federal, path: regulations/7-cfr/273/9/d/6/iii, issue: "#14"}
   # us-ma gaps (issue #14 comment): 364/945 unencoded; 365/180 exists as
   # block-1 not A; no policies/ tree yet.
   - {spec: programs/us-ma/snap/fy-2026.yaml, scope: state, path: regulations/106-cmr/364/945/block-1, issue: "#14"}

--- a/programs/us-al/snap/fy-2026.yaml
+++ b/programs/us-al/snap/fy-2026.yaml
@@ -18,7 +18,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/programs/us-ca/snap/fy-2026.yaml
+++ b/programs/us-ca/snap/fy-2026.yaml
@@ -36,7 +36,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/programs/us-ma/snap/fy-2026.yaml
+++ b/programs/us-ma/snap/fy-2026.yaml
@@ -23,7 +23,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/programs/us-nc/snap/fy-2026.yaml
+++ b/programs/us-nc/snap/fy-2026.yaml
@@ -18,7 +18,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/programs/us-ny/snap/fy-2026.yaml
+++ b/programs/us-ny/snap/fy-2026.yaml
@@ -27,7 +27,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a
@@ -144,9 +144,7 @@ transformations:
     source: axiom-programs/us-ny/snap/fy-2026 shelter-cost composition
     terms:
       - household_shelter_costs_incurred
-      - snap_standard_utility_allowance
-      - snap_limited_utility_allowance
-      - snap_individual_utility_allowance
+      - snap_utility_allowance_for_shelter_costs
 
   - pattern: sum_terms
     name: snap_excess_shelter_deduction

--- a/programs/us-sc/snap/fy-2026.yaml
+++ b/programs/us-sc/snap/fy-2026.yaml
@@ -18,7 +18,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/programs/us-tn/snap/fy-2026.yaml
+++ b/programs/us-tn/snap/fy-2026.yaml
@@ -18,7 +18,7 @@ scope:
     - regulations/7-cfr/273/6
     - regulations/7-cfr/273/7
     - regulations/7-cfr/273/8
-    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/9
     - regulations/7-cfr/273/10
     - statutes/7/2012/j
     - statutes/7/2014/a

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml
@@ -13,6 +13,8 @@
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_heating_cooling_standard_allowance_eligible: holds
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 1062
+    us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option: 1062
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 1062
 
 - name: heating_cooling_allowance_applies_in_nassau_or_suffolk
   period: 2026-01
@@ -25,6 +27,7 @@
       snap_utility_region_str: NY_NAS
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 988
+    us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option: 988
 
 - name: heating_cooling_allowance_applies_in_rest_of_state
   period: 2026-01
@@ -37,6 +40,7 @@
       snap_utility_region_str: NY_ONY
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 877
+    us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option: 877
 
 - name: central_meter_excess_cost_only_household_needs_heap_or_liheaa
   period: 2026-01

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml
@@ -14,6 +14,7 @@ module:
       heating_cooling_standard_amount_nassau_suffolk: 988
       heating_cooling_standard_amount_rest_of_state: 877
 imports:
+  - us:regulations/7-cfr/273/9
   - us:statutes/7/2012/j
 rules:
   - name: sets_snap_heating_cooling_standard_allowance
@@ -69,7 +70,7 @@ rules:
         formula: '877'
   - name: snap_standard_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml
@@ -14,6 +14,8 @@
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_utilities_standard_allowance_eligible: holds
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_limited_utility_allowance: 419
+    us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option: 419
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 419
 
 - name: utilities_allowance_applies_in_nassau_or_suffolk
   period: 2026-01
@@ -26,6 +28,7 @@
       snap_utility_region_str: NY_NAS
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_limited_utility_allowance: 388
+    us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option: 388
 
 - name: utilities_allowance_applies_in_rest_of_state
   period: 2026-01
@@ -38,6 +41,7 @@
       snap_utility_region_str: NY_ONY
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_limited_utility_allowance: 355
+    us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option: 355
 
 - name: heating_cooling_eligibility_prevents_utilities_allowance
   period: 2026-01

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml
@@ -63,7 +63,7 @@ rules:
         formula: '355'
   - name: snap_limited_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/c.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/c.test.yaml
@@ -7,11 +7,17 @@
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
     : false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/c#input.household_incurred_or_anticipated_basic_service_cost_for_one_telephone: true
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/c#snap_telephone_standard_allowance_eligible: holds
     us-ny:regulations/18-nycrr/387/12/f/3/v/c#snap_individual_utility_allowance: 32
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 32
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 32
 - name: no_telephone_basic_service_cost_prevents_telephone_allowance
   period: 2026-01
   input:

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml
@@ -43,7 +43,7 @@ rules:
           and not snap_utilities_standard_allowance_eligible
   - name: snap_individual_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD

--- a/us/regulations/7-cfr/273/9.test.yaml
+++ b/us/regulations/7-cfr/273/9.test.yaml
@@ -18,6 +18,10 @@
     us:regulations/7-cfr/273/9#snap_standard_net_income_eligible: holds
     us:regulations/7-cfr/273/9#snap_standard_income_eligible: holds
     us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies: not_holds
+    us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option: 0
+    us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option: 0
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
 - name: non_elderly_household_fails_when_gross_income_exceeds_standard
   period: 2026-01
   input:

--- a/us/regulations/7-cfr/273/9.yaml
+++ b/us/regulations/7-cfr/273/9.yaml
@@ -22,8 +22,11 @@ module:
     standard. Other non-categorically eligible households must meet both the
     gross income standard and the net income standard. Households with an
     elderly or disabled member also receive the full excess shelter deduction
-    rather than the capped excess shelter deduction. The monthly gross and net
-    standards are imported from the USDA FY 2026 income eligibility tables.
+    rather than the capped excess shelter deduction. Paragraph (d)(6)(iii)
+    delegates state standard utility allowances, which enter allowable shelter
+    costs through federal hook concepts set by state modules. The monthly gross
+    and net standards are imported from the USDA FY 2026 income eligibility
+    tables.
   source_verification:
     corpus_citation_path: us/regulation/7/273/9
 imports:
@@ -69,3 +72,53 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: snap_household_has_elderly_or_disabled_member
+  - name: snap_state_standard_utility_allowance_delegation
+    kind: source_relation
+    source: 7 CFR 273.9(d)(6)(iii)
+    source_relation:
+      type: delegates
+      target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+      authority: federal
+  - name: snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '0'
+  - name: snap_limited_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)(B)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '0'
+  - name: snap_individual_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)(C)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '0'
+  - name: snap_utility_allowance_for_shelter_costs
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_standard_utility_allowance_state_option
+          + snap_limited_utility_allowance_state_option
+          + snap_individual_utility_allowance_state_option


### PR DESCRIPTION
## Summary
- pin rulespec-us to the rules engine commit that supports derived source-relation sets
- add federal SNAP utility allowance hook concepts under 7 CFR 273.9(d)(6)(iii)
- wire New York utility allowance rules to set those federal hooks and consume the federal shelter-cost utility hook in NY SNAP
- replace stale 7 CFR 273.9(d)(6)(iii) program-scope paths with the existing section-level 7 CFR 273.9 module

Depends on TheAxiomFoundation/axiom-rules-engine#56.

## Validation
- AXIOM_RULESPEC_REPO_ROOTS=/tmp cargo run --quiet -- compile --program /tmp/rulespec-us/us/regulations/7-cfr/273/9.yaml --output /tmp/snap-273-9.compiled.json
- AXIOM_RULESPEC_REPO_ROOTS=/tmp cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml --output /tmp/ny-sua-a.compiled.json
- AXIOM_RULESPEC_REPO_ROOTS=/tmp cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml --output /tmp/ny-sua-b.compiled.json
- AXIOM_RULESPEC_REPO_ROOTS=/tmp cargo run --quiet -- compile --program /tmp/rulespec-us/us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml --output /tmp/ny-sua-c.compiled.json
- uv run --with pytest --with pyyaml pytest tests/test_repository_layout.py tests/test_program_specs.py
- git diff --check
- run-compiled smoke checks for NY standard, limited, and telephone utility hooks producing 1062, 419, and 32 respectively through us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs