### PR TITLE
Add Georgia CMS Medicaid availability markers

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
+++ b/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+      "sha256": "6ed3c9fbe408f98cc5388d6bf61f696d81ac62d4fef6cd9afaca4ea58dbe9338"
+    },
+    {
+      "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
+      "sha256": "239e282ec56d034e1c304ec3a8533daba4edff9d3c3241383bd42df9ad5f46c7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2234112b0f43c6024cc7977829961af98e399d2e",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-fr-11094",
+    "version": "0.2.760",
+    "version_commit": "2234112b0f43c6024cc7977829961af98e399d2e"
+  },
+  "axiom_encode_version": "0.2.760",
+  "backend": "deterministic",
+  "citation": "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-19T01:19:01.692286+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9e0qps4n/deterministic-repair/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9e0qps4n",
+  "generated_output_sha256": "6ed3c9fbe408f98cc5388d6bf61f696d81ac62d4fef6cd9afaca4ea58dbe9338",
+  "generation_prompt_sha256": null,
+  "model": "georgia-cms-medicaid-availability-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e2d8b95c00c736387b8cdc546d2da73765fc55ffb64fb24289939142f62d7cac"
+  },
+  "tool": "axiom-encode repair-georgia-cms-medicaid-availability",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
@@ -13,3 +13,6 @@
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_separate_chip_fpl_limit: 2.47
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_medicaid_fpl_limit: 2.2
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit: 0.28
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_standard_uses_dollar_amounts: true
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_chip_available: false
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_adult_medicaid_expansion_available: false

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
@@ -143,3 +143,64 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           0.28
+
+  - name: georgia_parent_caretaker_standard_uses_dollar_amounts
+    kind: parameter
+    dtype: Boolean
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row and dollar-amount footnote
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "28%($)"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Adults (Medicaid) Parent/Caretaker
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          true
+  - name: georgia_pregnant_women_chip_available
+    kind: parameter
+    dtype: Boolean
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "N/A"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Pregnant Women CHIP
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          false
+  - name: georgia_adult_medicaid_expansion_available
+    kind: parameter
+    dtype: Boolean
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "No"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Adults (Medicaid) Expansion to Adults
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          false


### PR DESCRIPTION
## Summary
- add the three missing Georgia CMS Medicaid/CHIP source-table marker concepts
- cover them in the Georgia CMS companion test
- include the signed axiom-encode apply manifest generated by `repair-georgia-cms-medicaid-availability`

## Validation
- `uv run axiom-encode validate --skip-reviewers /tmp/rulespec-us-fr-11094/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml`
- `uv run axiom-encode proof-validate /tmp/rulespec-us-fr-11094/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml`
- `uv run axiom-encode test --root /tmp/rulespec-us-fr-11094 /tmp/rulespec-us-fr-11094/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml`
- `uv run axiom-encode guard-generated --repo /tmp/rulespec-us-fr-11094 --base-ref origin/main --head-ref HEAD`
- `uv run axiom-encode oracle-coverage --root /tmp --oracle policyengine --program health --include-program-surfaces --limit 80 --json`

## Oracle coverage
- Health outputs: 183 total; 1 comparable; 182 known-not-comparable; 0 untested comparable
- `rulespec-us-ga`: 10 outputs, all known-not-comparable and tested
