### PR TITLE
Encode federal ACP rules

### DIFF
--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/1800.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/1800.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/1800.yaml",
+      "sha256": "571db2b4b1f3489888c393abf2075cc927c0bb83f209142ddd8ab7f32cd366da"
+    },
+    {
+      "path": "regulations/47-cfr/54/1800.test.yaml",
+      "sha256": "875fc20a814bcf308a96215b2af6fe012d79d6870278611a4d04b7e030d21665"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21c150207547fd966c773c3515b00d37af38a03e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.799",
+    "version_commit": "21c150207547fd966c773c3515b00d37af38a03e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "openai",
+  "citation": "us/regulation/47/54/1800",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-regulation-47-54-1800/workspace/context-manifest.json",
+  "context_manifest_sha256": "5fa332fce36257deaa192795df7608bcc021f56f419462cdfde6e7cc4a7c92dc",
+  "generated_at": "2026-06-23T19:34:07.008342+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/regulations/47-cfr/54/1800.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "571db2b4b1f3489888c393abf2075cc927c0bb83f209142ddd8ab7f32cd366da",
+  "generation_prompt_sha256": "78689ec1e26f00bd1915072363da8476474f04b1b36b7a680c8fa1c63969a320",
+  "model": "gpt-5.5",
+  "run_id": "c5cff816",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2de5881bf54eaa7ea8d6149780cfe1318b21ee4c659d331b6f73a67a56cf99b6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-regulation-47-54-1800.json",
+  "trace_sha256": "4f1f1586df4f21cc95f4f6cd91ba8a1c4529c4fe36a8b0ecaf0b5241d3a32aa0"
+}

--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/1800/j.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/1800/j.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/1800/j.yaml",
+      "sha256": "2278307b4d904f54c0b34aa78f33fb54e4cc3959489fc055733ec90adeb66c07"
+    },
+    {
+      "path": "regulations/47-cfr/54/1800/j.test.yaml",
+      "sha256": "9b2ee473e97512951fcf5b90a8b0a04dfdbf2e11a7f3c33d5d4550b6c84e28d3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21c150207547fd966c773c3515b00d37af38a03e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.799",
+    "version_commit": "21c150207547fd966c773c3515b00d37af38a03e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "openai",
+  "citation": "us/regulation/47/54/1800/j",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-regulation-47-54-1800-j/workspace/context-manifest.json",
+  "context_manifest_sha256": "e98ebf833b42c746dcf5245310581b446925cb3015988f452fd743641c031c99",
+  "generated_at": "2026-06-23T19:35:13.878306+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/regulations/47-cfr/54/1800/j.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "2278307b4d904f54c0b34aa78f33fb54e4cc3959489fc055733ec90adeb66c07",
+  "generation_prompt_sha256": "b7e67b518e3ed70a649ab4a898d271113dfcdaa916e924cbef0ffad7c6de8500",
+  "model": "gpt-5.5",
+  "run_id": "c090d497",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c3dc4c214a62b177070ecf93fb88b7a07142130eb027d971bf511c801a09682e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-regulation-47-54-1800-j.json",
+  "trace_sha256": "02c23d7af60b21a7cc32dd9e22133f90fe55fbd520baada28e00fc208bb899ea"
+}

--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/1803.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/1803.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/1803.yaml",
+      "sha256": "15e65b0263c8eef4f9581d550e18195db5fb1c59ea446e05b7045e688f477201"
+    },
+    {
+      "path": "regulations/47-cfr/54/1803.test.yaml",
+      "sha256": "6b8415ff4c5e6c75780123e707277fbf4ed8d1e2661c6718fcd424e6019fe34b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21c150207547fd966c773c3515b00d37af38a03e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.799",
+    "version_commit": "21c150207547fd966c773c3515b00d37af38a03e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "openai",
+  "citation": "us/regulation/47/54/1803",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-regulation-47-54-1803/workspace/context-manifest.json",
+  "context_manifest_sha256": "b12f1c4ec0043b6db288cc0d0aa89405e4618cc4cd3689df590af97113f8d5b3",
+  "generated_at": "2026-06-23T19:31:42.091251+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/regulations/47-cfr/54/1803.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "15e65b0263c8eef4f9581d550e18195db5fb1c59ea446e05b7045e688f477201",
+  "generation_prompt_sha256": "9618b2c1657af83c9526b0b43cd8cda7f35211d12847cfc7bd4c1a626db188f6",
+  "model": "gpt-5.5",
+  "run_id": "22349d41",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fd0616fe790e3d5cce162c94e5e4e6e7ea12337203aec5de7102a6479222e13c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-regulation-47-54-1803.json",
+  "trace_sha256": "38732d8b20131cc4ea70a0acf8e324010581b4cc26fa9a2dc8a0bb3f79519edc"
+}

--- a/us/.axiom/encoding-manifests/regulations/47-cfr/54/1805.json
+++ b/us/.axiom/encoding-manifests/regulations/47-cfr/54/1805.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/47-cfr/54/1805.yaml",
+      "sha256": "0ce9bd9cdce5789227da5ae817d94dc73c493237cb5549cc933c9a898b603ded"
+    },
+    {
+      "path": "regulations/47-cfr/54/1805.test.yaml",
+      "sha256": "6c344cb57dba5cf3189f5fb8dc7b3011188110b0ec5cd0a9d3be7fcea63a7ad3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "21c150207547fd966c773c3515b00d37af38a03e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.799",
+    "version_commit": "21c150207547fd966c773c3515b00d37af38a03e"
+  },
+  "axiom_encode_version": "0.2.799",
+  "backend": "openai",
+  "citation": "us/regulation/47/54/1805",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-regulation-47-54-1805/workspace/context-manifest.json",
+  "context_manifest_sha256": "2ae0e63437f36c20e82894410e8c381e8430e50e00985a1f62578fdc9c77faa9",
+  "generated_at": "2026-06-23T19:32:39.826993+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/regulations/47-cfr/54/1805.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "0ce9bd9cdce5789227da5ae817d94dc73c493237cb5549cc933c9a898b603ded",
+  "generation_prompt_sha256": "faf970a6de54bb4c51e53b721da0258e90afc4470f3ce67c84cf7a124d2b00f0",
+  "model": "gpt-5.5",
+  "run_id": "7c645741",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7b51201665e85104e0257c176482626b2c74fbb940fc10278488d32b413b8fb3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-regulation-47-54-1805.json",
+  "trace_sha256": "8a5c85f418749dd9addbe73e7d4323c810aea46d3aac2c5222b3e7230b2b888a"
+}

--- a/us/regulations/47-cfr/54/1800.test.yaml
+++ b/us/regulations/47-cfr/54/1800.test.yaml
@@ -1,0 +1,20 @@
+- name: standard_affordable_connectivity_benefit_is_actual_charge_capped_at_30
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1800#input.actual_amount_charged_to_household: 40
+    us:regulations/47-cfr/54/1800#input.internet_service_offering_provided_to_eligible_household_on_tribal_land: false
+  output:
+    us:regulations/47-cfr/54/1800#affordable_connectivity_benefit: 30
+- name: tribal_land_affordable_connectivity_benefit_is_actual_charge_capped_at_75
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1800#input.actual_amount_charged_to_household: 80
+    us:regulations/47-cfr/54/1800#input.internet_service_offering_provided_to_eligible_household_on_tribal_land: true
+  output:
+    us:regulations/47-cfr/54/1800#affordable_connectivity_benefit: 75
+- name: person_age_eighteen_is_household_adult
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1800#input.person_age_years: 18
+  output:
+    us:regulations/47-cfr/54/1800#household_adult: holds

--- a/us/regulations/47-cfr/54/1800.yaml
+++ b/us/regulations/47-cfr/54/1800.yaml
@@ -1,0 +1,162 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/1800
+  summary: |-
+    Definitions for the Affordable Connectivity Program include: "affordable connectivity benefit" as a monthly discount equal to the actual household charge but capped at $30, or $75 for an internet service offering on Tribal land; "eligible household" includes an income path at or below 200% of Federal Poverty Guidelines; and "household" includes adults eighteen years or older in one economic unit.
+  deferred_outputs:
+    - output: us:regulations/47-cfr/54/1800/a#administrator
+      reason: The provision is an institutional definition naming the Universal Service Administrative Company; no computable legal predicate or amount is needed in this module.
+    - output: us:regulations/47-cfr/54/1800/d#broadband_provider
+      reason: The provision defines broadband provider by reference to broadband internet access service, but the necessary upstream definition in 47 CFR 8.1(b) is not provided in copied RuleSpec context.
+    - output: us:regulations/47-cfr/54/1800/e#commission
+      reason: The provision is an institutional definition naming the Federal Communications Commission; no computable legal predicate or amount is needed in this module.
+    - output: us:regulations/47-cfr/54/1800/f#connected_device
+      reason: The provision classifies laptops, desktop computers, and tablets as connected devices; device-type ontology is outside the current executable scope.
+    - output: us:regulations/47-cfr/54/1800/g#designated_as_eligible_telecommunications_carrier
+      reason: The definition depends on designation under section 214(e) of the Communications Act of 1934, which is not provided in copied RuleSpec context.
+    - output: us:regulations/47-cfr/54/1800/h#direct_service
+      reason: The provision is a service-delivery definition requiring provider-consumer service relationship modeling outside the current executable scope.
+    - output: us:regulations/47-cfr/54/1800/k#enrollment_representative
+      reason: The provision defines a role through employment, agency, contractor, subcontractor, and submission-purpose relationships not represented in the current executable ontology.
+    - output: us:regulations/47-cfr/54/1800/m#income
+      reason: The definition depends on gross income as defined under section 61 of the Internal Revenue Code and exclusions under Part III of Title 26, which are not provided in copied RuleSpec context.
+    - output: us:regulations/47-cfr/54/1800/n#internet_service_offering
+      reason: The definition depends on broadband internet access service, whose upstream definition in 47 CFR 8.1(b) is not provided in copied RuleSpec context.
+    - output: us:regulations/47-cfr/54/1800/o#lifeline_qualifying_assistance_program
+      reason: The definition depends on the qualifying effect of participation under § 54.409(a) or (b); a complete program-enumeration relation for this definition is outside the current executable scope.
+    - output: us:regulations/47-cfr/54/1800/r#participating_provider
+      reason: The definition depends on provider approval, participation election, removal, and voluntary withdrawal under § 54.1801, which is not provided in copied RuleSpec context.
+rules:
+  - name: standard_affordable_connectivity_benefit_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 47 CFR 54.1800(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "not more than $30"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: tribal_land_affordable_connectivity_benefit_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 47 CFR 54.1800(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "if an internet service offering is provided to an eligible household on Tribal land, not more than $75"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          75
+
+  - name: affordable_connectivity_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 47 CFR 54.1800(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/1800#standard_affordable_connectivity_benefit_cap
+              output: standard_affordable_connectivity_benefit_cap
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/1800#tribal_land_affordable_connectivity_benefit_cap
+              output: tribal_land_affordable_connectivity_benefit_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(
+            max(0, actual_amount_charged_to_household),
+            if internet_service_offering_provided_to_eligible_household_on_tribal_land:
+              tribal_land_affordable_connectivity_benefit_cap
+            else:
+              standard_affordable_connectivity_benefit_cap
+          )
+
+  - name: eligible_household_income_limit_ratio
+    kind: parameter
+    dtype: Rate
+    source: 47 CFR 54.1800(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "at or below 200% of the Federal Poverty Guidelines"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.00
+
+  - name: household_adult_age_threshold_years
+    kind: parameter
+    dtype: Count
+    source: 47 CFR 54.1800(l)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "An adult is any person eighteen years or older"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          18
+
+  - name: household_adult
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.1800(l)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/1800#household_adult_age_threshold_years
+              output: household_adult_age_threshold_years
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_age_years >= household_adult_age_threshold_years

--- a/us/regulations/47-cfr/54/1800/j.test.yaml
+++ b/us/regulations/47-cfr/54/1800/j.test.yaml
@@ -1,0 +1,72 @@
+- name: household_eligible_by_income_at_or_below_200_percent_fpg
+  period: 2024-05
+  input:
+    us:regulations/47-cfr/54/1800/j#input.household_income: 40000
+    us:regulations/47-cfr/54/1800/j#input.federal_poverty_guidelines_for_household_size: 25000
+    us:regulations/47-cfr/54/1800/j#input.federal_pell_grant_award_is_verifiable_through_national_verifier_or_nlad: false
+    ? us:regulations/47-cfr/54/1800/j#input.participating_provider_verifies_federal_pell_grant_eligibility_under_section_54_1806_a_2
+    : false
+    us:regulations/47-cfr/54/1800/j#relation.member_of_household:
+    - us:regulations/47-cfr/54/1800/j#input.member_meets_qualifications_under_section_54_409_a_2_or_3_or_b: false
+      us:regulations/47-cfr/54/1800/j#input.member_approved_for_free_or_reduced_price_lunch_or_school_breakfast_benefits: false
+      us:regulations/47-cfr/54/1800/j#input.member_enrolled_in_community_eligibility_provision_school_or_district: false
+      us:regulations/47-cfr/54/1800/j#input.member_received_current_award_year_federal_pell_grant: false
+      ? us:regulations/47-cfr/54/1800/j#input.member_meets_participating_provider_existing_low_income_program_criteria_subject_to_section_54_1806_a_2
+      : false
+      us:regulations/47-cfr/54/1800/j#input.member_receives_wic_assistance: false
+  output:
+    us:regulations/47-cfr/54/1800/j#eligible_household: holds
+- name: household_eligible_by_verifiable_current_award_year_pell_grant
+  period: 2024-05
+  input:
+    us:regulations/47-cfr/54/1800/j#input.household_income: 60000
+    us:regulations/47-cfr/54/1800/j#input.federal_poverty_guidelines_for_household_size: 25000
+    us:regulations/47-cfr/54/1800/j#input.federal_pell_grant_award_is_verifiable_through_national_verifier_or_nlad: true
+    ? us:regulations/47-cfr/54/1800/j#input.participating_provider_verifies_federal_pell_grant_eligibility_under_section_54_1806_a_2
+    : false
+    us:regulations/47-cfr/54/1800/j#relation.member_of_household:
+    - us:regulations/47-cfr/54/1800/j#input.member_meets_qualifications_under_section_54_409_a_2_or_3_or_b: false
+      us:regulations/47-cfr/54/1800/j#input.member_approved_for_free_or_reduced_price_lunch_or_school_breakfast_benefits: false
+      us:regulations/47-cfr/54/1800/j#input.member_enrolled_in_community_eligibility_provision_school_or_district: false
+      us:regulations/47-cfr/54/1800/j#input.member_received_current_award_year_federal_pell_grant: true
+      ? us:regulations/47-cfr/54/1800/j#input.member_meets_participating_provider_existing_low_income_program_criteria_subject_to_section_54_1806_a_2
+      : false
+      us:regulations/47-cfr/54/1800/j#input.member_receives_wic_assistance: false
+  output:
+    us:regulations/47-cfr/54/1800/j#eligible_household: holds
+- name: household_eligible_by_wic_assistance
+  period: 2024-05
+  input:
+    us:regulations/47-cfr/54/1800/j#input.household_income: 60000
+    us:regulations/47-cfr/54/1800/j#input.federal_poverty_guidelines_for_household_size: 25000
+    us:regulations/47-cfr/54/1800/j#input.federal_pell_grant_award_is_verifiable_through_national_verifier_or_nlad: false
+    ? us:regulations/47-cfr/54/1800/j#input.participating_provider_verifies_federal_pell_grant_eligibility_under_section_54_1806_a_2
+    : false
+    us:regulations/47-cfr/54/1800/j#relation.member_of_household:
+    - us:regulations/47-cfr/54/1800/j#input.member_meets_qualifications_under_section_54_409_a_2_or_3_or_b: false
+      us:regulations/47-cfr/54/1800/j#input.member_approved_for_free_or_reduced_price_lunch_or_school_breakfast_benefits: false
+      us:regulations/47-cfr/54/1800/j#input.member_enrolled_in_community_eligibility_provision_school_or_district: false
+      us:regulations/47-cfr/54/1800/j#input.member_received_current_award_year_federal_pell_grant: false
+      ? us:regulations/47-cfr/54/1800/j#input.member_meets_participating_provider_existing_low_income_program_criteria_subject_to_section_54_1806_a_2
+      : false
+      us:regulations/47-cfr/54/1800/j#input.member_receives_wic_assistance: true
+  output:
+    us:regulations/47-cfr/54/1800/j#eligible_household: holds
+- name: household_not_eligible_when_no_path_satisfied
+  period: 2024-05
+  input:
+    us:regulations/47-cfr/54/1800/j#input.household_income: 60000
+    us:regulations/47-cfr/54/1800/j#input.federal_poverty_guidelines_for_household_size: 25000
+    us:regulations/47-cfr/54/1800/j#input.federal_pell_grant_award_is_verifiable_through_national_verifier_or_nlad: false
+    ? us:regulations/47-cfr/54/1800/j#input.participating_provider_verifies_federal_pell_grant_eligibility_under_section_54_1806_a_2
+    : false
+    us:regulations/47-cfr/54/1800/j#relation.member_of_household:
+    - us:regulations/47-cfr/54/1800/j#input.member_meets_qualifications_under_section_54_409_a_2_or_3_or_b: false
+      us:regulations/47-cfr/54/1800/j#input.member_approved_for_free_or_reduced_price_lunch_or_school_breakfast_benefits: false
+      us:regulations/47-cfr/54/1800/j#input.member_enrolled_in_community_eligibility_provision_school_or_district: false
+      us:regulations/47-cfr/54/1800/j#input.member_received_current_award_year_federal_pell_grant: false
+      ? us:regulations/47-cfr/54/1800/j#input.member_meets_participating_provider_existing_low_income_program_criteria_subject_to_section_54_1806_a_2
+      : false
+      us:regulations/47-cfr/54/1800/j#input.member_receives_wic_assistance: false
+  output:
+    us:regulations/47-cfr/54/1800/j#eligible_household: not_holds

--- a/us/regulations/47-cfr/54/1800/j.yaml
+++ b/us/regulations/47-cfr/54/1800/j.yaml
@@ -1,0 +1,94 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/1800
+  summary: |-
+    47 CFR 54.1800(j) defines “eligible household” as a household meeting any listed eligibility path, regardless of Lifeline support under subpart E or broadband-provider arrearages. Paths include a member meeting § 54.409(a)(2), (a)(3), or (b); household income at or below 200% of Federal Poverty Guidelines; school lunch/breakfast/CEP participation; current-award-year Federal Pell Grant with stated verification; provider low-income-program criteria subject to § 54.1806(a)(2); or WIC assistance.
+rules:
+  - name: federal_poverty_guidelines_income_limit_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 47 CFR 54.1800(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "at or below 200% of the Federal Poverty Guidelines"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.00
+
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
+
+  - name: eligible_household
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.1800(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "At least one member of the household meets the qualifications in § 54.409(a)(2) or (3) or (b)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "household's income ... at or below 200% of the Federal Poverty Guidelines"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "free and reduced price lunch program ... school breakfast program ... Community Eligibility Provision"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "Federal Pell Grant ... in the current award year ... verifiable"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "meets the eligibility criteria for a participating provider's existing low-income program"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1800
+              excerpt: "receives assistance through the special supplemental nutritional program for women, infants and children"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          count_where(member_of_household, member_meets_qualifications_under_section_54_409_a_2_or_3_or_b) > 0
+          or household_income <= federal_poverty_guidelines_income_limit_multiplier * federal_poverty_guidelines_for_household_size
+          or count_where(member_of_household, member_approved_for_free_or_reduced_price_lunch_or_school_breakfast_benefits) > 0
+          or count_where(member_of_household, member_enrolled_in_community_eligibility_provision_school_or_district) > 0
+          or (
+            count_where(member_of_household, member_received_current_award_year_federal_pell_grant) > 0
+            and (
+              federal_pell_grant_award_is_verifiable_through_national_verifier_or_nlad
+              or participating_provider_verifies_federal_pell_grant_eligibility_under_section_54_1806_a_2
+            )
+          )
+          or count_where(member_of_household, member_meets_participating_provider_existing_low_income_program_criteria_subject_to_section_54_1806_a_2) > 0
+          or count_where(member_of_household, member_receives_wic_assistance) > 0

--- a/us/regulations/47-cfr/54/1803.test.yaml
+++ b/us/regulations/47-cfr/54/1803.test.yaml
@@ -1,0 +1,92 @@
+- name: standard_monthly_support_is_actual_discount_capped_at_30
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1803#input.household_is_eligible_for_affordable_connectivity_benefit: true
+    us:regulations/47-cfr/54/1803#input.actual_discount_provided_to_household_off_actual_amount_charged: 40
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_on_tribal_lands: false
+    us:regulations/47-cfr/54/1803#input.household_is_on_tribal_lands_as_defined_in_section_54_1800_s: false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_in_high_cost_area: false
+    us:regulations/47-cfr/54/1803#input.household_is_in_high_cost_area_as_defined_in_section_54_1814_a: false
+    ? us:regulations/47-cfr/54/1803#input.provider_is_approved_to_offer_enhanced_high_cost_benefit_in_that_high_cost_area_pursuant_to_section_54_1814_b
+    : false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household: true
+  output:
+    us:regulations/47-cfr/54/1803#monthly_affordable_connectivity_benefit_support_amount: 30
+- name: tribal_lands_monthly_support_is_actual_discount_capped_at_75
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1803#input.household_is_eligible_for_affordable_connectivity_benefit: true
+    us:regulations/47-cfr/54/1803#input.actual_discount_provided_to_household_off_actual_amount_charged: 60
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_on_tribal_lands: true
+    us:regulations/47-cfr/54/1803#input.household_is_on_tribal_lands_as_defined_in_section_54_1800_s: true
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_in_high_cost_area: false
+    us:regulations/47-cfr/54/1803#input.household_is_in_high_cost_area_as_defined_in_section_54_1814_a: false
+    ? us:regulations/47-cfr/54/1803#input.provider_is_approved_to_offer_enhanced_high_cost_benefit_in_that_high_cost_area_pursuant_to_section_54_1814_b
+    : false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household: false
+  output:
+    us:regulations/47-cfr/54/1803#monthly_affordable_connectivity_benefit_support_amount: 60
+- name: connected_device_reimbursement_available_and_capped_at_100
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1803#input.provider_is_participating_provider: true
+    us:regulations/47-cfr/54/1803#input.household_is_eligible_for_affordable_connectivity_benefit: true
+    ? us:regulations/47-cfr/54/1803#input.provider_provides_broadband_internet_access_service_subject_to_affordable_connectivity_benefit_to_household
+    : true
+    us:regulations/47-cfr/54/1803#input.provider_supplies_connected_device_to_household: true
+    us:regulations/47-cfr/54/1803#input.amount_charged_to_and_paid_by_household_for_connected_device: 20
+    us:regulations/47-cfr/54/1803#input.connected_devices_already_received_by_household_under_affordable_connectivity_program: 0
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_emergency_broadband_benefit_program
+    : false
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_affordable_connectivity_program
+    : false
+    us:regulations/47-cfr/54/1803#input.connected_device_market_value: 150
+  output:
+    us:regulations/47-cfr/54/1803#connected_device_reimbursement_available: holds
+    us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount: 100
+- name: prior_affordable_connectivity_device_blocks_device_reimbursement
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1803#input.provider_is_participating_provider: true
+    us:regulations/47-cfr/54/1803#input.household_is_eligible_for_affordable_connectivity_benefit: true
+    ? us:regulations/47-cfr/54/1803#input.provider_provides_broadband_internet_access_service_subject_to_affordable_connectivity_benefit_to_household
+    : true
+    us:regulations/47-cfr/54/1803#input.provider_supplies_connected_device_to_household: true
+    us:regulations/47-cfr/54/1803#input.amount_charged_to_and_paid_by_household_for_connected_device: 20
+    us:regulations/47-cfr/54/1803#input.connected_devices_already_received_by_household_under_affordable_connectivity_program: 0
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_emergency_broadband_benefit_program
+    : false
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_affordable_connectivity_program
+    : true
+    us:regulations/47-cfr/54/1803#input.connected_device_market_value: 150
+  output:
+    us:regulations/47-cfr/54/1803#connected_device_reimbursement_available: not_holds
+    us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount: 0
+- name: auto_zero_monthly_affordable_connectivity_benefit_support_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/47-cfr/54/1803#input.actual_discount_provided_to_household_off_actual_amount_charged: 0
+    us:regulations/47-cfr/54/1803#input.amount_charged_to_and_paid_by_household_for_connected_device: 0
+    us:regulations/47-cfr/54/1803#input.connected_device_market_value: 0
+    us:regulations/47-cfr/54/1803#input.connected_devices_already_received_by_household_under_affordable_connectivity_program: 0
+    us:regulations/47-cfr/54/1803#input.household_is_eligible_for_affordable_connectivity_benefit: false
+    us:regulations/47-cfr/54/1803#input.household_is_in_high_cost_area_as_defined_in_section_54_1814_a: false
+    us:regulations/47-cfr/54/1803#input.household_is_on_tribal_lands_as_defined_in_section_54_1800_s: false
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_affordable_connectivity_program
+    : false
+    ? us:regulations/47-cfr/54/1803#input.household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_emergency_broadband_benefit_program
+    : false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household: false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_in_high_cost_area: false
+    us:regulations/47-cfr/54/1803#input.provider_certifies_full_support_pass_through_to_eligible_household_on_tribal_lands: false
+    ? us:regulations/47-cfr/54/1803#input.provider_is_approved_to_offer_enhanced_high_cost_benefit_in_that_high_cost_area_pursuant_to_section_54_1814_b
+    : false
+    us:regulations/47-cfr/54/1803#input.provider_is_participating_provider: false
+    ? us:regulations/47-cfr/54/1803#input.provider_provides_broadband_internet_access_service_subject_to_affordable_connectivity_benefit_to_household
+    : false
+    us:regulations/47-cfr/54/1803#input.provider_supplies_connected_device_to_household: false
+  output:
+    us:regulations/47-cfr/54/1803#monthly_affordable_connectivity_benefit_support_amount: 0

--- a/us/regulations/47-cfr/54/1803.yaml
+++ b/us/regulations/47-cfr/54/1803.yaml
@@ -1,0 +1,250 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/1803
+  summary: Monthly affordable connectivity benefit support equals the actual discount
+    to an eligible household, capped at $30 per month generally or $75 per month on
+    Tribal lands or approved high-cost areas. A participating provider supplying a
+    connected device may be reimbursed market value less the household charge/payment,
+    capped at $100, subject to household contribution, one-device, and prior-discount
+    limits.
+rules:
+- name: standard_monthly_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: not more than $30.00 per month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '30'
+- name: tribal_lands_monthly_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: not more than $75.00 per month ... on Tribal lands
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '75'
+- name: high_cost_area_monthly_support_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: not more than $75.00 per month ... in a high-cost area
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '75'
+- name: connected_device_reimbursement_amount_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: no more than $100.00 for such connected device
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '100'
+- name: connected_device_household_charge_lower_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: more than $10.00
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '10'
+- name: connected_device_household_charge_upper_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 47 CFR 54.1803(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: less than $50.00
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '50'
+- name: connected_device_per_household_limit
+  kind: parameter
+  dtype: Count
+  source: 47 CFR 54.1803(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+          excerpt: no more than one (1) connected device per eligible household
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1'
+- name: monthly_affordable_connectivity_benefit_support_amount
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 47 CFR 54.1803(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#standard_monthly_support_amount_cap
+          output: standard_monthly_support_amount_cap
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#tribal_lands_monthly_support_amount_cap
+          output: tribal_lands_monthly_support_amount_cap
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#high_cost_area_monthly_support_amount_cap
+          output: high_cost_area_monthly_support_amount_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if household_is_eligible_for_affordable_connectivity_benefit:\n  min(\n\
+      \    max(0, actual_discount_provided_to_household_off_actual_amount_charged),\n\
+      \    if provider_certifies_full_support_pass_through_to_eligible_household_on_tribal_lands\
+      \ and household_is_on_tribal_lands_as_defined_in_section_54_1800_s:\n      tribal_lands_monthly_support_amount_cap\n\
+      \    else:\n      if provider_certifies_full_support_pass_through_to_eligible_household_in_high_cost_area\
+      \ and household_is_in_high_cost_area_as_defined_in_section_54_1814_a and provider_is_approved_to_offer_enhanced_high_cost_benefit_in_that_high_cost_area_pursuant_to_section_54_1814_b:\n\
+      \        high_cost_area_monthly_support_amount_cap\n      else:\n        if\
+      \ provider_certifies_full_support_pass_through_to_eligible_household:\n    \
+      \      standard_monthly_support_amount_cap\n        else:\n          0\n  )\n\
+      else:\n  0"
+- name: connected_device_reimbursement_available
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 47 CFR 54.1803(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#connected_device_household_charge_lower_bound
+          output: connected_device_household_charge_lower_bound
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#connected_device_household_charge_upper_bound
+          output: connected_device_household_charge_upper_bound
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#connected_device_per_household_limit
+          output: connected_device_per_household_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'provider_is_participating_provider
+
+      and household_is_eligible_for_affordable_connectivity_benefit
+
+      and provider_provides_broadband_internet_access_service_subject_to_affordable_connectivity_benefit_to_household
+
+      and provider_supplies_connected_device_to_household
+
+      and amount_charged_to_and_paid_by_household_for_connected_device > connected_device_household_charge_lower_bound
+
+      and amount_charged_to_and_paid_by_household_for_connected_device < connected_device_household_charge_upper_bound
+
+      and connected_devices_already_received_by_household_under_affordable_connectivity_program
+      < connected_device_per_household_limit
+
+      and not household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_emergency_broadband_benefit_program
+
+      and not household_or_any_member_previously_received_discounted_connected_device_from_participating_provider_in_affordable_connectivity_program'
+- name: connected_device_reimbursement_amount
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 47 CFR 54.1803(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/47/54/1803
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#connected_device_reimbursement_available
+          output: connected_device_reimbursement_available
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount_cap
+          output: connected_device_reimbursement_amount_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if connected_device_reimbursement_available: min( max(0, connected_device_market_value
+      - amount_charged_to_and_paid_by_household_for_connected_device), connected_device_reimbursement_amount_cap
+      ) else: 0'

--- a/us/regulations/47-cfr/54/1805.test.yaml
+++ b/us/regulations/47-cfr/54/1805.test.yaml
@@ -1,0 +1,46 @@
+- name: eligible_household_with_no_other_benefit_qualifies_to_receive_from_participating_provider
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1805#input.household_constitutes_eligible_household_under_section_54_1800_j: true
+    us:regulations/47-cfr/54/1805#input.provider_is_participating_provider: true
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_that_participating_provider
+    : false
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_any_other_participating_provider
+    : false
+  output:
+    us:regulations/47-cfr/54/1805#qualifies_for_affordable_connectivity_program: holds
+    us:regulations/47-cfr/54/1805#qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider: holds
+- name: household_not_eligible_under_section_54_1800_j_does_not_qualify
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1805#input.household_constitutes_eligible_household_under_section_54_1800_j: false
+    us:regulations/47-cfr/54/1805#input.provider_is_participating_provider: true
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_that_participating_provider
+    : false
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_any_other_participating_provider
+    : false
+  output:
+    us:regulations/47-cfr/54/1805#qualifies_for_affordable_connectivity_program: not_holds
+    us:regulations/47-cfr/54/1805#qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider: not_holds
+- name: existing_benefit_from_same_participating_provider_blocks_receipt
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1805#input.household_constitutes_eligible_household_under_section_54_1800_j: true
+    us:regulations/47-cfr/54/1805#input.provider_is_participating_provider: true
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_that_participating_provider
+    : true
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_any_other_participating_provider
+    : false
+  output:
+    us:regulations/47-cfr/54/1805#qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider: not_holds
+- name: existing_benefit_from_other_participating_provider_blocks_receipt
+  period: 2024-01
+  input:
+    us:regulations/47-cfr/54/1805#input.household_constitutes_eligible_household_under_section_54_1800_j: true
+    us:regulations/47-cfr/54/1805#input.provider_is_participating_provider: true
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_that_participating_provider
+    : false
+    ? us:regulations/47-cfr/54/1805#input.household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_any_other_participating_provider
+    : true
+  output:
+    us:regulations/47-cfr/54/1805#qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider: not_holds

--- a/us/regulations/47-cfr/54/1805.yaml
+++ b/us/regulations/47-cfr/54/1805.yaml
@@ -1,0 +1,53 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/47/54/1805
+  summary: |-
+    A household qualifies for the Affordable Connectivity Program only if it is an eligible household under § 54.1800(j); to receive a benefit from a participating provider, neither the eligible household nor any member may already receive another affordable connectivity benefit from that or any other participating provider.
+rules:
+  - name: qualifies_for_affordable_connectivity_program
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.1805(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1805
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_constitutes_eligible_household_under_section_54_1800_j
+
+  - name: qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 47 CFR 54.1805(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/47/54/1805
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/47-cfr/54/1805#qualifies_for_affordable_connectivity_program
+              output: qualifies_for_affordable_connectivity_program
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          qualifies_for_affordable_connectivity_program
+          and provider_is_participating_provider
+          and not household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_that_participating_provider
+          and not household_or_any_member_already_receiving_another_affordable_connectivity_benefit_from_any_other_participating_provider


### PR DESCRIPTION
## Summary
- encode federal Affordable Connectivity Program definitions, support amount, and receipt rules from 47 CFR 54.1800, 54.1803, and 54.1805
- add targeted 54.1800(j) eligible-household definition with 200% FPG and categorical routes
- include signed axiom-encode apply manifests and companion tests

Related oracle registry PR: TheAxiomFoundation/axiom-encode#745

## Validation
- uv run axiom-encode validate us/regulations/47-cfr/54/1800.yaml --skip-reviewers
- uv run axiom-encode validate us/regulations/47-cfr/54/1800/j.yaml --skip-reviewers
- uv run axiom-encode validate us/regulations/47-cfr/54/1803.yaml --skip-reviewers
- uv run axiom-encode validate us/regulations/47-cfr/54/1805.yaml --skip-reviewers

All four deterministic validations passed locally. LLM reviewer tier was skipped because the local Codex reviewer path is currently blocked by OAuth reauthorization in this desktop session.