### PR TITLE
Add federal SSI income exclusion rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.786"
+axiom_encode_version = "0.2.789"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "f127c7a47a3f4ea475a5bf75eacc75b5d1054619"
+axiom_encode_ref = "2ae792077c504b85e603074146da4720ec9133a2"
 axiom_corpus_ref = "6f56cfadc6764aa2c3cdaba93e9f4b3cbd37c690"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1382a/b/2.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1382a/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1382a/b/2.yaml",
+      "sha256": "58316f34e146e9a320b2640f7bedf052143911ef8e0bb948f8a50eeb24bd1896"
+    },
+    {
+      "path": "statutes/42/1382a/b/2.test.yaml",
+      "sha256": "1a6466059d58ad9c90d67c909e07bc84109fdb8e598fe6d57d1c94c07b9fe6ac"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "834df05a7e0c0c25e51956ccf393571fd4c7fd76",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ssi-income-oracle-20260620",
+    "version": "0.2.788",
+    "version_commit": "834df05a7e0c0c25e51956ccf393571fd4c7fd76"
+  },
+  "axiom_encode_version": "0.2.788",
+  "backend": "deterministic",
+  "citation": "us:statutes/42/1382a/b/2",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-20T19:13:28.673502+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpgvlxs5as/deterministic-repair/statutes/42/1382a/b/2.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpgvlxs5as",
+  "generated_output_sha256": "58316f34e146e9a320b2640f7bedf052143911ef8e0bb948f8a50eeb24bd1896",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0027e80085d5172c3301ad99cfdb6c90049e837f0100c46c5072c918849e31e4"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/.axiom/encoding-manifests/statutes/42/1382a/b/4.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1382a/b/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1382a/b/4.yaml",
+      "sha256": "f7be94728d6ff64710ccd75de437f4f6ab2d702b8b9ebebc70ed792d9075b81b"
+    },
+    {
+      "path": "statutes/42/1382a/b/4.test.yaml",
+      "sha256": "5bf5088141d894a1dd46e3279deccdb04512012ee138f689394e40b653638b92"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2ae792077c504b85e603074146da4720ec9133a2",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ssi-income-oracle-20260620",
+    "version": "0.2.789",
+    "version_commit": "c6d9d1ac10e085ea2b0bfae6fe77ba437c2969dd"
+  },
+  "axiom_encode_version": "0.2.789",
+  "backend": "deterministic",
+  "citation": "us:statutes/42/1382a/b/4",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-20T19:25:21.807292+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpehy10su2/deterministic-repair/statutes/42/1382a/b/4.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpehy10su2",
+  "generated_output_sha256": "f7be94728d6ff64710ccd75de437f4f6ab2d702b8b9ebebc70ed792d9075b81b",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a4fdfce84012753516004bd590e187da436ff635e466bfd2eb4f709b8d904c6f"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/statutes/42/1382a/b/2.test.yaml
+++ b/us/statutes/42/1382a/b/2.test.yaml
@@ -1,0 +1,62 @@
+- name: annual_general_income_exclusion_capped_at_240
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/42/1382a/b/2#input.annual_income_not_paid_on_basis_of_need: 300
+  output:
+    us:statutes/42/1382a/b/2#annual_general_income_excluded: 240
+- name: annual_general_income_exclusion_uses_lower_non_need_income
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/42/1382a/b/2#input.annual_income_not_paid_on_basis_of_need: 180
+  output:
+    us:statutes/42/1382a/b/2#annual_general_income_excluded: 180
+- name: qualifying_state_age_residency_payment_is_excluded
+  period: 2024-01
+  input:
+    us:statutes/42/1382a/b/2#input.payment_is_monthly_or_other_periodic: true
+    us:statutes/42/1382a/b/2#input.payment_received_by_individual: true
+    us:statutes/42/1382a/b/2#input.program_established_prior_to_july_first_nineteen_seventy_three: true
+    ? us:statutes/42/1382a/b/2#input.program_established_prior_to_july_first_nineteen_seventy_three_and_subsequently_amended_to_conform_to_state_or_federal_constitutional_standards
+    : false
+    us:statutes/42/1382a/b/2#input.payment_made_by_state_of_which_receiving_individual_is_resident: true
+    us:statutes/42/1382a/b/2#input.payment_program_eligibility_not_based_on_need: true
+    us:statutes/42/1382a/b/2#input.payment_program_eligibility_based_solely_on_required_age_and_state_residency: true
+    ? us:statutes/42/1382a/b/2#input.individual_first_became_eligible_individual_or_eligible_spouse_on_or_before_september_thirtieth_nineteen_eighty_five
+    : true
+    ? us:statutes/42/1382a/b/2#input.individual_residency_years_under_program_as_in_effect_prior_to_january_first_nineteen_eighty_three
+    : 25
+  output:
+    us:statutes/42/1382a/b/2#state_age_residency_payment_excluded: holds
+- name: state_age_residency_payment_not_excluded_when_need_based
+  period: 2024-01
+  input:
+    us:statutes/42/1382a/b/2#input.payment_is_monthly_or_other_periodic: true
+    us:statutes/42/1382a/b/2#input.payment_received_by_individual: true
+    us:statutes/42/1382a/b/2#input.program_established_prior_to_july_first_nineteen_seventy_three: true
+    ? us:statutes/42/1382a/b/2#input.program_established_prior_to_july_first_nineteen_seventy_three_and_subsequently_amended_to_conform_to_state_or_federal_constitutional_standards
+    : false
+    us:statutes/42/1382a/b/2#input.payment_made_by_state_of_which_receiving_individual_is_resident: true
+    us:statutes/42/1382a/b/2#input.payment_program_eligibility_not_based_on_need: false
+    us:statutes/42/1382a/b/2#input.payment_program_eligibility_based_solely_on_required_age_and_state_residency: true
+    ? us:statutes/42/1382a/b/2#input.individual_first_became_eligible_individual_or_eligible_spouse_on_or_before_september_thirtieth_nineteen_eighty_five
+    : true
+    ? us:statutes/42/1382a/b/2#input.individual_residency_years_under_program_as_in_effect_prior_to_january_first_nineteen_eighty_three
+    : 25
+  output:
+    us:statutes/42/1382a/b/2#state_age_residency_payment_excluded: not_holds
+- name: oracle_parameter_annual_general_income_exclusion_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/1382a/b/2#annual_general_income_exclusion_limit: 240

--- a/us/statutes/42/1382a/b/2.yaml
+++ b/us/statutes/42/1382a/b/2.yaml
@@ -1,0 +1,151 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1382a/b/2
+  summary: |-
+    Excludes from income "(A) the first $240 per year (or proportionately smaller amounts for shorter periods) of income ... other than income which is paid on the basis of ... need" and "(B) monthly (or other periodic) payments" under certain pre-July 1, 1973 State age/residency programs where, on or before September 30, 1985, the individual first becomes eligible and satisfies the twenty-five-year residency requirement.
+rules:
+  - name: annual_general_income_exclusion_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 42 USC 1382a(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "the first $240 per year"
+          - path: versions[0].formula
+            kind: unit
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "$240 per year"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          240
+
+  - name: default_state_age_payment_age
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1382a(b)(2)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "attainment of age 65 or any other age set by the State"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          65
+
+  - name: state_age_payment_residency_year_requirement
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1382a(b)(2)(B)(iii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "twenty-five-year residency requirement"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          25
+
+  - name: annual_general_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "the first $240 per year ... of income ... other than income which is paid on the basis of ... need"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/2#annual_general_income_exclusion_limit
+              output: annual_general_income_exclusion_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          min(max(0, annual_income_not_paid_on_basis_of_need), annual_general_income_exclusion_limit)
+
+  - name: state_age_residency_payment_excluded
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1382a(b)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "monthly (or other periodic) payments received by any individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "under a program established prior to July 1, 1973"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "or any program established prior to such date but subsequently amended so as to conform"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "payments are made by the State of which the individual ... is a resident"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "eligibility ... is not based on need and is based solely on attainment of age 65 or any other age set by the State and residency"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/2
+              excerpt: "on or before September 30, 1985"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/2#state_age_payment_residency_year_requirement
+              output: state_age_payment_residency_year_requirement
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          payment_is_monthly_or_other_periodic
+          and payment_received_by_individual
+          and (
+            program_established_prior_to_july_first_nineteen_seventy_three
+            or program_established_prior_to_july_first_nineteen_seventy_three_and_subsequently_amended_to_conform_to_state_or_federal_constitutional_standards
+          )
+          and payment_made_by_state_of_which_receiving_individual_is_resident
+          and payment_program_eligibility_not_based_on_need
+          and payment_program_eligibility_based_solely_on_required_age_and_state_residency
+          and individual_first_became_eligible_individual_or_eligible_spouse_on_or_before_september_thirtieth_nineteen_eighty_five
+          and individual_residency_years_under_program_as_in_effect_prior_to_january_first_nineteen_eighty_three >= state_age_payment_residency_year_requirement

--- a/us/statutes/42/1382a/b/4.test.yaml
+++ b/us/statutes/42/1382a/b/4.test.yaml
@@ -1,0 +1,85 @@
+- name: blind_branch_excludes_initial_amount_remainder_expenses_and_pass_other_income
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_blind_branch_status_condition: true
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_disabled_not_blind_branch_status_condition: false
+    ? us:statutes/42/1382a/b/4#input.individual_or_spouse_has_attained_age_sixty_five_and_is_not_included_under_subparagraph_a_or_b
+    : false
+    us:statutes/42/1382a/b/4#input.earned_income_not_excluded_by_preceding_paragraphs: 1780
+    us:statutes/42/1382a/b/4#input.expenses_reasonably_attributable_to_earning_income: 300
+    us:statutes/42/1382a/b/4#input.individual_has_commissioner_approved_plan_for_achieving_self_support: true
+    us:statutes/42/1382a/b/4#input.other_income_amount_necessary_for_fulfillment_of_self_support_plan: 400
+    us:statutes/42/1382a/b/4#input.disability_work_expense_amount_necessary_and_within_commissioner_limits: 200
+  output:
+    us:statutes/42/1382a/b/4#blind_branch_earned_income_excluded: 1280
+    us:statutes/42/1382a/b/4#blind_branch_earning_expenses_excluded: 300
+    us:statutes/42/1382a/b/4#blind_branch_self_support_plan_other_income_excluded: 400
+    us:statutes/42/1382a/b/4#disabled_branch_earned_income_excluded: 0
+    us:statutes/42/1382a/b/4#disabled_branch_self_support_plan_other_income_excluded: 0
+    us:statutes/42/1382a/b/4#age_sixty_five_branch_earned_income_excluded: 0
+- name: disabled_branch_excludes_initial_amount_work_expenses_and_half_remaining
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_blind_branch_status_condition: false
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_disabled_not_blind_branch_status_condition: true
+    ? us:statutes/42/1382a/b/4#input.individual_or_spouse_has_attained_age_sixty_five_and_is_not_included_under_subparagraph_a_or_b
+    : false
+    us:statutes/42/1382a/b/4#input.earned_income_not_excluded_by_preceding_paragraphs: 1780
+    us:statutes/42/1382a/b/4#input.expenses_reasonably_attributable_to_earning_income: 300
+    us:statutes/42/1382a/b/4#input.individual_has_commissioner_approved_plan_for_achieving_self_support: true
+    us:statutes/42/1382a/b/4#input.other_income_amount_necessary_for_fulfillment_of_self_support_plan: 400
+    us:statutes/42/1382a/b/4#input.disability_work_expense_amount_necessary_and_within_commissioner_limits: 200
+  output:
+    us:statutes/42/1382a/b/4#blind_branch_earned_income_excluded: 0
+    us:statutes/42/1382a/b/4#blind_branch_earning_expenses_excluded: 0
+    us:statutes/42/1382a/b/4#blind_branch_self_support_plan_other_income_excluded: 0
+    us:statutes/42/1382a/b/4#disabled_branch_earned_income_excluded: 1380
+    us:statutes/42/1382a/b/4#disabled_branch_self_support_plan_other_income_excluded: 400
+    us:statutes/42/1382a/b/4#age_sixty_five_branch_earned_income_excluded: 0
+- name: age_sixty_five_branch_excludes_initial_amount_and_half_remainder
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_blind_branch_status_condition: false
+    us:statutes/42/1382a/b/4#input.individual_or_spouse_satisfies_disabled_not_blind_branch_status_condition: false
+    ? us:statutes/42/1382a/b/4#input.individual_or_spouse_has_attained_age_sixty_five_and_is_not_included_under_subparagraph_a_or_b
+    : true
+    us:statutes/42/1382a/b/4#input.earned_income_not_excluded_by_preceding_paragraphs: 1780
+    us:statutes/42/1382a/b/4#input.expenses_reasonably_attributable_to_earning_income: 300
+    us:statutes/42/1382a/b/4#input.individual_has_commissioner_approved_plan_for_achieving_self_support: false
+    us:statutes/42/1382a/b/4#input.other_income_amount_necessary_for_fulfillment_of_self_support_plan: 400
+    us:statutes/42/1382a/b/4#input.disability_work_expense_amount_necessary_and_within_commissioner_limits: 200
+  output:
+    us:statutes/42/1382a/b/4#blind_branch_earned_income_excluded: 0
+    us:statutes/42/1382a/b/4#blind_branch_earning_expenses_excluded: 0
+    us:statutes/42/1382a/b/4#blind_branch_self_support_plan_other_income_excluded: 0
+    us:statutes/42/1382a/b/4#disabled_branch_earned_income_excluded: 0
+    us:statutes/42/1382a/b/4#disabled_branch_self_support_plan_other_income_excluded: 0
+    us:statutes/42/1382a/b/4#age_sixty_five_branch_earned_income_excluded: 1280
+- name: oracle_parameter_annual_earned_income_initial_exclusion_limit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit: 780
+- name: oracle_parameter_earned_income_remainder_exclusion_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate: 0.5

--- a/us/statutes/42/1382a/b/4.yaml
+++ b/us/statutes/42/1382a/b/4.yaml
@@ -1,0 +1,254 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1382a/b/4
+  summary: |-
+    Excludes, for blind, disabled-but-not-blind, and certain age-65 individuals or spouses, "the first $780 per year ... of earned income" and, for blind or age-65 branches, "one-half of the remainder"; for disabled-but-not-blind, excludes specified impairment-related work expenses before excluding "one-half" of remaining earned income, and excludes approved self-support plan amounts of other income where stated.
+rules:
+  - name: annual_earned_income_initial_exclusion_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 42 USC 1382a(b)(4)(A)(i), (B)(i), (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "the first $780 per year"
+          - path: versions[0].formula
+            kind: unit
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "$780 per year"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          780
+
+  - name: earned_income_remainder_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1382a(b)(4)(A)(i), (B)(iii), (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "one-half"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1 / 2
+
+  - name: blind_branch_earned_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "if such individual (or such spouse) is blind"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "the first $780 per year ... plus one-half of the remainder"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit
+              output: annual_earned_income_initial_exclusion_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate
+              output: earned_income_remainder_exclusion_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_satisfies_blind_branch_status_condition: min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit) + (earned_income_remainder_exclusion_rate * max(0, earned_income_not_excluded_by_preceding_paragraphs - annual_earned_income_initial_exclusion_limit)) else: 0
+
+  - name: blind_branch_earning_expenses_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "if such individual (or such spouse) is blind"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "an amount equal to any expenses reasonably attributable to the earning of any income"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_satisfies_blind_branch_status_condition: max(0, expenses_reasonably_attributable_to_earning_income) else: 0
+
+  - name: blind_branch_self_support_plan_other_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(A)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "if such individual (or such spouse) is blind"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "has a plan for achieving self-support approved by the Commissioner"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "such additional amounts of other income ... as may be necessary for the fulfillment of such plan"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_satisfies_blind_branch_status_condition and individual_has_commissioner_approved_plan_for_achieving_self_support: max(0, other_income_amount_necessary_for_fulfillment_of_self_support_plan) else: 0
+
+  - name: disabled_branch_earned_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(B)(i)-(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "if such individual (or such spouse) is disabled but not blind"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "the first $780 per year"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "additional amounts of earned income ... necessary to pay the costs"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "one-half of the amount of earned income not excluded after the application of the preceding provisions"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit
+              output: annual_earned_income_initial_exclusion_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate
+              output: earned_income_remainder_exclusion_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_satisfies_disabled_not_blind_branch_status_condition: min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit) + min(max(0, earned_income_not_excluded_by_preceding_paragraphs - min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit)), max(0, disability_work_expense_amount_necessary_and_within_commissioner_limits)) + (earned_income_remainder_exclusion_rate * max(0, earned_income_not_excluded_by_preceding_paragraphs - min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit) - min(max(0, earned_income_not_excluded_by_preceding_paragraphs - min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit)), max(0, disability_work_expense_amount_necessary_and_within_commissioner_limits)))) else: 0
+
+  - name: disabled_branch_self_support_plan_other_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(B)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "if such individual (or such spouse) is disabled but not blind"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "has a plan for achieving self-support approved by the Commissioner"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "such additional amounts of other income ... as may be necessary for the fulfillment of such plan"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_satisfies_disabled_not_blind_branch_status_condition and individual_has_commissioner_approved_plan_for_achieving_self_support: max(0, other_income_amount_necessary_for_fulfillment_of_self_support_plan) else: 0
+
+  - name: age_sixty_five_branch_earned_income_excluded
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382a(b)(4)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "has attained age 65 and is not included under subparagraph (A) or (B)"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382a/b/4
+              excerpt: "the first $780 per year ... plus one-half of the remainder"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit
+              output: annual_earned_income_initial_exclusion_limit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate
+              output: earned_income_remainder_exclusion_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          if individual_or_spouse_has_attained_age_sixty_five_and_is_not_included_under_subparagraph_a_or_b: min(max(0, earned_income_not_excluded_by_preceding_paragraphs), annual_earned_income_initial_exclusion_limit) + (earned_income_remainder_exclusion_rate * max(0, earned_income_not_excluded_by_preceding_paragraphs - annual_earned_income_initial_exclusion_limit)) else: 0


### PR DESCRIPTION
## Summary
- encode 42 USC 1382a(b)(2) general income exclusions and state age/residency payment exclusion predicates
- encode 42 USC 1382a(b)(4) earned-income exclusions, including blind, disabled, and age-65 branches
- add generated companion tests and PolicyEngine oracle parameter tests for the general exclusion amount, earned exclusion amount, and earned remainder rate
- pin RuleSpec validation to axiom-encode 0.2.789 / 2ae792077c504b85e603074146da4720ec9133a2

## Local gates
- axiom-encode validate --skip-reviewers us/statutes/42/1382a/b/2.yaml us/statutes/42/1382a/b/4.yaml
- axiom-encode compile b/2.yaml and b/4.yaml
- axiom-encode test b/2.test.yaml b/4.test.yaml: 2 files, 10 cases
- axiom-encode oracle-coverage --program ssi --fail-on-unmapped --fail-on-untested-comparable: 33 executable outputs, 3 comparable, 30 known-not-comparable, 0 untested comparable
- axiom-encode guard-generated --repo us --base-ref origin/main --head-ref HEAD --json
- uv run --with pytest --with pyyaml python -m pytest tests -q: 12 passed