### PR TITLE
Add Georgia CMS effective MAGI limits

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
+++ b/.axiom/encoding-manifests/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
-      "sha256": "6ed3c9fbe408f98cc5388d6bf61f696d81ac62d4fef6cd9afaca4ea58dbe9338"
+      "sha256": "cd740ceee5637d63f2cb76a0012321041dfbfd856b4b29f4c48ed3a29cbf004d"
     },
     {
       "path": "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
-      "sha256": "239e282ec56d034e1c304ec3a8533daba4edff9d3c3241383bd42df9ad5f46c7"
+      "sha256": "806a66cb711fbd158764b858371bf1296e0c1dbfa129711ca53182f73cbb0a36"
     }
   ],
   "axiom_encode_git": {
-    "commit": "2234112b0f43c6024cc7977829961af98e399d2e",
+    "commit": "03900160850bc615beba6ba94d4120b726533a8b",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-fr-11094",
-    "version": "0.2.760",
-    "version_commit": "2234112b0f43c6024cc7977829961af98e399d2e"
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-program-surfaces-20260619",
+    "version": "0.2.776",
+    "version_commit": "99155ab3ce767ad85226caca383dc17b22969c30"
   },
-  "axiom_encode_version": "0.2.760",
+  "axiom_encode_version": "0.2.776",
   "backend": "deterministic",
   "citation": "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-19T01:19:01.692286+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9e0qps4n/deterministic-repair/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9e0qps4n",
-  "generated_output_sha256": "6ed3c9fbe408f98cc5388d6bf61f696d81ac62d4fef6cd9afaca4ea58dbe9338",
+  "generated_at": "2026-06-19T17:36:15.351661+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpuh3fliry/deterministic-repair/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpuh3fliry",
+  "generated_output_sha256": "cd740ceee5637d63f2cb76a0012321041dfbfd856b4b29f4c48ed3a29cbf004d",
   "generation_prompt_sha256": null,
-  "model": "georgia-cms-medicaid-availability-v1",
+  "model": "georgia-cms-effective-magi-limits-v1",
   "run_id": "deterministic-repair",
   "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "e2d8b95c00c736387b8cdc546d2da73765fc55ffb64fb24289939142f62d7cac"
+    "value": "16804562b7b06bbc701176c8097c20ca6945764c2ad11b0ce386abbefeee0b65"
   },
-  "tool": "axiom-encode repair-georgia-cms-medicaid-availability",
+  "tool": "axiom-encode repair-georgia-cms-effective-magi-limits",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
@@ -16,3 +16,8 @@
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_standard_uses_dollar_amounts: true
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_chip_available: false
     us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_adult_medicaid_expansion_available: false
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_effective_fpl_limit: 2.10
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_1_to_5_effective_fpl_limit: 1.54
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_6_to_18_effective_fpl_limit: 1.38
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_separate_chip_effective_fpl_limit: 2.52
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_medicaid_effective_fpl_limit: 2.25

--- a/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
+++ b/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
@@ -204,3 +204,84 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           false
+
+  - name: georgia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          georgia_children_medicaid_ages_0_to_1_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          georgia_children_medicaid_ages_1_to_5_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          georgia_children_medicaid_ages_6_to_18_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_separate_chip_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          georgia_children_separate_chip_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_pregnant_women_medicaid_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          georgia_pregnant_women_medicaid_fpl_limit + magi_fpl_disregard_rate


### PR DESCRIPTION
## Summary
- add derived effective Georgia CMS MAGI FPL limits for child Medicaid, child CHIP, and pregnant Medicaid thresholds
- preserve the raw CMS table values and availability footnotes as separate source-backed outputs
- refresh the signed applied-encoding manifest with axiom-encode 0.2.776 provenance

## Validation
- axiom-encode validate --skip-reviewers us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
- axiom-encode test us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml
- oracle coverage via a temp workspace pointed at this rulespec-us worktree: rulespec-us-ga comparable=5, known_not_comparable=72, untested comparable=0

Generated by merged axiom-encode PR #718.
