### PR TITLE
Encode SSI benefit formula

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.794"
+axiom_encode_version = "0.2.795"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "6cbf493dec041d26fdd47c3aaa51a3ed55a516f1"
+axiom_encode_ref = "96bf2d4b9ad01a903a5d8b1b8abdd8b5fe3543dc"
 axiom_corpus_ref = "6f56cfadc6764aa2c3cdaba93e9f4b3cbd37c690"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1382/b.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1382/b.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "statutes/42/1382/b.yaml",
-      "sha256": "b87e60ec4b290013b0a7a8639fecef0b82676f778bce90a78a764de3e7ad881c"
+      "sha256": "ef314bc070041ea2346a9bb22369b8649c9ec4b328863e91c2edfbbd2eb9a63f"
     },
     {
       "path": "statutes/42/1382/b.test.yaml",
-      "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+      "sha256": "d3d198e1edc87e5f9e083445d09a798a0a9e740d175a893edee5fd38c5074330"
     }
   ],
   "axiom_encode_git": {
-    "commit": "ed321585df7eec5b967c8fc8d0767b45c299b117",
+    "commit": "96bf2d4b9ad01a903a5d8b1b8abdd8b5fe3543dc",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ssi-20260620",
-    "version": "0.2.785",
-    "version_commit": "935bb5d765f519bf00886f51e852d18851897bc6"
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.795",
+    "version_commit": "af04f228733346e2c33dc9027d83683bb16a5026"
   },
-  "axiom_encode_version": "0.2.785",
-  "backend": "codex",
-  "citation": "us:statutes/42/1382/b",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-statutes-42-1382-b/workspace/context-manifest.json",
-  "context_manifest_sha256": "fad0d9d1990954cf2f2b0bb9676d23707161053f68066623228566373b00fd73",
-  "generated_at": "2026-06-20T15:38:56.924273+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/42/1382/b.yaml",
+  "axiom_encode_version": "0.2.795",
+  "backend": "openai",
+  "citation": "us/statute/42/1382/b",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-statute-42-1382-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "5a510c6c6ae76308453c411279b794183ddc59e660088f75e4c9cb78c5d7b6f0",
+  "generated_at": "2026-06-21T15:16:24.674970+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/42/1382/b.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "b87e60ec4b290013b0a7a8639fecef0b82676f778bce90a78a764de3e7ad881c",
-  "generation_prompt_sha256": "a78a3d8bf9bb12578d452a204ffd22d08b8ee86849f229e27732bc3cdc5aab4a",
+  "generated_output_sha256": "ef314bc070041ea2346a9bb22369b8649c9ec4b328863e91c2edfbbd2eb9a63f",
+  "generation_prompt_sha256": "1aa03c8079e8dd13d03c55965f07a3642e6a8cbccefc1c65d0bd473d66a6b604",
   "model": "gpt-5.5",
-  "run_id": "99807ee0",
-  "runner": "codex-gpt-5.5",
+  "run_id": "6872ee87",
+  "runner": "openai-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "dd43ac0aed128b628ceab4c0db147b61987bf06723581634cfce1e50537f208e"
+    "value": "36b85bd864eb05c15fd20e2f4add6551cdff362ebe55f7a73c5f21b15806949d"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-statutes-42-1382-b.json",
-  "trace_sha256": "f33d914bd3780e484b690a7ff140a8f0c1d47c89d707db656890885110a35ef3"
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-statute-42-1382-b.json",
+  "trace_sha256": "03c00957623d244375c1064fe82a533f005a1a920ccc7056507fc8121f6bc693"
 }

--- a/us/statutes/42/1382/b.test.yaml
+++ b/us/statutes/42/1382/b.test.yaml
@@ -1,1 +1,63 @@
-[]
+- name: base_rates_apply_when_section_1382f_amounts_are_lower
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/42/1382/b#input.individual_income_not_excluded_pursuant_to_section_1382a_b: 200
+    us:statutes/42/1382/b#input.individual_and_spouse_income_not_excluded_pursuant_to_section_1382a_b: 300
+    us:statutes/42/1382f/a#input.section_1382_b_1_dollar_amount_in_effect_for_month: 1740
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_1_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 1740
+    us:statutes/42/1382f/a#input.section_1382_b_2_dollar_amount_in_effect_for_month: 2616
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_2_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 2616
+    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0
+    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: false
+    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0
+  output:
+    us:statutes/42/1382/b#annual_benefit_without_eligible_spouse: 1552
+    us:statutes/42/1382/b#annual_benefit_with_eligible_spouse: 2328
+- name: section_1382f_amounts_apply_when_greater_than_statutory_base_rates
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/42/1382/b#input.individual_income_not_excluded_pursuant_to_section_1382a_b: 100
+    us:statutes/42/1382/b#input.individual_and_spouse_income_not_excluded_pursuant_to_section_1382a_b: 200
+    us:statutes/42/1382f/a#input.section_1382_b_1_dollar_amount_in_effect_for_month: 1800
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_1_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 1800
+    us:statutes/42/1382f/a#input.section_1382_b_2_dollar_amount_in_effect_for_month: 2700
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_2_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 2700
+    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0
+    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: false
+    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0
+  output:
+    us:statutes/42/1382/b#annual_benefit_without_eligible_spouse: 1700
+    us:statutes/42/1382/b#annual_benefit_with_eligible_spouse: 2500
+- name: income_reduction_cannot_make_payable_benefit_negative
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/42/1382/b#input.individual_income_not_excluded_pursuant_to_section_1382a_b: 3000
+    us:statutes/42/1382/b#input.individual_and_spouse_income_not_excluded_pursuant_to_section_1382a_b: 4000
+    us:statutes/42/1382f/a#input.section_1382_b_1_dollar_amount_in_effect_for_month: 1800
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_1_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 1800
+    us:statutes/42/1382f/a#input.section_1382_b_2_dollar_amount_in_effect_for_month: 2700
+    ? us:statutes/42/1382f/a#input.unrounded_section_1382_b_2_dollar_amount_that_would_have_been_in_effect_for_month_but_for_prior_rounding
+    : 2700
+    us:statutes/42/1382f/a#input.subchapter_ii_benefit_increase_percentage_for_month: 0
+    us:statutes/42/1382f/a#input.subchapter_ii_increase_was_determined_on_wage_increase_percentage: false
+    us:statutes/42/1382f/a#input.cpi_basis_subchapter_ii_increase_percentage_for_month: 0
+  output:
+    us:statutes/42/1382/b#annual_benefit_without_eligible_spouse: 0
+    us:statutes/42/1382/b#annual_benefit_with_eligible_spouse: 0

--- a/us/statutes/42/1382/b.yaml
+++ b/us/statutes/42/1382/b.yaml
@@ -1,22 +1,14 @@
 format: rulespec/v1
+imports:
+  - us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1
+  - us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2
 module:
   proof_validation:
     required: true
   source_verification:
     corpus_citation_path: us/statute/42/1382/b
   summary: |-
-    The no-eligible-spouse branch uses a "rate of $1,752" and the eligible-spouse branch uses a "rate of $2,628"; each applies for "the calendar year 1974 and any calendar year thereafter," subject to the greater section 1382f amount and reduction by income not excluded under section 1382a(b).
-  deferred_outputs:
-    - output: us:statutes/42/1382/b#annual_benefit_without_eligible_spouse
-      reason: |-
-        The final payable benefit for an individual without an eligible spouse requires comparing the $1,752 statutory base with the amount determined under section 1382f and reducing the greater rate by income not excluded under section 1382a(b). Those cross-referenced determinations are not available as executable RuleSpec imports in the copied context.
-      source_values:
-        - us:statutes/42/1382/b#statutory_base_annual_rate_without_eligible_spouse
-    - output: us:statutes/42/1382/b#annual_benefit_with_eligible_spouse
-      reason: |-
-        The final payable benefit for an individual with an eligible spouse requires comparing the $2,628 statutory base with the amount determined under section 1382f and reducing the greater rate by income not excluded under section 1382a(b) for the individual and spouse. Those cross-referenced determinations are not available as executable RuleSpec imports in the copied context.
-      source_values:
-        - us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse
+    Benefit for an individual without an eligible spouse is payable at "$1,752 (or, if greater, the amount determined under section 1382f)" reduced by the individual's non-excluded income; with an eligible spouse, "$2,628 (or, if greater, the amount determined under section 1382f)" reduced by the non-excluded income of the individual and spouse.
 rules:
   - name: statutory_base_annual_rate_without_eligible_spouse
     kind: parameter
@@ -63,3 +55,67 @@ rules:
       - effective_from: '1974-01-01'
         formula: |-
           2628
+
+  - name: annual_benefit_without_eligible_spouse
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382/b
+              excerpt: "reduced by the amount of income, not excluded pursuant to section 1382a(b)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382/b#statutory_base_annual_rate_without_eligible_spouse
+              output: statutory_base_annual_rate_without_eligible_spouse
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1
+              output: amount_determined_under_section_1382f_for_section_1382_b_1
+              hash: sha256:502268310fe317b035772003201f91a2006fab334630e90ead5b2cc591433048
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          max(0, max(statutory_base_annual_rate_without_eligible_spouse, amount_determined_under_section_1382f_for_section_1382_b_1) - individual_income_not_excluded_pursuant_to_section_1382a_b)
+
+  - name: annual_benefit_with_eligible_spouse
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 42 USC 1382(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1382/b
+              excerpt: "reduced by the amount of income, not excluded pursuant to section 1382a(b), of such individual and spouse"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse
+              output: statutory_base_annual_rate_with_eligible_spouse
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2
+              output: amount_determined_under_section_1382f_for_section_1382_b_2
+              hash: sha256:502268310fe317b035772003201f91a2006fab334630e90ead5b2cc591433048
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          max(0, max(statutory_base_annual_rate_with_eligible_spouse, amount_determined_under_section_1382f_for_section_1382_b_2) - individual_and_spouse_income_not_excluded_pursuant_to_section_1382a_b)


### PR DESCRIPTION
## Summary
- encode 42 USC 1382(b) annual SSI benefit formulas for individual and eligible-spouse branches
- add generated companion tests for base rates, section 1382f amounts, and income floor behavior
- update rulespec-us toolchain to axiom-encode 0.2.795 so the new PE oracle classifications cover the generated outputs

## Tests
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-benefit-retry-20260621/us/statutes/42/1382/b.yaml --skip-reviewers --json`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-benefit-retry-20260621`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-benefit-retry-20260621/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ssi-benefit-retry-20260621/us/statutes/42/1382/b.test.yaml --json`
- `uv run axiom-encode oracle-coverage --root <tmp-root-with-rulespec-us-symlink> --program ssi --fail-on-unmapped --fail-on-untested-comparable --json`

Oracle coverage result: 33 SSI outputs, 7 comparable, 26 known not comparable, 0 unmapped, 0 untested comparable.