### PR TITLE
Add SNAP utility allowance rule

### DIFF
--- a/us/.axiom/encoding-manifests/regulations/7-cfr/273/9/d/6/iii.json
+++ b/us/.axiom/encoding-manifests/regulations/7-cfr/273/9/d/6/iii.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/7-cfr/273/9/d/6/iii.yaml",
+      "sha256": "80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62"
+    },
+    {
+      "path": "regulations/7-cfr/273/9/d/6/iii.test.yaml",
+      "sha256": "f33e40befcf36e37307dc875570fca5cff1ec5c6c6c836d6e0511ef4b5f7c53e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "4a71b9e7de56848095b0f8b7f8ae17fde17b569c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.422",
+    "version_commit": "4a71b9e7de56848095b0f8b7f8ae17fde17b569c"
+  },
+  "axiom_encode_version": "0.2.422",
+  "backend": "codex",
+  "citation": "us:regulations/7-cfr/273/9/d/6/iii",
+  "context_manifest_file": "/tmp/axiom-snap-sua-273-9-d-6-iii-signed-apply4/_eval_workspaces/codex-gpt-5.5/us-regulations-7-cfr-273-9-d-6-iii/workspace/context-manifest.json",
+  "context_manifest_sha256": "7ba24d29f82f97fc293e4b28bc95a899073d21f352364d8f94197d44233a942d",
+  "generated_at": "2026-05-29T19:52:49.947255+00:00",
+  "generated_output_file": "/tmp/axiom-snap-sua-273-9-d-6-iii-signed-apply4/codex-gpt-5.5/regulations/7-cfr/273/9/d/6/iii.yaml",
+  "generated_output_root": "/tmp/axiom-snap-sua-273-9-d-6-iii-signed-apply4",
+  "generated_output_sha256": "80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62",
+  "generation_prompt_sha256": "99e7cafd53840ca718ee3ec30237ab65c5fb0259f3a498c045d60333f5f4bff3",
+  "model": "gpt-5.5",
+  "run_id": "245f4d02",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "af1a93f7dd73b3a311bbeb82d4bafaffff55476e87d3493e1c71e4ead1d4490e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-snap-sua-273-9-d-6-iii-signed-apply4/traces/codex-gpt-5.5/us-regulations-7-cfr-273-9-d-6-iii.json",
+  "trace_sha256": "83d40c0016a4ff477701c57cfa2ae1854201e98f7ce8a2e81b78a09e56132827"
+}

--- a/us/regulations/7-cfr/273/9/d/6/iii.test.yaml
+++ b/us/regulations/7-cfr/273/9/d/6/iii.test.yaml
@@ -1,0 +1,98 @@
+- name: separate_heating_or_cooling_expenses_make_heating_cooling_standard_available
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#liheaa_or_similar_energy_assistance_annual_payment_threshold: 20
+    us:regulations/7-cfr/273/9/d/6/iii#limited_utility_allowance_required_minimum_utility_count: 2
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: holds
+- name: rental_billing_without_central_meter_exception_makes_standard_available
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: holds
+- name: central_meter_excess_charge_exception_blocks_rental_billing_path
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : true
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 1
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: not_holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: not_holds
+- name: state_mandate_restores_standard_for_central_meter_excess_charge_household
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : true
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 1
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: not_holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: holds
+- name: liheaa_payment_at_threshold_is_not_enough
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : true
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 20
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: not_holds
+- name: liheaa_payment_above_threshold_makes_heating_cooling_standard_available
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : true
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 21
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+  output:
+    us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count: holds
+    us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available: holds

--- a/us/regulations/7-cfr/273/9/d/6/iii.yaml
+++ b/us/regulations/7-cfr/273/9/d/6/iii.yaml
@@ -1,0 +1,102 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/9
+  summary: |-
+    Standard utility allowances may replace actual utility costs for the excess shelter deduction. The limited utility allowance must include at least two utilities. A standard with a heating or cooling component must be available to households with separate heating or cooling costs, qualifying rental-billing arrangements, or qualifying LIHEAA/similar energy assistance payments greater than $20 annually.
+rules:
+  - name: liheaa_or_similar_energy_assistance_annual_payment_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)(D)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "$20 annually"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          20
+
+  - name: limited_utility_allowance_required_minimum_utility_count
+    kind: parameter
+    dtype: Count
+    source: 7 CFR 273.9(d)(6)(iii)(A)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "at least two utilities"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          2
+
+  - name: snap_limited_utility_allowance_meets_minimum_utility_count
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.9(d)(6)(iii)(A)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "at least two utilities"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          limited_utility_allowance_utility_count >= limited_utility_allowance_required_minimum_utility_count
+
+  - name: snap_standard_with_heating_or_cooling_component_available
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.9(d)(6)(iii)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "heating or cooling expenses separately"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "unless the State agency mandates"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/9
+              excerpt: "current month or in the immediately preceding 12 months"
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+          or (
+            household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+            and (
+              not household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+              or state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g
+            )
+          )
+          or (
+            liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+            and liheaa_or_similar_energy_assistance_annual_payment_amount > liheaa_or_similar_energy_assistance_annual_payment_threshold
+          )


### PR DESCRIPTION
Adds the signed RuleSpec encoding for 7 CFR 273.9(d)(6)(iii), including tests and the apply manifest.\n\nThis module is imported by the SNAP package specs used by the Axiom API compiled runtime artifacts for state SNAP packages.