### PR TITLE
Encode Pell Grant PE parity surfaces

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.802"
+axiom_encode_version = "0.2.803"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "07a4df4b3294b97678646718d493f87bfdb50742"
+axiom_encode_ref = "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c"
 axiom_corpus_ref = "6ec3b884e1bc28ad78e1dedcf1a1f8d1201b7ab7"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.801"
+axiom_encode_version = "0.2.802"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "f497d0e497a84a9054b3f8a79b9ae8f862ed64cb"
-axiom_corpus_ref = "29314ba476d233abf232861fb803dd8bb8038212"
+axiom_encode_ref = "07a4df4b3294b97678646718d493f87bfdb50742"
+axiom_corpus_ref = "6ec3b884e1bc28ad78e1dedcf1a1f8d1201b7ab7"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
-rulespec_us_ref = "98984a5b35ab424ba9910a121e7554168290d779"
+rulespec_us_ref = "dfffa886db3cde7e963f1595db11819e78a7239d"

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-30.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-30.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml",
-      "sha256": "cdbc2e2cc3c3cdd294618cc4e0ebcac72b1abf9688e86e303979f4f07b912705"
+      "sha256": "5823c7bcf084b5ce658b23d3e9bd57624620f8f8d96f695a7c2235c219401085"
     }
   ],
   "axiom_encode_git": {
-    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.802",
-    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+    "version": "0.2.803",
+    "version_commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c"
   },
-  "axiom_encode_version": "0.2.802",
-  "backend": "openai",
-  "citation": "us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30",
-  "context_manifest_file": "/tmp/axiom-encode-pell-sai-page-30/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-30/workspace/context-manifest.json",
-  "context_manifest_sha256": "f863f174fc77865e73eefbb448c7e7b35c9e1d562f68244517284811007b5811",
-  "generated_at": "2026-06-24T14:56:45.089712+00:00",
-  "generated_output_file": "/tmp/axiom-encode-pell-sai-page-30/openai-gpt-5.5/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml",
-  "generated_output_root": "/tmp/axiom-encode-pell-sai-page-30",
+  "axiom_encode_version": "0.2.803",
+  "backend": "deterministic",
+  "citation": "us:policies/ed/fsa/2026-27-sai-pell-guide/page-30",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-24T15:23:28.293254+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0fglxvdp/deterministic-repair/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0fglxvdp",
   "generated_output_sha256": "b43c0fa53e7bd1b4d35d6125e2d67bc577d0839e32b958c4e5681dd93b1963be",
-  "generation_prompt_sha256": "93caf35ed95e37b70bf881c9abab215b823587166c3b14b9fb0115bf58fbcc1f",
-  "model": "gpt-5.5",
-  "run_id": "fb2a8c1a",
-  "runner": "openai-gpt-5.5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "88cd3426ef847a01c33ab2cde57913bd56df13a4a221182feb74c496da5b406d"
+    "value": "93b00a847a4b33a205cc4d518b8c40efe1e2180230f8627348dfd7579a66c5e4"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-pell-sai-page-30/traces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-30.json",
-  "trace_sha256": "cbd0feffe8c097d528bb226095c1d1241b534d7c0b5c9524e8d315f4ce6de877"
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-30.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-30.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml",
+      "sha256": "b43c0fa53e7bd1b4d35d6125e2d67bc577d0839e32b958c4e5681dd93b1963be"
+    },
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml",
+      "sha256": "cdbc2e2cc3c3cdd294618cc4e0ebcac72b1abf9688e86e303979f4f07b912705"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30",
+  "context_manifest_file": "/tmp/axiom-encode-pell-sai-page-30/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-30/workspace/context-manifest.json",
+  "context_manifest_sha256": "f863f174fc77865e73eefbb448c7e7b35c9e1d562f68244517284811007b5811",
+  "generated_at": "2026-06-24T14:56:45.089712+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-sai-page-30/openai-gpt-5.5/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-sai-page-30",
+  "generated_output_sha256": "b43c0fa53e7bd1b4d35d6125e2d67bc577d0839e32b958c4e5681dd93b1963be",
+  "generation_prompt_sha256": "93caf35ed95e37b70bf881c9abab215b823587166c3b14b9fb0115bf58fbcc1f",
+  "model": "gpt-5.5",
+  "run_id": "fb2a8c1a",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "88cd3426ef847a01c33ab2cde57913bd56df13a4a221182feb74c496da5b406d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-sai-page-30/traces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-30.json",
+  "trace_sha256": "cbd0feffe8c097d528bb226095c1d1241b534d7c0b5c9524e8d315f4ce6de877"
+}

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-31.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-31.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml",
+      "sha256": "4bf0e88777c7cd956b6ea535bde8871c52111da59c4a24ceae79b3cacdbc9f0a"
+    },
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-31.test.yaml",
+      "sha256": "1cbcc3d25711ccd43556badda2bdde5570146697a04e92bd81bf9a5f88c865ab"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31",
+  "context_manifest_file": "/tmp/axiom-encode-pell-sai-page-31/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-31/workspace/context-manifest.json",
+  "context_manifest_sha256": "8622d45b114869891a5506b4291ae190b9e7b3105bee2b48afda5feeac33c2e0",
+  "generated_at": "2026-06-24T14:58:14.101169+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-sai-page-31/openai-gpt-5.5/policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-sai-page-31",
+  "generated_output_sha256": "4bf0e88777c7cd956b6ea535bde8871c52111da59c4a24ceae79b3cacdbc9f0a",
+  "generation_prompt_sha256": "8d1ed0432f966c12a32f80404473b26c0683a3393f5f04a31c66a6769b3a276d",
+  "model": "gpt-5.5",
+  "run_id": "a073279f",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fed9aaba19777a60d5e52e14cf50593205acf6b4090b2ab83a1b798877476497"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-sai-page-31/traces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-31.json",
+  "trace_sha256": "dc330692d88fa70cf1fc8b62d99300ae174507e40f3d807a439a5ec54f78c12a"
+}

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-8.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-8.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml",
-      "sha256": "a2b67cbe7fa4b4b7d4b7690fed5171eda0d3a7a4f5c6a02ee8e773b53365b74c"
+      "sha256": "111cc39dd4fdfc3c0bd0db3189d14144c6ced24e363ff7c0beb18a4285c903bc"
     }
   ],
   "axiom_encode_git": {
-    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.802",
-    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+    "version": "0.2.803",
+    "version_commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c"
   },
-  "axiom_encode_version": "0.2.802",
-  "backend": "openai",
-  "citation": "us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8",
-  "context_manifest_file": "/tmp/axiom-encode-pell-sai-page-8/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-8/workspace/context-manifest.json",
-  "context_manifest_sha256": "dfa370523bbc01eab280e7e8ee06e4293dfbe9881b6718007d1ba63ec689f1fb",
-  "generated_at": "2026-06-24T14:53:16.850633+00:00",
-  "generated_output_file": "/tmp/axiom-encode-pell-sai-page-8/openai-gpt-5.5/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml",
-  "generated_output_root": "/tmp/axiom-encode-pell-sai-page-8",
+  "axiom_encode_version": "0.2.803",
+  "backend": "deterministic",
+  "citation": "us:policies/ed/fsa/2026-27-sai-pell-guide/page-8",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-24T15:23:30.857887+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0_5txrq6/deterministic-repair/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0_5txrq6",
   "generated_output_sha256": "8b8ce8f6e8acaea6f03f1b2ef84d025c4010cccaf4040af23355c21e72c5436b",
-  "generation_prompt_sha256": "e16c389e78d2f9e8fb1128a22f565e9caaabc0470befa1f94a84f1a0caec9cb3",
-  "model": "gpt-5.5",
-  "run_id": "55200d93",
-  "runner": "openai-gpt-5.5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6873fc2f722629fa9cf4198b5889725e11249c86e2f0347f9b9a50ec62c7c25b"
+    "value": "5c74ecbd0e936f83fa8234c016727be7c5c5a3dd0ef3107f2830f92cba431a9b"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-pell-sai-page-8/traces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-8.json",
-  "trace_sha256": "d5e15ea20543b765b7bb16f806ce963fb819facd0a213e5452e86942d9094213"
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-8.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/2026-27-sai-pell-guide/page-8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml",
+      "sha256": "8b8ce8f6e8acaea6f03f1b2ef84d025c4010cccaf4040af23355c21e72c5436b"
+    },
+    {
+      "path": "policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml",
+      "sha256": "a2b67cbe7fa4b4b7d4b7690fed5171eda0d3a7a4f5c6a02ee8e773b53365b74c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8",
+  "context_manifest_file": "/tmp/axiom-encode-pell-sai-page-8/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "dfa370523bbc01eab280e7e8ee06e4293dfbe9881b6718007d1ba63ec689f1fb",
+  "generated_at": "2026-06-24T14:53:16.850633+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-sai-page-8/openai-gpt-5.5/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-sai-page-8",
+  "generated_output_sha256": "8b8ce8f6e8acaea6f03f1b2ef84d025c4010cccaf4040af23355c21e72c5436b",
+  "generation_prompt_sha256": "e16c389e78d2f9e8fb1128a22f565e9caaabc0470befa1f94a84f1a0caec9cb3",
+  "model": "gpt-5.5",
+  "run_id": "55200d93",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6873fc2f722629fa9cf4198b5889725e11249c86e2f0347f9b9a50ec62c7c25b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-sai-page-8/traces/openai-gpt-5.5/us-guidance-ed-fsa-2026-27-sai-pell-guide-page-8.json",
+  "trace_sha256": "d5e15ea20543b765b7bb16f806ce963fb819facd0a213e5452e86942d9094213"
+}

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml",
-      "sha256": "0867fc3d8f002bf69ec7c6aae8d7a9516ff416f0d6a4981fdf289394abe904ce"
+      "sha256": "b6c6d95e1ec899278b49ddfce24c834a17d15a6d53fcd21a97581e86ba247c98"
     }
   ],
   "axiom_encode_git": {
-    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.802",
-    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+    "version": "0.2.803",
+    "version_commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c"
   },
-  "axiom_encode_version": "0.2.802",
-  "backend": "openai",
-  "citation": "us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1",
-  "context_manifest_file": "/tmp/axiom-encode-pell-gen-26-01/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-gen-26-01-pell-award-amounts-block-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "8413bf1713e8d43f777f9ec7e4bd002f27a3fb5cb2bff35ff4427ca3b5676eec",
-  "generated_at": "2026-06-24T14:44:13.504597+00:00",
-  "generated_output_file": "/tmp/axiom-encode-pell-gen-26-01/openai-gpt-5.5/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml",
-  "generated_output_root": "/tmp/axiom-encode-pell-gen-26-01",
+  "axiom_encode_version": "0.2.803",
+  "backend": "deterministic",
+  "citation": "us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-24T15:23:33.464603+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0prm7c9x/deterministic-repair/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0prm7c9x",
   "generated_output_sha256": "0de9927bc09dc0103cdd4895d19da67e28ec6ffaa0a2941daa14db8e79bf6f42",
-  "generation_prompt_sha256": "982a459e0d7bc5ab80dd7060e84dff648d5850ab272a50b66ecb1241a8fa7887",
-  "model": "gpt-5.5",
-  "run_id": "16461765",
-  "runner": "openai-gpt-5.5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7300e99c04c22fa37f54658f8685aa4077486cf18b26022a176ad50320f7d72c"
+    "value": "75163c1ecc84ce9a87213e10b0f93cb2954f8203fafdffcfcbba928bdafd332f"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-pell-gen-26-01/traces/openai-gpt-5.5/us-guidance-ed-fsa-gen-26-01-pell-award-amounts-block-1.json",
-  "trace_sha256": "1685ebdb082219f976fd86ef250e580aa551273d11037bd5ef41b87bd581cb34"
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us/.axiom/encoding-manifests/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.json
+++ b/us/.axiom/encoding-manifests/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml",
+      "sha256": "0de9927bc09dc0103cdd4895d19da67e28ec6ffaa0a2941daa14db8e79bf6f42"
+    },
+    {
+      "path": "policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml",
+      "sha256": "0867fc3d8f002bf69ec7c6aae8d7a9516ff416f0d6a4981fdf289394abe904ce"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-pell-gen-26-01/_eval_workspaces/openai-gpt-5.5/us-guidance-ed-fsa-gen-26-01-pell-award-amounts-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "8413bf1713e8d43f777f9ec7e4bd002f27a3fb5cb2bff35ff4427ca3b5676eec",
+  "generated_at": "2026-06-24T14:44:13.504597+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-gen-26-01/openai-gpt-5.5/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-gen-26-01",
+  "generated_output_sha256": "0de9927bc09dc0103cdd4895d19da67e28ec6ffaa0a2941daa14db8e79bf6f42",
+  "generation_prompt_sha256": "982a459e0d7bc5ab80dd7060e84dff648d5850ab272a50b66ecb1241a8fa7887",
+  "model": "gpt-5.5",
+  "run_id": "16461765",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7300e99c04c22fa37f54658f8685aa4077486cf18b26022a176ad50320f7d72c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-gen-26-01/traces/openai-gpt-5.5/us-guidance-ed-fsa-gen-26-01-pell-award-amounts-block-1.json",
+  "trace_sha256": "1685ebdb082219f976fd86ef250e580aa551273d11037bd5ef41b87bd581cb34"
+}

--- a/us/.axiom/encoding-manifests/statutes/20/1070a/b/1.json
+++ b/us/.axiom/encoding-manifests/statutes/20/1070a/b/1.json
@@ -6,36 +6,36 @@
     },
     {
       "path": "statutes/20/1070a/b/1.test.yaml",
-      "sha256": "79e9bde1d82cbeaf4cee097ac91d32cb4a333ccec212388edab72ef80e58eba8"
+      "sha256": "95a0625287c7ed1e5dc1dcb0dce50a8c8238e8146e8fb23ac7c066842bd41670"
     }
   ],
   "axiom_encode_git": {
-    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.802",
-    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+    "version": "0.2.803",
+    "version_commit": "9f8413bcbafaa07cf375d9ceda1d820e3b96df2c"
   },
-  "axiom_encode_version": "0.2.802",
-  "backend": "openai",
-  "citation": "us/statute/20/1070a/b/1",
-  "context_manifest_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/_eval_workspaces/openai-gpt-5.5/us-statute-20-1070a-b-1/workspace/context-manifest.json",
-  "context_manifest_sha256": "7b5ce8ae9810c6db5a8828dba6ff5d94cca392ed31fe62cda94c97e08d834ebb",
-  "generated_at": "2026-06-24T15:02:21.734341+00:00",
-  "generated_output_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/openai-gpt-5.5/statutes/20/1070a/b/1.yaml",
-  "generated_output_root": "/tmp/axiom-encode-pell-1070a-b-1-retry",
+  "axiom_encode_version": "0.2.803",
+  "backend": "deterministic",
+  "citation": "us:statutes/20/1070a/b/1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-24T15:23:36.196961+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp2yps_9gi/deterministic-repair/statutes/20/1070a/b/1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp2yps_9gi",
   "generated_output_sha256": "e8e6386f4713df8f42a7e4c1f1098934526d98cb60bf9612a264e9cb7228f2a8",
-  "generation_prompt_sha256": "a6e4516676e0766ab6c8017775a0709849c63b6c08c1d385a8d0af2f72ee13ec",
-  "model": "gpt-5.5",
-  "run_id": "8d5ed134",
-  "runner": "openai-gpt-5.5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8efbc0f3ee14a56463591234dd8c9f9c1dbb0c06fc5ef8dc008a292d3f190b9b"
+    "value": "1bee4e73c8fa8a1513a0aa9cda4957a91aa023b7508ee7511d949812088940dc"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/traces/openai-gpt-5.5/us-statute-20-1070a-b-1.json",
-  "trace_sha256": "d3a73dbd17711437534d1cc6fcfff51bea479ceab89a780f52900879384910ff"
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us/.axiom/encoding-manifests/statutes/20/1070a/b/1.json
+++ b/us/.axiom/encoding-manifests/statutes/20/1070a/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/20/1070a/b/1.yaml",
+      "sha256": "e8e6386f4713df8f42a7e4c1f1098934526d98cb60bf9612a264e9cb7228f2a8"
+    },
+    {
+      "path": "statutes/20/1070a/b/1.test.yaml",
+      "sha256": "79e9bde1d82cbeaf4cee097ac91d32cb4a333ccec212388edab72ef80e58eba8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/statute/20/1070a/b/1",
+  "context_manifest_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/_eval_workspaces/openai-gpt-5.5/us-statute-20-1070a-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "7b5ce8ae9810c6db5a8828dba6ff5d94cca392ed31fe62cda94c97e08d834ebb",
+  "generated_at": "2026-06-24T15:02:21.734341+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/openai-gpt-5.5/statutes/20/1070a/b/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-1070a-b-1-retry",
+  "generated_output_sha256": "e8e6386f4713df8f42a7e4c1f1098934526d98cb60bf9612a264e9cb7228f2a8",
+  "generation_prompt_sha256": "a6e4516676e0766ab6c8017775a0709849c63b6c08c1d385a8d0af2f72ee13ec",
+  "model": "gpt-5.5",
+  "run_id": "8d5ed134",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8efbc0f3ee14a56463591234dd8c9f9c1dbb0c06fc5ef8dc008a292d3f190b9b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-1070a-b-1-retry/traces/openai-gpt-5.5/us-statute-20-1070a-b-1.json",
+  "trace_sha256": "d3a73dbd17711437534d1cc6fcfff51bea479ceab89a780f52900879384910ff"
+}

--- a/us/.axiom/encoding-manifests/statutes/20/1070a/b/3.json
+++ b/us/.axiom/encoding-manifests/statutes/20/1070a/b/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/20/1070a/b/3.yaml",
+      "sha256": "d61562feecb6e6088a5e1328413aa7bd47da99c1144250dc35bb97498e8e0493"
+    },
+    {
+      "path": "statutes/20/1070a/b/3.test.yaml",
+      "sha256": "f14633462500af15b43552bf0e8e9d3cd3010031dee73f421176d0254004ae4a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/statute/20/1070a/b/3",
+  "context_manifest_file": "/tmp/axiom-encode-pell-1070a-b-3/_eval_workspaces/openai-gpt-5.5/us-statute-20-1070a-b-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "8345692c7e57ed9f81663e9eeb43faf4f2e15a3229b822aad75385e1f8865cf2",
+  "generated_at": "2026-06-24T14:49:05.937835+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-1070a-b-3/openai-gpt-5.5/statutes/20/1070a/b/3.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-1070a-b-3",
+  "generated_output_sha256": "d61562feecb6e6088a5e1328413aa7bd47da99c1144250dc35bb97498e8e0493",
+  "generation_prompt_sha256": "815b862ba73d4fd0aff6cb792a3b20c0955b38936a5c10772b1e8151e80ef12e",
+  "model": "gpt-5.5",
+  "run_id": "2875ca86",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dd5804490f1ce07342c31ae5f93e37c9fae31a2cbd5083f6238fd593bb4c6628"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-1070a-b-3/traces/openai-gpt-5.5/us-statute-20-1070a-b-3.json",
+  "trace_sha256": "6fe995eafc5e8583b1899bdf160ffbffe07705c686517d55a5cfc9e50f5c8868"
+}

--- a/us/.axiom/encoding-manifests/statutes/20/1070a/b/5.json
+++ b/us/.axiom/encoding-manifests/statutes/20/1070a/b/5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/20/1070a/b/5.yaml",
+      "sha256": "6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279"
+    },
+    {
+      "path": "statutes/20/1070a/b/5.test.yaml",
+      "sha256": "baaefe530a7e002fb36002c67b073a130f6af1fdaa7a00c3d2c0dc7d670761b8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "07a4df4b3294b97678646718d493f87bfdb50742",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.802",
+    "version_commit": "07a4df4b3294b97678646718d493f87bfdb50742"
+  },
+  "axiom_encode_version": "0.2.802",
+  "backend": "openai",
+  "citation": "us/statute/20/1070a/b/5",
+  "context_manifest_file": "/tmp/axiom-encode-pell-1070a-b-5/_eval_workspaces/openai-gpt-5.5/us-statute-20-1070a-b-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "4068fc820b25ef84e14fd3c873f2bd3707281c52342905da6b5f64a9e03e1d87",
+  "generated_at": "2026-06-24T14:50:06.475838+00:00",
+  "generated_output_file": "/tmp/axiom-encode-pell-1070a-b-5/openai-gpt-5.5/statutes/20/1070a/b/5.yaml",
+  "generated_output_root": "/tmp/axiom-encode-pell-1070a-b-5",
+  "generated_output_sha256": "6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279",
+  "generation_prompt_sha256": "acb1a4e1a6b73d49ad0bf3d461b54c590a634fd25c899e110dcd71c4a70bdd1d",
+  "model": "gpt-5.5",
+  "run_id": "2e5ab872",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0e358f8455b0943d0432191054a123ba0fe46b54b25362f71191b658a43acd14"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-pell-1070a-b-5/traces/openai-gpt-5.5/us-statute-20-1070a-b-5.json",
+  "trace_sha256": "35f34676b47fa27a4fd86587a05661dcc6761cbe6b651924dab996e6611b8832"
+}

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml
@@ -1,0 +1,88 @@
+- name: dependent_student_single_parent_at_325_percent_gets_indicator_1
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_dependent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_is_single_parent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_agi_plus_foreign_income_exclusion_amount: 65000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_independent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_parent: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount
+    : 0
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_minimum_pell_indicator: 1
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_eligible_for_minimum_pell_grant: holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_minimum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_eligible_for_minimum_pell_grant: not_holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#student_eligible_for_minimum_pell_grant: holds
+- name: dependent_student_not_single_parent_above_275_percent_has_no_minimum_pell
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_dependent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_agi_plus_foreign_income_exclusion_amount: 60000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_independent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_parent: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount
+    : 0
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_minimum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_eligible_for_minimum_pell_grant: not_holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_minimum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_eligible_for_minimum_pell_grant: not_holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#student_eligible_for_minimum_pell_grant: not_holds
+- name: independent_student_parent_not_single_parent_at_350_percent_gets_indicator_4
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_dependent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_agi_plus_foreign_income_exclusion_amount: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_independent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_parent: true
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount
+    : 70000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_minimum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_eligible_for_minimum_pell_grant: not_holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_minimum_pell_indicator: 4
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_eligible_for_minimum_pell_grant: holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#student_eligible_for_minimum_pell_grant: holds
+- name: independent_student_not_parent_at_275_percent_gets_indicator_5
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_dependent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.parent_agi_plus_foreign_income_exclusion_amount: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_independent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_is_parent: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#input.student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount
+    : 55000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_minimum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_student_eligible_for_minimum_pell_grant: not_holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_minimum_pell_indicator: 5
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_eligible_for_minimum_pell_grant: holds
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#student_eligible_for_minimum_pell_grant: holds

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.test.yaml
@@ -86,3 +86,43 @@
     us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_minimum_pell_indicator: 5
     us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_student_eligible_for_minimum_pell_grant: holds
     us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#student_eligible_for_minimum_pell_grant: holds
+- name: oracle_parameter_dependent_minimum_pell_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_minimum_pell_single_parent_poverty_guideline_rate: 3.25
+- name: oracle_parameter_dependent_minimum_pell_not_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_minimum_pell_not_single_parent_poverty_guideline_rate: 2.75
+- name: oracle_parameter_independent_minimum_pell_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_single_parent_poverty_guideline_rate: 4.0
+- name: oracle_parameter_independent_minimum_pell_parent_not_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_parent_not_single_parent_poverty_guideline_rate: 3.5
+- name: oracle_parameter_independent_minimum_pell_not_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_not_parent_poverty_guideline_rate: 2.75

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml
@@ -1,0 +1,329 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+  summary: |-
+    "A student is eligible for a Minimum Pell Grant if any of the following is true" under the dependent and independent student criteria; "The Minimum Pell Indicator (1, 2, 3, 4, or 5) will be returned on the ISIR, if applicable."
+rules:
+  - name: dependent_minimum_pell_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student, Minimum Pell Indicator 1"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "less than or equal to 325% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3.25
+
+  - name: dependent_minimum_pell_not_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student, Minimum Pell Indicator 2"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "less than or equal to 275% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.75
+
+  - name: independent_minimum_pell_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student, Minimum Pell Indicator 3"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "less than or equal to 400% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          4.00
+
+  - name: independent_minimum_pell_parent_not_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student, Minimum Pell Indicator 4"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "less than or equal to 350% of the ... poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3.50
+
+  - name: independent_minimum_pell_not_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student, Minimum Pell Indicator 5"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "less than or equal to 275% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.75
+
+  - name: minimum_pell_indicator_dependent_single_parent
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 1"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: minimum_pell_indicator_dependent_not_single_parent
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 2"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: minimum_pell_indicator_independent_single_parent
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 3"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: minimum_pell_indicator_independent_parent_not_single_parent
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 4"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          4
+
+  - name: minimum_pell_indicator_independent_not_parent
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 5"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          5
+
+  - name: no_minimum_pell_indicator
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, note"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "will be returned on the ISIR, if applicable"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0
+
+  - name: dependent_student_minimum_pell_indicator
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 1"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 2"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if student_is_dependent and parent_is_single_parent and parent_agi_plus_foreign_income_exclusion_amount <= dependent_minimum_pell_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state: minimum_pell_indicator_dependent_single_parent else: if student_is_dependent and not parent_is_single_parent and parent_agi_plus_foreign_income_exclusion_amount <= dependent_minimum_pell_not_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state: minimum_pell_indicator_dependent_not_single_parent else: no_minimum_pell_indicator
+
+  - name: dependent_student_eligible_for_minimum_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "eligible for a Minimum Pell Grant if any of the following is true"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          dependent_student_minimum_pell_indicator != no_minimum_pell_indicator
+
+  - name: independent_student_minimum_pell_indicator
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 3"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 4"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "Minimum Pell Indicator = 5"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if student_is_independent and student_is_single_parent and student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount <= independent_minimum_pell_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state: minimum_pell_indicator_independent_single_parent else: if student_is_independent and student_is_parent and not student_is_single_parent and student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount <= independent_minimum_pell_parent_not_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state: minimum_pell_indicator_independent_parent_not_single_parent else: if student_is_independent and not student_is_parent and student_and_spouse_if_applicable_agi_plus_foreign_income_exclusion_amount <= independent_minimum_pell_not_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state: minimum_pell_indicator_independent_not_parent else: no_minimum_pell_indicator
+
+  - name: independent_student_eligible_for_minimum_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "eligible for a Minimum Pell Grant if any of the following is true"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          independent_student_minimum_pell_indicator != no_minimum_pell_indicator
+
+  - name: student_eligible_for_minimum_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 SAI and Pell Grant Eligibility Guide, Step 3"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-30
+              excerpt: "eligible for a Minimum Pell Grant if any of the following is true"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          dependent_student_eligible_for_minimum_pell_grant or independent_student_eligible_for_minimum_pell_grant

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.test.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.test.yaml
@@ -1,0 +1,84 @@
+- name: sai_within_maximum_minus_minimum_sets_federal_pell_grant_flag
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.graduate_flag_is_blank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.pursuing_teach_certification_is_yes: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index: 1000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.maximum_pell_sai: 7400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_sai: 6400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_indicator_is_nonblank: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_for_cfh: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_due_to_grandfather: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_for_iasg: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_due_to_grandfathering
+    : false
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#federal_pell_grant_flag_is_yes: holds
+- name: minimum_pell_indicator_and_sai_less_than_twice_maximum_sets_flag
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.graduate_flag_is_blank: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.pursuing_teach_certification_is_yes: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index: 14000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.maximum_pell_sai: 7400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_sai: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_indicator_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_for_cfh: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_due_to_grandfather: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_for_iasg: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_due_to_grandfathering
+    : false
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#federal_pell_grant_flag_is_yes: holds
+- name: cfh_grandfather_status_with_nonblank_sai_sets_flag
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.graduate_flag_is_blank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.pursuing_teach_certification_is_yes: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index: 20000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.maximum_pell_sai: 7400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_sai: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_indicator_is_nonblank: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_for_cfh: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_due_to_grandfather: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_for_iasg: false
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_due_to_grandfathering
+    : false
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#federal_pell_grant_flag_is_yes: holds
+- name: no_graduate_or_teach_certification_gate_blocks_flag
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.graduate_flag_is_blank: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.pursuing_teach_certification_is_yes: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.student_aid_index: 1000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.maximum_pell_sai: 7400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_sai: 6400
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.minimum_pell_indicator_is_nonblank: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_for_cfh: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.children_of_fallen_heroes_indicator_is_eligible_due_to_grandfather: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_for_iasg: true
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#input.iraq_afghanistan_service_grant_indicator_is_eligible_due_to_grandfathering
+    : false
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#federal_pell_grant_flag_is_yes: not_holds

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+  summary: |-
+    "The Federal Pell Grant Flag ... is set to Y" when the Graduate Flag is blank or Pursuing Teach Certification is "Yes" and one of the listed SAI, Minimum Pell Indicator, Children of Fallen Heroes, or Iraq Afghanistan Service Grant conditions is true.
+rules:
+  - name: pell_flag_twice_maximum_pell_sai_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Federal Pell Grant Flag, Table 2"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "SAI is less than twice Maximum Pell SAI"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: federal_pell_grant_flag_is_yes
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Federal Pell Grant Flag, Table 2"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "Graduate Flag is blank OR Pursuing Teach Certification is “Yes”"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "SAI is non-blank AND less than or equal to Maximum Pell SAI minus the Minimum Pell SAI"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "SAI is less than twice Maximum Pell SAI AND Minimum Pell Indicator is non-blank"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "Children of Fallen Heroes Indicator is \"Eligible for CFH\" OR “Eligible Due to Grandfather”"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-31
+              excerpt: "Iraq Afghanistan Service Grant Indicator is \"Eligible for IASG\" OR \"Eligible Due to Grandfathering”"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/2026-27-sai-pell-guide/page-31#pell_flag_twice_maximum_pell_sai_multiplier
+              output: pell_flag_twice_maximum_pell_sai_multiplier
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (graduate_flag_is_blank or pursuing_teach_certification_is_yes)
+          and (
+            (student_aid_index_is_nonblank and student_aid_index <= maximum_pell_sai - minimum_pell_sai)
+            or (student_aid_index < pell_flag_twice_maximum_pell_sai_multiplier * maximum_pell_sai and minimum_pell_indicator_is_nonblank)
+            or (student_aid_index_is_nonblank and (children_of_fallen_heroes_indicator_is_eligible_for_cfh or children_of_fallen_heroes_indicator_is_eligible_due_to_grandfather))
+            or (student_aid_index_is_nonblank and (iraq_afghanistan_service_grant_indicator_is_eligible_for_iasg or iraq_afghanistan_service_grant_indicator_is_eligible_due_to_grandfathering))
+          )

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml
@@ -1,0 +1,62 @@
+- name: dependent_student_parents_both_non_filers_get_indicator_1
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_dependent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parents_both_did_not_file_federal_income_tax_return: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parent_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parent_agi_plus_foreign_income_exclusion_amount: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#dependent_student_maximum_pell_indicator: 1
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#dependent_student_eligible_for_maximum_pell_grant: holds
+- name: dependent_student_single_parent_income_at_225_percent_gets_indicator_2
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_dependent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parents_both_did_not_file_federal_income_tax_return: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parent_is_single_parent: true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.parent_agi_plus_foreign_income_exclusion_amount: 45000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#dependent_student_maximum_pell_indicator: 2
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#dependent_student_eligible_for_maximum_pell_grant: holds
+- name: independent_student_and_spouse_if_applicable_non_filers_get_indicator_1
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_independent: true
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_and_spouse_if_applicable_did_not_file_federal_income_tax_return
+    : true
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_agi_plus_foreign_income_exclusion_amount: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_maximum_pell_indicator: 1
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_eligible_for_maximum_pell_grant: holds
+- name: independent_student_not_single_parent_income_above_175_percent_has_no_maximum_pell_indicator
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_independent: true
+    ? us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_and_spouse_if_applicable_did_not_file_federal_income_tax_return
+    : false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_is_single_parent: false
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.student_agi_plus_foreign_income_exclusion_amount: 40000
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#input.poverty_guideline_for_applicant_family_size_and_state: 20000
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_maximum_pell_indicator: 0
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_eligible_for_maximum_pell_grant: not_holds

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.test.yaml
@@ -60,3 +60,19 @@
   output:
     us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_maximum_pell_indicator: 0
     us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#independent_student_eligible_for_maximum_pell_grant: not_holds
+- name: oracle_parameter_maximum_pell_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#maximum_pell_single_parent_poverty_guideline_rate: 2.25
+- name: oracle_parameter_maximum_pell_not_single_parent_poverty_guideline_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#maximum_pell_not_single_parent_poverty_guideline_rate: 1.75

--- a/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml
+++ b/us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml
@@ -1,0 +1,250 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+  summary: |-
+    Under HEA Sec. 401(b)(1)(A), a student is eligible for a Maximum Pell Grant if specified dependent or independent student criteria are met. Dependent criteria use parents' non-filer status or parents' AGI plus Foreign Income Exclusion Amount compared with 225% or 175% of the poverty guideline depending on single-parent status. Independent criteria use the student and spouse non-filer status or the student's AGI plus Foreign Income Exclusion Amount compared with the same 225% or 175% poverty-guideline thresholds depending on single-parent status. The Maximum Pell Indicator is 1, 2, or 3 if applicable.
+rules:
+  - name: maximum_pell_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "less than or equal to 225% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.25
+
+  - name: maximum_pell_not_single_parent_poverty_guideline_rate
+    kind: parameter
+    dtype: Rate
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "less than or equal to 175% of the poverty guideline"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.75
+
+  - name: maximum_pell_positive_income_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "(AGI + Foreign Income Exclusion Amount) greater than zero"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0
+
+  - name: maximum_pell_indicator_non_filer
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 1"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: maximum_pell_indicator_single_parent_income
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 2"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: maximum_pell_indicator_not_single_parent_income
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 3"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: no_maximum_pell_indicator
+    kind: parameter
+    dtype: Integer
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility, notes"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "will be returned on the ISIR, if applicable"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0
+
+  - name: dependent_student_maximum_pell_indicator
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 1"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 2"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 3"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if student_is_dependent and parents_both_did_not_file_federal_income_tax_return:
+            maximum_pell_indicator_non_filer
+          else:
+            if student_is_dependent and parent_is_single_parent and parent_agi_plus_foreign_income_exclusion_amount > maximum_pell_positive_income_floor and parent_agi_plus_foreign_income_exclusion_amount <= maximum_pell_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state:
+              maximum_pell_indicator_single_parent_income
+            else:
+              if student_is_dependent and not parent_is_single_parent and parent_agi_plus_foreign_income_exclusion_amount > maximum_pell_positive_income_floor and parent_agi_plus_foreign_income_exclusion_amount <= maximum_pell_not_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state:
+                maximum_pell_indicator_not_single_parent_income
+              else:
+                no_maximum_pell_indicator
+
+  - name: independent_student_maximum_pell_indicator
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 1"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 2"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "Maximum Pell Indicator = 3"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if student_is_independent and student_and_spouse_if_applicable_did_not_file_federal_income_tax_return:
+            maximum_pell_indicator_non_filer
+          else:
+            if student_is_independent and student_is_single_parent and student_agi_plus_foreign_income_exclusion_amount > maximum_pell_positive_income_floor and student_agi_plus_foreign_income_exclusion_amount <= maximum_pell_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state:
+              maximum_pell_indicator_single_parent_income
+            else:
+              if student_is_independent and not student_is_single_parent and student_agi_plus_foreign_income_exclusion_amount > maximum_pell_positive_income_floor and student_agi_plus_foreign_income_exclusion_amount <= maximum_pell_not_single_parent_poverty_guideline_rate * poverty_guideline_for_applicant_family_size_and_state:
+                maximum_pell_indicator_not_single_parent_income
+              else:
+                no_maximum_pell_indicator
+
+  - name: dependent_student_eligible_for_maximum_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility, Dependent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "a student is eligible for a Maximum Pell Grant if any of the following is true: Dependent Student"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          dependent_student_maximum_pell_indicator != no_maximum_pell_indicator
+
+  - name: independent_student_eligible_for_maximum_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: "2026-27 Student Aid Index (SAI) and Pell Grant Eligibility Guide, Step 1: Determine Maximum Pell Grant Eligibility, Independent Student"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/2026-27-sai-pell-guide/page-8
+              excerpt: "a student is eligible for a Maximum Pell Grant if any of the following is true: Independent Student"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          independent_student_maximum_pell_indicator != no_maximum_pell_indicator

--- a/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml
+++ b/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml
@@ -54,3 +54,21 @@
     us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#sai_calculated_pell_grant: 0
     us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_receipt_prohibited_by_sai: not_holds
     us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_scheduled_pell_grant_funds_receivable: 7500
+- name: oracle_parameter_maximum_pell_grant_award
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input: {}
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_pell_grant_award: 7395
+- name: oracle_parameter_minimum_pell_grant_award
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input: {}
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#minimum_pell_grant_award: 740

--- a/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml
+++ b/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.test.yaml
@@ -1,0 +1,56 @@
+- name: sai_calculated_award_above_minimum_and_not_prohibited_below_threshold
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.calculated_sai: 1000
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.qualifies_for_pell_grant_under_special_rule: false
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.pell_grant_scheduled_award: 7395
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#sai_calculated_pell_grant: 6395
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_receipt_prohibited_by_sai: not_holds
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_scheduled_pell_grant_funds_receivable: 11092.5
+- name: sai_calculated_award_below_minimum_is_zero
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.calculated_sai: 7000
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.qualifies_for_pell_grant_under_special_rule: false
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.pell_grant_scheduled_award: 740
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#sai_calculated_pell_grant: 0
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_receipt_prohibited_by_sai: not_holds
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_scheduled_pell_grant_funds_receivable: 1110
+- name: sai_threshold_prohibits_pell_receipt_without_special_rule
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.calculated_sai: 14790
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.qualifies_for_pell_grant_under_special_rule: false
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.pell_grant_scheduled_award: 5000
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#sai_calculated_pell_grant: 0
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_receipt_prohibited_by_sai: holds
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_scheduled_pell_grant_funds_receivable: 7500
+- name: special_rule_exception_blocks_sai_prohibition
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2026-07-01'
+    end: '2027-06-30'
+  input:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.calculated_sai: 14790
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.qualifies_for_pell_grant_under_special_rule: true
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#input.pell_grant_scheduled_award: 5000
+  output:
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#sai_calculated_pell_grant: 0
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_receipt_prohibited_by_sai: not_holds
+    us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_scheduled_pell_grant_funds_receivable: 7500

--- a/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml
+++ b/us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml
@@ -1,0 +1,273 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+  summary: |-
+    "the Federal Pell Grant maximum and minimum award amounts for the 2026–27 award year ... will be effective July 1, 2026, through June 30, 2027"; "the maximum Pell Grant award remains fixed at $7,395"; "the minimum Pell Grant award is 10% of the maximum award amount"; "Pell Grant awards should be rounded to the nearest $5"; "the Pell Grant minimum award amount for 2026–27 is $740"; "An SAI-calculated Pell Grant is determined by subtracting the student’s calculated SAI from the annual published maximum Pell Grant amount, then rounding to the nearest $5"; applicants with SAI at least twice the maximum are prohibited from receiving a Pell Grant, except Special Rule applicants.
+rules:
+  - name: maximum_pell_grant_award
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, 2026-27 Pell Grant maximum award amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "for the 2026–27 award year, the maximum Pell Grant award remains fixed at $7,395"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          7395
+
+  - name: pell_grant_minimum_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, HEA section 401(a)(2)(F) minimum award rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "the minimum Pell Grant award is 10% of the maximum award amount"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          0.10
+
+  - name: pell_grant_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, HEA section 401(b)(1)(B)(ii) rounding
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: unit
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "Pell Grant awards should be rounded to the nearest $5"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          5
+
+  - name: minimum_pell_grant_award
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, 2026-27 Pell Grant minimum award amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "the Pell Grant minimum award amount for 2026–27 is $740"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          740
+
+  - name: pell_grant_sai_prohibition_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, OBBB SAI prohibition threshold for 2026-27
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "For the 2026–27 award year, that SAI threshold is $14,790"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          14790
+
+  - name: pell_grant_scheduled_award_annual_limit_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, annual receipt limit relative to scheduled award
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "eligible to receive Pell Grant funds for up to 150% of the student’s Pell Grant scheduled award"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          1.50
+
+  - name: pell_grant_lifetime_eligibility_semester_limit
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, HEA section 401(d)(5) lifetime eligibility limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "lifetime Pell Grant eligibility limit of 12 semesters"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "effective July 1, 2026, through June 30, 2027"
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          12
+
+  - name: sai_calculated_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, SAI-calculated Pell Grant calculation and minimum-award ineligibility rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "determined by subtracting the student’s calculated SAI from the annual published maximum Pell Grant amount, then rounding to the nearest $5"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "If the SAI-calculated Pell Grant is less than the published minimum Pell Grant amount, the student is ineligible for an SAI-calculated Pell Grant"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_pell_grant_award
+              output: maximum_pell_grant_award
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#minimum_pell_grant_award
+              output: minimum_pell_grant_award
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_rounding_multiple
+              output: pell_grant_rounding_multiple
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          if max(0, floor(((maximum_pell_grant_award - calculated_sai) / pell_grant_rounding_multiple) + 0.5) * pell_grant_rounding_multiple) < minimum_pell_grant_award: 0 else: max(0, floor(((maximum_pell_grant_award - calculated_sai) / pell_grant_rounding_multiple) + 0.5) * pell_grant_rounding_multiple)
+
+  - name: pell_grant_receipt_prohibited_by_sai
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, OBBB prohibition for SAI at or above twice the maximum Pell Grant, with Special Rule exception
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "prohibits an applicant whose SAI is equal to or greater than twice the maximum Pell Grant amount for the award year from receiving a Pell Grant"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "This prohibition does not apply to applicants who qualify for a Pell Grant under the Special Rule"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_sai_prohibition_threshold
+              output: pell_grant_sai_prohibition_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          calculated_sai >= pell_grant_sai_prohibition_threshold
+          and not qualifies_for_pell_grant_under_special_rule
+
+  - name: maximum_scheduled_pell_grant_funds_receivable
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Dear Colleague Letter GEN-26-01, maximum annual Pell Grant funds relative to scheduled award
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ed/fsa/gen-26-01-pell-award-amounts/block-1
+              excerpt: "eligible to receive Pell Grant funds for up to 150% of the student’s Pell Grant scheduled award"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#pell_grant_scheduled_award_annual_limit_rate
+              output: pell_grant_scheduled_award_annual_limit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-07-01'
+        formula: |-
+          max(0, pell_grant_scheduled_award * pell_grant_scheduled_award_annual_limit_rate)

--- a/us/statutes/20/1070a/b/1.test.yaml
+++ b/us/statutes/20/1070a/b/1.test.yaml
@@ -1,0 +1,105 @@
+- name: total_maximum_pell_grant_eligible_by_no_tax_return_requirement
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6340
+    us:statutes/20/1070a/b/1#input.adjusted_gross_income_for_pell_grant_calculation: 50000
+    us:statutes/20/1070a/b/1#input.college_grant_and_scholarship_aid_included_in_gross_income_elected_to_report: 0
+    us:statutes/20/1070a/b/1#input.income_earned_from_work_under_part_c_of_this_subchapter: 0
+    us:statutes/20/1070a/b/1#input.student_enrolled_in_eligible_program_full_time: true
+    us:statutes/20/1070a/b/1#input.applicable_persons_not_required_to_file_federal_income_tax_return_in_second_preceding_year: true
+    us:statutes/20/1070a/b/1#input.applicable_person_is_single_parent_for_maximum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.poverty_line_for_pell_grant_calculation: 10000
+    us:statutes/20/1070a/b/1#input.student_aid_index_for_award_year: 1000
+    us:statutes/20/1070a/b/1#input.minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F: 750
+    us:statutes/20/1070a/b/1#input.student_is_dependent_student: true
+    us:statutes/20/1070a/b/1#input.parent_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_parent_for_minimum_pell_grant: false
+  output:
+    us:statutes/20/1070a/b/1#adjusted_gross_income_for_pell_grant_eligibility: 50000
+    us:statutes/20/1070a/b/1#total_maximum_federal_pell_grant_eligible_under_paragraph_1: holds
+    us:statutes/20/1070a/b/1#federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review: 7400
+- name: calculated_pell_grant_uses_student_aid_index_floor_and_rounding
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6342
+    us:statutes/20/1070a/b/1#input.adjusted_gross_income_for_pell_grant_calculation: 30000
+    us:statutes/20/1070a/b/1#input.college_grant_and_scholarship_aid_included_in_gross_income_elected_to_report: 2000
+    us:statutes/20/1070a/b/1#input.income_earned_from_work_under_part_c_of_this_subchapter: 3000
+    us:statutes/20/1070a/b/1#input.student_enrolled_in_eligible_program_full_time: true
+    us:statutes/20/1070a/b/1#input.applicable_persons_not_required_to_file_federal_income_tax_return_in_second_preceding_year: false
+    us:statutes/20/1070a/b/1#input.applicable_person_is_single_parent_for_maximum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.poverty_line_for_pell_grant_calculation: 10000
+    us:statutes/20/1070a/b/1#input.student_aid_index_for_award_year: 1233
+    us:statutes/20/1070a/b/1#input.minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F: 750
+    us:statutes/20/1070a/b/1#input.student_is_dependent_student: true
+    us:statutes/20/1070a/b/1#input.parent_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_parent_for_minimum_pell_grant: false
+  output:
+    us:statutes/20/1070a/b/1#adjusted_gross_income_for_pell_grant_eligibility: 25000
+    us:statutes/20/1070a/b/1#total_maximum_federal_pell_grant_eligible_under_paragraph_1: not_holds
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_amount_under_paragraph_1: 6165
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_eligible_under_paragraph_1: holds
+    us:statutes/20/1070a/b/1#federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review: 6165
+- name: calculated_pell_grant_below_minimum_not_eligible_minimum_dependent_path_applies
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6340
+    us:statutes/20/1070a/b/1#input.adjusted_gross_income_for_pell_grant_calculation: 27000
+    us:statutes/20/1070a/b/1#input.college_grant_and_scholarship_aid_included_in_gross_income_elected_to_report: 0
+    us:statutes/20/1070a/b/1#input.income_earned_from_work_under_part_c_of_this_subchapter: 0
+    us:statutes/20/1070a/b/1#input.student_enrolled_in_eligible_program_full_time: true
+    us:statutes/20/1070a/b/1#input.applicable_persons_not_required_to_file_federal_income_tax_return_in_second_preceding_year: false
+    us:statutes/20/1070a/b/1#input.applicable_person_is_single_parent_for_maximum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.poverty_line_for_pell_grant_calculation: 10000
+    us:statutes/20/1070a/b/1#input.student_aid_index_for_award_year: 7000
+    us:statutes/20/1070a/b/1#input.minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F: 750
+    us:statutes/20/1070a/b/1#input.student_is_dependent_student: true
+    us:statutes/20/1070a/b/1#input.parent_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_parent_for_minimum_pell_grant: false
+  output:
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_amount_under_paragraph_1: 400
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_eligible_under_paragraph_1: not_holds
+    us:statutes/20/1070a/b/1#minimum_federal_pell_grant_eligible_under_paragraph_1: holds
+    us:statutes/20/1070a/b/1#federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review: 750
+- name: not_full_time_no_paragraph_1_grant
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6340
+    us:statutes/20/1070a/b/1#input.adjusted_gross_income_for_pell_grant_calculation: 10000
+    us:statutes/20/1070a/b/1#input.college_grant_and_scholarship_aid_included_in_gross_income_elected_to_report: 0
+    us:statutes/20/1070a/b/1#input.income_earned_from_work_under_part_c_of_this_subchapter: 0
+    us:statutes/20/1070a/b/1#input.student_enrolled_in_eligible_program_full_time: false
+    us:statutes/20/1070a/b/1#input.applicable_persons_not_required_to_file_federal_income_tax_return_in_second_preceding_year: true
+    us:statutes/20/1070a/b/1#input.applicable_person_is_single_parent_for_maximum_pell_grant: true
+    us:statutes/20/1070a/b/1#input.poverty_line_for_pell_grant_calculation: 10000
+    us:statutes/20/1070a/b/1#input.student_aid_index_for_award_year: -100
+    us:statutes/20/1070a/b/1#input.minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F: 750
+    us:statutes/20/1070a/b/1#input.student_is_dependent_student: false
+    us:statutes/20/1070a/b/1#input.parent_is_single_parent_for_minimum_pell_grant: false
+    us:statutes/20/1070a/b/1#input.student_is_single_parent_for_minimum_pell_grant: true
+    us:statutes/20/1070a/b/1#input.student_is_parent_for_minimum_pell_grant: true
+  output:
+    us:statutes/20/1070a/b/1#total_maximum_federal_pell_grant_eligible_under_paragraph_1: not_holds
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_amount_under_paragraph_1: 7400
+    us:statutes/20/1070a/b/1#calculated_federal_pell_grant_eligible_under_paragraph_1: not_holds
+    us:statutes/20/1070a/b/1#minimum_federal_pell_grant_eligible_under_paragraph_1: not_holds
+    us:statutes/20/1070a/b/1#federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review: 0

--- a/us/statutes/20/1070a/b/1.test.yaml
+++ b/us/statutes/20/1070a/b/1.test.yaml
@@ -103,3 +103,59 @@
     us:statutes/20/1070a/b/1#calculated_federal_pell_grant_eligible_under_paragraph_1: not_holds
     us:statutes/20/1070a/b/1#minimum_federal_pell_grant_eligible_under_paragraph_1: not_holds
     us:statutes/20/1070a/b/1#federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review: 0
+- name: oracle_parameter_maximum_pell_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#maximum_pell_single_parent_poverty_line_multiplier: 2.25
+- name: oracle_parameter_maximum_pell_not_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#maximum_pell_not_single_parent_poverty_line_multiplier: 1.75
+- name: oracle_parameter_minimum_pell_dependent_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#minimum_pell_dependent_single_parent_poverty_line_multiplier: 3.25
+- name: oracle_parameter_minimum_pell_dependent_not_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#minimum_pell_dependent_not_single_parent_poverty_line_multiplier: 2.75
+- name: oracle_parameter_minimum_pell_independent_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#minimum_pell_independent_single_parent_poverty_line_multiplier: 4.0
+- name: oracle_parameter_minimum_pell_independent_parent_not_single_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#minimum_pell_independent_parent_not_single_parent_poverty_line_multiplier: 3.5
+- name: oracle_parameter_minimum_pell_independent_not_parent_poverty_line_multiplier
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/20/1070a/b/1#minimum_pell_independent_not_parent_poverty_line_multiplier: 2.75

--- a/us/statutes/20/1070a/b/1.yaml
+++ b/us/statutes/20/1070a/b/1.yaml
@@ -1,0 +1,282 @@
+format: rulespec/v1
+imports:
+  - us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant
+  - us:statutes/20/1070a/b/5#pell_grant_rounding_increment
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/20/1070a/b/1
+  summary: |-
+    "A student shall be eligible for a total maximum Federal Pell Grant" under specified filing and poverty-line tests; otherwise a full-time student with student aid index less than the total maximum grant receives the total maximum grant less the student aid index, rounded to the nearest $5, unless below the minimum grant; otherwise specified students are eligible for the minimum Federal Pell Grant. Specified scholarship aid included in gross income and part C work income are subtracted from adjusted gross income for Pell eligibility calculations.
+  deferred_outputs:
+    - output: us:statutes/20/1070a/b/1#federal_pell_grant_provision_after_foreign_income_review_hold
+      reason: |-
+        Subparagraph (D) withholds a grant before July 1, 2026 until the student aid administrator evaluates the FAFSA and determines whether an adjustment under 20 U.S.C. 1087tt(b)(1)(B)(v) is appropriate. No copied RuleSpec source provides that cited adjustment determination.
+rules:
+  - name: maximum_pell_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "equal to or less than 225 percent of the poverty line"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.25
+
+  - name: maximum_pell_not_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(A)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "equal to or less than 175 percent of the poverty line"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.75
+
+  - name: minimum_pell_dependent_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(C)(i)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "dependent student ... parent is a single parent ... equal to or less than 325 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3.25
+
+  - name: minimum_pell_dependent_not_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(C)(i)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "dependent student ... parent is not a single parent ... equal to or less than 275 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.75
+
+  - name: minimum_pell_independent_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(C)(ii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "independent student ... single parent ... equal to or less than 400 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          4.00
+
+  - name: minimum_pell_independent_parent_not_single_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(C)(ii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "independent student ... parent and is not a single parent ... equal to or less than 350 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3.50
+
+  - name: minimum_pell_independent_not_parent_poverty_line_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 20 U.S.C. 1070a(b)(1)(C)(ii)(III)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "independent student ... not a parent ... equal to or less than 275 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2.75
+
+  - name: adjusted_gross_income_for_pell_grant_eligibility
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(1)(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "subtract from the student or parents’ adjusted gross income ... college grant and scholarship aid included in gross income ... Income earned from work under part C"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, adjusted_gross_income_for_pell_grant_calculation - college_grant_and_scholarship_aid_included_in_gross_income_elected_to_report + income_earned_from_work_under_part_c_of_this_subchapter * -1)
+
+  - name: total_maximum_federal_pell_grant_eligible_under_paragraph_1
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 20 U.S.C. 1070a(b)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          student_enrolled_in_eligible_program_full_time
+          and (applicable_persons_not_required_to_file_federal_income_tax_return_in_second_preceding_year
+          or (applicable_person_is_single_parent_for_maximum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility > 0 and adjusted_gross_income_for_pell_grant_eligibility <= maximum_pell_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation)
+          or (not applicable_person_is_single_parent_for_maximum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility > 0 and adjusted_gross_income_for_pell_grant_eligibility <= maximum_pell_not_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation))
+
+  - name: calculated_federal_pell_grant_amount_under_paragraph_1
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "total maximum Federal Pell Grant ... less ... student aid index ... less than zero shall be considered to be zero ... rounded to the nearest $5"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant
+              output: total_maximum_federal_pell_grant
+              hash: sha256:6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#pell_grant_rounding_increment
+              output: pell_grant_rounding_increment
+              hash: sha256:6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor(((max(0, total_maximum_federal_pell_grant - max(0, student_aid_index_for_award_year))) / pell_grant_rounding_increment) + 0.5) * pell_grant_rounding_increment
+
+  - name: calculated_federal_pell_grant_eligible_under_paragraph_1
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 20 U.S.C. 1070a(b)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+              excerpt: "not eligible ... under subparagraph (A) ... enrolled ... full time ... student aid index ... less than the total maximum ... except ... less than the minimum ... shall not be eligible"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant
+              output: total_maximum_federal_pell_grant
+              hash: sha256:6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          student_enrolled_in_eligible_program_full_time
+          and not total_maximum_federal_pell_grant_eligible_under_paragraph_1
+          and student_aid_index_for_award_year < total_maximum_federal_pell_grant
+          and calculated_federal_pell_grant_amount_under_paragraph_1 >= minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F
+
+  - name: minimum_federal_pell_grant_eligible_under_paragraph_1
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 20 U.S.C. 1070a(b)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          student_enrolled_in_eligible_program_full_time
+          and not total_maximum_federal_pell_grant_eligible_under_paragraph_1
+          and not calculated_federal_pell_grant_eligible_under_paragraph_1
+          and ((student_is_dependent_student and ((parent_is_single_parent_for_minimum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility <= minimum_pell_dependent_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation) or (not parent_is_single_parent_for_minimum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility <= minimum_pell_dependent_not_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation)))
+          or (not student_is_dependent_student and ((student_is_single_parent_for_minimum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility <= minimum_pell_independent_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation) or (student_is_parent_for_minimum_pell_grant and not student_is_single_parent_for_minimum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility <= minimum_pell_independent_parent_not_single_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation) or (not student_is_parent_for_minimum_pell_grant and adjusted_gross_income_for_pell_grant_eligibility <= minimum_pell_independent_not_parent_poverty_line_multiplier * poverty_line_for_pell_grant_calculation))))
+
+  - name: federal_pell_grant_amount_under_paragraph_1_before_foreign_income_review
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(1)(A)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/1
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant
+              output: total_maximum_federal_pell_grant
+              hash: sha256:6519e325bc31ddd9dbc4f77cfe8b0ca64fe807cea439baf8d3d28fbbf6fed279
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if total_maximum_federal_pell_grant_eligible_under_paragraph_1: total_maximum_federal_pell_grant else: if calculated_federal_pell_grant_eligible_under_paragraph_1: calculated_federal_pell_grant_amount_under_paragraph_1 else: if minimum_federal_pell_grant_eligible_under_paragraph_1: minimum_federal_pell_grant_amount_defined_in_subsection_a_2_F else: 0

--- a/us/statutes/20/1070a/b/3.test.yaml
+++ b/us/statutes/20/1070a/b/3.test.yaml
@@ -1,0 +1,22 @@
+- name: pell_grant_below_cost_of_attendance_not_reduced
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/3#input.federal_pell_grant_amount_for_student: 5000
+    us:statutes/20/1070a/b/3#input.cost_of_attendance_at_institution_for_student: 8000
+  output:
+    us:statutes/20/1070a/b/3#federal_pell_grant_after_cost_of_attendance_limit: 5000
+- name: pell_grant_exceeding_cost_of_attendance_reduced_to_cost
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/3#input.federal_pell_grant_amount_for_student: 10000
+    us:statutes/20/1070a/b/3#input.cost_of_attendance_at_institution_for_student: 7500
+  output:
+    us:statutes/20/1070a/b/3#federal_pell_grant_after_cost_of_attendance_limit: 7500

--- a/us/statutes/20/1070a/b/3.yaml
+++ b/us/statutes/20/1070a/b/3.yaml
@@ -1,0 +1,27 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/20/1070a/b/3
+  summary: |-
+    "No Federal Pell Grant under this subpart shall exceed the cost of attendance ... If ... the amount ... exceeds the cost of attendance for that year, the amount ... shall be reduced until the Federal Pell Grant does not exceed the cost of attendance at such institution."
+rules:
+  - name: federal_pell_grant_after_cost_of_attendance_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/3
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(federal_pell_grant_amount_for_student, cost_of_attendance_at_institution_for_student)

--- a/us/statutes/20/1070a/b/5.test.yaml
+++ b/us/statutes/20/1070a/b/5.test.yaml
@@ -1,0 +1,30 @@
+- name: total_maximum_pell_grant_exact_multiple_of_five
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6340
+  output:
+    us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant: 7400
+- name: total_maximum_pell_grant_rounded_down_to_nearest_five
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6342
+  output:
+    us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant: 7400
+- name: total_maximum_pell_grant_rounded_up_to_nearest_five
+  period:
+    period_kind: custom
+    name: award_year
+    start: '2024-07-01'
+    end: '2025-06-30'
+  input:
+    us:statutes/20/1070a/b/5#input.last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year: 6343
+  output:
+    us:statutes/20/1070a/b/5#total_maximum_federal_pell_grant: 7405

--- a/us/statutes/20/1070a/b/5.yaml
+++ b/us/statutes/20/1070a/b/5.yaml
@@ -1,0 +1,76 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/20/1070a/b/5
+  summary: |-
+    "For award year 2024–2025, and each subsequent award year, the total maximum Federal Pell Grant award per student shall be equal to the sum of— (i) $1,060; and (ii) the amount specified as the maximum Federal Pell Grant in the last enacted appropriation Act applicable to that award year. ... rounded to the nearest $5."
+rules:
+  - name: pell_grant_statutory_add_on_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(5)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/5
+              excerpt: "(i) $1,060"
+    versions:
+      - effective_from: '2024-07-01'
+        formula: |-
+          1060
+
+  - name: pell_grant_rounding_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(5)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/5
+              excerpt: "rounded to the nearest $5"
+    versions:
+      - effective_from: '2024-07-01'
+        formula: |-
+          5
+
+  - name: total_maximum_federal_pell_grant
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 20 U.S.C. 1070a(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/20/1070a/b/5
+              excerpt: "equal to the sum of ... $1,060; and ... the maximum Federal Pell Grant in the last enacted appropriation Act ... rounded to the nearest $5"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#pell_grant_statutory_add_on_amount
+              output: pell_grant_statutory_add_on_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/20/1070a/b/5#pell_grant_rounding_increment
+              output: pell_grant_rounding_increment
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-07-01'
+        formula: |-
+          floor(((pell_grant_statutory_add_on_amount + last_enacted_appropriation_act_maximum_federal_pell_grant_applicable_to_award_year) + (pell_grant_rounding_increment / 2)) / pell_grant_rounding_increment) * pell_grant_rounding_increment


### PR DESCRIPTION
## Summary
- encode 2026-27 Pell maximum/minimum award guidance and SAI prohibition/limit facts
- encode 20 U.S.C. 1070a(b)(1) statutory Pell amount determination, 1070a(b)(3) cost-of-attendance cap, and 1070a(b)(5) total maximum Pell formula
- encode 2026-27 SAI guide maximum/minimum Pell indicators and Federal Pell Grant flag
- add generated oracle parameter companion assertions for Pell PE parameter surfaces
- bump RuleSpec toolchain pins to axiom-encode 0.2.803 and axiom-corpus 6ec3b88

## Dependency
- Requires TheAxiomFoundation/axiom-encode#748 for Pell PolicyEngine oracle mappings and mid-year oracle-parameter repair periods.

## Validation
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pell-oracle-mapping-20260624 run axiom-encode guard-generated --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-pell-pe-parity-20260624 --base-ref origin/main --head-ref HEAD
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pell-oracle-mapping-20260624 run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-pell-pe-parity-20260624 <changed Pell .test.yaml files>
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pell-oracle-mapping-20260624 run axiom-encode validate <changed Pell .yaml files> --skip-reviewers
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pell-oracle-mapping-20260624 run axiom-encode proof-validate <changed Pell .yaml files>
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-pell-oracle-mapping-20260624 run axiom-encode oracle-coverage --root <CI-shaped temp root> --fail-on-unmapped --fail-on-untested-comparable --limit 80

## Follow-ups
- 20 U.S.C. 1070a(b)(2) less-than-full-time reduction was attempted but blocked by validation for an ungrounded 0.01 percentage-point conversion.
- SAI guide page 9 was attempted but blocked by an auto-generated positive Judgment companion test that omitted required upstream facts; rerun through the encoder after companion-test repair improvements.
- Direct standalone compile of 1070a(b)(1) from outside the RuleSpec root cannot resolve its cross-file import, while root-aware companion tests and validate pass; this appears to be a compile-command import-resolution limitation.
