### PR TITLE
Add Georgia SNAP delegated utility allowance import

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/3617.json
+++ b/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/3617.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/dfcs/snap/3617.yaml",
+      "sha256": "539405108a2d4b0f8b081a0619f6c7e2ead2f3f6b8768f0dc3130cec7f23c2f7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "259a78c483b9cefb3a4cb43db6913513ffdd700c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-fr-11094",
+    "version": "0.2.759",
+    "version_commit": "259a78c483b9cefb3a4cb43db6913513ffdd700c"
+  },
+  "axiom_encode_version": "0.2.759",
+  "backend": "deterministic",
+  "citation": "us-ga:policies/dfcs/snap/3617",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-19T00:57:22.918253+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmph36os8fu/deterministic-repair/us-ga/policies/dfcs/snap/3617.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmph36os8fu",
+  "generated_output_sha256": "539405108a2d4b0f8b081a0619f6c7e2ead2f3f6b8768f0dc3130cec7f23c2f7",
+  "generation_prompt_sha256": null,
+  "model": "delegated-policy-setting-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0ccd1f7fe52d13ecc39713709f6a0845248ef9153067d5530e1d4b4b58344031"
+  },
+  "tool": "axiom-encode repair-delegated-policy-settings",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ga/policies/dfcs/snap/3617.yaml
+++ b/us-ga/policies/dfcs/snap/3617.yaml
@@ -525,3 +525,6 @@ rules:
       - effective_from: '2025-11-01'
         formula: |-
           if snap_telephone_allowance_eligible: telephone_standard_amount else: 0
+
+imports:
+  - us:regulations/7-cfr/273/9


### PR DESCRIPTION
## Summary
- add the missing import from Georgia SNAP section 3617 to the federal SNAP utility allowance delegation module
- include the signed axiom-encode applied RuleSpec manifest for the generated repair

## Validation
- `uv run axiom-encode validate --skip-reviewers /tmp/rulespec-us-fr-11094/us-ga/policies/dfcs/snap/3617.yaml`
- `uv run axiom-encode test --root /tmp/rulespec-us-fr-11094 /tmp/rulespec-us-fr-11094/us-ga`
- `uv run axiom-encode proof-validate /tmp/rulespec-us-fr-11094/us-ga/policies/dfcs/snap/3617.yaml`
- `uv run axiom-encode guard-generated --repo /tmp/rulespec-us-fr-11094 --base-ref origin/main --head-ref HEAD`

## Provenance
Generated with `axiom-encode repair-delegated-policy-settings` from encoder commit `259a78c483b9cefb3a4cb43db6913513ffdd700c`, now merged via TheAxiomFoundation/axiom-encode#701.
