### PR TITLE
Encode ACA premium tax credit rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.753"
+axiom_encode_version = "0.2.772"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "5438bad6e797c300203ff754c9087aaa45ba36e4"
+axiom_encode_ref = "96cfb00786768d16e41921201691487bb576106c"
 axiom_corpus_ref = "2b0a843c13abf03854b9e93da88d77c41a0d38df"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/26/36B.json
+++ b/us/.axiom/encoding-manifests/statutes/26/36B.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/36B.yaml",
+      "sha256": "331472fc2d25390a9b0c1e485d0aa969a42d4faf1aee44f661eec5e2bf94c0c3"
+    },
+    {
+      "path": "statutes/26/36B.test.yaml",
+      "sha256": "0f2e788408be72e422013dcc7bf25cc8189a22ab6574c771470d48a7e355961c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "dd31cbbce33eadef4fc5b6975afa1435e4ef7a46",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-health-p1-20260619",
+    "version": "0.2.769",
+    "version_commit": "dd31cbbce33eadef4fc5b6975afa1435e4ef7a46"
+  },
+  "axiom_encode_version": "0.2.769",
+  "backend": "codex",
+  "citation": "26 USC 36B",
+  "context_manifest_file": "/tmp/axiom-aca-36b-parent-rerun-1/_eval_workspaces/codex-gpt-5.5/26-USC-36B/workspace/context-manifest.json",
+  "context_manifest_sha256": "97e7747ee3a1820927aed1fe49b55a1289d328fed67f352ff500e24243e82647",
+  "generated_at": "2026-06-19T14:02:26.282568+00:00",
+  "generated_output_file": "/tmp/axiom-aca-36b-parent-rerun-1/codex-gpt-5.5/statutes/26/36B.yaml",
+  "generated_output_root": "/tmp/axiom-aca-36b-parent-rerun-1",
+  "generated_output_sha256": "331472fc2d25390a9b0c1e485d0aa969a42d4faf1aee44f661eec5e2bf94c0c3",
+  "generation_prompt_sha256": null,
+  "model": "gpt-5.5",
+  "run_id": "91882093",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "61b16998edb8e1590654f539c801932a10e90f5401975edf4f12972493a083fc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-aca-36b-parent-rerun-1/traces/codex-gpt-5.5/26-USC-36B.json",
+  "trace_sha256": "5f804ef621c1cacff2da85962ccccb82a8d7464d2c5d50a9d396d3ee9fc1c700"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/36B/b.json
+++ b/us/.axiom/encoding-manifests/statutes/26/36B/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/36B/b.yaml",
+      "sha256": "bb6401d0e62ca78dfc0fca767db431e2d4c9e9c0ae1e20c991ee78b7455f08dc"
+    },
+    {
+      "path": "statutes/26/36B/b.test.yaml",
+      "sha256": "abeabceef3b28daf12fba40f0c48ba09e51e370e6775640f6cde6943b2c942d6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9b6526505776bc9b4097d41df77dc3ebd6f6a928",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-health-p1-20260619",
+    "version": "0.2.771",
+    "version_commit": "9b6526505776bc9b4097d41df77dc3ebd6f6a928"
+  },
+  "axiom_encode_version": "0.2.771",
+  "backend": "codex",
+  "citation": "26 USC 36B(b)",
+  "context_manifest_file": "/tmp/axiom-aca-36b-b-old-ci-rerun-4-merged-repair/_eval_workspaces/codex-gpt-5.5/26-USC-36B-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "10dd5e7b561b4210c9bdd3a99de92fb70bb51842d221eb794a06ff599bb471f5",
+  "generated_at": "2026-06-19T15:03:43.389840+00:00",
+  "generated_output_file": "/tmp/axiom-aca-36b-b-old-ci-rerun-4-merged-repair/codex-gpt-5.5/statutes/26/36B/b.yaml",
+  "generated_output_root": "/tmp/axiom-aca-36b-b-old-ci-rerun-4-merged-repair",
+  "generated_output_sha256": "bb6401d0e62ca78dfc0fca767db431e2d4c9e9c0ae1e20c991ee78b7455f08dc",
+  "generation_prompt_sha256": null,
+  "model": "gpt-5.5",
+  "run_id": "b60f2fec",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a74381aaa35d340d52829ead3c4e5e0ddf7d81cfcec1492ef077ad7e8b69c422"
+  },
+  "tool": "axiom-encode encode --apply (deterministic repair replay)",
+  "trace_file": "/tmp/axiom-aca-36b-b-old-ci-rerun-4-merged-repair/traces/codex-gpt-5.5/26-USC-36B-b.json",
+  "trace_sha256": "92b8e5bcaccbb84d6a303efe0dae21352774a8ca66d0c3963293f01664155faf"
+}

--- a/us/statutes/26/36B.test.yaml
+++ b/us/statutes/26/36B.test.yaml
@@ -1,0 +1,40 @@
+- name: applicable_taxpayer_income_percentage_within_general_range
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B#input.applicable_taxpayer_household_income_as_ratio_of_poverty_line: 2.5
+    us:statutes/26/36B#input.taxable_year_is_in_temporary_applicable_taxpayer_upper_limit_disregard_period: false
+  output:
+    us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met: holds
+- name: applicable_taxpayer_income_percentage_below_minimum
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B#input.applicable_taxpayer_household_income_as_ratio_of_poverty_line: 0.9
+    us:statutes/26/36B#input.taxable_year_is_in_temporary_applicable_taxpayer_upper_limit_disregard_period: false
+  output:
+    us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met: not_holds
+- name: applicable_taxpayer_income_percentage_above_general_maximum
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B#input.applicable_taxpayer_household_income_as_ratio_of_poverty_line: 4.5
+    us:statutes/26/36B#input.taxable_year_is_in_temporary_applicable_taxpayer_upper_limit_disregard_period: false
+  output:
+    us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met: not_holds
+- name: applicable_taxpayer_temporary_upper_limit_disregarded
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us:statutes/26/36B#input.applicable_taxpayer_household_income_as_ratio_of_poverty_line: 4.5
+    us:statutes/26/36B#input.taxable_year_is_in_temporary_applicable_taxpayer_upper_limit_disregard_period: true
+  output:
+    us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met: holds

--- a/us/statutes/26/36B.yaml
+++ b/us/statutes/26/36B.yaml
@@ -1,0 +1,192 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/36B
+  deferred_outputs:
+  - output: us:statutes/26/36B/b#premium_assistance_credit_amount
+    reason: The annual premium assistance credit amount requires coverage-month aggregation,
+      Exchange-qualified plan enrollment facts, and indexed or temporary applicable-percentage
+      mechanics not fully encoded in this parent source unit.
+    source_values:
+    - us:statutes/26/36B/b#required_contribution_monthly_fraction
+  - output: us:statutes/26/36B/c#applicable_taxpayer
+    reason: The full applicable-taxpayer definition also depends on section 7703 marital
+      status and section 151 deduction-allowable-to-another-taxpayer mechanics; this
+      artifact encodes only the source-stated household-income percentage test.
+    source_values:
+    - us:statutes/26/36B#applicable_taxpayer_minimum_household_income_poverty_line_ratio
+    - us:statutes/26/36B#applicable_taxpayer_maximum_household_income_poverty_line_ratio
+  - output: us:statutes/26/36B/d#household_income
+    reason: Household income and family size require section 151 family-size membership
+      and modified adjusted gross income aggregation across other filing-required
+      individuals.
+  - output: us:statutes/26/36B/e#lawfully_present_adjusted_premium_and_poverty_percentage
+    reason: The rules for individuals not lawfully present require allocating plan
+      premiums to particular covered individuals and applying HHS-prescribed family-size
+      and household-income calculation methods.
+  summary: '(b) The premium assistance amount for a coverage month is the lesser of
+    Exchange qualified health plan monthly premiums and the excess of adjusted monthly
+    premium over 1/12 of the applicable percentage times household income.
+
+    (c)(1) An applicable taxpayer''s household income must equal or exceed 100 percent,
+    and generally not exceed 400 percent, of the poverty line; for taxable years beginning
+    after December 31, 2020 and before January 1, 2026, the upper limit is disregarded.
+
+    (d) Household income, modified adjusted gross income, family size, and poverty
+    line are defined for purposes of this section.
+
+    (e) Premium and poverty-percentage rules are adjusted when section 151 deduction
+    individuals include individuals who are not lawfully present.'
+rules:
+- name: applicable_taxpayer_minimum_household_income_poverty_line_ratio
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(1)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: equals or exceeds 100 percent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '1'
+- name: applicable_taxpayer_maximum_household_income_poverty_line_ratio
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(1)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: does not exceed 400 percent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '4.00'
+- name: employer_sponsored_coverage_affordability_ratio
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(2)(C)(i)(II)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: exceeds 9.5 percent of the applicable taxpayer's household income
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '0.095'
+- name: employer_sponsored_plan_minimum_value_share
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(2)(C)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: less than 60 percent of such costs
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '0.60'
+- name: qualified_small_employer_hra_affordability_ratio
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(4)(C)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: 1/12 of 9.5 percent of the employee's household income
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '0.095'
+- name: qualified_small_employer_hra_permitted_benefit_month_count
+  kind: parameter
+  dtype: Count
+  source: 26 USC 36B(c)(4)(C)(i)(II)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: 1/12 of the employee's permitted benefit
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '12'
+- name: qualified_small_employer_hra_monthly_permitted_benefit_fraction
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 36B(c)(4)(C)(i)(II)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: 1/12 of the employee's permitted benefit
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/36B#qualified_small_employer_hra_permitted_benefit_month_count
+          output: qualified_small_employer_hra_permitted_benefit_month_count
+          hash: sha256:local
+  versions:
+  - effective_from: '2024-01-01'
+    formula: 1 / qualified_small_employer_hra_permitted_benefit_month_count
+- name: applicable_taxpayer_income_percentage_test_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 26 USC 36B(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: household income for the taxable year equals or exceeds 100 percent
+            but does not exceed 400 percent
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: before January 1, 2026, subparagraph (A) shall be applied without
+            regard to "but does not exceed 400 percent"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/36B#applicable_taxpayer_minimum_household_income_poverty_line_ratio
+          output: applicable_taxpayer_minimum_household_income_poverty_line_ratio
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/36B#applicable_taxpayer_maximum_household_income_poverty_line_ratio
+          output: applicable_taxpayer_maximum_household_income_poverty_line_ratio
+          hash: sha256:local
+  versions:
+  - effective_from: '2024-01-01'
+    formula: "applicable_taxpayer_household_income_as_ratio_of_poverty_line >= applicable_taxpayer_minimum_household_income_poverty_line_ratio\n\
+      and (\n    taxable_year_is_in_temporary_applicable_taxpayer_upper_limit_disregard_period\n\
+      \    or applicable_taxpayer_household_income_as_ratio_of_poverty_line <= applicable_taxpayer_maximum_household_income_poverty_line_ratio\n\
+      )"

--- a/us/statutes/26/36B/b.test.yaml
+++ b/us/statutes/26/36B/b.test.yaml
@@ -1,0 +1,42 @@
+- name: monthly_assistance_capped_by_actual_exchange_plan_premiums
+  period: 2026-06
+  input:
+    us:statutes/26/36B/b#input.applicable_percentage_for_taxable_year: 0.02
+    us:statutes/26/36B/b#input.household_income_for_taxable_year: 12000
+    us:statutes/26/36B/b#input.monthly_premiums_for_exchange_qualified_health_plans_covering_taxpayer_spouse_or_dependents: 300
+    us:statutes/26/36B/b#input.adjusted_monthly_premium_for_applicable_second_lowest_cost_silver_plan: 500
+  output:
+    us:statutes/26/36B/b#required_monthly_contribution: 20
+    us:statutes/26/36B/b#premium_assistance_amount: 300
+- name: monthly_assistance_capped_by_benchmark_excess
+  period: 2026-06
+  input:
+    us:statutes/26/36B/b#input.applicable_percentage_for_taxable_year: 0.02
+    us:statutes/26/36B/b#input.household_income_for_taxable_year: 12000
+    us:statutes/26/36B/b#input.monthly_premiums_for_exchange_qualified_health_plans_covering_taxpayer_spouse_or_dependents: 600
+    us:statutes/26/36B/b#input.adjusted_monthly_premium_for_applicable_second_lowest_cost_silver_plan: 500
+  output:
+    us:statutes/26/36B/b#required_monthly_contribution: 20
+    us:statutes/26/36B/b#premium_assistance_amount: 480
+- name: benchmark_excess_floor_prevents_negative_monthly_assistance
+  period: 2026-06
+  input:
+    us:statutes/26/36B/b#input.applicable_percentage_for_taxable_year: 0.02
+    us:statutes/26/36B/b#input.household_income_for_taxable_year: 12000
+    us:statutes/26/36B/b#input.monthly_premiums_for_exchange_qualified_health_plans_covering_taxpayer_spouse_or_dependents: 300
+    us:statutes/26/36B/b#input.adjusted_monthly_premium_for_applicable_second_lowest_cost_silver_plan: 10
+  output:
+    us:statutes/26/36B/b#required_monthly_contribution: 20
+    us:statutes/26/36B/b#premium_assistance_amount: 0
+- name: annual_credit_sums_coverage_month_amounts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/36B/b#relation.coverage_months:
+    - us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month: 300
+    - us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month: 480
+    - us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month: 0
+  output:
+    us:statutes/26/36B/b#premium_assistance_credit_amount: 780

--- a/us/statutes/26/36B/b.yaml
+++ b/us/statutes/26/36B/b.yaml
@@ -1,0 +1,133 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/36B
+  deferred_outputs:
+  - output: us:statutes/26/36B/b/3/A#applicable_percentage
+    reason: The detailed applicable-percentage computation is scoped to subparagraph
+      (3)(A) and requires indexing, the post-2018 additional adjustment and failsafe,
+      and the temporary 2021-through-2025 replacement percentage table. This parent
+      formula uses the source-stated applicable percentage as a boundary input.
+  - output: us:statutes/26/36B/b/3/B#applicable_second_lowest_cost_silver_plan
+    reason: The plan-selection definition depends on rating-area Exchange plan data,
+      section 1(c), section 151 deduction status, and subsection (e) spouse credit
+      denial mechanics that are not available as executable context.
+  - output: us:statutes/26/36B/b/3/C#adjusted_monthly_premium
+    reason: The adjusted monthly premium calculation requires the applicable second
+      lowest cost silver plan, age-rating mechanics under section 2701 of the Public
+      Health Service Act, and wellness-discount treatment under section 2705(d), which
+      are outside the copied executable context.
+  - output: us:statutes/26/36B/b/3/D#additional_benefit_premium_exclusion
+    reason: The exclusion for premiums allocable to additional benefits depends on
+      allocation rules prescribed by the Secretary of Health and Human Services and
+      Patient Protection and Affordable Care Act benefit classifications not available
+      as executable context.
+  - output: us:statutes/26/36B/b/3/E#pediatric_dental_premium_treatment
+    reason: The pediatric dental special rule depends on a plan described in section
+      1311(d)(2)(B)(ii)(I) of the Patient Protection and Affordable Care Act and Secretary-prescribed
+      allocation regulations, neither of which is available as executable context.
+  summary: Paragraph (1) defines the premium assistance credit amount as the sum of
+    premium assistance amounts for all coverage months. Paragraph (2) sets each monthly
+    amount as the lesser of qualified health plan premiums or the benchmark-premium
+    excess over 1/12 of applicable percentage times household income.
+rules:
+- name: coverage_months
+  kind: data_relation
+  source: 26 USC 36B(b)(1)
+  data_relation:
+    predicate: coverage_months
+    arity: 2
+    arguments:
+    - TaxUnit
+    - CoverageMonth
+- name: required_contribution_annual_to_monthly_divisor
+  kind: parameter
+  dtype: Decimal
+  source: 26 USC 36B(b)(2)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: 1/12 of the product
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '12'
+- name: required_monthly_contribution
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 26 USC 36B(b)(2)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: 1/12 of the product
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/36B/b#required_contribution_annual_to_monthly_divisor
+          output: required_contribution_annual_to_monthly_divisor
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: (household_income_for_taxable_year / required_contribution_annual_to_monthly_divisor)
+      * applicable_percentage_for_taxable_year
+- name: premium_assistance_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 26 USC 36B(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: lesser of
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: excess (if any)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/36B/b#required_monthly_contribution
+          output: required_monthly_contribution
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: min(max(0, monthly_premiums_for_exchange_qualified_health_plans_covering_taxpayer_spouse_or_dependents),
+      max(0, adjusted_monthly_premium_for_applicable_second_lowest_cost_silver_plan
+      - required_monthly_contribution))
+- name: premium_assistance_credit_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: paragraph (1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/36B
+          excerpt: sum of the premium assistance amounts
+  versions:
+  - effective_from: '1990-01-01'
+    formula: sum(coverage_months.premium_assistance_amount_determined_for_coverage_month)


### PR DESCRIPTION
## Summary
- adds signed RuleSpec encodings for 26 USC 36B and 36B(b)
- captures ACA premium tax credit income tests, employer/QSEHRA affordability parameters, required contribution fraction, monthly assistance amount, and annual coverage-month aggregation surface
- includes companion tests and encoder apply manifests for generated-file guard coverage

## Gates
- uv run axiom-encode validate --skip-reviewers us/statutes/26/36B.yaml us/statutes/26/36B/b.yaml
- uv run axiom-encode proof-validate us/statutes/26/36B.yaml us/statutes/26/36B/b.yaml
- uv run axiom-encode test --root . us/statutes/26/36B.test.yaml us/statutes/26/36B/b.test.yaml
- uv run axiom-encode guard-generated --repo . --base-ref origin/main --head-ref HEAD