### PR TITLE
Encode Head Start eligibility rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.808"
+axiom_encode_version = "0.2.809"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "34366b125739249810fb8368174525ddb68e717c"
-axiom_corpus_ref = "f3218aeb62443eaf9caf2169e71f972417ff2f2f"
+axiom_encode_ref = "1f9aac8603b8c6da04b6af6bb69f4ebe22d00bfe"
+axiom_corpus_ref = "56232c9fd6a5a54ce28c0c530285252ab40a2a4a"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "a42a45ae270f7298bcb3a02408ed11299f6e2916"

--- a/us/.axiom/encoding-manifests/regulations/45-cfr/1302/12.json
+++ b/us/.axiom/encoding-manifests/regulations/45-cfr/1302/12.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/45-cfr/1302/12.yaml",
+      "sha256": "228a16f4fcb940d482c75bbd11a2dbb3b00c067622fc6ee571b4eac69dc1b623"
+    },
+    {
+      "path": "regulations/45-cfr/1302/12.test.yaml",
+      "sha256": "8feecd900af32271c5d428ee965509ec64e23cbaa4d64421333838aad9f87d74"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "34366b125739249810fb8368174525ddb68e717c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.808",
+    "version_commit": "34366b125739249810fb8368174525ddb68e717c"
+  },
+  "axiom_encode_version": "0.2.808",
+  "backend": "openai",
+  "citation": "us/regulation/45/1302/12",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-regulation-45-1302-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "c1bb2c9df859454ba3bcd8eccf27a235719b4059e6afe49d1324f2a47f7195e4",
+  "generated_at": "2026-06-24T23:13:12.800941+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/regulations/45-cfr/1302/12.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "228a16f4fcb940d482c75bbd11a2dbb3b00c067622fc6ee571b4eac69dc1b623",
+  "generation_prompt_sha256": "226cefd6015c86c03a438d77d78e39814902077c016d83fe7560743fa0ed1c37",
+  "model": "gpt-5.5",
+  "run_id": "2c32976a",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8065ca9778a3b07724bec9464211ccd7942d5ddabe6a55916ff577a536246bff"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-regulation-45-1302-12.json",
+  "trace_sha256": "17ccb31b60902f41fdbc2fc1227cc787ac2e020e05594a0a92953452e20b09c5"
+}

--- a/us/regulations/45-cfr/1302/12.test.yaml
+++ b/us/regulations/45-cfr/1302/12.test.yaml
@@ -1,0 +1,124 @@
+- name: paragraph_c_income_eligible_and_special_program_paths_hold
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:regulations/45-cfr/1302/12#input.family_income: 9000
+    us:regulations/45-cfr/1302/12#input.poverty_line_amount: 10000
+    us:regulations/45-cfr/1302/12#input.family_is_eligible_for_public_assistance: false
+    us:regulations/45-cfr/1302/12#input.family_would_be_potentially_eligible_for_public_assistance_in_absence_of_child_care: false
+    us:regulations/45-cfr/1302/12#input.child_is_homeless_as_defined_in_part_1305: false
+    us:regulations/45-cfr/1302/12#input.child_is_in_foster_care: false
+    us:regulations/45-cfr/1302/12#input.participant_would_benefit_from_services: false
+    us:regulations/45-cfr/1302/12#input.program_paragraph_c_2_participant_share_after_enrollment: 0
+    us:regulations/45-cfr/1302/12#input.family_does_not_meet_paragraph_c_criterion: true
+    us:regulations/45-cfr/1302/12#input.program_additional_allowance_participant_share_after_enrollment: 0.2
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_and_implements_required_outreach_and_enrollment_policies_before_serving_non_paragraph_c_participants
+    : true
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_criteria_serving_paragraph_c_eligible_pregnant_women_and_children_first
+    : true
+    us:regulations/45-cfr/1302/12#input.tribal_program: true
+    us:regulations/45-cfr/1302/12#input.participant_in_approved_service_area: true
+    us:regulations/45-cfr/1302/12#input.participant_meets_age_requirements_under_paragraph_b: true
+    us:regulations/45-cfr/1302/12#input.at_least_one_family_member_income_comes_primarily_from_agricultural_employment: true
+  output:
+    us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible: holds
+    us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled: holds
+    us:regulations/45-cfr/1302/12#report_to_regional_office_required_for_between_100_and_130_percent_enrollment: not_holds
+    us:regulations/45-cfr/1302/12#tribal_service_area_participant_eligible: holds
+    us:regulations/45-cfr/1302/12#migrant_or_seasonal_participant_eligible: holds
+- name: paragraph_c_ten_percent_benefit_allowance_holds
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:regulations/45-cfr/1302/12#input.family_income: 15000
+    us:regulations/45-cfr/1302/12#input.poverty_line_amount: 10000
+    us:regulations/45-cfr/1302/12#input.family_is_eligible_for_public_assistance: false
+    us:regulations/45-cfr/1302/12#input.family_would_be_potentially_eligible_for_public_assistance_in_absence_of_child_care: false
+    us:regulations/45-cfr/1302/12#input.child_is_homeless_as_defined_in_part_1305: false
+    us:regulations/45-cfr/1302/12#input.child_is_in_foster_care: false
+    us:regulations/45-cfr/1302/12#input.participant_would_benefit_from_services: true
+    us:regulations/45-cfr/1302/12#input.program_paragraph_c_2_participant_share_after_enrollment: 0.1
+    us:regulations/45-cfr/1302/12#input.family_does_not_meet_paragraph_c_criterion: true
+    us:regulations/45-cfr/1302/12#input.program_additional_allowance_participant_share_after_enrollment: 0.2
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_and_implements_required_outreach_and_enrollment_policies_before_serving_non_paragraph_c_participants
+    : true
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_criteria_serving_paragraph_c_eligible_pregnant_women_and_children_first
+    : true
+    us:regulations/45-cfr/1302/12#input.tribal_program: false
+    us:regulations/45-cfr/1302/12#input.participant_in_approved_service_area: false
+    us:regulations/45-cfr/1302/12#input.participant_meets_age_requirements_under_paragraph_b: true
+    us:regulations/45-cfr/1302/12#input.at_least_one_family_member_income_comes_primarily_from_agricultural_employment: false
+  output:
+    us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible: holds
+    us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled: not_holds
+    us:regulations/45-cfr/1302/12#report_to_regional_office_required_for_between_100_and_130_percent_enrollment: not_holds
+    us:regulations/45-cfr/1302/12#tribal_service_area_participant_eligible: not_holds
+    us:regulations/45-cfr/1302/12#migrant_or_seasonal_participant_eligible: not_holds
+- name: additional_allowance_between_100_and_130_percent_triggers_reporting
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:regulations/45-cfr/1302/12#input.family_income: 12000
+    us:regulations/45-cfr/1302/12#input.poverty_line_amount: 10000
+    us:regulations/45-cfr/1302/12#input.family_is_eligible_for_public_assistance: false
+    us:regulations/45-cfr/1302/12#input.family_would_be_potentially_eligible_for_public_assistance_in_absence_of_child_care: false
+    us:regulations/45-cfr/1302/12#input.child_is_homeless_as_defined_in_part_1305: false
+    us:regulations/45-cfr/1302/12#input.child_is_in_foster_care: false
+    us:regulations/45-cfr/1302/12#input.participant_would_benefit_from_services: false
+    us:regulations/45-cfr/1302/12#input.program_paragraph_c_2_participant_share_after_enrollment: 0.2
+    us:regulations/45-cfr/1302/12#input.family_does_not_meet_paragraph_c_criterion: true
+    us:regulations/45-cfr/1302/12#input.program_additional_allowance_participant_share_after_enrollment: 0.35
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_and_implements_required_outreach_and_enrollment_policies_before_serving_non_paragraph_c_participants
+    : true
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_criteria_serving_paragraph_c_eligible_pregnant_women_and_children_first
+    : true
+    us:regulations/45-cfr/1302/12#input.tribal_program: false
+    us:regulations/45-cfr/1302/12#input.participant_in_approved_service_area: false
+    us:regulations/45-cfr/1302/12#input.participant_meets_age_requirements_under_paragraph_b: false
+    us:regulations/45-cfr/1302/12#input.at_least_one_family_member_income_comes_primarily_from_agricultural_employment: false
+  output:
+    us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible: not_holds
+    us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled: holds
+    us:regulations/45-cfr/1302/12#report_to_regional_office_required_for_between_100_and_130_percent_enrollment: holds
+    us:regulations/45-cfr/1302/12#tribal_service_area_participant_eligible: not_holds
+    us:regulations/45-cfr/1302/12#migrant_or_seasonal_participant_eligible: not_holds
+- name: additional_allowance_fails_when_130_percent_limit_exceeded
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us:regulations/45-cfr/1302/12#input.family_income: 14000
+    us:regulations/45-cfr/1302/12#input.poverty_line_amount: 10000
+    us:regulations/45-cfr/1302/12#input.family_is_eligible_for_public_assistance: false
+    us:regulations/45-cfr/1302/12#input.family_would_be_potentially_eligible_for_public_assistance_in_absence_of_child_care: false
+    us:regulations/45-cfr/1302/12#input.child_is_homeless_as_defined_in_part_1305: false
+    us:regulations/45-cfr/1302/12#input.child_is_in_foster_care: false
+    us:regulations/45-cfr/1302/12#input.participant_would_benefit_from_services: false
+    us:regulations/45-cfr/1302/12#input.program_paragraph_c_2_participant_share_after_enrollment: 0.2
+    us:regulations/45-cfr/1302/12#input.family_does_not_meet_paragraph_c_criterion: true
+    us:regulations/45-cfr/1302/12#input.program_additional_allowance_participant_share_after_enrollment: 0.35
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_and_implements_required_outreach_and_enrollment_policies_before_serving_non_paragraph_c_participants
+    : true
+    ? us:regulations/45-cfr/1302/12#input.program_establishes_criteria_serving_paragraph_c_eligible_pregnant_women_and_children_first
+    : true
+    us:regulations/45-cfr/1302/12#input.tribal_program: true
+    us:regulations/45-cfr/1302/12#input.participant_in_approved_service_area: true
+    us:regulations/45-cfr/1302/12#input.participant_meets_age_requirements_under_paragraph_b: false
+    us:regulations/45-cfr/1302/12#input.at_least_one_family_member_income_comes_primarily_from_agricultural_employment: true
+  output:
+    us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible: not_holds
+    us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled: not_holds
+    us:regulations/45-cfr/1302/12#report_to_regional_office_required_for_between_100_and_130_percent_enrollment: not_holds
+    us:regulations/45-cfr/1302/12#tribal_service_area_participant_eligible: not_holds
+    us:regulations/45-cfr/1302/12#migrant_or_seasonal_participant_eligible: not_holds

--- a/us/regulations/45-cfr/1302/12.yaml
+++ b/us/regulations/45-cfr/1302/12.yaml
@@ -1,0 +1,240 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/45/1302/12
+  deferred_outputs:
+    - output: us:regulations/45-cfr/1302/12/g#community_with_1000_or_fewer_individuals_eligibility_criteria
+      reason: >-
+        Paragraph (g) allows programs in communities with 1,000 or fewer individuals to establish eligibility criteria
+        by reference to section 645(a)(2) of the Act and protects children eligible under paragraphs (c) through (f);
+        the cross-referenced Act criteria and community/program administrative structure are not encoded here.
+    - output: us:regulations/45-cfr/1302/12/h#age_verification_compliance
+      reason: >-
+        Paragraph (h) imposes a program-staff verification and documentation-barrier procedural duty rather than a
+        participant eligibility computation represented by the current executable surface.
+    - output: us:regulations/45-cfr/1302/12/j#eligibility_duration
+      reason: >-
+        Paragraph (j) governs continuing eligibility across program years, transitions, and program types, including
+        discretionary compelling-reason exceptions and section 645A-funded programs, which require enrollment-history
+        and program-year lifecycle modeling not represented here.
+    - output: us:regulations/45-cfr/1302/12/k#eligibility_determination_records
+      reason: >-
+        Paragraph (k) prescribes recordkeeping contents and retention periods, not a participant eligibility formula.
+    - output: us:regulations/45-cfr/1302/12/l#eligibility_violation_policies_and_procedures
+      reason: >-
+        Paragraph (l) requires written personnel policies and procedures for intentional eligibility violations; it is
+        an administrative compliance duty outside the participant eligibility calculations encoded here.
+  summary: |-
+    45 CFR 1302.12 sets Head Start eligibility paths: income at or below the poverty line, public assistance,
+    homelessness, or foster care; a 10 percent benefit-from-services allowance; an additional 35 percent allowance
+    for families below 130 percent of poverty with required outreach/selection policies; Tribal eligibility
+    notwithstanding paragraph (c); and Migrant or Seasonal Head Start eligibility based on primary agricultural
+    employment income and paragraph (b) age requirements.
+rules:
+  - name: overincome_exception_enrollment_cap
+    kind: parameter
+    dtype: Rate
+    source: 45 CFR 1302.12(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+              excerpt: "only make up to 10 percent of a program's enrollment"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.10
+
+  - name: additional_allowance_enrollment_cap
+    kind: parameter
+    dtype: Rate
+    source: 45 CFR 1302.12(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+              excerpt: "may enroll an additional 35 percent of participants"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.35
+
+  - name: additional_allowance_income_limit_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 45 CFR 1302.12(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+              excerpt: "whose incomes are below 130 percent of the poverty line"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          1.30
+
+  - name: reportable_overincome_lower_bound_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 45 CFR 1302.12(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+              excerpt: "family incomes are between 100 and 130 percent of the poverty line"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          1.00
+
+  - name: paragraph_c_participant_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 45 CFR 1302.12(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/45-cfr/1302/12#overincome_exception_enrollment_cap
+              output: overincome_exception_enrollment_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          family_income <= poverty_line_amount
+          or family_is_eligible_for_public_assistance
+          or family_would_be_potentially_eligible_for_public_assistance_in_absence_of_child_care
+          or child_is_homeless_as_defined_in_part_1305
+          or child_is_in_foster_care
+          or (
+              participant_would_benefit_from_services
+              and program_paragraph_c_2_participant_share_after_enrollment <= overincome_exception_enrollment_cap
+          )
+
+  - name: additional_allowance_participant_may_be_enrolled
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 45 CFR 1302.12(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/45-cfr/1302/12#additional_allowance_enrollment_cap
+              output: additional_allowance_enrollment_cap
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/45-cfr/1302/12#additional_allowance_income_limit_multiplier
+              output: additional_allowance_income_limit_multiplier
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          family_does_not_meet_paragraph_c_criterion
+          and family_income < poverty_line_amount * additional_allowance_income_limit_multiplier
+          and program_additional_allowance_participant_share_after_enrollment <= additional_allowance_enrollment_cap
+          and program_establishes_and_implements_required_outreach_and_enrollment_policies_before_serving_non_paragraph_c_participants
+          and program_establishes_criteria_serving_paragraph_c_eligible_pregnant_women_and_children_first
+
+  - name: report_to_regional_office_required_for_between_100_and_130_percent_enrollment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 45 CFR 1302.12(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+              excerpt: "family incomes are between 100 and 130 percent of the poverty line"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/45-cfr/1302/12#reportable_overincome_lower_bound_multiplier
+              output: reportable_overincome_lower_bound_multiplier
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/45-cfr/1302/12#additional_allowance_income_limit_multiplier
+              output: additional_allowance_income_limit_multiplier
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          family_does_not_meet_paragraph_c_criterion
+          and family_income >= poverty_line_amount * reportable_overincome_lower_bound_multiplier
+          and family_income < poverty_line_amount * additional_allowance_income_limit_multiplier
+
+  - name: tribal_service_area_participant_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 45 CFR 1302.12(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          tribal_program
+          and participant_in_approved_service_area
+          and participant_meets_age_requirements_under_paragraph_b
+
+  - name: migrant_or_seasonal_participant_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 45 CFR 1302.12(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/45/1302/12
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          at_least_one_family_member_income_comes_primarily_from_agricultural_employment
+          and participant_meets_age_requirements_under_paragraph_b


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 45 CFR 1302.12 Head Start eligibility and enrollment-allowance rules
- add companion tests and signed axiom-encode application manifest
- pin toolchain to axiom-encode 0.2.809 and axiom-corpus commit with the 45 CFR 1302 corpus scope

## Validation
- AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-20260624/us/regulations/45-cfr/1302/12.yaml
- uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run pytest /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-20260624/tests
- uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run axiom-encode oracle-coverage --root /tmp/axiom-root-head-start --program head_start --include-program-surfaces --json

## Coverage
- Head Start outputs: 9 total, 9 known_not_comparable, 0 untested comparable
- Program surfaces: national head_start is known_not_comparable; Washington ECEAP and Birth to Three ECEAP remain deferred_jurisdiction
