### PR TITLE
Add NY TANF program composition

### DIFF
--- a/programs/us-ny/tanf/fy-2026.yaml
+++ b/programs/us-ny/tanf/fy-2026.yaml
@@ -1,0 +1,54 @@
+# New York TANF -- FY 2026
+#
+# This program spec composes the NY State Plan rules already encoded under
+# us-ny/policies/otda/tanf-state-plan-2024-2026. Shelter schedules with
+# county-by-family-size caps are still deferred in the source modules, so the
+# top-level amount is acknowledged as incomplete until that table shape is
+# executable.
+
+program: us-ny/tanf
+period: 2026-01
+
+outputs:
+  - ny_tanf_grant_standard
+  - ny_tanf_countable_income
+  - ny_tanf
+
+acknowledged_incomplete:
+  - ny_tanf
+
+scope:
+  state:
+    - policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant
+    - policies/otda/tanf-state-plan-2024-2026/financial-eligibility-and-income-disregards
+
+transformations:
+  - pattern: derived_formula
+    name: ny_tanf_grant_standard
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ny/tanf/fy-2026 grant-standard composition
+    formula: monthly_grant_and_allowance_with_home_energy + monthly_rent_allowance_with_children
+
+  - pattern: derived_formula
+    name: ny_tanf_countable_income
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ny/tanf/fy-2026 income composition
+    formula: max(0, earned_income + unearned_income - regular_earned_income_disregarded_amount)
+
+  - pattern: derived_formula
+    name: ny_tanf
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ny/tanf/fy-2026 amount composition
+    formula: max(0, ny_tanf_grant_standard - ny_tanf_countable_income)


### PR DESCRIPTION
## Summary
- add a FY 2026 NY TANF declarative program spec under programs/us-ny/tanf
- compose tested State Plan standard-of-need, grant, shelter-cap, asset, and income-disregard slices into PE-shaped TANF amount outputs
- mark the top-level ny_tanf output acknowledged incomplete because shelter schedules are still partially deferred

## Validation
- uv run --with pytest --with pyyaml pytest tests/test_repository_layout.py tests/test_program_specs.py
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ny-tanf-program-20260622 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ny-tanf-program-20260622/us-ny/policies/otda/tanf-state-plan-2024-2026
- axiom-compose emitted the program from rulespec-us monorepo after the compose loader fix
- axiom-rules-engine compiled and ran a sample household: ny_tanf_grant_standard=639, ny_tanf_countable_income=430, ny_tanf=209