### PR TITLE
Encode Georgia SSP nursing home supplement

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.809"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
 axiom_encode_ref = "1f9aac8603b8c6da04b6af6bb69f4ebe22d00bfe"
-axiom_corpus_ref = "56232c9fd6a5a54ce28c0c530285252ab40a2a4a"
+axiom_corpus_ref = "c176c0c92cdc186a8519658da805ae43270f837f"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "a42a45ae270f7298bcb3a02408ed11299f6e2916"

--- a/us-ga/.axiom/encoding-manifests/policies/dfcs/medicaid/2578.json
+++ b/us-ga/.axiom/encoding-manifests/policies/dfcs/medicaid/2578.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfcs/medicaid/2578.yaml",
+      "sha256": "5bb3aedefcabef37e4038eb9d8e421a75445832f0234f6519881d6b9315c04f1"
+    },
+    {
+      "path": "policies/dfcs/medicaid/2578.test.yaml",
+      "sha256": "4e87ea1a04035abe6cf5b682c1f8c653f8d159276eb46d136121edba152cd553"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1f9aac8603b8c6da04b6af6bb69f4ebe22d00bfe",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.809",
+    "version_commit": "1f9aac8603b8c6da04b6af6bb69f4ebe22d00bfe"
+  },
+  "axiom_encode_version": "0.2.809",
+  "backend": "openai",
+  "citation": "us-ga/manual/dfcs/medicaid/2578",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-ga-manual-dfcs-medicaid-2578/workspace/context-manifest.json",
+  "context_manifest_sha256": "6b8c604ba8ba44d872fe18c736c6f33d331a3b91a58bb94947079a94abf28391",
+  "generated_at": "2026-06-24T23:47:34.470412+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/policies/dfcs/medicaid/2578.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "5bb3aedefcabef37e4038eb9d8e421a75445832f0234f6519881d6b9315c04f1",
+  "generation_prompt_sha256": "ff9ae98ab265e147cbdcc6f6a627e0ed1fb5876eb9d86874265586258754f370",
+  "model": "gpt-5.5",
+  "run_id": "110797e0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0d4460743407f4acb6ce1a0d01d9afd921899911f784ef8dd56038775b9e110c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-ga-manual-dfcs-medicaid-2578.json",
+  "trace_sha256": "44dd66a7668073bcbf5fdb8c11014a82d57dda0194fc5792d1366f51188ced3e"
+}

--- a/us-ga/policies/dfcs/medicaid/2578.test.yaml
+++ b/us-ga/policies/dfcs/medicaid/2578.test.yaml
@@ -1,0 +1,129 @@
+- name: authorizable_with_all_conditions_and_computes_amounts
+  period: 2019-07
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: true
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: true
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: true
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_only: true
+    us-ga:policies/dfcs/medicaid/2578#input.month_following_nursing_home_admission: true
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_admission_month_to_lad: true
+    us-ga:policies/dfcs/medicaid/2578#input.all_income_available_in_month_including_ssi: 800
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_after_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 30
+    us-ga:policies/dfcs/medicaid/2578#input.other_income: 700
+  output:
+    us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable: holds
+    us-ga:policies/dfcs/medicaid/2578#expected_ssi_only_payment_after_nursing_home_admission: 30
+    us-ga:policies/dfcs/medicaid/2578#expected_state_supplement_for_nursing_home_ssi_recipient: 40
+    us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_of_admission_to_lad: 800
+    us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_after_admission_to_lad: 0
+- name: not_authorizable_when_not_ssi_prior_to_admission
+  period: 2019-07
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: true
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: true
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable: not_holds
+- name: not_authorizable_when_not_georgia_resident
+  period: 2019-07
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: true
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: false
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: true
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable: not_holds
+- name: not_authorizable_when_level_of_care_not_approved
+  period: 2019-07
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: true
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: true
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: false
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable: not_holds
+- name: not_authorizable_when_resource_transferred_within_lookback
+  period: 2019-07
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: true
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: true
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: true
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: true
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 12
+  output:
+    us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable: not_holds
+- name: following_month_patient_liability_uses_lad_ssi_and_other_income
+  period: 2019-08
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_after_admission_month_to_lad: true
+    us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 30
+    us-ga:policies/dfcs/medicaid/2578#input.other_income: 700
+  output:
+    us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_after_admission_to_lad: 730
+- name: auto_zero_expected_ssi_only_payment_after_nursing_home_admission
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.all_income_available_in_month_including_ssi: false
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_following_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_after_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+    us-ga:policies/dfcs/medicaid/2578#input.other_income: 0
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_only: false
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: false
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#expected_ssi_only_payment_after_nursing_home_admission: 0
+- name: auto_zero_expected_state_supplement_for_nursing_home_ssi_recipient
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.all_income_available_in_month_including_ssi: false
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_following_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_after_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+    us-ga:policies/dfcs/medicaid/2578#input.other_income: 0
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_only: false
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: false
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#expected_state_supplement_for_nursing_home_ssi_recipient: 0
+- name: auto_zero_patient_liability_for_month_of_admission_to_lad
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/dfcs/medicaid/2578#input.all_income_available_in_month_including_ssi: false
+    us-ga:policies/dfcs/medicaid/2578#input.approved_level_of_care: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_following_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.month_is_after_admission_month_to_lad: false
+    us-ga:policies/dfcs/medicaid/2578#input.months_before_application_of_resource_transfer: 0
+    us-ga:policies/dfcs/medicaid/2578#input.other_income: 0
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_only: false
+    us-ga:policies/dfcs/medicaid/2578#input.receives_ssi_prior_to_nursing_home_admission: false
+    us-ga:policies/dfcs/medicaid/2578#input.resident_of_georgia: false
+    us-ga:policies/dfcs/medicaid/2578#input.resource_transferred_for_less_than_fair_market_value: false
+    us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 0
+  output:
+    us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_of_admission_to_lad: 0

--- a/us-ga/policies/dfcs/medicaid/2578.yaml
+++ b/us-ga/policies/dfcs/medicaid/2578.yaml
@@ -1,0 +1,194 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+  summary: |-
+    "A NH vendor payment can be authorized for the SSI recipient entering a NH if all the following conditions are met: The A/R is a resident of Georgia. The A/R has an approved Level of Care (LOC). The A/R has not transferred a resource for less than fair market value within 60 months prior to the month of application." SSI-only payments are reduced to "$30.00 the month following the month of NH admission" and State Supplement amounts are "$20.00", "$35.00", and "$40.00" for the listed effective dates. Patient liability uses all income including SSI for the admission month and only LA-D SSI entitlement plus other income for following months.
+rules:
+  - name: resource_transfer_lookback_months
+    kind: parameter
+    dtype: Count
+    source: Policy 2578, Basic Considerations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "within 60 months prior to the month of application"
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          60
+
+  - name: ssi_only_nursing_home_payment_amount_after_admission
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Basic Considerations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "reduced to $30.00 the month following the month of NH admission"
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          30
+
+  - name: nursing_home_state_supplement_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Basic Considerations, State Supplement table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "Effective Date State Supplement Amount 7/1/2006 $20.00"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "7/1/2018 $35.00"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "7/1/2019 $40.00"
+    versions:
+      - effective_from: '2006-07-01'
+        formula: |-
+          20
+      - effective_from: '2018-07-01'
+        formula: |-
+          35
+      - effective_from: '2019-07-01'
+        formula: |-
+          40
+
+  - name: ssi_recipient_nursing_home_vendor_payment_authorizable
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Policy 2578, Basic Considerations; SSI Recipient is not a Resident of Georgia; SSI Recipient is not approved for Level of Care
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "within 60 months prior to the month of application"
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          receives_ssi_prior_to_nursing_home_admission
+          and resident_of_georgia
+          and approved_level_of_care
+          and not (
+            resource_transferred_for_less_than_fair_market_value
+            and months_before_application_of_resource_transfer <= resource_transfer_lookback_months
+          )
+
+  - name: expected_ssi_only_payment_after_nursing_home_admission
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Basic Considerations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "SSI payment amount reduced to $30.00 the month following the month of NH admission"
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          if receives_ssi_only and month_following_nursing_home_admission: ssi_only_nursing_home_payment_amount_after_admission else: 0
+
+  - name: expected_state_supplement_for_nursing_home_ssi_recipient
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Basic Considerations, State Supplement table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+              excerpt: "They will also receive a State Supplement."
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          if receives_ssi_only and month_following_nursing_home_admission: nursing_home_state_supplement_amount else: 0
+
+  - name: patient_liability_for_month_of_admission_to_lad
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Procedures Step 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          if month_is_admission_month_to_lad: max(0, all_income_available_in_month_including_ssi) else: 0
+
+  - name: patient_liability_for_month_after_admission_to_lad
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Policy 2578, Procedures Step 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/medicaid/2578
+    versions:
+      - effective_from: '2019-07-01'
+        formula: |-
+          if month_is_after_admission_month_to_lad: max(0, ssi_entitled_in_lad + other_income) else: 0


### PR DESCRIPTION
## Summary
- Encodes Georgia DFCS Medicaid Policy 2578 for SSI recipients entering nursing homes, including the state supplement amount schedule.
- Adds focused rulespec tests for vendor-payment authorization, SSI-only payment reduction, state supplement amount, and patient-liability mechanics.
- Bumps the pinned axiom-corpus ref to the merged Georgia SSP corpus ingest from TheAxiomFoundation/axiom-corpus#124.

## Validation
- File: /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ga-ssp-20260624/us-ga/policies/dfcs/medicaid/2578.yaml
CI: ✓
Result: ✓ PASSED
- ============================= test session starts ==============================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ga-ssp-20260624
plugins: anyio-4.12.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 12 items

tests/test_program_specs.py ...                                          [ 25%]
tests/test_repository_layout.py .........                                [100%]

============================= 12 passed in 55.93s ==============================