### PR TITLE
Enforce repository structure

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -1,0 +1,62 @@
+version: 1
+allowed_root_directories:
+  - .axiom
+  - .github
+  - programs
+  - tests
+  - us
+  - us-al
+  - us-ar
+  - us-az
+  - us-ca
+  - us-co
+  - us-de
+  - us-fl
+  - us-ga
+  - us-id
+  - us-ma
+  - us-md
+  - us-nc
+  - us-nh
+  - us-ny
+  - us-ok
+  - us-sc
+  - us-tn
+  - us-tx
+allowed_root_files:
+  - .gitattributes
+  - .gitignore
+  - CLAUDE.md
+  - README.md
+  - known-dangling.yaml
+  - known-validation-gaps.yaml
+path_rules:
+  - patterns:
+      - ".axiom/**"
+    allow_extensions:
+      - ".json"
+      - ".toml"
+      - ".yaml"
+  - patterns:
+      - ".github/**"
+    allow_extensions:
+      - ".yml"
+      - ".yaml"
+  - patterns:
+      - "programs/**"
+    allow_extensions:
+      - ".yaml"
+  - patterns:
+      - "tests/**"
+    allow_extensions:
+      - ".py"
+  - patterns:
+      - "us/**"
+      - "us-*/**"
+    allow_extensions:
+      - ".json"
+      - ".md"
+      - ".toml"
+      - ".yaml"
+    allow_filenames:
+      - ".gitignore"

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -45,6 +45,7 @@ def rulespec_content_roots() -> list[Path]:
 
 def allowed_yaml_roots() -> set[str]:
     return {
+        ".axiom",
         ".github",
         "programs",
         "known-dangling.yaml",


### PR DESCRIPTION
## Summary
- add `.axiom/repository-structure.yaml` so the shared RuleSpec workflow enforces US repo roots and file types
- keep `programs/` as YAML-only declarative compose specs
- allow `.axiom/repository-structure.yaml` in the existing stray-YAML layout test

## Verification
- strict shared layout step against `.axiom/repository-structure.yaml`
- `uv run --python 3.13 --with pytest --with pyyaml python -m pytest -q tests`
- `git diff --cached --check`
- `ruby -ryaml -e 'YAML.load_file(".axiom/repository-structure.yaml"); puts "structure yaml ok"'`
