### PR TITLE
Encode SSI resource limits

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.792"
+axiom_encode_version = "0.2.793"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "fc9de71fd989b10c8fc3c9c8f31d9a5d3b84530c"
+axiom_encode_ref = "a17b33b8c1a6e015537d6a7e1f92c3555b80c985"
 axiom_corpus_ref = "6f56cfadc6764aa2c3cdaba93e9f4b3cbd37c690"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1382/a/3.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1382/a/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1382/a/3.yaml",
+      "sha256": "adcb915790ccca04d6a1fda7a9b54d775625bf33020f35925ba341b55b563e6a"
+    },
+    {
+      "path": "statutes/42/1382/a/3.test.yaml",
+      "sha256": "3bc636403e4ea37ed06d240a9a8651d08edb57ae1a9afcda349a31d2d5c3de18"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fc9de71fd989b10c8fc3c9c8f31d9a5d3b84530c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.792",
+    "version_commit": "fc9de71fd989b10c8fc3c9c8f31d9a5d3b84530c"
+  },
+  "axiom_encode_version": "0.2.792",
+  "backend": "openai",
+  "citation": "us/statute/42/1382/a/3",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-statute-42-1382-a-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "e76d0d8a4182da11bdaafb4ac420268309eeb2a0bf73be197fbb2e6e0c9a74cd",
+  "generated_at": "2026-06-21T13:19:32.754313+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/42/1382/a/3.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "adcb915790ccca04d6a1fda7a9b54d775625bf33020f35925ba341b55b563e6a",
+  "generation_prompt_sha256": "b93b0329a363bdb84dee38d8ac1cd2293bbb89047b560fe4e83ecb2ac83bdda4",
+  "model": "gpt-5.5",
+  "run_id": "16abbb50",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1aec24393ae854f60c333f50dc84a7f3cef9c44190956398e1bcebef25dbcada"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-statute-42-1382-a-3.json",
+  "trace_sha256": "c165d8d756ba665523082372f7a195c52032384ae99ab178050f41352fd5a1ee"
+}

--- a/us/statutes/42/1382/a/3.test.yaml
+++ b/us/statutes/42/1382/a/3.test.yaml
@@ -1,0 +1,18 @@
+- name: resource_limits_prior_to_january_1985
+  period: 1984-12
+  input: {}
+  output:
+    us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit: 2250
+    us:statutes/42/1382/a/3#individual_no_spouse_resource_limit: 1500
+- name: resource_limits_on_january_1985
+  period: 1985-01
+  input: {}
+  output:
+    us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit: 2400
+    us:statutes/42/1382/a/3#individual_no_spouse_resource_limit: 1600
+- name: resource_limits_on_january_1989
+  period: 1989-01
+  input: {}
+  output:
+    us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit: 3000
+    us:statutes/42/1382/a/3#individual_no_spouse_resource_limit: 2000

--- a/us/statutes/42/1382/a/3.yaml
+++ b/us/statutes/42/1382/a/3.yaml
@@ -1,0 +1,236 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1382/a/3
+  summary: |-
+    Paragraph (3) sets the dollar amount referred to in paragraph (1)(B)(i) and paragraph (2)(B) at $2,250 before January 1, 1985, increasing to $3,000 on January 1, 1989; it sets the dollar amount referred to in paragraph (1)(B)(ii) at $1,500 before January 1, 1985, increasing to $2,000 on January 1, 1989.
+rules:
+  - name: resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 42 USC 1382(a)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "shall be $2,250 prior to January 1, 1985"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "prior to January 1, 1985"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "increased to $2,400 on January 1, 1985"
+          - path: versions[1].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1985"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $2,550 on January 1, 1986"
+          - path: versions[2].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1986"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $2,700 on January 1, 1987"
+          - path: versions[3].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1987"
+          - path: versions[4].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $2,850 on January 1, 1988"
+          - path: versions[4].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1988"
+          - path: versions[5].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $3,000 on January 1, 1989"
+          - path: versions[5].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1989"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          2250
+      - effective_from: '1985-01-01'
+        formula: |-
+          2400
+      - effective_from: '1986-01-01'
+        formula: |-
+          2550
+      - effective_from: '1987-01-01'
+        formula: |-
+          2700
+      - effective_from: '1988-01-01'
+        formula: |-
+          2850
+      - effective_from: '1989-01-01'
+        formula: |-
+          3000
+
+  - name: resource_limit_amount_for_paragraph_1_B_ii
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 42 USC 1382(a)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "shall be $1,500 prior to January 1, 1985"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "prior to January 1, 1985"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "increased to $1,600 on January 1, 1985"
+          - path: versions[1].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1985"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $1,700 on January 1, 1986"
+          - path: versions[2].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1986"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $1,800 on January 1, 1987"
+          - path: versions[3].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1987"
+          - path: versions[4].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $1,900 on January 1, 1988"
+          - path: versions[4].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1988"
+          - path: versions[5].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "to $2,000 on January 1, 1989"
+          - path: versions[5].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "on January 1, 1989"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1500
+      - effective_from: '1985-01-01'
+        formula: |-
+          1600
+      - effective_from: '1986-01-01'
+        formula: |-
+          1700
+      - effective_from: '1987-01-01'
+        formula: |-
+          1800
+      - effective_from: '1988-01-01'
+        formula: |-
+          1900
+      - effective_from: '1989-01-01'
+        formula: |-
+          2000
+
+  - name: couple_or_living_with_spouse_resource_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382(a)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "The dollar amount referred to in clause (i) of paragraph (1)(B), and in paragraph (2)(B)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+              output: resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+
+  - name: individual_no_spouse_resource_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382(a)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382/a/3
+              excerpt: "The dollar amount referred to in clause (ii) of paragraph (1)(B)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_ii
+              output: resource_limit_amount_for_paragraph_1_B_ii
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          resource_limit_amount_for_paragraph_1_B_ii


### PR DESCRIPTION
## Summary
- encode the 42 USC 1382(a)(3) SSI resource-limit schedule for individual and couple/living-with-spouse cases
- add companion tests for pre-1985, 1985, and 1989 amounts
- pin rulespec-us validation to axiom-encode 0.2.793, which adds the PE oracle mappings for these outputs

## Verification
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-pe-parity-20260621/us/statutes/42/1382/a/3.yaml --skip-reviewers --json
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-pe-parity-20260621
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-pe-parity-20260621/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-pe-parity-20260621/us/statutes/42/1382/a/3.test.yaml --json
- uv run axiom-encode oracle-coverage --root <single-repo-temp-root> --program ssi --fail-on-unmapped --fail-on-untested-comparable --json