### PR TITLE
Reencode SNAP utility delegated settings

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.655"
+axiom_encode_version = "0.2.663"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+axiom_encode_ref = "ed1676d18053e216217587cdc0590082fcea10b5"
 axiom_corpus_ref = "f880b1758701cfb85472a50597d5253495e8476e"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.663"
+axiom_encode_version = "0.2.664"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "ed1676d18053e216217587cdc0590082fcea10b5"
+axiom_encode_ref = "6ac4670f6038b7ab0c2c677e5cca0b6784eb9fb9"
 axiom_corpus_ref = "f880b1758701cfb85472a50597d5253495e8476e"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/snap/standard-utility-allowance.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/snap/standard-utility-allowance.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "policies/cdss/snap/standard-utility-allowance.yaml",
-      "sha256": "ab2d88c0bbf95cf79e675f0b6f3832adfe3130128c6f6e97093ba85182785582"
+      "sha256": "c02ac3e11cfa19dd07ff0ca017df697dff968719b34a59ef0a75177be0132734"
     },
     {
       "path": "policies/cdss/snap/standard-utility-allowance.test.yaml",
-      "sha256": "0a44d7fbb872d47d4627a83c0125f118c9c1691114b251da659a72ba98a4e4bc"
+      "sha256": "443cfe80ae169cc45005a3ea4d51f7596cdacd548055cd98c19cf08dbf242546"
     }
   ],
   "axiom_encode_git": {
-    "commit": "b456390b255b32493fd132ca6cceab0af7fa5216",
+    "commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode",
-    "version": "0.2.507",
-    "version_commit": "b456390b255b32493fd132ca6cceab0af7fa5216"
+    "root": "/private/tmp/axiom-encode-policy-shape",
+    "version": "0.2.659",
+    "version_commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f"
   },
-  "axiom_encode_version": "0.2.507",
-  "backend": "deterministic",
-  "citation": "us-ca:policies/cdss/snap/standard-utility-allowance",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-06-01T04:58:31.701476+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp546vf5w/deterministic-repair/policies/cdss/snap/standard-utility-allowance.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp546vf5w",
-  "generated_output_sha256": "ab2d88c0bbf95cf79e675f0b6f3832adfe3130128c6f6e97093ba85182785582",
-  "generation_prompt_sha256": null,
-  "model": "california-snap-shelter-surface-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "axiom_encode_version": "0.2.659",
+  "backend": "openai",
+  "citation": "us-ca/policies/cdss/snap/standard-utility-allowance",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-ca4/_eval_workspaces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance/workspace/context-manifest.json",
+  "context_manifest_sha256": "27e5a7adbc99373b519e96b455aab0eb7738967e702bf4ccaf4b0988970b611a",
+  "generated_at": "2026-06-14T23:13:19.262558+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-ca4/openai-gpt-5.5/policies/cdss/snap/standard-utility-allowance.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-ca4",
+  "generated_output_sha256": "c02ac3e11cfa19dd07ff0ca017df697dff968719b34a59ef0a75177be0132734",
+  "generation_prompt_sha256": "c68bf6a7dfa985da5e28592b7b28d6f1e149e69f42e127cd7b61238926cdcfa6",
+  "model": "gpt-5.5",
+  "run_id": "de0ad81c",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b83830eff68f2c3739a2b21cf38daff2c06d2457548fb2883e5ab9d0a38fbf40"
+    "value": "672a5c622009ac88702f856aab3b4e3a1ce6de95a73477e04ad11f6c8460303e"
   },
-  "tool": "axiom-encode repair-california-snap-shelter-surface",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-ca4/traces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance.json",
+  "trace_sha256": "14c946e7b2248615f90669dc3dd669a65284fc808aa834f059152653e56fe62f"
 }

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/snap/standard-utility-allowance.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/snap/standard-utility-allowance.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "policies/cdss/snap/standard-utility-allowance.yaml",
-      "sha256": "c02ac3e11cfa19dd07ff0ca017df697dff968719b34a59ef0a75177be0132734"
+      "sha256": "313fc8ece41e5c5455ad88d75c724fa0b1fc8b1ea963b2f4f7d1f611e9db8d44"
     },
     {
       "path": "policies/cdss/snap/standard-utility-allowance.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f",
+    "commit": "a217a5382422f3a53f507f49d05ed632a1972902",
     "dirty_tracked": false,
     "root": "/private/tmp/axiom-encode-policy-shape",
-    "version": "0.2.659",
-    "version_commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f"
+    "version": "0.2.662",
+    "version_commit": "a217a5382422f3a53f507f49d05ed632a1972902"
   },
-  "axiom_encode_version": "0.2.659",
+  "axiom_encode_version": "0.2.662",
   "backend": "openai",
   "citation": "us-ca/policies/cdss/snap/standard-utility-allowance",
-  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-ca4/_eval_workspaces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance/workspace/context-manifest.json",
-  "context_manifest_sha256": "27e5a7adbc99373b519e96b455aab0eb7738967e702bf4ccaf4b0988970b611a",
-  "generated_at": "2026-06-14T23:13:19.262558+00:00",
-  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-ca4/openai-gpt-5.5/policies/cdss/snap/standard-utility-allowance.yaml",
-  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-ca4",
-  "generated_output_sha256": "c02ac3e11cfa19dd07ff0ca017df697dff968719b34a59ef0a75177be0132734",
-  "generation_prompt_sha256": "c68bf6a7dfa985da5e28592b7b28d6f1e149e69f42e127cd7b61238926cdcfa6",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-ca6/_eval_workspaces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance/workspace/context-manifest.json",
+  "context_manifest_sha256": "03d452d6ca21c713ed96106ef9a68ea9f1ba19481341e8b29eb8b92ac57e4c3d",
+  "generated_at": "2026-06-15T00:49:01.775715+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-ca6/openai-gpt-5.5/policies/cdss/snap/standard-utility-allowance.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-ca6",
+  "generated_output_sha256": "313fc8ece41e5c5455ad88d75c724fa0b1fc8b1ea963b2f4f7d1f611e9db8d44",
+  "generation_prompt_sha256": "49ca499ba976e1ad522eb98e25a0430a2d91365b69c7a9ecd11b6f7fefd93722",
   "model": "gpt-5.5",
-  "run_id": "de0ad81c",
+  "run_id": "9fa1076d",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "672a5c622009ac88702f856aab3b4e3a1ce6de95a73477e04ad11f6c8460303e"
+    "value": "ed51d46f636f282a99134ad80166d815c102fa3972a25098d650f0fe6bfd4ae5"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-reencode-snap-delegated-ca4/traces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance.json",
-  "trace_sha256": "14c946e7b2248615f90669dc3dd669a65284fc808aa834f059152653e56fe62f"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-ca6/traces/openai-gpt-5.5/us-ca-policies-cdss-snap-standard-utility-allowance.json",
+  "trace_sha256": "6cc493740126d5b99118ae692acf4f65661ca0a324523f8943676c0c8998c707"
 }

--- a/us-ca/policies/cdss/snap/standard-utility-allowance.test.yaml
+++ b/us-ca/policies/cdss/snap/standard-utility-allowance.test.yaml
@@ -4,7 +4,6 @@
     ? us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage
     : true
   output:
-    us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_amount: 663
     us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_eligible: holds
     us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance: 663
 - name: household_without_separate_heating_and_cooling_costs_receives_no_sua
@@ -13,6 +12,5 @@
     ? us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage
     : false
   output:
-    us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_amount: 663
     us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_eligible: not_holds
     us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance: 0

--- a/us-ca/policies/cdss/snap/standard-utility-allowance.yaml
+++ b/us-ca/policies/cdss/snap/standard-utility-allowance.yaml
@@ -5,8 +5,19 @@ module:
   source_verification:
     corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
   summary: |-
-    FFY 2026 Standard Utility Allowance: "The SUA amount increased from $645 to $663 ... A household that has heating and cooling costs separate from their rent or mortgage is eligible for the SUA."
+    FFY 2026 Standard Utility Allowance (SUA): "The SUA amount increased from $645 to $663 ... A household that has heating and cooling costs separate from their rent or mortgage is eligible for the SUA."
 rules:
+  - name: sets_snap_standard_utility_allowance_state_option
+    kind: source_relation
+    source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
   - name: snap_standard_utility_allowance_amount
     kind: parameter
     dtype: Money
@@ -38,6 +49,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
+              excerpt: "A household that has heating and cooling costs separate from their rent or mortgage is eligible for the SUA."
     versions:
       - effective_from: '2025-10-01'
         formula: |-

--- a/us-ca/policies/cdss/snap/standard-utility-allowance.yaml
+++ b/us-ca/policies/cdss/snap/standard-utility-allowance.yaml
@@ -4,84 +4,83 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
-  summary: |-
-    FFY 2026 Standard Utility Allowance (SUA): "The SUA amount increased from $645 to $663 ... A household that has heating and cooling costs separate from their rent or mortgage is eligible for the SUA."
+  summary: 'FFY 2026 Standard Utility Allowance (SUA): "The SUA amount increased from
+    $645 to $663 ... A household that has heating and cooling costs separate from
+    their rent or mortgage is eligible for the SUA."'
 rules:
-  - name: sets_snap_standard_utility_allowance_state_option
-    kind: source_relation
-    source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-      authority: state
-      value: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-
-  - name: snap_standard_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
-              excerpt: "The SUA amount increased from $645 to $663"
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          663
-
-  - name: snap_standard_utility_allowance_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
-              excerpt: "A household that has heating and cooling costs separate from their rent or mortgage is eligible for the SUA."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage
-
-  - name: snap_standard_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_amount
-              output: snap_standard_utility_allowance_amount
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_eligible
-              output: snap_standard_utility_allowance_eligible
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_standard_utility_allowance_eligible: snap_standard_utility_allowance_amount else: 0
+- name: sets_snap_standard_utility_allowance_state_option
+  kind: source_relation
+  source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
+          excerpt: The SUA amount increased from $645 to $663
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '663'
+- name: snap_standard_utility_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
+          excerpt: A household that has heating and cooling costs separate from their
+            rent or mortgage is eligible for the SUA.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: ACIN I-46-25, page 3, FFY 2026 Standard Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ca/guidance/cdss/acin-2025-i-46-25/page-4
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_amount
+          output: snap_standard_utility_allowance_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_eligible
+          output: snap_standard_utility_allowance_eligible
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_standard_utility_allowance_eligible: snap_standard_utility_allowance_amount
+      else: 0'
+imports:
+- us:regulations/7-cfr/273/9

--- a/us-co/.axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json
+++ b/us-co/.axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json
@@ -2,32 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/10-ccr-2506-1/4.407.31.yaml",
-      "sha256": "31fbd6bb60dec05503e71445176cd5b8510ab7de6c7b224b15202a8be7ce10df"
+      "sha256": "b4145d7d3cf46a2fd4b3b422c750f6717f2ea545be2f31c6265fa3297994000f"
     },
     {
       "path": "regulations/10-ccr-2506-1/4.407.31.test.yaml",
-      "sha256": "53f0278dabf92579d22064e11e20989f5d29a78fe5dca5c14b66bae95960b9c1"
+      "sha256": "dffbe5e4abc610bcab6ee3662534799fcc9cb918e73aa9e34f130d7662647e78"
     }
   ],
-  "axiom_encode_version": "0.1.0",
-  "backend": "manual-companion-test-repair",
-  "citation": "",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-05-10T22:46:20.943639+00:00",
-  "generated_output_file": null,
-  "generated_output_root": null,
-  "generated_output_sha256": null,
-  "model": "",
-  "run_id": null,
-  "runner": "codex",
+  "axiom_encode_git": {
+    "commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-policy-shape",
+    "version": "0.2.659",
+    "version_commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f"
+  },
+  "axiom_encode_version": "0.2.659",
+  "backend": "openai",
+  "citation": "us-co/regulations/10-ccr-2506-1/4.407.31",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-co/_eval_workspaces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31/workspace/context-manifest.json",
+  "context_manifest_sha256": "d81d5cfadedc1a36925fb850c342b693952cba89088c7297d0bf3514f948580a",
+  "generated_at": "2026-06-14T23:19:40.433408+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-co/openai-gpt-5.5/regulations/10-ccr-2506-1/4.407.31.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-co",
+  "generated_output_sha256": "b4145d7d3cf46a2fd4b3b422c750f6717f2ea545be2f31c6265fa3297994000f",
+  "generation_prompt_sha256": "e9dabd7424a0450adc6cb263765f6b26dd7ec7827add76cb0013f8354b9da170",
+  "model": "gpt-5.5",
+  "run_id": "c0885086",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "a9451e3346acc6c64ba27293a495b55a758d2f863c5ccfbe9009d3b19bc0d932"
+    "value": "e9a054052fe186afbd0421e4654464c51c149cc04b7e8a8971d793034ea6861c"
   },
-  "tool": "axiom-encode companion-test-coverage",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-co/traces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31.json",
+  "trace_sha256": "661da5bf02c5616dd3d9b5ea2b1bb7a968326866d8ae1c4aa1ec131102bfb118"
 }

--- a/us-co/.axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json
+++ b/us-co/.axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/10-ccr-2506-1/4.407.31.yaml",
-      "sha256": "b4145d7d3cf46a2fd4b3b422c750f6717f2ea545be2f31c6265fa3297994000f"
+      "sha256": "fe8dd4bf4079a30850c5304da6bf10dd71b07806bf9526b40c0f1c7886551545"
     },
     {
       "path": "regulations/10-ccr-2506-1/4.407.31.test.yaml",
-      "sha256": "dffbe5e4abc610bcab6ee3662534799fcc9cb918e73aa9e34f130d7662647e78"
+      "sha256": "c63f9028861dab60304904b81edbe9ae6b5de07ad31ed291b2ef76a5034fdd36"
     }
   ],
   "axiom_encode_git": {
-    "commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f",
+    "commit": "a217a5382422f3a53f507f49d05ed632a1972902",
     "dirty_tracked": false,
     "root": "/private/tmp/axiom-encode-policy-shape",
-    "version": "0.2.659",
-    "version_commit": "ddd5c0433b90434daa0eb7c5b0371a5b34af980f"
+    "version": "0.2.662",
+    "version_commit": "a217a5382422f3a53f507f49d05ed632a1972902"
   },
-  "axiom_encode_version": "0.2.659",
+  "axiom_encode_version": "0.2.662",
   "backend": "openai",
   "citation": "us-co/regulations/10-ccr-2506-1/4.407.31",
-  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-co/_eval_workspaces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31/workspace/context-manifest.json",
-  "context_manifest_sha256": "d81d5cfadedc1a36925fb850c342b693952cba89088c7297d0bf3514f948580a",
-  "generated_at": "2026-06-14T23:19:40.433408+00:00",
-  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-co/openai-gpt-5.5/regulations/10-ccr-2506-1/4.407.31.yaml",
-  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-co",
-  "generated_output_sha256": "b4145d7d3cf46a2fd4b3b422c750f6717f2ea545be2f31c6265fa3297994000f",
-  "generation_prompt_sha256": "e9dabd7424a0450adc6cb263765f6b26dd7ec7827add76cb0013f8354b9da170",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-co2/_eval_workspaces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31/workspace/context-manifest.json",
+  "context_manifest_sha256": "936ff4b1068f2e4a8539741d7b82ca4d72f3bc7b516796cda30a0876e9a0a21a",
+  "generated_at": "2026-06-15T00:56:39.414555+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-co2/openai-gpt-5.5/regulations/10-ccr-2506-1/4.407.31.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-co2",
+  "generated_output_sha256": "fe8dd4bf4079a30850c5304da6bf10dd71b07806bf9526b40c0f1c7886551545",
+  "generation_prompt_sha256": "52cd6205851607ed4b4a026774cfb98dbff8b7802ac6285eddbf9db406c4bed9",
   "model": "gpt-5.5",
-  "run_id": "c0885086",
+  "run_id": "9c135ec0",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "e9a054052fe186afbd0421e4654464c51c149cc04b7e8a8971d793034ea6861c"
+    "value": "ddd1e7592703900504c60e1a8890a0ee02357a4dc1b25d75a58c607e69887ffd"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-reencode-snap-delegated-co/traces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31.json",
-  "trace_sha256": "661da5bf02c5616dd3d9b5ea2b1bb7a968326866d8ae1c4aa1ec131102bfb118"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-co2/traces/openai-gpt-5.5/us-co-regulations-10-ccr-2506-1-4.407.31.json",
+  "trace_sha256": "15952b81cbef168328f4df8fc8203b0a7eee2916a80d682b7b8bcc4addbd1464"
 }

--- a/us-co/regulations/10-ccr-2506-1/4.407.31.test.yaml
+++ b/us-co/regulations/10-ccr-2506-1/4.407.31.test.yaml
@@ -15,12 +15,15 @@
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_cooking_fuel_utility_cost: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost: false
   output:
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: holds
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_amount: 594
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_amount: 377
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_amount: 71
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_utility_allowance_amount: 97
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 0
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible: not_holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible: not_holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 594
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance: 0
@@ -45,6 +48,8 @@
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 2
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible: holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible: not_holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 377
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance: 0
@@ -70,11 +75,12 @@
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 1
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible: holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance: 71
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_individual_utility_allowance: 0
-- name: telephone_allowance_applies_when_phone_is_only_utility
+- name: telephone_allowance_applies_when_telephone_is_only_utility_cost
   period: 2026-01
   input:
     ? us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage

--- a/us-co/regulations/10-ccr-2506-1/4.407.31.test.yaml
+++ b/us-co/regulations/10-ccr-2506-1/4.407.31.test.yaml
@@ -1,7 +1,8 @@
-- name: no_allowance_without_utility_costs
+- name: heating_cooling_allowance_applies_for_qualifying_heating_or_cooling_cost
   period: 2026-01
-  input: &no_utility_costs
-    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
+  input:
+    ? us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
+    : true
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_received_leap_or_e_ebt_payment_within_previous_12_months: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.private_rental_housing_landlord_bills_heating_or_cooling_separately: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_shares_residence_and_pays_portion_of_heating_or_cooling_cost: false
@@ -14,24 +15,12 @@
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_cooking_fuel_utility_cost: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost: false
   output:
-    us-co:regulations/10-ccr-2506-1/4.407.31#colorado_snap_heating_cooling_utility_allowance_amount: 594
-    us-co:regulations/10-ccr-2506-1/4.407.31#colorado_snap_basic_utility_allowance_amount: 377
-    us-co:regulations/10-ccr-2506-1/4.407.31#colorado_snap_one_utility_allowance_amount: 71
-    us-co:regulations/10-ccr-2506-1/4.407.31#colorado_snap_telephone_utility_allowance_amount: 97
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: not_holds
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 0
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 0
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance: 0
-    us-co:regulations/10-ccr-2506-1/4.407.31#snap_individual_utility_allowance: 0
-- name: heating_cooling_allowance_applies_for_qualifying_heating_cost
-  period: 2026-01
-  input:
-    <<: *no_utility_costs
-    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
-  output:
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 0
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_amount: 594
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_amount: 377
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_amount: 71
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_utility_allowance_amount: 97
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 594
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance: 0
@@ -39,10 +28,19 @@
 - name: basic_utility_allowance_applies_for_two_non_heating_cooling_utilities
   period: 2026-01
   input:
-    <<: *no_utility_costs
-    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
+    ? us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
+    : false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_received_leap_or_e_ebt_payment_within_previous_12_months: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.private_rental_housing_landlord_bills_heating_or_cooling_separately: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_shares_residence_and_pays_portion_of_heating_or_cooling_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.public_housing_responsible_for_excess_heating_or_cooling_costs: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.irregular_heating_or_cooling_costs_between_billing_periods: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_electricity_utility_cost: true
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_water_utility_cost: true
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_sewer_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_trash_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_cooking_fuel_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost: false
   output:
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 2
@@ -54,10 +52,23 @@
 - name: one_utility_allowance_applies_for_single_non_phone_utility
   period: 2026-01
   input:
-    <<: *no_utility_costs
+    ? us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
+    : false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_received_leap_or_e_ebt_payment_within_previous_12_months: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.private_rental_housing_landlord_bills_heating_or_cooling_separately: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_shares_residence_and_pays_portion_of_heating_or_cooling_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.public_housing_responsible_for_excess_heating_or_cooling_costs: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.irregular_heating_or_cooling_costs_between_billing_periods: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_electricity_utility_cost: true
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_water_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_sewer_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_trash_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_cooking_fuel_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost: false
   output:
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 1
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible: holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0
@@ -66,10 +77,24 @@
 - name: telephone_allowance_applies_when_phone_is_only_utility
   period: 2026-01
   input:
-    <<: *no_utility_costs
+    ? us-co:regulations/10-ccr-2506-1/4.407.31#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
+    : false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_received_leap_or_e_ebt_payment_within_previous_12_months: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.private_rental_housing_landlord_bills_heating_or_cooling_separately: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_shares_residence_and_pays_portion_of_heating_or_cooling_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.public_housing_responsible_for_excess_heating_or_cooling_costs: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.irregular_heating_or_cooling_costs_between_billing_periods: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_electricity_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_water_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_sewer_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_trash_utility_cost: false
+    us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_cooking_fuel_utility_cost: false
     us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost: true
   output:
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count: 1
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible: not_holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible: not_holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible: holds
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 0
     us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance: 0

--- a/us-co/regulations/10-ccr-2506-1/4.407.31.yaml
+++ b/us-co/regulations/10-ccr-2506-1/4.407.31.yaml
@@ -1,29 +1,169 @@
 format: rulespec/v1
 module:
-  summary: |-
-    Colorado's SNAP rule manual sets four monthly utility allowance standards
-    effective October 1, 2025: $594 heating and cooling utility allowance
-    (HCUA), $377 basic utility allowance (BUA, encoded as LUA), $71 one
-    utility allowance (OUA), and $97 telephone allowance. Households receive
-    only one of the four allowances. HCUA applies when the household has a
-    qualifying heating or cooling cost, prior 12-month LEAP or E-EBT payment,
-    qualifying landlord-billed heating or cooling charge, shared heating or
-    cooling cost, public-housing excess heating or cooling cost, or irregular
-    heating or cooling cost between billing periods. BUA applies when the
-    household is not HCUA-eligible and has at least 2 non-heating or
-    non-cooling utility costs. OUA applies when the household is not HCUA- or
-    BUA-eligible and has exactly 1 non-heating or non-cooling utility cost
-    other than telephone. The telephone allowance applies when the household's
-    only utility cost is telephone service.
+  proof_validation:
+    required: true
   source_verification:
     corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+  summary: |-
+    Effective October 1, 2008, Colorado implemented a four-tiered mandatory standard utility allowance deduction for SNAP excess shelter deduction determinations. Households cannot claim actual utility expenses and are entitled to only one of four allowances. Effective October 1, 2025, the standards are HCUA $594, BUA $377, OUA $71, and telephone $97. HCUA is available for qualifying heating/cooling costs or prior LEAP/E-EBT, BUA for households not entitled to HCUA with at least two non-heating/non-cooling utility costs, OUA for households not entitled to HCUA or BUA with one non-heating/non-cooling utility expense other than telephone, and the telephone allowance when telephone is the household's only utility cost.
 rules:
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source: 10 CCR 2506-1 section 4.407.31(A)
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: sets_snap_limited_utility_allowance
+    kind: source_relation
+    source: 10 CCR 2506-1 section 4.407.31(B)
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: sets_snap_individual_utility_allowance
+    kind: source_relation
+    source: 10 CCR 2506-1 section 4.407.31(C)-(D)
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_individual_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_heating_cooling_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 10 CCR 2506-1 section 4.407.31(A)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "HCUA Standard Effective October 1, 2025 $594"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Effective October 1, 2025 $594"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          594
+  - name: snap_basic_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 10 CCR 2506-1 section 4.407.31(B)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "BUA Standard Effective October 1, 2025 $377"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Effective October 1, 2025 $377"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          377
+  - name: snap_one_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 10 CCR 2506-1 section 4.407.31(C)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "OUA Standard Effective October 1, 2025 $71"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Effective October 1, 2025 $71"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          71
+  - name: snap_telephone_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 10 CCR 2506-1 section 4.407.31(D)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Telephone Standard Effective October 1, 2025 $97"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Effective October 1, 2025 $97"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          97
   - name: snap_heating_cooling_utility_allowance_eligible
     kind: derived
     entity: Household
     dtype: Judgment
     period: Month
-    source: 10 CCR 2506-1 section 4.407.31(A)
+    source: 10 CCR 2506-1 section 4.407.31(A)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "HCUA is available only to households that incur or anticipate heating or cooling costs separate and apart from their rent or mortgage."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Received a Low-Income Energy Assistance Program (LEAP) or an Energy Electronic Benefit Transfer (E-EBT) payment within the previous twelve (12) month period."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Live in private rental housing and are billed by their landlords on the basis of individual usage or charged a flat rate separately from their rent for heating and cooling."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Share a residence and incur at least a portion of the heating or cooling cost."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Live in public housing and are responsible for excess heating and/or cooling costs."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "incurs or anticipates heating or cooling costs on an irregular basis, may continue to receive the HCUA between billing periods."
     versions:
       - effective_from: '2025-10-01'
         formula: |-
@@ -39,6 +179,19 @@ rules:
     dtype: Integer
     period: Month
     source: 10 CCR 2506-1 section 4.407.31(B)-(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "non-heating or non-cooling utility costs, such as electricity, water, sewer, trash, cooking fuel, or telephone."
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "households whose only utility cost is for a telephone."
     versions:
       - effective_from: '2025-10-01'
         formula: |-
@@ -53,7 +206,27 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: 10 CCR 2506-1 section 4.407.31(B)
+    source: 10 CCR 2506-1 section 4.407.31(B)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "mandated for any households that are not entitled to the HCUA and that incur at least two (2) non-heating or non-cooling utility costs."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+              output: snap_heating_cooling_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+              output: snap_non_heating_cooling_utility_expense_count
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
@@ -64,7 +237,38 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: 10 CCR 2506-1 section 4.407.31(C)
+    source: 10 CCR 2506-1 section 4.407.31(C)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "not entitled to the HCUA or BUA but is responsible for only one (1) non-heating or one (1) non-cooling utility expense."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "The OUA is not allowed if the household’s only utility expense is a telephone."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+              output: snap_heating_cooling_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+              output: snap_basic_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+              output: snap_non_heating_cooling_utility_expense_count
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
@@ -77,7 +281,33 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: 10 CCR 2506-1 section 4.407.31(D)
+    source: 10 CCR 2506-1 section 4.407.31(D)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "telephone allowance is available to households whose only utility cost is for a telephone."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+              output: snap_heating_cooling_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+              output: snap_basic_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+              output: snap_non_heating_cooling_utility_expense_count
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
@@ -85,87 +315,135 @@ rules:
           and not snap_basic_utility_allowance_eligible
           and snap_non_heating_cooling_utility_expense_count == 1
           and household_pays_telephone_service_cost
-  - name: colorado_snap_heating_cooling_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(A)(4)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '594'
-  - name: colorado_snap_basic_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(B)(3)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '377'
-  - name: colorado_snap_one_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(C)(3)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '71'
-  - name: colorado_snap_telephone_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(D)(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '97'
   - name: snap_standard_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD
     source: 10 CCR 2506-1 section 4.407.31(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+              output: snap_heating_cooling_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_amount
+              output: snap_heating_cooling_utility_allowance_amount
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
           if snap_heating_cooling_utility_allowance_eligible:
-              colorado_snap_heating_cooling_utility_allowance_amount
+              snap_heating_cooling_utility_allowance_amount
           else: 0
   - name: snap_limited_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD
     source: 10 CCR 2506-1 section 4.407.31(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+              output: snap_basic_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_amount
+              output: snap_basic_utility_allowance_amount
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
           if snap_basic_utility_allowance_eligible:
-              colorado_snap_basic_utility_allowance_amount
+              snap_basic_utility_allowance_amount
           else: 0
   - name: snap_one_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD
     source: 10 CCR 2506-1 section 4.407.31(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible
+              output: snap_one_utility_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_amount
+              output: snap_one_utility_allowance_amount
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
           if snap_one_utility_allowance_eligible:
-              colorado_snap_one_utility_allowance_amount
+              snap_one_utility_allowance_amount
           else: 0
   - name: snap_individual_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD
     source: 10 CCR 2506-1 section 4.407.31(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible
+              output: snap_telephone_allowance_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_utility_allowance_amount
+              output: snap_telephone_utility_allowance_amount
+              hash: sha256:local
     versions:
       - effective_from: '2025-10-01'
         formula: |-
           if snap_telephone_allowance_eligible:
-              colorado_snap_telephone_utility_allowance_amount
+              snap_telephone_utility_allowance_amount
           else: 0

--- a/us-co/regulations/10-ccr-2506-1/4.407.31.yaml
+++ b/us-co/regulations/10-ccr-2506-1/4.407.31.yaml
@@ -4,446 +4,432 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-  summary: |-
-    Effective October 1, 2008, Colorado implemented a four-tiered mandatory standard utility allowance deduction for SNAP excess shelter deduction determinations. Households cannot claim actual utility expenses and are entitled to only one of four allowances. Effective October 1, 2025, the standards are HCUA $594, BUA $377, OUA $71, and telephone $97. HCUA is available for qualifying heating/cooling costs or prior LEAP/E-EBT, BUA for households not entitled to HCUA with at least two non-heating/non-cooling utility costs, OUA for households not entitled to HCUA or BUA with one non-heating/non-cooling utility expense other than telephone, and the telephone allowance when telephone is the household's only utility cost.
+  summary: Colorado uses a four-tiered mandatory standard utility allowance deduction
+    for SNAP excess shelter determinations; households cannot claim actual utility
+    expenses and receive only one allowance. Effective October 1, 2025, the HCUA is
+    $594, BUA is $377, OUA is $71, and telephone standard is $97.
 rules:
-  - name: sets_snap_standard_utility_allowance
-    kind: source_relation
-    source: 10 CCR 2506-1 section 4.407.31(A)
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-      authority: state
-      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-  - name: sets_snap_limited_utility_allowance
-    kind: source_relation
-    source: 10 CCR 2506-1 section 4.407.31(B)
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
-      authority: state
-      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-  - name: sets_snap_individual_utility_allowance
-    kind: source_relation
-    source: 10 CCR 2506-1 section 4.407.31(C)-(D)
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
-      authority: state
-      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_individual_utility_allowance
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-  - name: snap_heating_cooling_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(A)(4)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "HCUA Standard Effective October 1, 2025 $594"
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Effective October 1, 2025 $594"
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          594
-  - name: snap_basic_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(B)(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "BUA Standard Effective October 1, 2025 $377"
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Effective October 1, 2025 $377"
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          377
-  - name: snap_one_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(C)(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "OUA Standard Effective October 1, 2025 $71"
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Effective October 1, 2025 $71"
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          71
-  - name: snap_telephone_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(D)(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Telephone Standard Effective October 1, 2025 $97"
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Effective October 1, 2025 $97"
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          97
-  - name: snap_heating_cooling_utility_allowance_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: 10 CCR 2506-1 section 4.407.31(A)(1)-(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "HCUA is available only to households that incur or anticipate heating or cooling costs separate and apart from their rent or mortgage."
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Received a Low-Income Energy Assistance Program (LEAP) or an Energy Electronic Benefit Transfer (E-EBT) payment within the previous twelve (12) month period."
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Live in private rental housing and are billed by their landlords on the basis of individual usage or charged a flat rate separately from their rent for heating and cooling."
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Share a residence and incur at least a portion of the heating or cooling cost."
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Live in public housing and are responsible for excess heating and/or cooling costs."
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "incurs or anticipates heating or cooling costs on an irregular basis, may continue to receive the HCUA between billing periods."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
-          or household_received_leap_or_e_ebt_payment_within_previous_12_months
-          or private_rental_housing_landlord_bills_heating_or_cooling_separately
-          or household_shares_residence_and_pays_portion_of_heating_or_cooling_cost
-          or public_housing_responsible_for_excess_heating_or_cooling_costs
-          or irregular_heating_or_cooling_costs_between_billing_periods
-  - name: snap_non_heating_cooling_utility_expense_count
-    kind: derived
-    entity: Household
-    dtype: Integer
-    period: Month
-    source: 10 CCR 2506-1 section 4.407.31(B)-(D)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "non-heating or non-cooling utility costs, such as electricity, water, sewer, trash, cooking fuel, or telephone."
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "households whose only utility cost is for a telephone."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          (if household_pays_electricity_utility_cost: 1 else: 0)
-          + (if household_pays_water_utility_cost: 1 else: 0)
-          + (if household_pays_sewer_utility_cost: 1 else: 0)
-          + (if household_pays_trash_utility_cost: 1 else: 0)
-          + (if household_pays_cooking_fuel_utility_cost: 1 else: 0)
-          + (if household_pays_telephone_service_cost: 1 else: 0)
-  - name: snap_basic_utility_allowance_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: 10 CCR 2506-1 section 4.407.31(B)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "mandated for any households that are not entitled to the HCUA and that incur at least two (2) non-heating or non-cooling utility costs."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
-              output: snap_heating_cooling_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
-              output: snap_non_heating_cooling_utility_expense_count
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          not snap_heating_cooling_utility_allowance_eligible
-          and snap_non_heating_cooling_utility_expense_count >= 2
-  - name: snap_one_utility_allowance_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: 10 CCR 2506-1 section 4.407.31(C)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "not entitled to the HCUA or BUA but is responsible for only one (1) non-heating or one (1) non-cooling utility expense."
-          - path: versions[0].formula
-            kind: exception
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "The OUA is not allowed if the household’s only utility expense is a telephone."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
-              output: snap_heating_cooling_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
-              output: snap_basic_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
-              output: snap_non_heating_cooling_utility_expense_count
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          not snap_heating_cooling_utility_allowance_eligible
-          and not snap_basic_utility_allowance_eligible
-          and snap_non_heating_cooling_utility_expense_count == 1
-          and not household_pays_telephone_service_cost
-  - name: snap_telephone_allowance_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: 10 CCR 2506-1 section 4.407.31(D)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "telephone allowance is available to households whose only utility cost is for a telephone."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
-              output: snap_heating_cooling_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
-              output: snap_basic_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
-              output: snap_non_heating_cooling_utility_expense_count
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          not snap_heating_cooling_utility_allowance_eligible
-          and not snap_basic_utility_allowance_eligible
-          and snap_non_heating_cooling_utility_expense_count == 1
-          and household_pays_telephone_service_cost
-  - name: snap_standard_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(A)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
-              output: snap_heating_cooling_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_amount
-              output: snap_heating_cooling_utility_allowance_amount
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_heating_cooling_utility_allowance_eligible:
-              snap_heating_cooling_utility_allowance_amount
-          else: 0
-  - name: snap_limited_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(B)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
-              output: snap_basic_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_amount
-              output: snap_basic_utility_allowance_amount
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_basic_utility_allowance_eligible:
-              snap_basic_utility_allowance_amount
-          else: 0
-  - name: snap_one_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(C)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible
-              output: snap_one_utility_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_amount
-              output: snap_one_utility_allowance_amount
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_one_utility_allowance_eligible:
-              snap_one_utility_allowance_amount
-          else: 0
-  - name: snap_individual_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 10 CCR 2506-1 section 4.407.31(D)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
-              excerpt: "Households cannot claim actual utility expenses and are only entitled to one (1) of the four (4) utility allowances."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible
-              output: snap_telephone_allowance_eligible
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_utility_allowance_amount
-              output: snap_telephone_utility_allowance_amount
-              hash: sha256:local
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_telephone_allowance_eligible:
-              snap_telephone_utility_allowance_amount
-          else: 0
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source: 10 CCR 2506-1 section 4.407.31(A)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source: 10 CCR 2506-1 section 4.407.31(B)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_limited_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source: 10 CCR 2506-1 section 4.407.31(C)-(D)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_individual_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_heating_cooling_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: HCUA Standard Effective October 1, 2025 $594
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Effective October 1, 2025 $594
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '594'
+- name: snap_basic_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(B)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: BUA Standard Effective October 1, 2025 $377
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Effective October 1, 2025 $377
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '377'
+- name: snap_one_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(C)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: OUA Standard Effective October 1, 2025 $71
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Effective October 1, 2025 $71
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '71'
+- name: snap_telephone_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(D)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Telephone Standard Effective October 1, 2025 $97
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Effective October 1, 2025 $97
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '97'
+- name: snap_heating_cooling_utility_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 10 CCR 2506-1 section 4.407.31(A)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: may continue to receive the HCUA between billing periods
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
+
+      or household_received_leap_or_e_ebt_payment_within_previous_12_months
+
+      or private_rental_housing_landlord_bills_heating_or_cooling_separately
+
+      or household_shares_residence_and_pays_portion_of_heating_or_cooling_cost
+
+      or public_housing_responsible_for_excess_heating_or_cooling_costs
+
+      or irregular_heating_or_cooling_costs_between_billing_periods'
+- name: snap_non_heating_cooling_utility_expense_count
+  kind: derived
+  entity: Household
+  dtype: Integer
+  period: Month
+  source: 10 CCR 2506-1 section 4.407.31(B)-(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: non-heating or non-cooling utility costs, such as electricity,
+            water, sewer, trash, cooking fuel, or telephone
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '(if household_pays_electricity_utility_cost: 1 else: 0)
+
+      + (if household_pays_water_utility_cost: 1 else: 0)
+
+      + (if household_pays_sewer_utility_cost: 1 else: 0)
+
+      + (if household_pays_trash_utility_cost: 1 else: 0)
+
+      + (if household_pays_cooking_fuel_utility_cost: 1 else: 0)
+
+      + (if household_pays_telephone_service_cost: 1 else: 0)'
+- name: snap_basic_utility_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 10 CCR 2506-1 section 4.407.31(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: not entitled to the HCUA and that incur at least two (2) non-heating
+            or non-cooling utility costs
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+          output: snap_heating_cooling_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+          output: snap_non_heating_cooling_utility_expense_count
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'not snap_heating_cooling_utility_allowance_eligible
+
+      and snap_non_heating_cooling_utility_expense_count >= 2'
+- name: snap_one_utility_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 10 CCR 2506-1 section 4.407.31(C)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: not entitled to the HCUA or BUA but is responsible for only one
+            (1) non-heating or one (1) non-cooling utility expense
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: "not allowed if the household\u2019s only utility expense is a\
+            \ telephone"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+          output: snap_heating_cooling_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+          output: snap_basic_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+          output: snap_non_heating_cooling_utility_expense_count
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'not snap_heating_cooling_utility_allowance_eligible
+
+      and not snap_basic_utility_allowance_eligible
+
+      and snap_non_heating_cooling_utility_expense_count == 1
+
+      and not household_pays_telephone_service_cost'
+- name: snap_telephone_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 10 CCR 2506-1 section 4.407.31(D)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: available to households whose only utility cost is for a telephone
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+          output: snap_heating_cooling_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+          output: snap_basic_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_non_heating_cooling_utility_expense_count
+          output: snap_non_heating_cooling_utility_expense_count
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'not snap_heating_cooling_utility_allowance_eligible
+
+      and not snap_basic_utility_allowance_eligible
+
+      and snap_non_heating_cooling_utility_expense_count == 1
+
+      and household_pays_telephone_service_cost'
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Households cannot claim actual utility expenses and are only entitled
+            to one (1) of the four (4) utility allowances.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
+          output: snap_heating_cooling_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_amount
+          output: snap_heating_cooling_utility_allowance_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_heating_cooling_utility_allowance_eligible: snap_heating_cooling_utility_allowance_amount
+      else: 0'
+- name: snap_limited_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Households cannot claim actual utility expenses and are only entitled
+            to one (1) of the four (4) utility allowances.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_eligible
+          output: snap_basic_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_basic_utility_allowance_amount
+          output: snap_basic_utility_allowance_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_basic_utility_allowance_eligible: snap_basic_utility_allowance_amount
+      else: 0'
+- name: snap_one_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Households cannot claim actual utility expenses and are only entitled
+            to one (1) of the four (4) utility allowances.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible
+          output: snap_one_utility_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_amount
+          output: snap_one_utility_allowance_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_one_utility_allowance_eligible: snap_one_utility_allowance_amount
+      else: 0'
+- name: snap_individual_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 10 CCR 2506-1 section 4.407.31(C)-(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.407.31
+          excerpt: Households cannot claim actual utility expenses and are only entitled
+            to one (1) of the four (4) utility allowances.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_allowance_eligible
+          output: snap_telephone_allowance_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/10-ccr-2506-1/4.407.31#snap_telephone_utility_allowance_amount
+          output: snap_telephone_utility_allowance_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_telephone_allowance_eligible: snap_telephone_utility_allowance_amount
+      else: 0'
+imports:
+- us:regulations/7-cfr/273/9

--- a/us-nc/.axiom/encoding-manifests/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.json
+++ b/us-nc/.axiom/encoding-manifests/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
-      "sha256": "7b63e595a62d9657e6459a381ba135f38d91ea0fc8abce2faf78c5f4e5634e13"
+      "sha256": "e577eebae32adfa876401f6182973de95ef52b4dfaf4a27e226efa615bacd175"
     },
     {
       "path": "policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml",
-      "sha256": "a11919a99beb2ff226dca054af27ab98693bf6318de4efc978b15588d7b341dc"
+      "sha256": "040544c1b11b33934ca26615cf54ffc812a7c6105cb4cbd36f972209770a8d55"
     }
   ],
   "axiom_encode_git": {
-    "commit": "68f7a4f872f70d09220d53e21007c202cafb6223",
+    "commit": "a217a5382422f3a53f507f49d05ed632a1972902",
     "dirty_tracked": false,
     "root": "/private/tmp/axiom-encode-policy-shape",
-    "version": "0.2.660",
-    "version_commit": "68f7a4f872f70d09220d53e21007c202cafb6223"
+    "version": "0.2.662",
+    "version_commit": "a217a5382422f3a53f507f49d05ed632a1972902"
   },
-  "axiom_encode_version": "0.2.660",
+  "axiom_encode_version": "0.2.662",
   "backend": "openai",
   "citation": "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1",
-  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-nc3/_eval_workspaces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "b76924303609355881dd0f392450a26ccbae502ecdc7a9c86a8a45b9aabab8bc",
-  "generated_at": "2026-06-14T23:30:56.001139+00:00",
-  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-nc3/openai-gpt-5.5/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
-  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-nc3",
-  "generated_output_sha256": "7b63e595a62d9657e6459a381ba135f38d91ea0fc8abce2faf78c5f4e5634e13",
-  "generation_prompt_sha256": "71a4ce3bc0825bf7bef63dc9a77055189ff2d947f112156098736c685ff685e2",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-nc4/_eval_workspaces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "e579f7586abd5ac1adb58fe50cb59189c80739d207242c6ad155bb3ea4039f8e",
+  "generated_at": "2026-06-15T01:06:16.546926+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-nc4/openai-gpt-5.5/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-nc4",
+  "generated_output_sha256": "e577eebae32adfa876401f6182973de95ef52b4dfaf4a27e226efa615bacd175",
+  "generation_prompt_sha256": "17fc4f39eb1add79c282a57789a083110bcd53b1372306247c74d5dea302e5d1",
   "model": "gpt-5.5",
-  "run_id": "6e443a3a",
+  "run_id": "3e196cc9",
   "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "d6f54e4891b56b4cc4bc4402a1199c5df0af4420eb54024903824305e8602459"
+    "value": "d79e5f009122bd8b02f26d9906960af9b88e93bf5def29b484aabb4b55f22c54"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-reencode-snap-delegated-nc3/traces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1.json",
-  "trace_sha256": "8fc3d6d08f933a754809c66e680912dc6ba9f56021b82a1f934cc99675fe7fef"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-nc4/traces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1.json",
+  "trace_sha256": "c210e5ceffd68a5bb077d983137289b032a57ba2f5a0c5bc3cbe22e7ae83666b"
 }

--- a/us-nc/.axiom/encoding-manifests/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.json
+++ b/us-nc/.axiom/encoding-manifests/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
-      "sha256": "57ed3b4ae6da28be63a011335af743c917bbdf2f76dac2294d6597aab32c2695"
+      "sha256": "7b63e595a62d9657e6459a381ba135f38d91ea0fc8abce2faf78c5f4e5634e13"
     },
     {
       "path": "policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml",
-      "sha256": "2557686da9b5388b3c5a9faaff13caf5cfe74e22382c35d9a7d2566e02e32b5b"
+      "sha256": "a11919a99beb2ff226dca054af27ab98693bf6318de4efc978b15588d7b341dc"
     }
   ],
   "axiom_encode_git": {
-    "commit": "431861c8312271b168e0055e2213bcfafcecc31a",
+    "commit": "68f7a4f872f70d09220d53e21007c202cafb6223",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-clean-431861c",
-    "version": "0.2.455",
-    "version_commit": "431861c8312271b168e0055e2213bcfafcecc31a"
+    "root": "/private/tmp/axiom-encode-policy-shape",
+    "version": "0.2.660",
+    "version_commit": "68f7a4f872f70d09220d53e21007c202cafb6223"
   },
-  "axiom_encode_version": "0.2.455",
-  "backend": "codex",
-  "citation": "us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-nc-manual-dhhs-fns-fns-360-determining-benefit-levels-page-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "fcaf9de40635d7a6c8625c8bf981d8730096f95a1bb3e4f784e3b48beeb23ee7",
-  "generated_at": "2026-05-31T20:44:44.948080+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "57ed3b4ae6da28be63a011335af743c917bbdf2f76dac2294d6597aab32c2695",
-  "generation_prompt_sha256": "943c1609a952a5cb43c5f8d56ab90786d8e9964d4e5a245600b3957eb38a9889",
+  "axiom_encode_version": "0.2.660",
+  "backend": "openai",
+  "citation": "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-nc3/_eval_workspaces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "b76924303609355881dd0f392450a26ccbae502ecdc7a9c86a8a45b9aabab8bc",
+  "generated_at": "2026-06-14T23:30:56.001139+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-nc3/openai-gpt-5.5/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-nc3",
+  "generated_output_sha256": "7b63e595a62d9657e6459a381ba135f38d91ea0fc8abce2faf78c5f4e5634e13",
+  "generation_prompt_sha256": "71a4ce3bc0825bf7bef63dc9a77055189ff2d947f112156098736c685ff685e2",
   "model": "gpt-5.5",
-  "run_id": "3372ad57",
-  "runner": "codex-gpt-5.5",
+  "run_id": "6e443a3a",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "86a99c489b1ce7e826353fd9092ba8e0ed72e1018b370cb610a8a358b3949fe3"
+    "value": "d6f54e4891b56b4cc4bc4402a1199c5df0af4420eb54024903824305e8602459"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-nc-manual-dhhs-fns-fns-360-determining-benefit-levels-page-1.json",
-  "trace_sha256": "7d92abd45e4b169a191c307b8b70d716a9240491bed711b344dc92af7a940c43"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-nc3/traces/openai-gpt-5.5/us-nc-policies-dhhs-fns-fns-360-determining-benefit-levels-page-1.json",
+  "trace_sha256": "8fc3d6d08f933a754809c66e680912dc6ba9f56021b82a1f934cc99675fe7fef"
 }

--- a/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml
+++ b/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml
@@ -4,6 +4,8 @@
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.eligible_fns_unit_member_count: 1
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.utility_allowance_fns_unit_size_after_exclusions: 1
   output:
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction_max_household_size: 6
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#utility_allowance_max_unit_size: 5
     ? us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
     : 1
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions: 1

--- a/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml
+++ b/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.test.yaml
@@ -4,6 +4,9 @@
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.eligible_fns_unit_member_count: 1
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.utility_allowance_fns_unit_size_after_exclusions: 1
   output:
+    ? us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
+    : 1
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions: 1
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction: 209
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance: 637
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance: 392
@@ -14,6 +17,9 @@
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.eligible_fns_unit_member_count: 4
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.utility_allowance_fns_unit_size_after_exclusions: 3
   output:
+    ? us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
+    : 4
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions: 3
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction: 223
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance: 768
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance: 474
@@ -24,6 +30,9 @@
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.eligible_fns_unit_member_count: 6
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.utility_allowance_fns_unit_size_after_exclusions: 5
   output:
+    ? us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
+    : 6
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions: 5
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction: 299
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance: 912
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance: 564
@@ -34,6 +43,9 @@
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.eligible_fns_unit_member_count: 7
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#input.utility_allowance_fns_unit_size_after_exclusions: 8
   output:
+    ? us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
+    : 6
+    us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions: 5
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction: 299
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance: 912
     us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance: 564

--- a/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml
+++ b/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml
@@ -4,14 +4,11 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-  summary: 'FNS 360.01 provides standard utility allowances and the standard deduction
-    effective October 1, 2025. Roomers, boarders, foster children not included in
-    the FNS unit, and ineligible students are not included in the unit size for utility
-    allowances. Only eligible FNS unit members are included in household size for
-    the standard deduction. Effective October 1, 2025, standard deductions are $209
-    for household sizes 1-3, $223 for size 4, $261 for size 5, and $299 for 6+. Current
-    utility allowances by FNS unit size are SUA/BUA/TUA: size 1 $637/$392/$42; size
-    2 $699/$431/$42; size 3 $768/$474/$42; size 4 $837/$518/$42; size 5 or more $912/$564/$42.'
+  summary: Effective October 1, 2025, FNS 360.01 provides the standard deduction by
+    household size and current SUA, BUA, and TUA amounts by Food and Nutrition Services
+    unit size. Roomers, boarders, foster children not included in the FNS unit, and
+    ineligible students are excluded from unit size for utility allowances. Only eligible
+    FNS unit members are included in household size for the standard deduction.
 rules:
 - name: sets_snap_standard_utility_allowance
   kind: source_relation
@@ -46,7 +43,7 @@ rules:
 - name: standard_deduction_max_household_size
   kind: parameter
   dtype: Count
-  source: FNS 360.01(B), Standard Deduction
+  source: FNS 360.01(B), Standard Deduction table
   metadata:
     proof:
       atoms:
@@ -66,7 +63,7 @@ rules:
 - name: utility_allowance_max_unit_size
   kind: parameter
   dtype: Count
-  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts table
   metadata:
     proof:
       atoms:
@@ -88,7 +85,7 @@ rules:
   dtype: Money
   unit: USD
   indexed_by: capped_eligible_fns_unit_member_count_for_standard_deduction
-  source: FNS 360.01(B), Standard Deduction
+  source: FNS 360.01(B), Standard Deduction table
   metadata:
     proof:
       atoms:
@@ -96,8 +93,8 @@ rules:
         kind: parameter_table
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: 'Effective October 1, 2025: Household Size Standard Deduction 1
-            $209 2 $209 3 $209 4 $223 5 $261 6+ $299'
+          excerpt: Household Size Standard Deduction 1 $209 2 $209 3 $209 4 $223 5
+            $261 6+ $299
           table:
             header: Household Size Standard Deduction
             row_key: household_size
@@ -121,7 +118,7 @@ rules:
   dtype: Money
   unit: USD
   indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
-  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts table
   metadata:
     proof:
       atoms:
@@ -153,7 +150,7 @@ rules:
   dtype: Money
   unit: USD
   indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
-  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts table
   metadata:
     proof:
       atoms:
@@ -161,8 +158,8 @@ rules:
         kind: parameter_table
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: Food and Nutrition Services Unit Size ... BUA ... 1 $392 2 $431
-            3 $474 4 $518 5 or more $564
+          excerpt: Food and Nutrition Services Unit Size BUA ... 1 $392 2 $431 3 $474
+            4 $518 5 or more $564
           table:
             header: Current SUA, BUA, and TUA Amounts
             row_key: food_and_nutrition_services_unit_size
@@ -185,7 +182,7 @@ rules:
   dtype: Money
   unit: USD
   indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
-  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts table
   metadata:
     proof:
       atoms:
@@ -193,7 +190,7 @@ rules:
         kind: parameter_table
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: Food and Nutrition Services Unit Size ... TUA 1 $42 2 $42 3 $42
+          excerpt: Food and Nutrition Services Unit Size TUA ... 1 $42 2 $42 3 $42
             4 $42 5 or more $42
           table:
             header: Current SUA, BUA, and TUA Amounts
@@ -235,8 +232,7 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2025-10-01'
-    formula: 'if eligible_fns_unit_member_count >= standard_deduction_max_household_size:
-      standard_deduction_max_household_size else: eligible_fns_unit_member_count'
+    formula: min(eligible_fns_unit_member_count, standard_deduction_max_household_size)
 - name: capped_utility_allowance_fns_unit_size_after_exclusions
   kind: derived
   entity: Household
@@ -261,8 +257,7 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2025-10-01'
-    formula: 'if utility_allowance_fns_unit_size_after_exclusions >= utility_allowance_max_unit_size:
-      utility_allowance_max_unit_size else: utility_allowance_fns_unit_size_after_exclusions'
+    formula: min(utility_allowance_fns_unit_size_after_exclusions, utility_allowance_max_unit_size)
 - name: standard_deduction
   kind: derived
   entity: Household
@@ -277,8 +272,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: A standard deduction is allowed ... each month according to household
-            size.
+          excerpt: A standard deduction is allowed for Food and Nutrition Services
+            unit (FNS unit) each month according to household size.
       - path: versions[0].formula
         kind: import
         import:
@@ -300,7 +295,7 @@ rules:
   dtype: Money
   period: Month
   unit: USD
-  source: FNS 360.01(A), Heating and Cooling Standard Utility Allowance
+  source: FNS 360.01(A), Standard Allowance for Utilities
   metadata:
     proof:
       atoms:
@@ -308,8 +303,7 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
-            Size SUA
+          excerpt: Heating and Cooling Standard Utility Allowance (SUA)
       - path: versions[0].formula
         kind: import
         import:
@@ -331,7 +325,7 @@ rules:
   dtype: Money
   period: Month
   unit: USD
-  source: FNS 360.01(A), Non-Heating/Non-Cooling Basic Utility Allowance
+  source: FNS 360.01(A), Standard Allowance for Utilities
   metadata:
     proof:
       atoms:
@@ -339,8 +333,7 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
-            Size ... BUA
+          excerpt: Non-Heating/Non-Cooling Basic Utility Allowance (BUA)
       - path: versions[0].formula
         kind: import
         import:
@@ -362,7 +355,7 @@ rules:
   dtype: Money
   period: Month
   unit: USD
-  source: FNS 360.01(A), Telephone Utility Allowance
+  source: FNS 360.01(A), Standard Allowance for Utilities
   metadata:
     proof:
       atoms:
@@ -370,8 +363,7 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
-            Size ... TUA
+          excerpt: Telephone Utility Allowance (TUA)
       - path: versions[0].formula
         kind: import
         import:
@@ -387,3 +379,5 @@ rules:
   versions:
   - effective_from: '2025-10-01'
     formula: telephone_utility_allowance_for_unit_size[capped_utility_allowance_fns_unit_size_after_exclusions]
+imports:
+- us:regulations/7-cfr/273/9

--- a/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml
+++ b/us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml
@@ -4,214 +4,386 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-  summary: |-
-    Roomers, boarders and foster children who are not included in the FNS unit and ineligible students are not included in the unit size for calculation of the standard allowance for utilities. A standard deduction is allowed each month according to household size; only eligible FNS unit members are included. Effective October 1, 2025: standard deductions are $209 for sizes 1-3, $223 for size 4, $261 for size 5, and $299 for 6+. Current SUA, BUA, and TUA amounts by FNS unit size are: 1 $637/$392/$42; 2 $699/$431/$42; 3 $768/$474/$42; 4 $837/$518/$42; 5 or more $912/$564/$42.
+  summary: 'FNS 360.01 provides standard utility allowances and the standard deduction
+    effective October 1, 2025. Roomers, boarders, foster children not included in
+    the FNS unit, and ineligible students are not included in the unit size for utility
+    allowances. Only eligible FNS unit members are included in household size for
+    the standard deduction. Effective October 1, 2025, standard deductions are $209
+    for household sizes 1-3, $223 for size 4, $261 for size 5, and $299 for 6+. Current
+    utility allowances by FNS unit size are SUA/BUA/TUA: size 1 $637/$392/$42; size
+    2 $699/$431/$42; size 3 $768/$474/$42; size 4 $837/$518/$42; size 5 or more $912/$564/$42.'
 rules:
-  - name: standard_deduction_for_eligible_fns_unit_members
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: eligible_fns_unit_member_count
-    source: FNS 360.01(B), Standard Deduction
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Effective October 1, 2025: Household Size Standard Deduction 1 $209 2 $209 3 $209 4 $223 5 $261 6+ $299"
-              table:
-                header: "Household Size Standard Deduction"
-                row_key: household_size
-                column_key: standard_deduction
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Effective October 1, 2025"
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 209
-          2: 209
-          3: 209
-          4: 223
-          5: 261
-          6: 299
-
-  - name: heating_cooling_standard_utility_allowance_for_unit_size
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: utility_allowance_fns_unit_size_after_exclusions
-    source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Food and Nutrition Services Unit Size SUA ... 1 $637 ... 2 $699 ... 3 $768 ... 4 $837 ... 5 or more $912"
-              table:
-                header: "Current SUA, BUA, and TUA Amounts"
-                row_key: food_and_nutrition_services_unit_size
-                column_key: sua
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "CHANGE# 01-2025 OCTOBER 1, 2025"
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 637
-          2: 699
-          3: 768
-          4: 837
-          5: 912
-
-  - name: non_heating_non_cooling_basic_utility_allowance_for_unit_size
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: utility_allowance_fns_unit_size_after_exclusions
-    source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Food and Nutrition Services Unit Size ... BUA ... 1 $392 2 $431 3 $474 4 $518 5 or more $564"
-              table:
-                header: "Current SUA, BUA, and TUA Amounts"
-                row_key: food_and_nutrition_services_unit_size
-                column_key: bua
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "CHANGE# 01-2025 OCTOBER 1, 2025"
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 392
-          2: 431
-          3: 474
-          4: 518
-          5: 564
-
-  - name: telephone_utility_allowance_for_unit_size
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: utility_allowance_fns_unit_size_after_exclusions
-    source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Food and Nutrition Services Unit Size ... TUA 1 $42 2 $42 3 $42 4 $42 5 or more $42"
-              table:
-                header: "Current SUA, BUA, and TUA Amounts"
-                row_key: food_and_nutrition_services_unit_size
-                column_key: tua
-          - path: versions[0].effective_from
-            kind: effective_period
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "CHANGE# 01-2025 OCTOBER 1, 2025"
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 42
-          2: 42
-          3: 42
-          4: 42
-          5: 42
-
-  - name: standard_deduction
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: FNS 360.01(B), Standard Deduction
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Only eligible FNS unit members are included in the household size for calculation of the standard deduction."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          standard_deduction_for_eligible_fns_unit_members[min(eligible_fns_unit_member_count, 6)]
-
-  - name: heating_cooling_standard_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: FNS 360.01(A), Standard Allowance for Utilities
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Roomers, boarders and foster children who are not included in the FNS unit and ineligible students are not included in the unit size for calculation of the standard allowance for utilities."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          heating_cooling_standard_utility_allowance_for_unit_size[min(utility_allowance_fns_unit_size_after_exclusions, 5)]
-
-  - name: non_heating_non_cooling_basic_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: FNS 360.01(A), Standard Allowance for Utilities
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Roomers, boarders and foster children who are not included in the FNS unit and ineligible students are not included in the unit size for calculation of the standard allowance for utilities."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          non_heating_non_cooling_basic_utility_allowance_for_unit_size[min(utility_allowance_fns_unit_size_after_exclusions, 5)]
-
-  - name: telephone_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: FNS 360.01(A), Standard Allowance for Utilities
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
-              excerpt: "Roomers, boarders and foster children who are not included in the FNS unit and ineligible students are not included in the unit size for calculation of the standard allowance for utilities."
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          telephone_utility_allowance_for_unit_size[min(utility_allowance_fns_unit_size_after_exclusions, 5)]
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FNS 360.01(A), Heating and Cooling Standard Utility Allowance
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FNS 360.01(A), Non-Heating/Non-Cooling Basic Utility Allowance
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#telephone_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FNS 360.01(A), Telephone Utility Allowance
+- name: standard_deduction_max_household_size
+  kind: parameter
+  dtype: Count
+  source: FNS 360.01(B), Standard Deduction
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Household Size Standard Deduction ... 6+ $299
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '6'
+- name: utility_allowance_max_unit_size
+  kind: parameter
+  dtype: Count
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Food and Nutrition Services Unit Size ... 5 or more
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: CHANGE# 01-2025 OCTOBER 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '5'
+- name: standard_deduction_for_eligible_fns_unit_members
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_eligible_fns_unit_member_count_for_standard_deduction
+  source: FNS 360.01(B), Standard Deduction
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: 'Effective October 1, 2025: Household Size Standard Deduction 1
+            $209 2 $209 3 $209 4 $223 5 $261 6+ $299'
+          table:
+            header: Household Size Standard Deduction
+            row_key: household_size
+            column_key: standard_deduction
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 209
+      2: 209
+      3: 209
+      4: 223
+      5: 261
+      6: 299
+- name: heating_cooling_standard_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Food and Nutrition Services Unit Size SUA ... 1 $637 2 $699 3 $768
+            4 $837 5 or more $912
+          table:
+            header: Current SUA, BUA, and TUA Amounts
+            row_key: food_and_nutrition_services_unit_size
+            column_key: sua
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: CHANGE# 01-2025 OCTOBER 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 637
+      2: 699
+      3: 768
+      4: 837
+      5: 912
+- name: non_heating_non_cooling_basic_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Food and Nutrition Services Unit Size ... BUA ... 1 $392 2 $431
+            3 $474 4 $518 5 or more $564
+          table:
+            header: Current SUA, BUA, and TUA Amounts
+            row_key: food_and_nutrition_services_unit_size
+            column_key: bua
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: CHANGE# 01-2025 OCTOBER 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 392
+      2: 431
+      3: 474
+      4: 518
+      5: 564
+- name: telephone_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_utility_allowance_fns_unit_size_after_exclusions
+  source: FNS 360.01(A), Current SUA, BUA, and TUA Amounts
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Food and Nutrition Services Unit Size ... TUA 1 $42 2 $42 3 $42
+            4 $42 5 or more $42
+          table:
+            header: Current SUA, BUA, and TUA Amounts
+            row_key: food_and_nutrition_services_unit_size
+            column_key: tua
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: CHANGE# 01-2025 OCTOBER 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 42
+      2: 42
+      3: 42
+      4: 42
+      5: 42
+- name: capped_eligible_fns_unit_member_count_for_standard_deduction
+  kind: derived
+  entity: Household
+  dtype: Count
+  period: Month
+  source: FNS 360.01(B), Standard Deduction
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Only eligible FNS unit members are included in the household size
+            for calculation of the standard deduction.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction_max_household_size
+          output: standard_deduction_max_household_size
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if eligible_fns_unit_member_count >= standard_deduction_max_household_size:
+      standard_deduction_max_household_size else: eligible_fns_unit_member_count'
+- name: capped_utility_allowance_fns_unit_size_after_exclusions
+  kind: derived
+  entity: Household
+  dtype: Count
+  period: Month
+  source: FNS 360.01(A), Standard Allowance for Utilities
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Roomers, boarders and foster children who are not included in the
+            FNS unit and ineligible students are not included in the unit size for
+            calculation of the standard allowance for utilities.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#utility_allowance_max_unit_size
+          output: utility_allowance_max_unit_size
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if utility_allowance_fns_unit_size_after_exclusions >= utility_allowance_max_unit_size:
+      utility_allowance_max_unit_size else: utility_allowance_fns_unit_size_after_exclusions'
+- name: standard_deduction
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FNS 360.01(B), Standard Deduction
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: A standard deduction is allowed ... each month according to household
+            size.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#standard_deduction_for_eligible_fns_unit_members
+          output: standard_deduction_for_eligible_fns_unit_members
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_eligible_fns_unit_member_count_for_standard_deduction
+          output: capped_eligible_fns_unit_member_count_for_standard_deduction
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: standard_deduction_for_eligible_fns_unit_members[capped_eligible_fns_unit_member_count_for_standard_deduction]
+- name: heating_cooling_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FNS 360.01(A), Heating and Cooling Standard Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
+            Size SUA
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance_for_unit_size
+          output: heating_cooling_standard_utility_allowance_for_unit_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions
+          output: capped_utility_allowance_fns_unit_size_after_exclusions
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: heating_cooling_standard_utility_allowance_for_unit_size[capped_utility_allowance_fns_unit_size_after_exclusions]
+- name: non_heating_non_cooling_basic_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FNS 360.01(A), Non-Heating/Non-Cooling Basic Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
+            Size ... BUA
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance_for_unit_size
+          output: non_heating_non_cooling_basic_utility_allowance_for_unit_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions
+          output: capped_utility_allowance_fns_unit_size_after_exclusions
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: non_heating_non_cooling_basic_utility_allowance_for_unit_size[capped_utility_allowance_fns_unit_size_after_exclusions]
+- name: telephone_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FNS 360.01(A), Telephone Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/manual/dhhs/fns/fns-360-determining-benefit-levels/page-1
+          excerpt: Current SUA, BUA, and TUA Amounts Food and Nutrition Services Unit
+            Size ... TUA
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#telephone_utility_allowance_for_unit_size
+          output: telephone_utility_allowance_for_unit_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#capped_utility_allowance_fns_unit_size_after_exclusions
+          output: capped_utility_allowance_fns_unit_size_after_exclusions
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: telephone_utility_allowance_for_unit_size[capped_utility_allowance_fns_unit_size_after_exclusions]

--- a/us-sc/.axiom/encoding-manifests/policies/dss/snap-policy-manual/page-369.json
+++ b/us-sc/.axiom/encoding-manifests/policies/dss/snap-policy-manual/page-369.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "policies/dss/snap-policy-manual/page-369.yaml",
-      "sha256": "e8a0cdefa95a00beafa3a5a301bf4e6d4a82b955e82b6d55ba9fc2981122315e"
+      "sha256": "cf153b6b7401044cddaafaeb7df01c0b242ec584dff24416e0694e2e60fcb9d4"
     },
     {
       "path": "policies/dss/snap-policy-manual/page-369.test.yaml",
-      "sha256": "4cae01156505de86fcac28d088df52433a1ebe4058d780328502980dbd216685"
+      "sha256": "53bd6bac17425225cd566f934df492359e8a60d8840629287b5715d327670e14"
     }
   ],
   "axiom_encode_git": {
-    "commit": "431861c8312271b168e0055e2213bcfafcecc31a",
+    "commit": "97496aa44adb3f5c824673383ac7fe6dd073ca2b",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-clean-431861c",
-    "version": "0.2.455",
-    "version_commit": "431861c8312271b168e0055e2213bcfafcecc31a"
+    "root": "/private/tmp/axiom-encode-policy-shape",
+    "version": "0.2.661",
+    "version_commit": "97496aa44adb3f5c824673383ac7fe6dd073ca2b"
   },
-  "axiom_encode_version": "0.2.455",
-  "backend": "codex",
-  "citation": "us-sc/manual/dss/snap-policy-manual/page-369",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-369/workspace/context-manifest.json",
-  "context_manifest_sha256": "2a8e5799177b0718a2bb372e7f65aa51097b573b5d1db1bdfa76e0367c776872",
-  "generated_at": "2026-05-31T09:25:38.484747+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/snap-policy-manual/page-369.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "e8a0cdefa95a00beafa3a5a301bf4e6d4a82b955e82b6d55ba9fc2981122315e",
-  "generation_prompt_sha256": "746182bf06517cf00ec97f5b71639412e2b3035c7ff27043e4456c99ce45f21e",
+  "axiom_encode_version": "0.2.661",
+  "backend": "openai",
+  "citation": "us-sc/policies/dss/snap-policy-manual/page-369",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-sc1/_eval_workspaces/openai-gpt-5.5/us-sc-policies-dss-snap-policy-manual-page-369/workspace/context-manifest.json",
+  "context_manifest_sha256": "b04a9e6e3abfcb140ff1f6e36979971c1e14a24d061dacfe5b81e95a4e92faa4",
+  "generated_at": "2026-06-15T00:38:00.407444+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-sc1/openai-gpt-5.5/policies/dss/snap-policy-manual/page-369.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-sc1",
+  "generated_output_sha256": "cf153b6b7401044cddaafaeb7df01c0b242ec584dff24416e0694e2e60fcb9d4",
+  "generation_prompt_sha256": "3f9766320f7e242dab7bb585bb3c77cfdc2a926cc0d172a1d97b6724cea3e44b",
   "model": "gpt-5.5",
-  "run_id": "1c92440d",
-  "runner": "codex-gpt-5.5",
+  "run_id": "8870e991",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8d41f18357613c023f879f9a57e0f556cf163725f3e175909c2fcbb4d9aee07e"
+    "value": "3eed78f60ef37814b98db09d48cba4c5eb21cf4538c5009216c079835f337eb4"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-369.json",
-  "trace_sha256": "26c2c29406eab26c6b9fad95f922f0b6882f60e1a69c8c7edb2c7303c70cb6d7"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-sc1/traces/openai-gpt-5.5/us-sc-policies-dss-snap-policy-manual-page-369.json",
+  "trace_sha256": "e4c028f41e271723ef75e51d3ad767205bcae362e76a435f120299c72b273bcb"
 }

--- a/us-sc/policies/dss/snap-policy-manual/page-369.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-369.test.yaml
@@ -1,7 +1,15 @@
-- name: utility_standard_amounts_updated_on_page_369
+- name: utility_standard_amounts_updated_for_september_2009
   period: 2009-09
   input: {}
   output:
     us-sc:policies/dss/snap-policy-manual/page-369#monthly_utility_standard_mu: 272
     us-sc:policies/dss/snap-policy-manual/page-369#basic_utility_standard_bu: 134
     us-sc:policies/dss/snap-policy-manual/page-369#telephone_standard_te: 33
+- name: auto_output_snap_individual_utility_allowance_state_value
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33

--- a/us-sc/policies/dss/snap-policy-manual/page-369.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-369.yaml
@@ -4,60 +4,104 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
-  summary: |-
-    "Section 12.1 Income Deductions/General: Change to utility standards, MU from 221 to 272, BU from 109 to 134 and TE from 27 to 33."
+  summary: '"Volume 4 September 2009 ... Section 12.1 Income Deductions/General: Change
+    to utility standards, MU from 221 to 272, BU from 109 to 134 and TE from 27 to
+    33."'
 rules:
-  - name: monthly_utility_standard_mu
-    kind: parameter
-    dtype: Money
-    period: Month
-    unit: USD
-    source: SNAP Manual page 369, Section 12.1 Income Deductions/General
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
-              excerpt: "MU from 221 to 272"
-    versions:
-      - effective_from: '2009-09-01'
-        formula: |-
-          272
-  - name: basic_utility_standard_bu
-    kind: parameter
-    dtype: Money
-    period: Month
-    unit: USD
-    source: SNAP Manual page 369, Section 12.1 Income Deductions/General
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
-              excerpt: "BU from 109 to 134"
-    versions:
-      - effective_from: '2009-09-01'
-        formula: |-
-          134
-  - name: telephone_standard_te
-    kind: parameter
-    dtype: Money
-    period: Month
-    unit: USD
-    source: SNAP Manual page 369, Section 12.1 Income Deductions/General
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
-              excerpt: "TE from 27 to 33"
-    versions:
-      - effective_from: '2009-09-01'
-        formula: |-
-          33
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: SNAP Manual page 369, Section 12.1 Income Deductions/General
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2009-09-01'
+    formula: telephone_standard_te
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-369#telephone_standard_te
+          output: telephone_standard_te
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP Manual page 369, Section 12.1 Income Deductions/General
+- name: monthly_utility_standard_mu
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP Manual page 369, Section 12.1 Income Deductions/General
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: MU from 221 to 272
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: Volume 4 September 2009
+  versions:
+  - effective_from: '2009-09-01'
+    formula: '272'
+- name: basic_utility_standard_bu
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP Manual page 369, Section 12.1 Income Deductions/General
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: BU from 109 to 134
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: Volume 4 September 2009
+  versions:
+  - effective_from: '2009-09-01'
+    formula: '134'
+- name: telephone_standard_te
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP Manual page 369, Section 12.1 Income Deductions/General
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: TE from 27 to 33
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-369
+          excerpt: Volume 4 September 2009
+  versions:
+  - effective_from: '2009-09-01'
+    formula: '33'
+imports:
+- us:regulations/7-cfr/273/9

--- a/us-tn/.axiom/encoding-manifests/regulations/1240-01/04/27/block-1.json
+++ b/us-tn/.axiom/encoding-manifests/regulations/1240-01/04/27/block-1.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/1240-01/04/27/block-1.yaml",
-      "sha256": "980b1e46a2d4b399f012e097256ad7fefc64cf9e95a8f32ddb4663c13e0d0cf2"
+      "sha256": "244fd10ce8106799893775e4e43171cdd48e318f5357ad9babd3611b73e9d4f7"
     },
     {
       "path": "regulations/1240-01/04/27/block-1.test.yaml",
-      "sha256": "248657db35f6d39695a840df5a38ab071873c5661afe2dc83b230003f81296a1"
+      "sha256": "2b15bae33e4d48f7394b1db7b71d307d3d6ba63aea53e2f4c371723565cb772a"
     }
   ],
   "axiom_encode_git": {
-    "commit": "6685fc52cf79a2e5a2eac728393bb6c6fdb17acd",
+    "commit": "97496aa44adb3f5c824673383ac7fe6dd073ca2b",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode",
-    "version": "0.2.401",
-    "version_commit": "6685fc52cf79a2e5a2eac728393bb6c6fdb17acd"
+    "root": "/private/tmp/axiom-encode-policy-shape",
+    "version": "0.2.661",
+    "version_commit": "97496aa44adb3f5c824673383ac7fe6dd073ca2b"
   },
-  "axiom_encode_version": "0.2.401",
-  "backend": "claude",
-  "citation": "us-tn/regulation/1240-01/04/27/block-1",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/claude-opus/us-tn-regulation-1240-01-04-27-block-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "68d16fa5f383f25cfeca33bbf3ec8a3b2cafdd08d2545940850bd78827a3fe51",
-  "generated_at": "2026-05-29T05:31:34.936273+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/claude-opus/regulations/1240-01/04/27/block-1.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "980b1e46a2d4b399f012e097256ad7fefc64cf9e95a8f32ddb4663c13e0d0cf2",
-  "generation_prompt_sha256": "a6ec5f97a457edf167b3fc4c5b3de0d8ab8954279febccd29ba8c18a529cece7",
-  "model": "opus",
-  "run_id": "151aa58f",
-  "runner": "claude-opus",
+  "axiom_encode_version": "0.2.661",
+  "backend": "openai",
+  "citation": "us-tn/regulations/1240-01/04/27/block-1",
+  "context_manifest_file": "/tmp/axiom-reencode-snap-delegated-tn11/_eval_workspaces/openai-gpt-5.5/us-tn-regulations-1240-01-04-27-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "8a9ea1038728b86795594d17aebc821567ab6f7946248a6f2068355e75981268",
+  "generated_at": "2026-06-15T00:38:30.251209+00:00",
+  "generated_output_file": "/tmp/axiom-reencode-snap-delegated-tn11/openai-gpt-5.5/regulations/1240-01/04/27/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-reencode-snap-delegated-tn11",
+  "generated_output_sha256": "244fd10ce8106799893775e4e43171cdd48e318f5357ad9babd3611b73e9d4f7",
+  "generation_prompt_sha256": "b2d839ce4c588991a8a2c3f279d9ca45e81fc1b25c6f5a1c09dce78a30daacc2",
+  "model": "gpt-5.5",
+  "run_id": "ad5f4d67",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bf5556f687161fd4b5a74a8503b182a40c64c3b718569825c48f6714a39a76ca"
+    "value": "c75036164b434acc663d5a498b7e3df59ce3aa3264d475dfc34f53bdeb278d82"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/claude-opus/us-tn-regulation-1240-01-04-27-block-1.json",
-  "trace_sha256": "e832f81ccab124bff9e2005511d9c3005e9440a66bcf1d9e1929be8df910ccb2"
+  "trace_file": "/tmp/axiom-reencode-snap-delegated-tn11/traces/openai-gpt-5.5/us-tn-regulations-1240-01-04-27-block-1.json",
+  "trace_sha256": "5b21a3f13490664734948fefbb9d1b169968b0d48bb200458bd2281b3059adeb"
 }

--- a/us-tn/regulations/1240-01/04/27/block-1.test.yaml
+++ b/us-tn/regulations/1240-01/04/27/block-1.test.yaml
@@ -1,37 +1,36 @@
-- name: snap_household_size_4_standards
-  period: 2024-01
-  input:
-    us-tn:regulations/1240-01/04/27/block-1#input.household_member_count: 4
-  output:
-    us-tn:regulations/1240-01/04/27/block-1#household_size: 4
-    us-tn:regulations/1240-01/04/27/block-1#snap_max_shelter_deduction_non_elderly_disabled: 458
-    us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance: 126
-    us-tn:regulations/1240-01/04/27/block-1#snap_telephone_standard: 25
-    us-tn:regulations/1240-01/04/27/block-1#snap_homeless_shelter_standard: 143
-    us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard_additional_member: 406
-    us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income_additional_member: 312
-- name: snap_household_size_1_standards
+- name: snap_household_size_1_food_stamp_standards
   period: 2024-01
   input:
     us-tn:regulations/1240-01/04/27/block-1#input.household_member_count: 1
   output:
     us-tn:regulations/1240-01/04/27/block-1#household_size: 1
-- name: snap_household_size_6_standards
+    us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard_additional_member: 406
+    us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income_additional_member: 312
+    us-tn:regulations/1240-01/04/27/block-1#snap_max_shelter_deduction_non_elderly_disabled: 458
+    us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance: 126
+    us-tn:regulations/1240-01/04/27/block-1#snap_telephone_standard: 25
+    us-tn:regulations/1240-01/04/27/block-1#snap_homeless_shelter_standard: 143
+    us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance_state_value: 314
+    us-tn:regulations/1240-01/04/27/block-1#snap_limited_utility_allowance_state_value: 126
+    us-tn:regulations/1240-01/04/27/block-1#snap_individual_utility_allowance_state_value: 25
+- name: snap_household_size_10_food_stamp_standards
   period: 2024-01
   input:
-    us-tn:regulations/1240-01/04/27/block-1#input.household_member_count: 6
+    us-tn:regulations/1240-01/04/27/block-1#input.household_member_count: 10
   output:
-    us-tn:regulations/1240-01/04/27/block-1#household_size: 6
-- name: afdc_assistance_unit_3
+    us-tn:regulations/1240-01/04/27/block-1#household_size: 10
+    us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance_state_value: 419
+- name: afdc_assistance_unit_1_standards
   period: 2024-01
   input:
-    us-tn:regulations/1240-01/04/27/block-1#input.assistance_unit_member_count: 3
+    us-tn:regulations/1240-01/04/27/block-1#input.assistance_unit_member_count: 1
   output:
-    us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size: 3
+    us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size: 1
     us-tn:regulations/1240-01/04/27/block-1#minimum_afdc_payment: 10
-- name: afdc_assistance_unit_15
+- name: afdc_assistance_unit_20_standards
   period: 2024-01
   input:
-    us-tn:regulations/1240-01/04/27/block-1#input.assistance_unit_member_count: 15
+    us-tn:regulations/1240-01/04/27/block-1#input.assistance_unit_member_count: 20
   output:
-    us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size: 15
+    us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size: 20
+    us-tn:regulations/1240-01/04/27/block-1#minimum_afdc_payment: 10

--- a/us-tn/regulations/1240-01/04/27/block-1.yaml
+++ b/us-tn/regulations/1240-01/04/27/block-1.yaml
@@ -4,464 +4,547 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-  summary: |-
-    Tables I-VII set Food Stamp Program income standards, maximum coupon allotments, standard deductions, maximum shelter/dependent care deductions, standard and basic utility allowances, telephone standard, and homeless household shelter allowance, indexed by household size. Table VIII sets AFDC gross income standard, consolidated need standard, and standard payment amount by assistance unit size, with a $10 minimum AFDC payment.
+  summary: Tables I through VII show Food Stamp Program income standards, coupon allotment,
+    standard deductions, maximum shelter/dependent-care deductions, utility and telephone
+    allowances, and homeless shelter allowance. Table VIII shows AFDC gross income
+    standards, consolidated need standards, standard payment amounts, and a $10 minimum
+    AFDC payment.
 rules:
-  - name: household_size
-    kind: derived
-    entity: Household
-    dtype: Count
-    period: Month
-    source: Tables I-VII row key
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_member_count
-
-  - name: snap_gross_income_standard
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: household_size
-    source: Table I
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table I Gross Income Standard"
-                row_key: household_size
-                column_key: gross_income_standard
-              excerpt: "$1174 $1579 $1984 $2389 $2794 $3200 $3605 $4010 $4416 $4822 For each additional member add $406"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 1174
-          2: 1579
-          3: 1984
-          4: 2389
-          5: 2794
-          6: 3200
-          7: 3605
-          8: 4010
-          9: 4416
-          10: 4822
-
-  - name: snap_gross_income_standard_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table I "For each additional member add $406"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "For each additional member add $406"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          406
-
-  - name: snap_max_net_income
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: household_size
-    source: Table II
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table II Maximum Net Income"
-                row_key: household_size
-                column_key: max_net_income
-              excerpt: "$903 $1215 $1526 $1838 $2150 $2461 $2773 $3085 $3397 $3709 For each additional member add $312"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 903
-          2: 1215
-          3: 1526
-          4: 1838
-          5: 2150
-          6: 2461
-          7: 2773
-          8: 3085
-          9: 3397
-          10: 3709
-
-  - name: snap_max_net_income_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table II "For each additional member add $312"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "For each additional member add $312"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          312
-
-  - name: snap_max_coupon_allotment
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: household_size
-    source: Table III
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table III Maximum Coupon Allotment"
-                row_key: household_size
-                column_key: max_coupon_allotment
-              excerpt: "$200 $367 $526 $668 $793 $952 $1052 $1202 $1352 $1502"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 200
-          2: 367
-          3: 526
-          4: 668
-          5: 793
-          6: 952
-          7: 1052
-          8: 1202
-          9: 1352
-          10: 1502
-
-  - name: snap_standard_deduction
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: household_size
-    source: Table IV-A
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table IV-A Standard Deduction"
-                row_key: household_size
-                column_key: standard_deduction
-              excerpt: "$142 $142 $142 $153 $179 $205"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 142
-          2: 142
-          3: 142
-          4: 153
-          5: 179
-          6: 205
-
-  - name: snap_max_shelter_deduction_non_elderly_disabled
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table IV-B
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "Maximum Shelter Deduction for Non-Elderly/Disabled Households $458"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          458
-
-  - name: snap_standard_utility_allowance
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: household_size
-    source: Table V-A
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table V-A Food Stamp Standard Utility Allowance"
-                row_key: household_size
-                column_key: standard_utility_allowance
-              excerpt: "$314 $326 $338 $350 $360 $372 $384 $396 $408 $419"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 314
-          2: 326
-          3: 338
-          4: 350
-          5: 360
-          6: 372
-          7: 384
-          8: 396
-          9: 408
-          10: 419
-
-  - name: snap_basic_utility_allowance
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table V-B
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "Basic Utility Allowance $126 $126 $126 $126 $126 $126 $126 $126 $126 $126"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          126
-
-  - name: snap_telephone_standard
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Food Stamp Standard Telephone Allowance
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "Telephone Standard $25 $25 $25 $25 $25 $25 $25 $25 $25 $25"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          25
-
-  - name: snap_homeless_shelter_standard
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table VII Homeless Household Shelter Allowance
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "Homeless Shelter Standard 143 143 143 143 143 143 143 143 143 143"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          143
-
-  - name: assistance_unit_size
-    kind: derived
-    entity: TanfUnit
-    dtype: Count
-    period: Month
-    source: Table VIII row key
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: definition
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          assistance_unit_member_count
-
-  - name: afdc_gross_income_standard
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: assistance_unit_size
-    source: Table VIII Gross Income Standard
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table VIII Gross Income Standard"
-                row_key: assistance_unit_size
-                column_key: gross_income_standard
-              excerpt: "Gross Income Standard 777 1110 1252 1289 1489 1507 1633 1655 1838 1875 ... 1929 1977 2020 2055 2083 2109 2131 2149 2162 2173"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 777
-          2: 1110
-          3: 1252
-          4: 1289
-          5: 1489
-          6: 1507
-          7: 1633
-          8: 1655
-          9: 1838
-          10: 1875
-          11: 1929
-          12: 1977
-          13: 2020
-          14: 2055
-          15: 2083
-          16: 2109
-          17: 2131
-          18: 2149
-          19: 2162
-          20: 2173
-
-  - name: afdc_consolidated_need_standard
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: assistance_unit_size
-    source: Table VIII Consolidated Need Standard
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table VIII Consolidated Need Standard"
-                row_key: assistance_unit_size
-                column_key: consolidated_need_standard
-              excerpt: "Consolidated Need Standard 420 600 677 697 805 815 883 895 994 1014 ... 1043 1069 1092 1111 1126 1140 1152 1162 1169 1175"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 420
-          2: 600
-          3: 677
-          4: 697
-          5: 805
-          6: 815
-          7: 883
-          8: 895
-          9: 994
-          10: 1014
-          11: 1043
-          12: 1069
-          13: 1092
-          14: 1111
-          15: 1126
-          16: 1140
-          17: 1152
-          18: 1162
-          19: 1169
-          20: 1175
-
-  - name: afdc_standard_payment_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    indexed_by: assistance_unit_size
-    source: Table VIII Standard Payment Amount
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              table:
-                header: "Table VIII Standard Payment Amount"
-                row_key: assistance_unit_size
-                column_key: standard_payment_amount
-              excerpt: "Standard Payment Amount 95 142 185 226 264 305 345 386 425 467 ... 508 549 589 630 670 711 750 790 831 871"
-    versions:
-      - effective_from: '0001-01-01'
-        values:
-          1: 95
-          2: 142
-          3: 185
-          4: 226
-          5: 264
-          6: 305
-          7: 345
-          8: 386
-          9: 425
-          10: 467
-          11: 508
-          12: 549
-          13: 589
-          14: 630
-          15: 670
-          16: 711
-          17: 750
-          18: 790
-          19: 831
-          20: 871
-
-  - name: minimum_afdc_payment
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: Table VIII Minimum AFDC Payment
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
-              excerpt: "Minimum AFDC Payment $10 per month for any assistance unit."
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          10
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Table V-A
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_limited_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Table V-B
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Food Stamp Standard Telephone Allowance
+- name: household_size
+  kind: derived
+  entity: Household
+  dtype: Count
+  period: Month
+  source: Tables I-VII row key
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: No. of Persons in Household
+  versions:
+  - effective_from: '0001-01-01'
+    formula: household_member_count
+- name: snap_gross_income_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: household_size
+  source: Table I
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table I Gross Income Standard
+            row_key: No. of Persons in Household
+            column_key: Gross Income Standard
+          excerpt: $1174 $1579 $1984 $2389 $2794 $3200 $3605 $4010 $4416 $4822
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 1174
+      2: 1579
+      3: 1984
+      4: 2389
+      5: 2794
+      6: 3200
+      7: 3605
+      8: 4010
+      9: 4416
+      10: 4822
+- name: snap_gross_income_standard_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table I
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: For each additional member add $406
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '406'
+- name: snap_max_net_income
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: household_size
+  source: Table II
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table II Maximum Net Income
+            row_key: No. of Persons in Household
+            column_key: Maximum Net Income
+          excerpt: $903 $1215 $1526 $1838 $2150 $2461 $2773 $3085 $3397 $3709
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 903
+      2: 1215
+      3: 1526
+      4: 1838
+      5: 2150
+      6: 2461
+      7: 2773
+      8: 3085
+      9: 3397
+      10: 3709
+- name: snap_max_net_income_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table II
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: For each additional member add $312
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '312'
+- name: snap_max_coupon_allotment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: household_size
+  source: Table III
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table III Maximum Coupon Allotment
+            row_key: No. of Persons in Household
+            column_key: Maximum Coupon Allotment
+          excerpt: $200 $367 $526 $668 $793 $952 $1052 $1202 $1352 $1502
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 200
+      2: 367
+      3: 526
+      4: 668
+      5: 793
+      6: 952
+      7: 1052
+      8: 1202
+      9: 1352
+      10: 1502
+- name: snap_standard_deduction
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: household_size
+  source: Table IV-A
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table IV-A Standard Deduction
+            row_key: Household Size
+            column_key: Standard Deduction
+          excerpt: Household Size 1 2 3 4 5 6+ Standard Deduction $142 $142 $142 $153
+            $179 $205
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 142
+      2: 142
+      3: 142
+      4: 153
+      5: 179
+      6: 205
+      7: 205
+      8: 205
+      9: 205
+      10: 205
+- name: snap_max_shelter_deduction_non_elderly_disabled
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table IV-B
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Maximum Shelter Deduction for Non-Elderly/Disabled Households $458
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '458'
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: household_size
+  source: Table V-A
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table V-A Food Stamp Standard Utility Allowance
+            row_key: Household Size
+            column_key: Standard Utility Allowance
+          excerpt: $314 $326 $338 $350 $360 $372 $384 $396 $408 $419
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 314
+      2: 326
+      3: 338
+      4: 350
+      5: 360
+      6: 372
+      7: 384
+      8: 396
+      9: 408
+      10: 419
+- name: snap_basic_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table V-B
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Basic Utility Allowance $126
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '126'
+- name: snap_telephone_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Food Stamp Standard Telephone Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Telephone Standard $25
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25'
+- name: snap_homeless_shelter_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table VII
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Homeless Shelter Standard 143
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '143'
+- name: snap_standard_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Table V-A
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+          output: snap_standard_utility_allowance
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-tn:regulations/1240-01/04/27/block-1#household_size
+          output: household_size
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: snap_standard_utility_allowance[household_size]
+- name: snap_limited_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Table V-B
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance
+          output: snap_basic_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: snap_basic_utility_allowance
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Food Stamp Standard Telephone Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-tn:regulations/1240-01/04/27/block-1#snap_telephone_standard
+          output: snap_telephone_standard
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: snap_telephone_standard
+- name: assistance_unit_size
+  kind: derived
+  entity: TanfUnit
+  dtype: Count
+  period: Month
+  source: Table VIII row key
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Number of Persons in Assistance Unit
+  versions:
+  - effective_from: '0001-01-01'
+    formula: assistance_unit_member_count
+- name: afdc_gross_income_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: assistance_unit_size
+  source: Table VIII
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table VIII AFDC
+            row_key: Number of Persons in Assistance Unit
+            column_key: Gross Income Standard
+          excerpt: Gross Income Standard 777 1110 1252 1289 1489 1507 1633 1655 1838
+            1875 ... 2173
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 777
+      2: 1110
+      3: 1252
+      4: 1289
+      5: 1489
+      6: 1507
+      7: 1633
+      8: 1655
+      9: 1838
+      10: 1875
+      11: 1929
+      12: 1977
+      13: 2020
+      14: 2055
+      15: 2083
+      16: 2109
+      17: 2131
+      18: 2149
+      19: 2162
+      20: 2173
+- name: afdc_consolidated_need_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: assistance_unit_size
+  source: Table VIII
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table VIII AFDC
+            row_key: Number of Persons in Assistance Unit
+            column_key: Consolidated Need Standard
+          excerpt: Consolidated Need Standard 420 600 677 697 805 815 883 895 994
+            1014 ... 1175
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 420
+      2: 600
+      3: 677
+      4: 697
+      5: 805
+      6: 815
+      7: 883
+      8: 895
+      9: 994
+      10: 1014
+      11: 1043
+      12: 1069
+      13: 1092
+      14: 1111
+      15: 1126
+      16: 1140
+      17: 1152
+      18: 1162
+      19: 1169
+      20: 1175
+- name: afdc_standard_payment_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: assistance_unit_size
+  source: Table VIII
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          table:
+            header: Table VIII AFDC
+            row_key: Number of Persons in Assistance Unit
+            column_key: Standard Payment Amount
+          excerpt: Standard Payment Amount 95 142 185 226 264 305 345 386 425 467
+            ... 871
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 95
+      2: 142
+      3: 185
+      4: 226
+      5: 264
+      6: 305
+      7: 345
+      8: 386
+      9: 425
+      10: 467
+      11: 508
+      12: 549
+      13: 589
+      14: 630
+      15: 670
+      16: 711
+      17: 750
+      18: 790
+      19: 831
+      20: 871
+- name: minimum_afdc_payment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Table VIII
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Minimum AFDC Payment $10 per month for any assistance unit.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '10'
+imports:
+- us:regulations/7-cfr/273/9


### PR DESCRIPTION
## Summary
- Re-encodes SNAP utility allowance delegated settings for CA, CO, NC, SC, and TN using the encoder/apply path only.
- Updates the generated RuleSpec YAML, generated tests, and signed encoding manifests for those citations.
- Aligns state utility allowance settings with the delegated-setting `sets` shape enforced in TheAxiomFoundation/axiom-encode#613.

## Encoder provenance
Generated from the updated encoder branch in TheAxiomFoundation/axiom-encode#613. No RuleSpec files were hand-edited.

## Validation
- `uv run --extra dev python -m pytest tests/test_cli.py -k 'embedded_scalar_literal_repair or delegated_policy_setting_repair_retargets_aggregate_hook_edge or derived_output_test_repair_uses_positive_count_defaults'` in `axiom-encode`
- `uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py` in `axiom-encode`
- `git diff --check` in `axiom-encode` and `rulespec-us`
- delegated setting scanner over `rulespec-us`: `issue_count=0`
- `uv run --project /tmp/axiom-encode-policy-shape --extra dev python -m pytest tests` in `rulespec-us`: 12 passed
