### PR TITLE
Encode SSI 1382f branch amounts

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.793"
+axiom_encode_version = "0.2.794"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "a17b33b8c1a6e015537d6a7e1f92c3555b80c985"
+axiom_encode_ref = "6cbf493dec041d26fdd47c3aaa51a3ed55a516f1"
 axiom_corpus_ref = "6f56cfadc6764aa2c3cdaba93e9f4b3cbd37c690"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1382f/a.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1382f/a.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/42/1382f/a.yaml",
-      "sha256": "4257e4880c17fe2b754af7f3886bb5c9950c9f130330e9f7aaf74d2df7c58c82"
+      "sha256": "502268310fe317b035772003201f91a2006fab334630e90ead5b2cc591433048"
     },
     {
       "path": "statutes/42/1382f/a.test.yaml",
-      "sha256": "935f27b0626a5d58300e22facbca76d6e4cd14c4c5e89edf4b6401d5e64216da"
+      "sha256": "a62f596468b9cae9e65222fe0b67886c811d3d5c9c9f093a2e17db823e3f2681"
     }
   ],
   "axiom_encode_git": {
-    "commit": "ed321585df7eec5b967c8fc8d0767b45c299b117",
+    "commit": "6cbf493dec041d26fdd47c3aaa51a3ed55a516f1",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ssi-20260620",
-    "version": "0.2.785",
-    "version_commit": "935bb5d765f519bf00886f51e852d18851897bc6"
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.794",
+    "version_commit": "6cbf493dec041d26fdd47c3aaa51a3ed55a516f1"
   },
-  "axiom_encode_version": "0.2.785",
-  "backend": "codex",
-  "citation": "us:statutes/42/1382f/a",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-statutes-42-1382f-a/workspace/context-manifest.json",
-  "context_manifest_sha256": "1ea538d551466717ff6c6a38c37a9e2a62f94b362067f3b7a896a738a8edaae5",
-  "generated_at": "2026-06-20T15:50:34.115031+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/42/1382f/a.yaml",
+  "axiom_encode_version": "0.2.794",
+  "backend": "openai",
+  "citation": "us/statute/42/1382f/a",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-statute-42-1382f-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "104bb671da0e55740e38a5d0a2c68303c2538f04bd0e9d17e9c30613e0925236",
+  "generated_at": "2026-06-21T13:53:31.481530+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/42/1382f/a.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "4257e4880c17fe2b754af7f3886bb5c9950c9f130330e9f7aaf74d2df7c58c82",
-  "generation_prompt_sha256": "32e4bd5620a647b98801c3cfa105f70819c1f7aacc70cfde1df0a037047ed808",
+  "generated_output_sha256": "502268310fe317b035772003201f91a2006fab334630e90ead5b2cc591433048",
+  "generation_prompt_sha256": "f68cc5fb023a63e0186d124b2b2157bc126a5754256056a8893b6a69a05f19c7",
   "model": "gpt-5.5",
-  "run_id": "72df6f2c",
-  "runner": "codex-gpt-5.5",
+  "run_id": "89c2bd18",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "d255e038511e1f2ebdba92743f7c21351451ed76f118dcf5fb26977ba16ab6fc"
+    "value": "1aa059100514dd959377443940e48ec96838010ced7aa3e2c14278d9f5a6286b"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-statutes-42-1382f-a.json",
-  "trace_sha256": "24566a3abd61772dc47e6bcaea4a2aaa844cb6bc88edd8785c1807784b9f51f7"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-statute-42-1382f-a.json",
+  "trace_sha256": "403e43fb62ec966f81e490c613fa0003937990e4c6950f86138b8a32df2e1e47"
 }

--- a/us/statutes/42/1382f/a.test.yaml
+++ b/us/statutes/42/1382f/a.test.yaml
@@ -24,16 +24,29 @@
     us:statutes/42/1382f/a#amount_after_paragraph_1_increase: 1200
     us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage: 0.08
     us:statutes/42/1382f/a#amount_after_subsection_a_increase: 1296
-- name: wage_basis_percentage_used_when_cpi_is_not_greater
+- name: branch_specific_section_1382_b_1_amount_uses_own_prior_rounding_inputs
   period: 2026-01
   input:
-    us:statutes/42/1382f/a#input.dollar_amount_in_effect_for_month: 1200
-    us:statutes/42/1382f/a#input.unrounded_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding: 1200
-    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0.07
-    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: true
-    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0.04
+    us:statutes/42/1382f/a#input.section_1382_b_1_dollar_amount_in_effect_for_month: 1200
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_1_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 1207
+    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0.1
+    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: false
+    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0.08
   output:
-    us:statutes/42/1382f/a#prior_rounding_carryover_increase: 0
-    us:statutes/42/1382f/a#amount_after_paragraph_1_increase: 1200
-    us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage: 0.07
-    us:statutes/42/1382f/a#amount_after_subsection_a_increase: 1284
+    us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_1_amount: 7
+    us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage: 0.1
+    us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1: 1320
+- name: branch_specific_section_1382_b_2_amount_uses_wage_basis_cpi_when_greater
+  period: 2026-01
+  input:
+    us:statutes/42/1382f/a#input.section_1382_b_2_dollar_amount_in_effect_for_month: 1200
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_2_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 1190
+    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0.05
+    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: true
+    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0.08
+  output:
+    us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_2_amount: 0
+    us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage: 0.08
+    us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2: 1296

--- a/us/statutes/42/1382f/a.yaml
+++ b/us/statutes/42/1382f/a.yaml
@@ -5,7 +5,7 @@ module:
   source_verification:
     corpus_citation_path: us/statute/42/1382f/a
   summary: |-
-    "Whenever benefit amounts under subchapter II are increased by any percentage effective with any month" the covered dollar amounts are first increased by any prior-rounding excess, then further increased by the applicable subchapter II percentage and "rounded, when not a multiple of $12, to the next lower multiple of $12."
+    Whenever subchapter II benefit amounts are increased effective with a month, each listed SSI dollar amount "shall be increased" by any prior-rounding excess and then "further increased" by the applicable percentage, "rounded, when not a multiple of $12, to the next lower multiple of $12."
 rules:
   - name: annual_rounding_multiple
     kind: parameter
@@ -39,7 +39,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/42/1382f/a
-              excerpt: "the amount which would have been in effect for such month under such subsection but for the rounding ... exceeds ... the amount in effect for such month"
+              excerpt: "the amount which would have been in effect for such month ... but for the rounding ... exceeds ... the amount in effect"
     versions:
       - effective_from: '1975-01-01'
         formula: |-
@@ -104,7 +104,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/statute/42/1382f/a
-              excerpt: "shall be further increased by the same percentage ... and rounded ... to the next lower multiple of $12"
+              excerpt: "shall be further increased ... and rounded ... to the next lower multiple of $12"
           - path: versions[0].formula
             kind: import
             import:
@@ -127,3 +127,119 @@ rules:
       - effective_from: '1975-01-01'
         formula: |-
           floor((amount_after_paragraph_1_increase * (1 + subsection_a_applicable_increase_percentage)) / annual_rounding_multiple) * annual_rounding_multiple
+
+  - name: prior_rounding_carryover_increase_for_section_1382_b_1_amount
+    kind: derived
+    entity: StatutoryDollarAmount
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382f(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382f/a
+              excerpt: "subsections ... (b)(1) ... of section 1382 ... the amount which would have been in effect ... but for the rounding ... exceeds ... the amount in effect"
+    versions:
+      - effective_from: '1975-01-01'
+        formula: |-
+          max(0, unrounded_section_1382_b_1_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding - section_1382_b_1_dollar_amount_in_effect_for_month)
+
+  - name: amount_determined_under_section_1382f_for_section_1382_b_1
+    kind: derived
+    entity: StatutoryDollarAmount
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382f(a)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382f/a
+              excerpt: "subsections ... (b)(1) ... of section 1382 ... shall be further increased ... and rounded ... to the next lower multiple of $12"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_1_amount
+              output: prior_rounding_carryover_increase_for_section_1382_b_1_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage
+              output: subsection_a_applicable_increase_percentage
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#annual_rounding_multiple
+              output: annual_rounding_multiple
+              hash: sha256:local
+    versions:
+      - effective_from: '1975-01-01'
+        formula: |-
+          floor(((section_1382_b_1_dollar_amount_in_effect_for_month + prior_rounding_carryover_increase_for_section_1382_b_1_amount) * (1 + subsection_a_applicable_increase_percentage)) / annual_rounding_multiple) * annual_rounding_multiple
+
+  - name: prior_rounding_carryover_increase_for_section_1382_b_2_amount
+    kind: derived
+    entity: StatutoryDollarAmount
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382f(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382f/a
+              excerpt: "subsections ... (b)(2) of section 1382 ... the amount which would have been in effect ... but for the rounding ... exceeds ... the amount in effect"
+    versions:
+      - effective_from: '1975-01-01'
+        formula: |-
+          max(0, unrounded_section_1382_b_2_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding - section_1382_b_2_dollar_amount_in_effect_for_month)
+
+  - name: amount_determined_under_section_1382f_for_section_1382_b_2
+    kind: derived
+    entity: StatutoryDollarAmount
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 42 USC 1382f(a)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382f/a
+              excerpt: "subsections ... (b)(2) of section 1382 ... shall be further increased ... and rounded ... to the next lower multiple of $12"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_2_amount
+              output: prior_rounding_carryover_increase_for_section_1382_b_2_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage
+              output: subsection_a_applicable_increase_percentage
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#annual_rounding_multiple
+              output: annual_rounding_multiple
+              hash: sha256:local
+    versions:
+      - effective_from: '1975-01-01'
+        formula: |-
+          floor(((section_1382_b_2_dollar_amount_in_effect_for_month + prior_rounding_carryover_increase_for_section_1382_b_2_amount) * (1 + subsection_a_applicable_increase_percentage)) / annual_rounding_multiple) * annual_rounding_multiple


### PR DESCRIPTION
## Summary
- encode branch-specific annual SSI amounts determined under 42 USC 1382f(a) for section 1382(b)(1) and 1382(b)(2)
- add companion tests for individual and couple branch rounding/carryover behavior
- pin rulespec-us to axiom-encode 0.2.794 so the new PE oracle mappings are available

## Local gates
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode validate us/statutes/42/1382f/a.yaml --skip-reviewers --json
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-1382f-branch-amounts-20260621
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-1382f-branch-amounts-20260621/us us/statutes/42/1382f/a.test.yaml --json
- uv run axiom-encode oracle-coverage --program ssi --fail-on-unmapped --fail-on-untested-comparable --json (31 outputs: 7 comparable, 24 known non-comparable, 0 untested comparable)