### PR TITLE
Add Georgia SSP oracle parameter test

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/dfcs/medicaid/2578.json
+++ b/.axiom/encoding-manifests/us-ga/policies/dfcs/medicaid/2578.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/dfcs/medicaid/2578.yaml",
+      "sha256": "5bb3aedefcabef37e4038eb9d8e421a75445832f0234f6519881d6b9315c04f1"
+    },
+    {
+      "path": "us-ga/policies/dfcs/medicaid/2578.test.yaml",
+      "sha256": "f26ed1f5af4fbf54fc24f0623a00c47e27ca2a73e895910ead96f3330c13b9e3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e3f2601824f416fb2da5e80a308954378e37ae44",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.811",
+    "version_commit": "e3f2601824f416fb2da5e80a308954378e37ae44"
+  },
+  "axiom_encode_version": "0.2.811",
+  "backend": "deterministic",
+  "citation": "us-ga:policies/dfcs/medicaid/2578",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-25T00:38:02.918037+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmppy4hwjmu/deterministic-repair/us-ga/policies/dfcs/medicaid/2578.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmppy4hwjmu",
+  "generated_output_sha256": "5bb3aedefcabef37e4038eb9d8e421a75445832f0234f6519881d6b9315c04f1",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "55149bc0349265cc1e2c5072ca08142d3eca49e167d8175eb2e89b79a7066709"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ga/policies/dfcs/medicaid/2578.test.yaml
+++ b/us-ga/policies/dfcs/medicaid/2578.test.yaml
@@ -127,3 +127,12 @@
     us-ga:policies/dfcs/medicaid/2578#input.ssi_entitled_in_lad: 0
   output:
     us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_of_admission_to_lad: 0
+- name: oracle_parameter_nursing_home_state_supplement_amount
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2006-07-01'
+    end: '2007-06-30'
+  input: {}
+  output:
+    us-ga:policies/dfcs/medicaid/2578#nursing_home_state_supplement_amount: 20


### PR DESCRIPTION
## Summary
- add a deterministic oracle parameter test for Georgia SSP nursing-home supplement amount
- include the signed deterministic repair manifest generated by `axiom-encode repair-oracle-parameter-tests`
- closes the remaining P1 comparable-untested gap for the `ssi_state_supplement` program surface

## Validation
- `uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ga-ssp-oracle-test-20260624/us-ga/policies/dfcs/medicaid/2578.yaml`
- `uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode oracle-candidates --root /tmp/axiom-root-ga-ssp-oracle-test --program ssi_state_supplement --json` -> no P1 candidates; only reviewed P4 non-comparable candidates remain