### PR TITLE
Encode federal Lifeline rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.798"
+axiom_encode_version = "0.2.799"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "a0f79da796dfc347761ec51f22db6863e5272b01"
-axiom_corpus_ref = "082c845023f09c1aa17ef04f397c21e16f2a7213"
+axiom_encode_ref = "21c150207547fd966c773c3515b00d37af38a03e"
+axiom_corpus_ref = "05fc2973265971abe77b68374ed24fac133088ba"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "98984a5b35ab424ba9910a121e7554168290d779"

--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/403.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/403.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/403.yaml",
+      "sha256": "32ac24918104018755c5155cc5d6c9ba40c1a5eb2ad76cdae23eb7da828ce324"
+    },
+    {
+      "path": "regulations/47-cfr/54/403.test.yaml",
+      "sha256": "bbfc5d44fa04c4d109ba32ff6f7cb12f26cd1676f807f733ba34630ffe168665"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0be35aab7517fa49cb93655a5fc59526ef42991e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-lifeline-mappings-20260623",
+    "version": "0.2.799",
+    "version_commit": "0be35aab7517fa49cb93655a5fc59526ef42991e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "deterministic",
+  "citation": "us:regulations/47-cfr/54/403",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-23T18:46:23.600656+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpxe420i0c/deterministic-repair/regulations/47-cfr/54/403.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpxe420i0c",
+  "generated_output_sha256": "32ac24918104018755c5155cc5d6c9ba40c1a5eb2ad76cdae23eb7da828ce324",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d378c658e6f09b12a039ffae954ee261316b0956e8338767395fc90816cb4e71"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/409.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/409.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/409.yaml",
+      "sha256": "13bf7e7f13149046456b5a8643b77709136dd20a9047f214b5c1e27eb37a016f"
+    },
+    {
+      "path": "regulations/47-cfr/54/409.test.yaml",
+      "sha256": "6bd29f36a708e0838025702aa8cc67a7f1cdc0308a8681959b36618091d18ad6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "0be35aab7517fa49cb93655a5fc59526ef42991e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-lifeline-mappings-20260623",
+    "version": "0.2.799",
+    "version_commit": "0be35aab7517fa49cb93655a5fc59526ef42991e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "deterministic",
+  "citation": "us:regulations/47-cfr/54/409",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-23T18:46:23.492885+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpf8yo0tkp/deterministic-repair/regulations/47-cfr/54/409.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpf8yo0tkp",
+  "generated_output_sha256": "13bf7e7f13149046456b5a8643b77709136dd20a9047f214b5c1e27eb37a016f",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3e906a83b0d95c21b1ffd5b7319f4747b799487ce26ce3350f81fa684d37f7c6"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/regulations/47-cfr/54/403.test.yaml
+++ b/us/regulations/47-cfr/54/403.test.yaml
@@ -1,0 +1,180 @@
+- name: basic_lifeline_support_with_tribal_additional_support
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: true
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: true
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : false
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: false
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: true
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : true
+  output:
+    us:regulations/47-cfr/54/403#federal_lifeline_support_amount: 34.25
+- name: standalone_voice_after_phaseout_only_provider_retains_support
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: true
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: true
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : true
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: true
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : false
+  output:
+    us:regulations/47-cfr/54/403#federal_lifeline_support_amount: 5.25
+- name: emergency_communications_support_with_tribal_support
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/403#input.carrier_provides_service_to_qualifying_survivor: true
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_support_pass_through_to_qualifying_survivor: true
+    ? us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_emergency_rate_reduction
+    : true
+    us:regulations/47-cfr/54/403#input.survivor_service_meets_minimum_service_standard_for_voice_or_broadband: true
+    ? us:regulations/47-cfr/54/403#input.carrier_provides_emergency_communications_support_to_eligible_survivor_resident_of_tribal_lands
+    : true
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_tribal_lands_support_pass_through_to_eligible_survivor_resident_of_tribal_lands
+    : true
+  output:
+    us:regulations/47-cfr/54/403#emergency_communications_support_amount: 34.25
+- name: discount_application_for_other_carrier
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/403#input.carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges: false
+    ? us:regulations/47-cfr/54/403#input.carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_offers_generally_available_residential_service_plan_or_package_with_at_least_one_service_commensurate_with_section_54_408
+    : true
+    us:regulations/47-cfr/54/403#input.additional_federal_support_amount: 2
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: true
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: true
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : false
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: false
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : false
+  output:
+    us:regulations/47-cfr/54/403#federal_end_user_common_line_charges_must_be_waived: not_holds
+    us:regulations/47-cfr/54/403#residential_service_plan_lifeline_discount_amount: 11.25
+- name: auto_zero_federal_lifeline_support_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/403#input.additional_federal_support_amount: 0
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_support_pass_through_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_tribal_lands_support_pass_through_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges: false
+    ? us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_emergency_rate_reduction
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: false
+    ? us:regulations/47-cfr/54/403#input.carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_offers_generally_available_residential_service_plan_or_package_with_at_least_one_service_commensurate_with_section_54_408
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_provides_emergency_communications_support_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: false
+    us:regulations/47-cfr/54/403#input.carrier_provides_service_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : false
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: false
+    us:regulations/47-cfr/54/403#input.survivor_service_meets_minimum_service_standard_for_voice_or_broadband: false
+  output:
+    us:regulations/47-cfr/54/403#federal_lifeline_support_amount: 0
+- name: auto_zero_emergency_communications_support_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/403#input.additional_federal_support_amount: 0
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_support_pass_through_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_tribal_lands_support_pass_through_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges: false
+    ? us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_emergency_rate_reduction
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: false
+    ? us:regulations/47-cfr/54/403#input.carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_offers_generally_available_residential_service_plan_or_package_with_at_least_one_service_commensurate_with_section_54_408
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_provides_emergency_communications_support_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: false
+    us:regulations/47-cfr/54/403#input.carrier_provides_service_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : false
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: false
+    us:regulations/47-cfr/54/403#input.survivor_service_meets_minimum_service_standard_for_voice_or_broadband: false
+  output:
+    us:regulations/47-cfr/54/403#emergency_communications_support_amount: 0
+- name: auto_zero_residential_service_plan_lifeline_discount_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/403#input.additional_federal_support_amount: 0
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_support_pass_through_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_emergency_tribal_lands_support_pass_through_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer: false
+    ? us:regulations/47-cfr/54/403#input.carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges: false
+    ? us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_emergency_rate_reduction
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction: false
+    ? us:regulations/47-cfr/54/403#input.carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_offers_generally_available_residential_service_plan_or_package_with_at_least_one_service_commensurate_with_section_54_408
+    : false
+    ? us:regulations/47-cfr/54/403#input.carrier_provides_emergency_communications_support_to_eligible_survivor_resident_of_tribal_lands
+    : false
+    us:regulations/47-cfr/54/403#input.carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands: false
+    us:regulations/47-cfr/54/403#input.carrier_provides_service_to_qualifying_survivor: false
+    ? us:regulations/47-cfr/54/403#input.lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards
+    : false
+    us:regulations/47-cfr/54/403#input.provider_is_only_lifeline_provider_in_census_block: false
+    us:regulations/47-cfr/54/403#input.survivor_service_meets_minimum_service_standard_for_voice_or_broadband: false
+  output:
+    us:regulations/47-cfr/54/403#residential_service_plan_lifeline_discount_amount: 0
+- name: auto_positive_federal_end_user_common_line_charges_must_be_waived
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/403#input.carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges: true
+    ? us:regulations/47-cfr/54/403#input.carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers
+    : true
+  output:
+    us:regulations/47-cfr/54/403#federal_end_user_common_line_charges_must_be_waived: holds
+- name: oracle_parameter_basic_lifeline_support_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:regulations/47-cfr/54/403#basic_lifeline_support_amount: 9.25
+- name: oracle_parameter_tribal_lands_support_amount_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:regulations/47-cfr/54/403#tribal_lands_support_amount_cap: 25

--- a/us/regulations/47-cfr/54/403.yaml
+++ b/us/regulations/47-cfr/54/403.yaml
@@ -1,0 +1,264 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/403
+  summary: Federal Lifeline support is $9.25 per month for qualifying low-income consumers
+    with required carrier certifications, subject to a standalone-voice phase-down
+    schedule; additional Tribal lands support is up to $25 per month; emergency communications
+    support is up to $9.25 per month plus up to $25 Tribal lands support. Carriers
+    charging Federal End User Common Line or equivalent Federal charges must waive
+    those charges for Lifeline voice subscribers when seeking reimbursement, and other
+    carriers must apply support to reduce generally available residential service
+    plans.
+rules:
+- name: basic_lifeline_support_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: $9.25 per month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '9.25'
+- name: standalone_voice_lifeline_support_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: Until December 1, 2019, the support amount will be $9.25 per month
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: From December 1, 2019 until November 30, 2020, the support amount
+            will be $7.25 per month
+      - path: versions[2].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: From December 1, 2020 until November 30, 2021, the support amount
+            will be $5.25 per month
+      - path: versions[3].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: On December 1, 2021 ... will not be eligible for Lifeline support
+            unless the Commission has previously determined otherwise
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '9.25'
+  - effective_from: '2019-12-01'
+    formula: '7.25'
+  - effective_from: '2020-12-01'
+    formula: '5.25'
+  - effective_from: '2021-12-01'
+    formula: '0'
+- name: only_provider_census_block_standalone_voice_support_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(2)(v)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: the support amount specified in paragraph (a)(2)(iii)
+  versions:
+  - effective_from: '2021-12-01'
+    formula: '5.25'
+- name: tribal_lands_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: Additional Federal Lifeline support of up to $25 per month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25'
+- name: emergency_communications_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: Emergency communications support in the amount of up to $9.25 per
+            month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '9.25'
+- name: emergency_tribal_lands_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.403(a)(4)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: Additional Federal Lifeline support of up to $25 per month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25'
+- name: federal_lifeline_support_amount
+  kind: derived
+  entity: EligibleTelecommunicationsCarrier
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 47 CFR 54.403(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#basic_lifeline_support_amount
+          output: basic_lifeline_support_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#standalone_voice_lifeline_support_amount
+          output: standalone_voice_lifeline_support_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#only_provider_census_block_standalone_voice_support_amount
+          output: only_provider_census_block_standalone_voice_support_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#tribal_lands_support_amount_cap
+          output: tribal_lands_support_amount_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if carrier_certifies_full_support_pass_through_to_qualifying_low_income_consumer\
+      \ and carrier_has_received_non_federal_regulatory_approvals_needed_for_rate_reduction:\n\
+      \  (if lifeline_provider_offers_standalone_voice_service_or_voice_with_broadband_below_minimum_standards:\n\
+      \    (if provider_is_only_lifeline_provider_in_census_block:\n      max(standalone_voice_lifeline_support_amount,\
+      \ only_provider_census_block_standalone_voice_support_amount)\n    else:\n \
+      \     standalone_voice_lifeline_support_amount)\n  else:\n    basic_lifeline_support_amount)\n\
+      \  + (if carrier_provides_lifeline_service_to_eligible_resident_of_tribal_lands\
+      \ and carrier_certifies_full_tribal_lands_support_pass_through_to_eligible_resident_of_tribal_lands:\n\
+      \    tribal_lands_support_amount_cap\n  else:\n    0)\nelse:\n  0"
+- name: emergency_communications_support_amount
+  kind: derived
+  entity: EligibleTelecommunicationsCarrier
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 47 CFR 54.403(a)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#emergency_communications_support_amount_cap
+          output: emergency_communications_support_amount_cap
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#emergency_tribal_lands_support_amount_cap
+          output: emergency_tribal_lands_support_amount_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if carrier_provides_service_to_qualifying_survivor and carrier_certifies_full_emergency_support_pass_through_to_qualifying_survivor\
+      \ and carrier_has_received_non_federal_regulatory_approvals_needed_for_emergency_rate_reduction\
+      \ and survivor_service_meets_minimum_service_standard_for_voice_or_broadband:\n\
+      \  emergency_communications_support_amount_cap\n  + (if carrier_provides_emergency_communications_support_to_eligible_survivor_resident_of_tribal_lands\
+      \ and carrier_certifies_full_emergency_tribal_lands_support_pass_through_to_eligible_survivor_resident_of_tribal_lands:\n\
+      \    emergency_tribal_lands_support_amount_cap\n  else:\n    0)\nelse:\n  0"
+- name: federal_end_user_common_line_charges_must_be_waived
+  kind: derived
+  entity: EligibleTelecommunicationsCarrier
+  dtype: Judgment
+  period: Month
+  source: 47 CFR 54.403(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+          excerpt: must apply Federal Lifeline support to waive the Federal End User
+            Common Line charges
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges
+
+      and carrier_is_seeking_lifeline_reimbursement_for_eligible_voice_telephony_service_to_subscribers'
+- name: residential_service_plan_lifeline_discount_amount
+  kind: derived
+  entity: EligibleTelecommunicationsCarrier
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 47 CFR 54.403(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/403
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/403#federal_lifeline_support_amount
+          output: federal_lifeline_support_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if not carrier_charges_federal_end_user_common_line_charges_or_equivalent_federal_charges
+      and carrier_offers_generally_available_residential_service_plan_or_package_with_at_least_one_service_commensurate_with_section_54_408:
+      federal_lifeline_support_amount + additional_federal_support_amount else: 0'

--- a/us/regulations/47-cfr/54/409.test.yaml
+++ b/us/regulations/47-cfr/54/409.test.yaml
@@ -1,0 +1,133 @@
+- name: income_path_qualifies_when_no_household_lifeline_subscription
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/409#input.household_income_fpg_ratio: 1.2
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_medicaid: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_snap: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_supplemental_security_income: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_federal_public_housing_assistance: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit: false
+    us:regulations/47-cfr/54/409#input.consumer_is_survivor: false
+    us:regulations/47-cfr/54/409#input.survivor_suffers_financial_hardship_as_defined_by_section_54_400_s: false
+    us:regulations/47-cfr/54/409#input.survivor_requested_line_separation_under_47_usc_345_c_1: false
+    us:regulations/47-cfr/54/409#input.consumer_lives_on_tribal_lands: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_bureau_of_indian_affairs_general_assistance
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_tribally_administered_tanf: false
+    us:regulations/47-cfr/54/409#input.household_participates_in_head_start_and_meets_its_income_qualifying_standard: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_food_distribution_program_on_indian_reservations
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_already_receiving_lifeline_service: false
+    us:regulations/47-cfr/54/409#input.anyone_else_in_subscriber_household_subscribed_to_lifeline_service: false
+  output:
+    us:regulations/47-cfr/54/409#income_qualifies_for_lifeline: holds
+    us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#survivor_emergency_communications_support_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification: holds
+    us:regulations/47-cfr/54/409#tribal_specific_assistance_program_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#tribal_lands_lifeline_qualification: not_holds
+    us:regulations/47-cfr/54/409#qualifying_low_income_consumer_for_lifeline: holds
+- name: tribal_lands_head_start_path_qualifies_above_income_limit
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/409#input.household_income_fpg_ratio: 2.0
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_medicaid: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_snap: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_supplemental_security_income: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_federal_public_housing_assistance: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit: false
+    us:regulations/47-cfr/54/409#input.consumer_is_survivor: false
+    us:regulations/47-cfr/54/409#input.survivor_suffers_financial_hardship_as_defined_by_section_54_400_s: false
+    us:regulations/47-cfr/54/409#input.survivor_requested_line_separation_under_47_usc_345_c_1: false
+    us:regulations/47-cfr/54/409#input.consumer_lives_on_tribal_lands: true
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_bureau_of_indian_affairs_general_assistance
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_tribally_administered_tanf: false
+    us:regulations/47-cfr/54/409#input.household_participates_in_head_start_and_meets_its_income_qualifying_standard: true
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_food_distribution_program_on_indian_reservations
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_already_receiving_lifeline_service: false
+    us:regulations/47-cfr/54/409#input.anyone_else_in_subscriber_household_subscribed_to_lifeline_service: false
+  output:
+    us:regulations/47-cfr/54/409#income_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#survivor_emergency_communications_support_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification: not_holds
+    us:regulations/47-cfr/54/409#tribal_specific_assistance_program_qualifies_for_lifeline: holds
+    us:regulations/47-cfr/54/409#tribal_lands_lifeline_qualification: holds
+    us:regulations/47-cfr/54/409#qualifying_low_income_consumer_for_lifeline: holds
+- name: survivor_emergency_path_qualifies_without_ordinary_income_or_program_path
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/409#input.household_income_fpg_ratio: 2.0
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_medicaid: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_snap: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_supplemental_security_income: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_federal_public_housing_assistance: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit: false
+    us:regulations/47-cfr/54/409#input.consumer_is_survivor: true
+    us:regulations/47-cfr/54/409#input.survivor_suffers_financial_hardship_as_defined_by_section_54_400_s: true
+    us:regulations/47-cfr/54/409#input.survivor_requested_line_separation_under_47_usc_345_c_1: true
+    us:regulations/47-cfr/54/409#input.consumer_lives_on_tribal_lands: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_bureau_of_indian_affairs_general_assistance
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_tribally_administered_tanf: false
+    us:regulations/47-cfr/54/409#input.household_participates_in_head_start_and_meets_its_income_qualifying_standard: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_food_distribution_program_on_indian_reservations
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_already_receiving_lifeline_service: false
+    us:regulations/47-cfr/54/409#input.anyone_else_in_subscriber_household_subscribed_to_lifeline_service: false
+  output:
+    us:regulations/47-cfr/54/409#income_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#survivor_emergency_communications_support_qualifies_for_lifeline: holds
+    us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification: holds
+    us:regulations/47-cfr/54/409#tribal_specific_assistance_program_qualifies_for_lifeline: not_holds
+    us:regulations/47-cfr/54/409#tribal_lands_lifeline_qualification: not_holds
+    us:regulations/47-cfr/54/409#qualifying_low_income_consumer_for_lifeline: holds
+- name: otherwise_qualified_consumer_blocked_when_already_receiving_lifeline
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/409#input.household_income_fpg_ratio: 1.2
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_medicaid: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_snap: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_supplemental_security_income: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_federal_public_housing_assistance: false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit: false
+    us:regulations/47-cfr/54/409#input.consumer_is_survivor: false
+    us:regulations/47-cfr/54/409#input.survivor_suffers_financial_hardship_as_defined_by_section_54_400_s: false
+    us:regulations/47-cfr/54/409#input.survivor_requested_line_separation_under_47_usc_345_c_1: false
+    us:regulations/47-cfr/54/409#input.consumer_lives_on_tribal_lands: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_bureau_of_indian_affairs_general_assistance
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_tribally_administered_tanf: false
+    us:regulations/47-cfr/54/409#input.household_participates_in_head_start_and_meets_its_income_qualifying_standard: false
+    ? us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_participates_in_food_distribution_program_on_indian_reservations
+    : false
+    us:regulations/47-cfr/54/409#input.consumer_already_receiving_lifeline_service: true
+    us:regulations/47-cfr/54/409#input.anyone_else_in_subscriber_household_subscribed_to_lifeline_service: false
+  output:
+    us:regulations/47-cfr/54/409#income_qualifies_for_lifeline: holds
+    us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification: holds
+    us:regulations/47-cfr/54/409#qualifying_low_income_consumer_for_lifeline: not_holds
+- name: auto_positive_federal_assistance_program_qualifies_for_lifeline
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_federal_public_housing_assistance: true
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_medicaid: true
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_snap: true
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_supplemental_security_income: true
+    us:regulations/47-cfr/54/409#input.consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit: true
+  output:
+    us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline: holds
+- name: oracle_parameter_lifeline_income_limit_ratio
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:regulations/47-cfr/54/409#lifeline_income_limit_ratio: 1.35

--- a/us/regulations/47-cfr/54/409.yaml
+++ b/us/regulations/47-cfr/54/409.yaml
@@ -1,0 +1,213 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/409
+  summary: |-
+    To constitute a qualifying low-income consumer, household income must be at or below 135% of Federal Poverty Guidelines, or the consumer/dependent/household must receive listed federal assistance; survivors may qualify for emergency communications support if they suffer financial hardship and requested line separation. Tribal-lands consumers are eligible if they meet paragraph (a) or participate in listed Tribal-specific federal assistance programs. In addition, the consumer and anyone else in the subscriber's household must not already be subscribed to Lifeline service.
+rules:
+  - name: lifeline_income_limit_ratio
+    kind: parameter
+    dtype: Rate
+    source: 47 CFR 54.409(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+              excerpt: "at or below 135% of the Federal Poverty Guidelines"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.35
+
+  - name: income_qualifies_for_lifeline
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#lifeline_income_limit_ratio
+              output: lifeline_income_limit_ratio
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_income_fpg_ratio <= lifeline_income_limit_ratio
+
+  - name: federal_assistance_program_qualifies_for_lifeline
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          consumer_or_dependent_or_household_receives_medicaid
+          or consumer_or_dependent_or_household_receives_snap
+          or consumer_or_dependent_or_household_receives_supplemental_security_income
+          or consumer_or_dependent_or_household_receives_federal_public_housing_assistance
+          or consumer_or_dependent_or_household_receives_veterans_and_survivors_pension_benefit
+
+  - name: survivor_emergency_communications_support_qualifies_for_lifeline
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          consumer_is_survivor
+          and survivor_suffers_financial_hardship_as_defined_by_section_54_400_s
+          and survivor_requested_line_separation_under_47_usc_345_c_1
+
+  - name: paragraph_a_lifeline_qualification
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#income_qualifies_for_lifeline
+              output: income_qualifies_for_lifeline
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline
+              output: federal_assistance_program_qualifies_for_lifeline
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#survivor_emergency_communications_support_qualifies_for_lifeline
+              output: survivor_emergency_communications_support_qualifies_for_lifeline
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          income_qualifies_for_lifeline
+          or federal_assistance_program_qualifies_for_lifeline
+          or survivor_emergency_communications_support_qualifies_for_lifeline
+
+  - name: tribal_specific_assistance_program_qualifies_for_lifeline
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          consumer_or_dependent_or_household_participates_in_bureau_of_indian_affairs_general_assistance
+          or consumer_or_dependent_or_household_participates_in_tribally_administered_tanf
+          or household_participates_in_head_start_and_meets_its_income_qualifying_standard
+          or consumer_or_dependent_or_household_participates_in_food_distribution_program_on_indian_reservations
+
+  - name: tribal_lands_lifeline_qualification
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification
+              output: paragraph_a_lifeline_qualification
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#tribal_specific_assistance_program_qualifies_for_lifeline
+              output: tribal_specific_assistance_program_qualifies_for_lifeline
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          consumer_lives_on_tribal_lands
+          and (paragraph_a_lifeline_qualification or tribal_specific_assistance_program_qualifies_for_lifeline)
+
+  - name: qualifying_low_income_consumer_for_lifeline
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.409(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/409
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification
+              output: paragraph_a_lifeline_qualification
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/409#tribal_lands_lifeline_qualification
+              output: tribal_lands_lifeline_qualification
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (paragraph_a_lifeline_qualification or tribal_lands_lifeline_qualification)
+          and not consumer_already_receiving_lifeline_service
+          and not anyone_else_in_subscriber_household_subscribed_to_lifeline_service


### PR DESCRIPTION
## Summary
- encode 47 CFR 54.409 Lifeline consumer qualification
- encode 47 CFR 54.403 Lifeline support amounts and carrier application rules
- add signed encoder apply manifests and companion tests
- add deterministic oracle-parameter test assertions for comparable PE parameters

## Validation
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us/regulations/47-cfr/54/409.test.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us/regulations/47-cfr/54/403.test.yaml
- uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us/regulations/47-cfr/54/409.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us/regulations/47-cfr/54/403.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-lifeline-20260623/us --base-ref origin/main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root /tmp/axiom-lifeline-pe-root-coverage --oracle policyengine --program lifeline --include-program-surfaces --fail-on-untested-comparable --limit 100

Depends on:
- TheAxiomFoundation/axiom-corpus#119 for the 47 CFR part 54 corpus source
- TheAxiomFoundation/axiom-encode#744 for oracle mappings and signed repair provenance