### PR TITLE
Add Florida SNAP special income circumstances encoding

### DIFF
--- a/us-fl/.axiom/encoding-manifests/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.json
+++ b/us-fl/.axiom/encoding-manifests/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.yaml",
+      "sha256": "6376a9ca720331f594155d05bb9fd578db97df6b97e943d8298277a9909d3f46"
+    },
+    {
+      "path": "policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.test.yaml",
+      "sha256": "383563562a34c18858b2fdc6a333b865ec15ec543d98a34153ac6471c424b5cc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1e6b9f6d31c0485d092617813df15b5f41f833a8",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-fl-clean",
+    "version": "0.2.671",
+    "version_commit": "8e7971729a471e401114a19f3474c50680d45104"
+  },
+  "axiom_encode_version": "0.2.671",
+  "backend": "codex",
+  "citation": "us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-fl-manual-dcf-ess-program-policy-manual-2600-calculation-of-benefits-page-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "bff376c9bd2282974e8f572848138d80769471b0b603ca5c6853eedeeb598346",
+  "generated_at": "2026-06-16T05:19:12.798209+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6376a9ca720331f594155d05bb9fd578db97df6b97e943d8298277a9909d3f46",
+  "generation_prompt_sha256": "868c66da039b32226e1c9be13bfef3a2ab192d530b03166e641f2e309fab73c3",
+  "model": "gpt-5.5",
+  "run_id": "52278238",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6831c425813d92e2ddef5e9267ad91ec64e35354135eb4b23c0742c70fe2e41e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-fl-manual-dcf-ess-program-policy-manual-2600-calculation-of-benefits-page-16.json",
+  "trace_sha256": "ca1da3cbe318bc17f404135f9ce7755b58dcaf29648eb781848323ece9850706"
+}

--- a/us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.test.yaml
+++ b/us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.test.yaml
@@ -1,0 +1,411 @@
+- name: recurring SSI lump sum payment is unearned income
+  period: 2026-01
+  tables:
+    Payment:
+    - us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: true
+    - us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#recurring_ssi_lump_sum_payment_is_unearned_income
+    : - holds
+      - not_holds
+- name: migrant student unidentified group payment proration
+  period: 2026-01
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 900
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 3
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#unidentified_group_payment_prorated_student_excluded_amount
+    : 300
+- name: less than one year contract income prorated over covered months
+  period: 2026-01
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 6000
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 6
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#monthly_income_from_contract_employment_less_than_one_year
+    : 1000
+- name: contractual school employment annual income averaged over 12 months
+  period: 2026-01
+  input:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 24000
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#school_employee_considered_under_contract
+    : holds
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#monthly_income_from_contractual_school_employment
+    : 2000
+- name: auto_output_federal_tax_refund_or_credit_asset_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#federal_tax_refund_or_credit_asset_excluded
+    : not_holds
+- name: auto_output_resident_farm_laborer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#resident_farm_laborer: not_holds
+- name: auto_output_migrant_farm_laborer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#migrant_farm_laborer: not_holds
+- name: auto_output_migrant_child_student_earned_income_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#migrant_child_student_earned_income_excluded
+    : not_holds
+- name: auto_positive_federal_tax_refund_or_credit_asset_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : true
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#federal_tax_refund_or_credit_asset_excluded
+    : holds
+- name: auto_positive_resident_farm_laborer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: true
+  output:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#resident_farm_laborer: holds
+- name: auto_positive_migrant_farm_laborer
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : true
+  output:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#migrant_farm_laborer: holds
+- name: auto_positive_migrant_child_student_earned_income_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: true
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : true
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : true
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#migrant_child_student_earned_income_excluded
+    : holds
+- name: auto_zero_unidentified_group_payment_prorated_student_excluded_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#unidentified_group_payment_prorated_student_excluded_amount
+    : 0
+- name: auto_zero_monthly_income_from_contract_employment_less_than_one_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#monthly_income_from_contract_employment_less_than_one_year
+    : 0
+- name: auto_zero_monthly_income_from_contractual_school_employment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.annual_contractual_school_employment_income
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_is_federal_income_tax_refund_or_credit
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.asset_month_is_month_received_or_within_12_months_from_receipt
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.assistance_group_received_one_payment_for_group_work
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.contract_income_amount: 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.group_work_payment_amount: 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_can_be_identified_as_earned_specifically_by_student
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_is_earned_by_student: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.income_received_under_employment_contract_less_than_one_year
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.months_contract_income_intended_to_cover
+    : 0
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.number_of_assistance_group_members_working
+    : 0
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.payment_is_recurring_ssi_lump_sum: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_age_under_18: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_currently_attending_school: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_has_fixed_place_of_residence
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_assistance_group_member: false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_farm_laborer: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_migrant_child_under_parental_control
+    : false
+    us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_is_school_employee: false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_moves_from_place_to_place_to_follow_work_flow
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.person_plans_to_return_to_school_after_academic_break
+    : false
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#input.school_employee_income_not_hourly_or_piece_rate
+    : false
+  output:
+    ? us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#monthly_income_from_contractual_school_employment
+    : 0

--- a/us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.yaml
+++ b/us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.yaml
@@ -1,0 +1,207 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  summary: Federal income tax refunds and credits are excluded as assets in the month
+    received and for 12 months from receipt. Recurring SSI lump sum payments are unearned
+    income. Resident and migrant farm laborers are defined; migrant student children's
+    earned income is excluded or prorated when not identifiable. Contract employment
+    under one year is prorated over covered months, and annual contractual school
+    employment income is averaged over 12 months.
+rules:
+- name: federal_tax_refund_or_credit_asset_excluded
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Month
+  source: Chapter 2600, note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+          excerpt: Federal income tax refunds and credits are excluded as assets in
+            the month received and for 12 months from the date of receipt.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'asset_is_federal_income_tax_refund_or_credit
+
+      and asset_month_is_month_received_or_within_12_months_from_receipt'
+- name: recurring_ssi_lump_sum_payment_is_unearned_income
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Month
+  source: 2610.0403.02
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: payment_is_recurring_ssi_lump_sum
+- name: resident_farm_laborer
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 2610.0404.01
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_is_farm_laborer
+
+      and person_has_fixed_place_of_residence'
+- name: migrant_farm_laborer
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 2610.0405.01
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_is_farm_laborer
+
+      and person_moves_from_place_to_place_to_follow_work_flow'
+- name: migrant_child_student_earned_income_excluded
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 2610.0405.02
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_is_migrant_child_under_parental_control
+
+      and person_age_under_18
+
+      and (person_currently_attending_school or person_plans_to_return_to_school_after_academic_break)
+
+      and income_is_earned_by_student'
+- name: unidentified_group_payment_prorated_student_excluded_amount
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 2610.0405.02
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if person_is_migrant_child_under_parental_control and person_age_under_18
+      and (person_currently_attending_school or person_plans_to_return_to_school_after_academic_break)
+      and assistance_group_received_one_payment_for_group_work and not income_can_be_identified_as_earned_specifically_by_student:
+      group_work_payment_amount / number_of_assistance_group_members_working else:
+      0'
+- name: monthly_income_from_contract_employment_less_than_one_year
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 2610.0407
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if income_received_under_employment_contract_less_than_one_year: contract_income_amount
+      / months_contract_income_intended_to_cover else: 0'
+- name: school_employee_considered_under_contract
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 2610.0408.01
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_is_school_employee
+
+      and school_employee_income_not_hourly_or_piece_rate'
+- name: monthly_income_from_contractual_school_employment_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: 2610.0408.01
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+          excerpt: Annual income received by assistance group members from the contractual
+            school employment must be averaged over 12 months.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '12'
+- name: monthly_income_from_contractual_school_employment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 2610.0408.01
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-fl/manual/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16
+          excerpt: Annual income received by assistance group members from the contractual
+            school employment must be averaged over 12 months.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16#monthly_income_from_contractual_school_employment_scalar_limit
+          output: monthly_income_from_contractual_school_employment_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if person_is_assistance_group_member and school_employee_considered_under_contract:
+      annual_contractual_school_employment_income / monthly_income_from_contractual_school_employment_scalar_limit
+      else: 0'


### PR DESCRIPTION
## Summary
- encode Florida ESS Manual 2600 Calculation of Benefits page 16
- add federal refund/credit asset exclusion, recurring SSI lump-sum treatment, farm laborer definitions, migrant child/student income exclusion, and contract/school employment income averaging
- include signed axiom-encode apply manifest

## Validation
- python3 -m pytest tests
- set -a; source ~/.config/axiom-foundation/axiom-encode.env; set +a; uv run --python 3.13 axiom-encode guard-generated --repo /tmp/rulespec-us/us-fl