### PR TITLE
Add Colorado CCAP income eligibility limits

### DIFF
--- a/us-co/.axiom/encoding-manifests/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.json
+++ b/us-co/.axiom/encoding-manifests/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml",
+      "sha256": "fa720d263804218812f4e34e0c8a0fcd6dc80c2cdcdfdc7e70feb230f807984f"
+    },
+    {
+      "path": "regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.test.yaml",
+      "sha256": "06b50d16793c3c394f415ec3d3c0d00bd2df2b1c21d9dd6de5ed664ec30bbc9b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5438bad6e797c300203ff754c9087aaa45ba36e4",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/axiom-encode-co-ccap-20260618",
+    "version": "0.2.753",
+    "version_commit": "5438bad6e797c300203ff754c9087aaa45ba36e4"
+  },
+  "axiom_encode_version": "0.2.753",
+  "backend": "openai",
+  "citation": "us-co/regulation/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines",
+  "context_manifest_file": "/tmp/co-ccap-encode-3.111h-usco-signed/_eval_workspaces/openai-gpt-5.5/us-co-regulation-8-ccr-1403-1-3.111-h-low-income-eligibility-guidelines/workspace/context-manifest.json",
+  "context_manifest_sha256": "ef64e01f2f08d89aa9d91748b2579a0f4bc6da8ce912813bb9fbfc7d3fa08be9",
+  "generated_at": "2026-06-18T22:19:38.455208+00:00",
+  "generated_output_file": "/tmp/co-ccap-encode-3.111h-usco-signed/openai-gpt-5.5/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml",
+  "generated_output_root": "/tmp/co-ccap-encode-3.111h-usco-signed",
+  "generated_output_sha256": "fa720d263804218812f4e34e0c8a0fcd6dc80c2cdcdfdc7e70feb230f807984f",
+  "generation_prompt_sha256": "90358c666c59c91801d14805d69487c5c64980d804495800e66d494991d45d73",
+  "model": "gpt-5.5",
+  "run_id": "1683cc8e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5e8886d4194a58381ca1b9a1e1f6c03daa23a1c438cb12a639432ca73ec97638"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/co-ccap-encode-3.111h-usco-signed/traces/openai-gpt-5.5/us-co-regulation-8-ccr-1403-1-3.111-h-low-income-eligibility-guidelines.json",
+  "trace_sha256": "bcb36a178706a5dbbddf8481c1b2f769aeeeca3d85c18da703b01585c087567e"
+}

--- a/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.test.yaml
+++ b/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.test.yaml
@@ -1,0 +1,59 @@
+- name: family_size_four_limits_and_eligible_at_boundaries
+  period: 2025-10
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 4
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_monthly_gross_income: 9828.83
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets: 1000000
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_federal_poverty_guideline_100_limit: 2679.17
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit: 9828.83
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling: holds
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#assets_within_ccap_limit: holds
+    ? us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines
+    : holds
+- name: family_size_nine_uses_each_additional_person_increments
+  period: 2025-10
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 9
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_monthly_gross_income: 13858.66
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets: 999999
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_federal_poverty_guideline_100_limit: 4970.83
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit: 13858.66
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling: holds
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#assets_within_ccap_limit: holds
+    ? us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines
+    : holds
+- name: income_above_state_median_income_ceiling_fails
+  period: 2025-10
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 4
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_monthly_gross_income: 9828.84
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets: 1000000
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling: not_holds
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#assets_within_ccap_limit: holds
+    ? us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines
+    : not_holds
+- name: assets_above_one_million_fails
+  period: 2025-10
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 4
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_monthly_gross_income: 9828.83
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets: 1000000.01
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling: holds
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#assets_within_ccap_limit: not_holds
+    ? us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines
+    : not_holds
+- name: auto_output_monthly_entry_income_floor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 1
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets: 0
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_monthly_gross_income: 0
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_entry_income_floor: 2412.7145

--- a/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml
+++ b/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml
@@ -1,0 +1,295 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+  summary: |-
+    8 CCR 1403-1 3.111(H): Adult caretaker(s) or teen parent(s) gross income must not exceed eighty-five percent (85%) of the state median income. Entry eligibility shall be set by the Department based on the self-sufficiency standard, not below one hundred eighty-five percent (185%) of the federal poverty level; exit income eligibility must be eighty-five percent (85%) of state median income. Effective October 1, 2025, monthly gross income levels for 100% Federal Poverty Guideline and 85% State Median Income are listed by family size 1 through 8, with each additional person increments. Under 3.111(H)(4)(c), adult caretakers or teen parents self-declare that liquid and non-liquid assets do not exceed one million dollars; if assets exceed one million dollars the household is ineligible for CCCAP.
+rules:
+  - name: federal_poverty_guideline_100_monthly_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: family_size
+    source: 8 CCR 1403-1 3.111(H)(2), 100% Federal Poverty Guideline table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Effective October 1, 2025, monthly gross income levels, for one-hundred percent (100%) of the Federal Poverty Guideline (FPG) ... Family Size 1 $1,304.17 ... 8 $4,512.50"
+              table:
+                header: "Monthly gross income levels effective October 1, 2025"
+                row_key: "Family Size"
+                column_key: "100% Federal Poverty Guideline (FPG)"
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 1304.17
+          2: 1762.50
+          3: 2220.83
+          4: 2679.17
+          5: 3137.50
+          6: 3595.83
+          7: 4054.17
+          8: 4512.50
+
+  - name: state_median_income_85_monthly_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: family_size
+    source: 8 CCR 1403-1 3.111(H)(2), 85% State Median Income table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Effective October 1, 2025 ... eighty-five percent (85%) of State Median Income (SMI) ... Family Size 1 $5,100.99 ... 8 $13,563.79"
+              table:
+                header: "Monthly gross income levels effective October 1, 2025"
+                row_key: "Family Size"
+                column_key: "85% State Median Income (SMI) (State and Federal Maximum Income Limit)"
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 5100.99
+          2: 6683.61
+          3: 8256.22
+          4: 9828.83
+          5: 11401.45
+          6: 12974.06
+          7: 13268.93
+          8: 13563.79
+
+  - name: federal_poverty_guideline_100_monthly_each_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(2), each additional person row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Each Additional person $458.33"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          458.33
+
+  - name: state_median_income_85_monthly_each_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(2), each additional person row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Each Additional person ... $294.87"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          294.87
+
+  - name: published_income_table_maximum_family_size
+    kind: parameter
+    dtype: Count
+    source: 8 CCR 1403-1 3.111(H)(2), family-size rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Family Size ... 8"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          8
+
+  - name: entry_income_floor_federal_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: 8 CCR 1403-1 3.111(H)(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "not to be set below one hundred eighty-five percent (185%) of the federal poverty level"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          1.85
+
+  - name: gross_income_state_median_income_ceiling_rate
+    kind: parameter
+    dtype: Rate
+    source: 8 CCR 1403-1 3.111(H)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "gross income must not exceed eighty-five percent (85%) of the state median income"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          0.85
+
+  - name: ccap_asset_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 8 CCR 1403-1 3.111(H)(4)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "assets do not exceed one million dollars. If assets exceed one million dollars the household is ineligible for CCCAP."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          1000000
+
+  - name: monthly_federal_poverty_guideline_100_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Family Size ... 8 $4,512.50; Each Additional person $458.33"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if family_size <= published_income_table_maximum_family_size: federal_poverty_guideline_100_monthly_by_family_size[family_size] else: federal_poverty_guideline_100_monthly_by_family_size[published_income_table_maximum_family_size] + ((family_size - published_income_table_maximum_family_size) * federal_poverty_guideline_100_monthly_each_additional_person)
+
+  - name: monthly_entry_income_floor
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(1)(a), (H)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Entry eligibility shall be set by the Department ... not to be set below one hundred eighty-five percent (185%) of the federal poverty level."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          monthly_federal_poverty_guideline_100_limit * entry_income_floor_federal_poverty_guideline_rate
+
+  - name: monthly_state_median_income_85_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(1), (H)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Exit income eligibility must be eighty-five percent (85%) of the state median income ... Family Size ... 8 $13,563.79; Each Additional person ... $294.87"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if family_size <= published_income_table_maximum_family_size: state_median_income_85_monthly_by_family_size[family_size] else: state_median_income_85_monthly_by_family_size[published_income_table_maximum_family_size] + ((family_size - published_income_table_maximum_family_size) * state_median_income_85_monthly_each_additional_person)
+
+  - name: gross_income_within_state_median_income_ceiling
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(1), (H)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "Adult caretaker(s) or teen parent(s) gross income must not exceed eighty-five percent (85%) of the state median income."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          household_monthly_gross_income <= monthly_state_median_income_85_limit
+
+  - name: assets_within_ccap_limit
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(4)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "If assets exceed one million dollars the household is ineligible for CCCAP."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          household_assets <= ccap_asset_limit
+
+  - name: income_and_asset_eligible_for_ccap_low_income_guidelines
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 8 CCR 1403-1 3.111(H)(1), (H)(4)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-co/regulation/8-ccr-1403-1/3.111
+              excerpt: "gross income must not exceed eighty-five percent (85%) of the state median income ... If assets exceed one million dollars the household is ineligible for CCCAP."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          gross_income_within_state_median_income_ceiling
+          and assets_within_ccap_limit


### PR DESCRIPTION
## Summary

- Adds a source-first RuleSpec encoding for Colorado CCAP low-income eligibility guidelines from 8 CCR 1403-1 3.111(H).
- Encodes the 2025-10-01 100% FPG and 85% SMI monthly tables, each-additional-person increments, the 185% FPG entry floor, the 85% SMI income ceiling, and the $1,000,000 asset cap.
- Includes companion tests for family size 4, family size 9 additional-person increments, income above the SMI ceiling, and assets above the cap.
- Adds the signed `axiom-encode --apply` manifest generated from clean encoder version 0.2.753.

## Validation

- `axiom-encode validate us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml --skip-reviewers`
- `axiom-encode proof-validate us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml`
- `axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us-co-ccap/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml`
- `axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us-co-ccap/us-co --json`

## Notes

Attempted follow-on encodings for 3.124 parent fees and 3.130 provider reimbursement mechanics, but retired those drafts before committing. They exposed encoder/harness issues rather than promotion-ready RuleSpec:

- TheAxiomFoundation/axiom-encode#694: canonical imports from monorepo jurisdiction content roots were exposed as `us-co:external/...`, or cold mode replaced the cross-reference with a local FPG input.
- TheAxiomFoundation/axiom-encode#695: apply promoted a low-score reviewer failure and auto-generated nonsensical positive tests.
