### PR TITLE
Encode Medicare eligibility thresholds

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.795"
+axiom_encode_version = "0.2.798"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "96bf2d4b9ad01a903a5d8b1b8abdd8b5fe3543dc"
-axiom_corpus_ref = "6f56cfadc6764aa2c3cdaba93e9f4b3cbd37c690"
+axiom_encode_ref = "a0f79da796dfc347761ec51f22db6863e5272b01"
+axiom_corpus_ref = "082c845023f09c1aa17ef04f397c21e16f2a7213"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "98984a5b35ab424ba9910a121e7554168290d779"

--- a/us/.axiom/encoding-manifests/statutes/42/426/a/1.json
+++ b/us/.axiom/encoding-manifests/statutes/42/426/a/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/426/a/1.yaml",
+      "sha256": "2af89360acacfd1b386436af06a134225d36a1987ecf7e64bad1c1b9d761b624"
+    },
+    {
+      "path": "statutes/42/426/a/1.test.yaml",
+      "sha256": "78417191592851d46a95d2e08765f1736f4be60dfd7689f7b2ed9930f9b78249"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicare-mappings-20260623",
+    "version": "0.2.798",
+    "version_commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152"
+  },
+  "axiom_encode_version": "0.2.798",
+  "backend": "deterministic",
+  "citation": "us:statutes/42/426/a/1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-23T16:24:43.217856+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsa7hna4c/deterministic-repair/statutes/42/426/a/1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsa7hna4c",
+  "generated_output_sha256": "2af89360acacfd1b386436af06a134225d36a1987ecf7e64bad1c1b9d761b624",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "479c118732e3b129f1c8a923387ed94635366615926da986502c84032060e179"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/.axiom/encoding-manifests/statutes/42/426/b/1.json
+++ b/us/.axiom/encoding-manifests/statutes/42/426/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/426/b/1.yaml",
+      "sha256": "7dde629facacc6753d2e2bf5b644131b43ff9410911c015f82515c8256e43ca8"
+    },
+    {
+      "path": "statutes/42/426/b/1.test.yaml",
+      "sha256": "5e043202ad343786d6221e3b046b5ca58cc609661118509945f9edd3c0cdb6ca"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicare-mappings-20260623",
+    "version": "0.2.798",
+    "version_commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152"
+  },
+  "axiom_encode_version": "0.2.798",
+  "backend": "deterministic",
+  "citation": "us:statutes/42/426/b/1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-23T16:24:43.299428+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpt2k__8_l/deterministic-repair/statutes/42/426/b/1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpt2k__8_l",
+  "generated_output_sha256": "7dde629facacc6753d2e2bf5b644131b43ff9410911c015f82515c8256e43ca8",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "643cd7b7489d7725a8be194053d18e509ebcee76c74d999ecb83488b168902e5"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/.axiom/encoding-manifests/statutes/42/426/b/2.json
+++ b/us/.axiom/encoding-manifests/statutes/42/426/b/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/426/b/2.yaml",
+      "sha256": "833ffdf6d0aab3bb7c1ba53dd325d3edf7a10ed72d56e3922de36b1b544cd3f5"
+    },
+    {
+      "path": "statutes/42/426/b/2.test.yaml",
+      "sha256": "e596322219e0d431d452f8d83187373be90b069d1b0250ecfd1a9f9ace4c7db6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicare-mappings-20260623",
+    "version": "0.2.798",
+    "version_commit": "59d9bc74d958d82dd20f5a34f8f03575b21b7152"
+  },
+  "axiom_encode_version": "0.2.798",
+  "backend": "deterministic",
+  "citation": "us:statutes/42/426/b/2",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-23T16:24:43.642991+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpr1f7eerb/deterministic-repair/statutes/42/426/b/2.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpr1f7eerb",
+  "generated_output_sha256": "833ffdf6d0aab3bb7c1ba53dd325d3edf7a10ed72d56e3922de36b1b544cd3f5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "29add03308f277abf1f153cad910dc75cc7cfe158bb88c697513db47f4a42396"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/statutes/42/426/a/1.test.yaml
+++ b/us/statutes/42/426/a/1.test.yaml
@@ -1,0 +1,20 @@
+- name: attained_age_65_requirement_holds
+  period: 2024-01
+  input:
+    us:statutes/42/426/a/1#input.age: 65
+  output:
+    us:statutes/42/426/a/1#attained_age_65_requirement_satisfied: holds
+- name: attained_age_65_requirement_not_met
+  period: 2024-01
+  input:
+    us:statutes/42/426/a/1#input.age: 64
+  output:
+    us:statutes/42/426/a/1#attained_age_65_requirement_satisfied: not_holds
+- name: oracle_parameter_attained_age_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/426/a/1#attained_age_threshold: 65

--- a/us/statutes/42/426/a/1.yaml
+++ b/us/statutes/42/426/a/1.yaml
@@ -1,0 +1,44 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/426/a/1
+  summary: |-
+    has attained age 65, and
+rules:
+  - name: attained_age_threshold
+    kind: parameter
+    dtype: Count
+    source: 42 USC 426(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/a/1
+              excerpt: "age 65"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          65
+
+  - name: attained_age_65_requirement_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 426(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/a/1
+              excerpt: "has attained age 65"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          age >= attained_age_threshold

--- a/us/statutes/42/426/b/1.test.yaml
+++ b/us/statutes/42/426/b/1.test.yaml
@@ -1,0 +1,20 @@
+- name: person_under_age_threshold_satisfies_limb
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/1#input.age: 64
+  output:
+    us:statutes/42/426/b/1#person_has_not_attained_age_threshold: holds
+- name: person_at_age_threshold_does_not_satisfy_limb
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/1#input.age: 65
+  output:
+    us:statutes/42/426/b/1#person_has_not_attained_age_threshold: not_holds
+- name: oracle_parameter_age_attainment_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/426/b/1#age_attainment_threshold: 65

--- a/us/statutes/42/426/b/1.yaml
+++ b/us/statutes/42/426/b/1.yaml
@@ -1,0 +1,44 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/426/b/1
+  summary: |-
+    has not attained age 65, and
+rules:
+  - name: age_attainment_threshold
+    kind: parameter
+    dtype: Integer
+    source: 42 U.S.C. 426(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/b/1
+              excerpt: age 65
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          65
+
+  - name: person_has_not_attained_age_threshold
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 U.S.C. 426(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/b/1
+              excerpt: has not attained age 65
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          age < age_attainment_threshold

--- a/us/statutes/42/426/b/2.test.yaml
+++ b/us/statutes/42/426/b/2.test.yaml
@@ -1,0 +1,104 @@
+- name: disability insurance entitlement path satisfies paragraph condition
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/2#input.entitled_to_disability_insurance_benefits_under_section_423: true
+    ? us:statutes/42/426/b/2#input.entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d
+    : false
+    ? us:statutes/42/426/b/2#input.entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d
+    : false
+    us:statutes/42/426/b/2#input.calendar_months_entitled_to_specified_disability_related_benefits: 24
+    us:statutes/42/426/b/2#input.disabled_qualified_railroad_retirement_beneficiary_within_meaning_of_section_231f_d: false
+    us:statutes/42/426/b/2#input.months_as_disabled_qualified_railroad_retirement_beneficiary: 0
+    ? us:statutes/42/426/b/2#input.filed_application_for_hospital_insurance_benefits_under_part_a_in_conformity_with_secretary_regulations
+    : false
+    us:statutes/42/426/b/2#input.counterfactual_disability_criteria_including_reviews_applied_under_this_subchapter_satisfied: false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_disability_insurance_benefits_under_section_423_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactual_months_entitled_to_specified_disability_related_benefits_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : 0
+  output:
+    us:statutes/42/426/b/2#part_a_disability_or_railroad_condition_satisfied: holds
+- name: railroad retirement beneficiary path satisfies paragraph condition
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/2#input.entitled_to_disability_insurance_benefits_under_section_423: false
+    ? us:statutes/42/426/b/2#input.entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d
+    : false
+    ? us:statutes/42/426/b/2#input.entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d
+    : false
+    us:statutes/42/426/b/2#input.calendar_months_entitled_to_specified_disability_related_benefits: 0
+    us:statutes/42/426/b/2#input.disabled_qualified_railroad_retirement_beneficiary_within_meaning_of_section_231f_d: true
+    us:statutes/42/426/b/2#input.months_as_disabled_qualified_railroad_retirement_beneficiary: 24
+    ? us:statutes/42/426/b/2#input.filed_application_for_hospital_insurance_benefits_under_part_a_in_conformity_with_secretary_regulations
+    : false
+    us:statutes/42/426/b/2#input.counterfactual_disability_criteria_including_reviews_applied_under_this_subchapter_satisfied: false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_disability_insurance_benefits_under_section_423_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactual_months_entitled_to_specified_disability_related_benefits_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : 0
+  output:
+    us:statutes/42/426/b/2#part_a_disability_or_railroad_condition_satisfied: holds
+- name: government employment application path satisfies paragraph condition
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/2#input.entitled_to_disability_insurance_benefits_under_section_423: false
+    ? us:statutes/42/426/b/2#input.entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d
+    : false
+    ? us:statutes/42/426/b/2#input.entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d
+    : false
+    us:statutes/42/426/b/2#input.calendar_months_entitled_to_specified_disability_related_benefits: 0
+    us:statutes/42/426/b/2#input.disabled_qualified_railroad_retirement_beneficiary_within_meaning_of_section_231f_d: false
+    us:statutes/42/426/b/2#input.months_as_disabled_qualified_railroad_retirement_beneficiary: 0
+    ? us:statutes/42/426/b/2#input.filed_application_for_hospital_insurance_benefits_under_part_a_in_conformity_with_secretary_regulations
+    : true
+    us:statutes/42/426/b/2#input.counterfactual_disability_criteria_including_reviews_applied_under_this_subchapter_satisfied: true
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_disability_insurance_benefits_under_section_423_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : true
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactual_months_entitled_to_specified_disability_related_benefits_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : 24
+  output:
+    us:statutes/42/426/b/2#part_a_disability_or_railroad_condition_satisfied: holds
+- name: no path satisfies paragraph condition below duration thresholds
+  period: 2024-01
+  input:
+    us:statutes/42/426/b/2#input.entitled_to_disability_insurance_benefits_under_section_423: true
+    ? us:statutes/42/426/b/2#input.entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d
+    : false
+    ? us:statutes/42/426/b/2#input.entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d
+    : false
+    us:statutes/42/426/b/2#input.calendar_months_entitled_to_specified_disability_related_benefits: 23
+    us:statutes/42/426/b/2#input.disabled_qualified_railroad_retirement_beneficiary_within_meaning_of_section_231f_d: true
+    us:statutes/42/426/b/2#input.months_as_disabled_qualified_railroad_retirement_beneficiary: 23
+    ? us:statutes/42/426/b/2#input.filed_application_for_hospital_insurance_benefits_under_part_a_in_conformity_with_secretary_regulations
+    : true
+    us:statutes/42/426/b/2#input.counterfactual_disability_criteria_including_reviews_applied_under_this_subchapter_satisfied: true
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_disability_insurance_benefits_under_section_423_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : true
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactually_entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : false
+    ? us:statutes/42/426/b/2#input.counterfactual_months_entitled_to_specified_disability_related_benefits_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+    : 23
+  output:
+    us:statutes/42/426/b/2#part_a_disability_or_railroad_condition_satisfied: not_holds
+- name: oracle_parameter_disability_related_benefit_entitlement_calendar_month_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/42/426/b/2#disability_related_benefit_entitlement_calendar_month_threshold: 24

--- a/us/statutes/42/426/b/2.yaml
+++ b/us/statutes/42/426/b/2.yaml
@@ -1,0 +1,111 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/426/b/2
+  summary: |-
+    (A) is entitled to, and has for 24 calendar months been entitled to ... disability-related benefits, or (B) is, and has been for not less than 24 months, a disabled qualified railroad retirement beneficiary, or (C) has filed an application ... and would meet the requirements of subparagraph (A) ... if ...
+rules:
+  - name: disability_related_benefit_entitlement_calendar_month_threshold
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 426(b)(2)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "has for 24 calendar months been entitled to"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          24
+
+  - name: disabled_qualified_railroad_retirement_beneficiary_month_threshold
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 426(b)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "has been for not less than 24 months"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          24
+
+  - name: government_employment_specified_benefit_entitlement_month_threshold
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 426(b)(2)(C)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "including the requirement that he has been entitled to the specified benefits for 24 months"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          24
+
+  - name: part_a_disability_or_railroad_condition_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 U.S.C. 426(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "(A) is entitled to, and has for 24 calendar months been entitled to"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "(B) is, and has been for not less than 24 months, a disabled qualified railroad retirement beneficiary"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/b/2
+              excerpt: "(C) (i) has filed an application ... and (ii) would meet the requirements of subparagraph (A)"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          (
+            (
+              (
+                entitled_to_disability_insurance_benefits_under_section_423
+                or entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d
+                or entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d
+              )
+              and calendar_months_entitled_to_specified_disability_related_benefits >= disability_related_benefit_entitlement_calendar_month_threshold
+            )
+            or (
+              disabled_qualified_railroad_retirement_beneficiary_within_meaning_of_section_231f_d
+              and months_as_disabled_qualified_railroad_retirement_beneficiary >= disabled_qualified_railroad_retirement_beneficiary_month_threshold
+            )
+            or (
+              filed_application_for_hospital_insurance_benefits_under_part_a_in_conformity_with_secretary_regulations
+              and counterfactual_disability_criteria_including_reviews_applied_under_this_subchapter_satisfied
+              and (
+                counterfactually_entitled_to_disability_insurance_benefits_under_section_423_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+                or counterfactually_entitled_to_childs_insurance_benefits_under_section_402_d_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+                or counterfactually_entitled_to_widows_or_widowers_insurance_benefits_under_section_402_e_or_402_f_by_reason_of_disability_defined_in_section_423_d_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing
+              )
+              and counterfactual_months_entitled_to_specified_disability_related_benefits_if_medicare_qualified_government_employment_treated_as_employment_and_application_deemed_disability_benefits_filing >= government_employment_specified_benefit_entitlement_month_threshold
+            )
+          )


### PR DESCRIPTION
## Summary
- encode 42 USC 426(a)(1), 426(b)(1), and 426(b)(2) Medicare hospital insurance eligibility limbs
- add signed encoder manifests and companion tests for age, disability-benefit duration, Railroad Retirement, and government-employment counterfactual paths
- leaves the broader section composition for a follow-up because the whole-section apply path still needs encoder harness cleanup

## Dependencies
- Corpus source rows: TheAxiomFoundation/axiom-corpus#118
- PolicyEngine oracle coverage mapping: TheAxiomFoundation/axiom-encode#743

## Validation
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicare-eligibility-20260623/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicare-eligibility-20260623/us/statutes/42/426
- uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicare-eligibility-20260623/us/statutes/42/426/a/1.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicare-eligibility-20260623/us/statutes/42/426/b/1.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicare-eligibility-20260623/us/statutes/42/426/b/2.yaml
- uv run axiom-encode oracle-coverage --root /tmp/axiom-medicare-coverage-root --oracle policyengine --program medicare --include-program-surfaces --fail-on-untested-comparable --limit 50