### PR TITLE
Add residential clean energy credit source coverage

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.772"
+axiom_encode_version = "0.2.781"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "96cfb00786768d16e41921201691487bb576106c"
+axiom_encode_ref = "672285ac0d844c5916b345c03364a1e7de72a72e"
 axiom_corpus_ref = "2b0a843c13abf03854b9e93da88d77c41a0d38df"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -4,7 +4,7 @@
 [toolchain]
 axiom_encode_version = "0.2.781"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "672285ac0d844c5916b345c03364a1e7de72a72e"
+axiom_encode_ref = "672285ac4727d5dc2468f97908ab3c3bf4c97a2b"
 axiom_corpus_ref = "2b0a843c13abf03854b9e93da88d77c41a0d38df"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/26/25D.json
+++ b/us/.axiom/encoding-manifests/statutes/26/25D.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/25D.yaml",
+      "sha256": "d3a719c9bc673f033b1941fcb0dc5b588c64f92b16ea2e3205b6fe3ee5ed2372"
+    },
+    {
+      "path": "statutes/26/25D.test.yaml",
+      "sha256": "b44052c70d79c6da7f1cd01e9585b3c86419f7ba346952fbb894338b7ddb5e73"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8e0348cce8843cac05a9f66dfcbf132e1660a3bf",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pe-next-20260619",
+    "version": "0.2.780",
+    "version_commit": "8e0348cce8843cac05a9f66dfcbf132e1660a3bf"
+  },
+  "axiom_encode_version": "0.2.780",
+  "backend": "openai",
+  "citation": "26 USC 25D",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.1/26-USC-25D/workspace/context-manifest.json",
+  "context_manifest_sha256": "d6a2cf73ca6f7182747066e482a188c84016e50901ea11abc78d63e8e6caab2b",
+  "generated_at": "2026-06-19T19:12:39.609577+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.1/statutes/26/25D.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d3a719c9bc673f033b1941fcb0dc5b588c64f92b16ea2e3205b6fe3ee5ed2372",
+  "generation_prompt_sha256": "107303d2d6a554535d3d86fdeba74706dda0abc6556c4c91f391ab48692806c8",
+  "model": "gpt-5.1",
+  "run_id": "59fe271a",
+  "runner": "openai-gpt-5.1",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9af58f9302e5ba63ae735b1ba90eab41e9ec59c12936e1918aa5ed4c47bbeadd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.1/26-USC-25D.json",
+  "trace_sha256": "ff756ab353e911b9569f43312aee2652d43322af2870b72389aed20f550aba63"
+}

--- a/us/statutes/26/25D.test.yaml
+++ b/us/statutes/26/25D.test.yaml
@@ -1,0 +1,95 @@
+- name: full_credit_when_potential_below_tax_limit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/25D#input.taxable_year_begins_after_credit_termination_date: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2016_and_before_2020: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2019_and_before_2022: false
+    us:statutes/26/25D#input.total_qualified_solar_electric_property_expenditures: 10000
+    us:statutes/26/25D#input.total_qualified_solar_water_heating_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_fuel_cell_property_expenditures: 0
+    us:statutes/26/25D#input.qualified_fuel_cell_property_capacity_in_half_kilowatt_units: 0
+    us:statutes/26/25D#input.total_qualified_small_wind_energy_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_geothermal_heat_pump_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_battery_storage_technology_expenditures: 0
+    us:statutes/26/25D#input.income_tax_before_refundable_credits_under_section_26_a: 5000
+    us:statutes/26/25D#input.other_nonrefundable_personal_credits_under_this_subpart_except_residential_clean_energy_credit: 1000
+  output:
+    us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage: 0.3
+    us:statutes/26/25D#residential_clean_energy_credit_potential: 3000
+    us:statutes/26/25D#residential_clean_energy_credit_current_year_limit_under_section_25D_c: 4000
+    us:statutes/26/25D#residential_clean_energy_credit: 3000
+    us:statutes/26/25D#residential_clean_energy_credit_carryforward_to_succeeding_taxable_year: 0
+- name: fuel_cell_component_capped_by_per_half_kilowatt_limit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/25D#input.taxable_year_begins_after_credit_termination_date: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2016_and_before_2020: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2019_and_before_2022: false
+    us:statutes/26/25D#input.total_qualified_solar_electric_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_solar_water_heating_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_fuel_cell_property_expenditures: 10000
+    us:statutes/26/25D#input.qualified_fuel_cell_property_capacity_in_half_kilowatt_units: 4
+    us:statutes/26/25D#input.total_qualified_small_wind_energy_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_geothermal_heat_pump_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_battery_storage_technology_expenditures: 0
+    us:statutes/26/25D#input.income_tax_before_refundable_credits_under_section_26_a: 10000
+    us:statutes/26/25D#input.other_nonrefundable_personal_credits_under_this_subpart_except_residential_clean_energy_credit: 0
+  output:
+    us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage: 0.3
+    us:statutes/26/25D#residential_clean_energy_credit_potential: 2000
+    us:statutes/26/25D#residential_clean_energy_credit_current_year_limit_under_section_25D_c: 10000
+    us:statutes/26/25D#residential_clean_energy_credit: 2000
+    us:statutes/26/25D#residential_clean_energy_credit_carryforward_to_succeeding_taxable_year: 0
+- name: section_26_a_limit_binds_with_carryforward
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:statutes/26/25D#input.taxable_year_begins_after_credit_termination_date: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2016_and_before_2020: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2019_and_before_2022: true
+    us:statutes/26/25D#input.total_qualified_solar_electric_property_expenditures: 20000
+    us:statutes/26/25D#input.total_qualified_solar_water_heating_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_fuel_cell_property_expenditures: 0
+    us:statutes/26/25D#input.qualified_fuel_cell_property_capacity_in_half_kilowatt_units: 0
+    us:statutes/26/25D#input.total_qualified_small_wind_energy_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_geothermal_heat_pump_property_expenditures: 0
+    us:statutes/26/25D#input.total_qualified_battery_storage_technology_expenditures: 0
+    us:statutes/26/25D#input.income_tax_before_refundable_credits_under_section_26_a: 4000
+    us:statutes/26/25D#input.other_nonrefundable_personal_credits_under_this_subpart_except_residential_clean_energy_credit: 1000
+  output:
+    us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage: 0.26
+    us:statutes/26/25D#residential_clean_energy_credit_potential: 5200
+    us:statutes/26/25D#residential_clean_energy_credit_current_year_limit_under_section_25D_c: 3000
+    us:statutes/26/25D#residential_clean_energy_credit: 3000
+    us:statutes/26/25D#residential_clean_energy_credit_carryforward_to_succeeding_taxable_year: 2200
+- name: no_credit_for_taxable_years_after_termination_date
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/25D#input.taxable_year_begins_after_credit_termination_date: true
+    us:statutes/26/25D#input.property_placed_in_service_after_2016_and_before_2020: false
+    us:statutes/26/25D#input.property_placed_in_service_after_2019_and_before_2022: false
+    us:statutes/26/25D#input.total_qualified_solar_electric_property_expenditures: 10000
+    us:statutes/26/25D#input.total_qualified_solar_water_heating_property_expenditures: 5000
+    us:statutes/26/25D#input.total_qualified_fuel_cell_property_expenditures: 4000
+    us:statutes/26/25D#input.qualified_fuel_cell_property_capacity_in_half_kilowatt_units: 4
+    us:statutes/26/25D#input.total_qualified_small_wind_energy_property_expenditures: 2000
+    us:statutes/26/25D#input.total_qualified_geothermal_heat_pump_property_expenditures: 3000
+    us:statutes/26/25D#input.total_qualified_battery_storage_technology_expenditures: 1000
+    us:statutes/26/25D#input.income_tax_before_refundable_credits_under_section_26_a: 8000
+    us:statutes/26/25D#input.other_nonrefundable_personal_credits_under_this_subpart_except_residential_clean_energy_credit: 0
+  output:
+    us:statutes/26/25D#residential_clean_energy_credit_potential: 0
+    us:statutes/26/25D#residential_clean_energy_credit_current_year_limit_under_section_25D_c: 0
+    us:statutes/26/25D#residential_clean_energy_credit: 0
+    us:statutes/26/25D#residential_clean_energy_credit_carryforward_to_succeeding_taxable_year: 0

--- a/us/statutes/26/25D.yaml
+++ b/us/statutes/26/25D.yaml
@@ -1,0 +1,267 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/25D
+  summary: 'Section 25D allows an individual a nonrefundable income tax credit equal
+    to
+
+    the applicable percentage of qualified solar electric, solar water heating,
+
+    fuel cell, small wind energy, geothermal heat pump, and battery storage
+
+    technology expenditures made during the taxable year, subject to a per-half-
+
+    kilowatt dollar cap for fuel cells, a general limitation tied to section
+
+    26(a) with carryforward of excess credit, special rules for labor and
+
+    structural components, and termination for expenditures made after
+
+    December 31, 2025. Applicable percentages are 30 percent for property
+
+    placed in service after 2016 and before 2020, 26 percent for property
+
+    placed in service after 2019 and before 2022, and 30 percent for property
+
+    placed in service after 2021.'
+  deferred_outputs:
+  - output: us:statutes/26/25D/d#qualified_residential_clean_energy_expenditures_definition
+    reason: "Subsection 25D(d) defines multiple categories of \u201Cqualified\u201D\
+      \ property expenditures by detailed technology and use conditions. A faithful\
+      \ executable classification would require additional upstream legal and factual\
+      \ structure (for example, property-level energy-source shares and dwelling-use\
+      \ facts) that is not modeled in this slice. This artifact therefore treats the\
+      \ qualified expenditure amounts as boundary inputs and records subsection (d)\
+      \ as a deferred definitional output."
+    source: 26 USC 25D(d)
+rules:
+- name: fuel_cell_credit_per_half_kilowatt_cap_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 25D(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: $500 with respect to each half kilowatt of capacity of the qualified
+            fuel cell property
+  versions:
+  - effective_from: '2017-01-01'
+    formula: '500'
+- name: fuel_cell_joint_occupancy_max_expenditures_per_half_kilowatt
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 25D(e)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: $1,667 in the case of each half kilowatt of capacity of qualified
+            fuel cell property
+  versions:
+  - effective_from: '2017-01-01'
+    formula: '1667'
+- name: residential_clean_energy_credit_applicable_percentage_property_placed_after_2016_and_before_2020
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 25D(g)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: in the case of property placed in service after December 31, 2016,
+            and before January 1, 2020, 30 percent
+  versions:
+  - effective_from: '2017-01-01'
+    formula: '0.30'
+- name: residential_clean_energy_credit_applicable_percentage_property_placed_after_2019_and_before_2022
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 25D(g)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: in the case of property placed in service after December 31, 2019,
+            and before January 1, 2022, 26 percent
+  versions:
+  - effective_from: '2020-01-01'
+    formula: '0.26'
+- name: residential_clean_energy_credit_applicable_percentage_property_placed_after_2021
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 25D(g)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: in the case of property placed in service after December 31, 2021,
+            30 percent
+  versions:
+  - effective_from: '2022-01-01'
+    formula: '0.30'
+- name: residential_clean_energy_credit_applicable_percentage
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  source: 26 USC 25D(g)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: "the applicable percentage shall be\u2014 (1) ... 30 percent, (2)\
+            \ ... 26 percent, and (3) ... 30 percent"
+  versions:
+  - effective_from: '2017-01-01'
+    formula: "if property_placed_in_service_after_2016_and_before_2020:\n    residential_clean_energy_credit_applicable_percentage_property_placed_after_2016_and_before_2020\n\
+      else:\n    if property_placed_in_service_after_2019_and_before_2022:\n     \
+      \   residential_clean_energy_credit_applicable_percentage_property_placed_after_2019_and_before_2022\n\
+      \    else:\n        residential_clean_energy_credit_applicable_percentage_property_placed_after_2021"
+- name: residential_clean_energy_credit_potential
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 25D(a), 26 USC 25D(b)(1), 26 USC 25D(g), 26 USC 25D(h)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: "an amount equal to the sum of the applicable percentages of\u2014\
+            \ (1) the qualified solar electric property expenditures, (2) the qualified\
+            \ solar water heating property expenditures, (3) the qualified fuel cell\
+            \ property expenditures, (4) the qualified small wind energy property\
+            \ expenditures, (5) the qualified geothermal heat pump property expenditures,\
+            \ and (6) the qualified battery storage technology expenditures"
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: shall not exceed $500 with respect to each half kilowatt of capacity
+            of the qualified fuel cell property
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: The credit allowed under this section shall not apply with respect
+            to any expenditures made after December 31, 2025.
+  versions:
+  - effective_from: '2017-01-01'
+    formula: 'if taxable_year_begins_after_credit_termination_date: 0 else: residential_clean_energy_credit_applicable_percentage
+      * ( total_qualified_solar_electric_property_expenditures + total_qualified_solar_water_heating_property_expenditures
+      + total_qualified_small_wind_energy_property_expenditures + total_qualified_geothermal_heat_pump_property_expenditures
+      + total_qualified_battery_storage_technology_expenditures ) + min( residential_clean_energy_credit_applicable_percentage
+      * total_qualified_fuel_cell_property_expenditures, fuel_cell_credit_per_half_kilowatt_cap_amount
+      * qualified_fuel_cell_property_capacity_in_half_kilowatt_units )'
+- name: residential_clean_energy_credit_current_year_limit_under_section_25D_c
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 25D(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: If the credit allowable under subsection (a) exceeds the limitation
+            imposed by section 26(a) for such taxable year reduced by the sum of the
+            credits allowable under this subpart (other than this section), such excess
+            shall be carried to the succeeding taxable year
+  versions:
+  - effective_from: '2017-01-01'
+    formula: 'if taxable_year_begins_after_credit_termination_date: 0 else: max( 0,
+      income_tax_before_refundable_credits_under_section_26_a - other_nonrefundable_personal_credits_under_this_subpart_except_residential_clean_energy_credit
+      )'
+- name: residential_clean_energy_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 25D(a), 26 USC 25D(c), 26 USC 25D(h)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: there shall be allowed as a credit against the tax imposed by this
+            chapter for the taxable year an amount equal to the sum of the applicable
+            percentages of [qualified expenditures]
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: If the credit allowable under subsection (a) exceeds the limitation
+            imposed by section 26(a) ... such excess shall be carried to the succeeding
+            taxable year
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: The credit allowed under this section shall not apply with respect
+            to any expenditures made after December 31, 2025.
+  versions:
+  - effective_from: '2017-01-01'
+    formula: 'if taxable_year_begins_after_credit_termination_date: 0 else: min( residential_clean_energy_credit_potential,
+      residential_clean_energy_credit_current_year_limit_under_section_25D_c )'
+- name: residential_clean_energy_credit_carryforward_to_succeeding_taxable_year
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 25D(c), 26 USC 25D(h)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: such excess shall be carried to the succeeding taxable year and
+            added to the credit allowable under subsection (a) for such succeeding
+            taxable year.
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/25D
+          excerpt: The credit allowed under this section shall not apply with respect
+            to any expenditures made after December 31, 2025.
+  versions:
+  - effective_from: '2017-01-01'
+    formula: 'if taxable_year_begins_after_credit_termination_date: 0 else: max( 0,
+      residential_clean_energy_credit_potential - residential_clean_energy_credit
+      )'


### PR DESCRIPTION
## Summary
- add signed encoder-generated RuleSpec for 26 USC 25D residential clean energy credit
- encode applicable percentages, fuel-cell caps, potential credit, 25D(c) current-year limitation, final credit, and carryforward amount
- include tests for full credit, fuel-cell cap binding, section 26(a) limit binding with carryforward, and post-2025 termination

## PolicyEngine oracle status
- `residential_clean_energy_credit` is marked known-not-comparable because PolicyEngine-US still has the pre-Pub. L. 119-21 2033/2034 phase-down schedule. Filed PolicyEngine/policyengine-us#8694.

## Validation
- `uv run axiom-encode validate --skip-reviewers .../us/statutes/26/25D.yaml`
- `uv run axiom-encode compile .../us/statutes/26/25D.yaml --json`
- `uv run axiom-encode test --root ... .../us/statutes/26/25D.test.yaml --json`
- `uv run axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees --oracle policyengine --program residential_clean_energy_credit --include-program-surfaces --limit 50`