### PR TITLE
Add California CalWORKs encodings

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.817"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
 axiom_encode_ref = "143aca38632250d3060b8196b229635356cb68ea"
-axiom_corpus_ref = "c176c0c92cdc186a8519658da805ae43270f837f"
+axiom_corpus_ref = "992aaf666d00b9d263b0ec509d4317c02b0d8b76"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "a42a45ae270f7298bcb3a02408ed11299f6e2916"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.809"
+axiom_encode_version = "0.2.817"
 axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "1f9aac8603b8c6da04b6af6bb69f4ebe22d00bfe"
+axiom_encode_ref = "143aca38632250d3060b8196b229635356cb68ea"
 axiom_corpus_ref = "c176c0c92cdc186a8519658da805ae43270f837f"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml",
+      "sha256": "424e4ac64b17f9fb9abe55a20f2d16e2230d18af67e0c3dd6a9f40fb48def0ff"
+    },
+    {
+      "path": "policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.test.yaml",
+      "sha256": "e2b4d60c8250803e8b6d0261311c7a384df28964b7e82a8c247781526caa47b9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.813",
+    "version_commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3"
+  },
+  "axiom_encode_version": "0.2.813",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-countable-non-exempt-motor-vehicle-equity-value/workspace/context-manifest.json",
+  "context_manifest_sha256": "c539ad04db40088f3a35adee19619daced336c64aaa3130eb1de5aac25ecace3",
+  "generated_at": "2026-06-25T02:14:29.930977+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "424e4ac64b17f9fb9abe55a20f2d16e2230d18af67e0c3dd6a9f40fb48def0ff",
+  "generation_prompt_sha256": "2c38918c378c8318b06e092287d108e962acac34dbc59a3408e73f554c861d18",
+  "model": "gpt-5.5",
+  "run_id": "4420d936",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "82df95015cbbff69c75d3e992f9071ef67f1b70023ba62030ad63bd262a0ba9e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-countable-non-exempt-motor-vehicle-equity-value.json",
+  "trace_sha256": "7d3c2303a38acb8997736151ebe9e0935fd72a712e5b7456de3e896c0c357349"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/financial-eligibility-income-tests.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/financial-eligibility-income-tests.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/financial-eligibility-income-tests.yaml",
+      "sha256": "a0d50eeee01aba7ca06398e000113197d16c0c8de0cc8c3696408180d59d07ff"
+    },
+    {
+      "path": "policies/cdss/calworks/financial-eligibility-income-tests.test.yaml",
+      "sha256": "2e8209d3c50ba7ab615fc2f5f0e03a53b779d43a199f259de08fc75cdcd6f4d9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ff1b11d2e131281a6b1a8aff0f0598a311356181",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.815",
+    "version_commit": "ff1b11d2e131281a6b1a8aff0f0598a311356181"
+  },
+  "axiom_encode_version": "0.2.815",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/financial-eligibility-income-tests",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-financial-eligibility-income-tests/workspace/context-manifest.json",
+  "context_manifest_sha256": "50a010c972f1c1e4768ba63455eeda02bde8116600b6ab0a27bbe0d05c49df22",
+  "generated_at": "2026-06-25T05:15:38.102759+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/financial-eligibility-income-tests.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a0d50eeee01aba7ca06398e000113197d16c0c8de0cc8c3696408180d59d07ff",
+  "generation_prompt_sha256": "607ee2e530a5045c1ab4bc0ee74ab45f6041e933fa8861782770a218e86a8687",
+  "model": "gpt-5.5",
+  "run_id": "1b31d8be",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "489e0b31b76ddd096876da1999f91aba4452b0eb080da247195cb7f8f32b968d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-financial-eligibility-income-tests.json",
+  "trace_sha256": "1f15047f63ad77296bc2c3bbae092bed9d2a4384a63dd61bc0951b89e7fb4507"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-aid-payment-region-1.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-aid-payment-region-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/maximum-aid-payment-region-1.yaml",
+      "sha256": "b8a010cc316e9d3c1e6462152a33410de99984eecb7710f2654b9da26e015e78"
+    },
+    {
+      "path": "policies/cdss/calworks/maximum-aid-payment-region-1.test.yaml",
+      "sha256": "e86b355c0e11a5835a0bd74fb524b4678a4c1566c1eab484c7547d008679c6ba"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.813",
+    "version_commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3"
+  },
+  "axiom_encode_version": "0.2.813",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/maximum-aid-payment-region-1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-maximum-aid-payment-region-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "9e5df8dd4ac96980f31520bd6b8ab752db358b2a3321f6cf16c2eba27510bfa8",
+  "generated_at": "2026-06-25T02:19:32.441331+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/maximum-aid-payment-region-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b8a010cc316e9d3c1e6462152a33410de99984eecb7710f2654b9da26e015e78",
+  "generation_prompt_sha256": "d87b64a1797019e0deb473270f9c1014ffdcbb734f4cdff740423f00703f9163",
+  "model": "gpt-5.5",
+  "run_id": "943cf06b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f076ae06cd440e1e2347a050f6288ad1b1a404844eabce48244d5e9ec20a2e5e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-maximum-aid-payment-region-1.json",
+  "trace_sha256": "3f09a0530f01369c118606c32f9748903ac51a88f9d1fa638a39f707336f2376"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-aid-payment-region-2.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-aid-payment-region-2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/maximum-aid-payment-region-2.yaml",
+      "sha256": "df6f816665e53d0ceaa767dceb414a6c9b6fc38679a1784bd5cbae5d8f855fa8"
+    },
+    {
+      "path": "policies/cdss/calworks/maximum-aid-payment-region-2.test.yaml",
+      "sha256": "6c367a7baa3cd422d6ca5983ffa6e38a80a1aa0fde90800d67924fb5b552705d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.813",
+    "version_commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3"
+  },
+  "axiom_encode_version": "0.2.813",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/maximum-aid-payment-region-2",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-maximum-aid-payment-region-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "e9d3b0091e8720bba13bbd8d60c7f315d8131a9ce7f819a84af11af1bd3d0f94",
+  "generated_at": "2026-06-25T02:23:37.455413+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/maximum-aid-payment-region-2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "df6f816665e53d0ceaa767dceb414a6c9b6fc38679a1784bd5cbae5d8f855fa8",
+  "generation_prompt_sha256": "d29bf8cd24730ef432b9d7e97b3367cd9183c6d0f72139aa33b8c0cc426a2183",
+  "model": "gpt-5.5",
+  "run_id": "80b33703",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cd9ae1dc6f36346a9a3ff870d456c65485e299fe60324904fe5159a9d0776a9d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-maximum-aid-payment-region-2.json",
+  "trace_sha256": "4fddb9cd98487f2032a005c1d0ce05dca2d334907a82024d7954371fd191b5bb"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-resource-limit.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/maximum-resource-limit.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/maximum-resource-limit.yaml",
+      "sha256": "eb6de5609d267c43e3b197d4706f7a24031b17cfb3b854f40cb039600cd9d8c5"
+    },
+    {
+      "path": "policies/cdss/calworks/maximum-resource-limit.test.yaml",
+      "sha256": "a67a4976571304ac82d615a57eaa49227bb1959c15a3ad2374d7c284804e8cf5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.813",
+    "version_commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3"
+  },
+  "axiom_encode_version": "0.2.813",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/maximum-resource-limit",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-maximum-resource-limit/workspace/context-manifest.json",
+  "context_manifest_sha256": "c943029e0b31e17f9f2d9bafd4e4242f18927b028255472d38db021b3399350d",
+  "generated_at": "2026-06-25T02:16:31.737466+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/maximum-resource-limit.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "eb6de5609d267c43e3b197d4706f7a24031b17cfb3b854f40cb039600cd9d8c5",
+  "generation_prompt_sha256": "6f74a57dc31b1965f48647431360fd01e711c97cdb2745da8f8fb063b5b1f2a2",
+  "model": "gpt-5.5",
+  "run_id": "3f838970",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc103b9f16af32e257bf2a4938570fc5c26f9df2a65913561bc3333122c8d367"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-maximum-resource-limit.json",
+  "trace_sha256": "1b6fb97b8960f81408921655ef8f10e0709be7dbfc097915a86378fa2a4022d6"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml",
+      "sha256": "b074596ebc9236f63f90d1aa6d1c437fe4e4a91130391fba3c7c432edf873a14"
+    },
+    {
+      "path": "policies/cdss/calworks/minimum-basic-standard-of-adequate-care.test.yaml",
+      "sha256": "3b8feaa969508822ce29dbb253f4c252a24ea818852da103e7b12a18eb289cfc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b3b2d8114f24403baeebd46c52f8951198c363ab",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.814",
+    "version_commit": "b3b2d8114f24403baeebd46c52f8951198c363ab"
+  },
+  "axiom_encode_version": "0.2.814",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/minimum-basic-standard-of-adequate-care",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-minimum-basic-standard-of-adequate-care/workspace/context-manifest.json",
+  "context_manifest_sha256": "a15e4b751aa2525e3743f334e76e3ff47727b9f9d526b8718eaa70ea4a7b451e",
+  "generated_at": "2026-06-25T04:01:49.279000+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b074596ebc9236f63f90d1aa6d1c437fe4e4a91130391fba3c7c432edf873a14",
+  "generation_prompt_sha256": "f94e28544fe89d55fb1b03f1cf640fe2ce15b5ca8bc8593281be1af0b689245d",
+  "model": "gpt-5.5",
+  "run_id": "805bc4ea",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9558bbc0a3cf1bce3f73d0cc6bd623be11bec69c0a68e8d9f1d53c2a4737c1d8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-minimum-basic-standard-of-adequate-care.json",
+  "trace_sha256": "a72ae6b09e8a623698f0a867045e5abee2d9597c9913b5f91f3d8193c322746b"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/monthly-aid-payment.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/monthly-aid-payment.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/monthly-aid-payment.yaml",
+      "sha256": "320eb02cea538742c5073ef198925040757a82fd76e16d9aac945ec0f855ed63"
+    },
+    {
+      "path": "policies/cdss/calworks/monthly-aid-payment.test.yaml",
+      "sha256": "b57e826032f39cf660bee7c11db304c30d45ec8b89abaedeafdd9399503225ea"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "143aca38632250d3060b8196b229635356cb68ea",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.817",
+    "version_commit": "143aca38632250d3060b8196b229635356cb68ea"
+  },
+  "axiom_encode_version": "0.2.817",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/monthly-aid-payment",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-monthly-aid-payment/workspace/context-manifest.json",
+  "context_manifest_sha256": "85e0d320551758a9d88887f18f06d91bb58b8c00561bf70f2c4de896cfd8c50e",
+  "generated_at": "2026-06-25T06:26:03.319780+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/monthly-aid-payment.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "320eb02cea538742c5073ef198925040757a82fd76e16d9aac945ec0f855ed63",
+  "generation_prompt_sha256": "8915e0b47a2e753733dc09002bfc1dec0bcd7c8a24cd373ec33fd7b8d4b6620c",
+  "model": "gpt-5.5",
+  "run_id": "952174b9",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2cd7180f31d192279a54e1beb67402789b4857d058bd1f5bcda56ba8d60f433d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-monthly-aid-payment.json",
+  "trace_sha256": "5b49d54a63560f52146fe1347d22b0a30c2bd5d4b4fe9ebe98baac5643b8ad03"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/recipient-income-disregard.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/recipient-income-disregard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/recipient-income-disregard.yaml",
+      "sha256": "7805b2660877c11d62cccb5619f36771d5cf1e66c3df935b892f333521cfb22c"
+    },
+    {
+      "path": "policies/cdss/calworks/recipient-income-disregard.test.yaml",
+      "sha256": "720a97828508834b0de5359dbaf6b1197bb702deba7add4ef21e7d3e3cf6a398"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ff1b11d2e131281a6b1a8aff0f0598a311356181",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.815",
+    "version_commit": "ff1b11d2e131281a6b1a8aff0f0598a311356181"
+  },
+  "axiom_encode_version": "0.2.815",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/recipient-income-disregard",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-recipient-income-disregard/workspace/context-manifest.json",
+  "context_manifest_sha256": "70231a3c489c1fce7cdac19da84a9991b5902bf9d8063e97f6a3f99f2935557c",
+  "generated_at": "2026-06-25T04:59:38.611005+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/recipient-income-disregard.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7805b2660877c11d62cccb5619f36771d5cf1e66c3df935b892f333521cfb22c",
+  "generation_prompt_sha256": "48fe174dc148a66d1bbcb1e934a94ccc5e82eb78b33833494b2aff4559c63f63",
+  "model": "gpt-5.5",
+  "run_id": "9446e246",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1ba114167967d0009f0ffa88e123fcfe5a32d40401f2a5e52c0051ae442c2bec"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-recipient-income-disregard.json",
+  "trace_sha256": "8440a35acd72e2e864e3c8bf097df1c8030fd4e16653e50e96335c07e677c58e"
+}

--- a/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/regional-minimum-basic-standard.json
+++ b/us-ca/.axiom/encoding-manifests/policies/cdss/calworks/regional-minimum-basic-standard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cdss/calworks/regional-minimum-basic-standard.yaml",
+      "sha256": "2f2a054d3c70a60ec8d3e68c2be611ed7422fff1a49cf75d828cac20faa96523"
+    },
+    {
+      "path": "policies/cdss/calworks/regional-minimum-basic-standard.test.yaml",
+      "sha256": "6e2b1344f8818daaaca03c45618855c8ed3bcaefe2d8ab01bc25260a57ed86b5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.813",
+    "version_commit": "abf3803e182159412e763c629f2adbbfa8b1c6b3"
+  },
+  "axiom_encode_version": "0.2.813",
+  "backend": "codex",
+  "citation": "policies/cdss/calworks/regional-minimum-basic-standard",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/policies-cdss-calworks-regional-minimum-basic-standard/workspace/context-manifest.json",
+  "context_manifest_sha256": "3bacbbcfdb772423ee52a7b9b2d51ece34767f0206cedf60ff1134ab54fae22d",
+  "generated_at": "2026-06-25T03:38:54.792911+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/regional-minimum-basic-standard.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "2f2a054d3c70a60ec8d3e68c2be611ed7422fff1a49cf75d828cac20faa96523",
+  "generation_prompt_sha256": "3930247d7d45e8616ed48ed66008ff1b9ea01eb246c7e6aa550560860e0e2760",
+  "model": "gpt-5.5",
+  "run_id": "ca754202",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "61b9bf97ad3ec9776192c2ef37d13b62c1d34fa57abbd60841652740d77b5163"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/policies-cdss-calworks-regional-minimum-basic-standard.json",
+  "trace_sha256": "3f00ea1a0dcaf9a76a8907412307fb192ab0beae89cdade1601050e37a06032e"
+}

--- a/us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.test.yaml
+++ b/us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.test.yaml
@@ -1,0 +1,24 @@
+- name: non_exempt_vehicle_equity_above_limit_counts_excess
+  period: 2024-07
+  input:
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.asset_is_non_exempt_motor_vehicle: true
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.motor_vehicle_equity_value: 35000
+  output:
+    ? us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#countable_non_exempt_motor_vehicle_equity_value
+    : 2032
+- name: non_exempt_vehicle_equity_at_limit_counts_zero
+  period: 2024-07
+  input:
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.asset_is_non_exempt_motor_vehicle: true
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.motor_vehicle_equity_value: 32968
+  output:
+    ? us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#countable_non_exempt_motor_vehicle_equity_value
+    : 0
+- name: exempt_or_non_vehicle_asset_counts_zero
+  period: 2024-07
+  input:
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.asset_is_non_exempt_motor_vehicle: false
+    us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#input.motor_vehicle_equity_value: 35000
+  output:
+    ? us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#countable_non_exempt_motor_vehicle_equity_value
+    : 0

--- a/us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml
+++ b/us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml
@@ -1,0 +1,53 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-36/page-3
+  summary: |-
+    Effective July 1, 2024, the maximum value allowed for non-exempt vehicles will increase by 2.88 percent, per the increase reflected in the CPI-U. The new maximum non-exempt vehicle value limit will be $32,968. The equity value for each motor vehicle in excess of $32,968 will be counted towards the maximum asset limit for CalWORKs, for applicants and recipients.
+rules:
+  - name: calworks_non_exempt_vehicle_value_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: All County Letter No. 24-36, Vehicle's Value Increase
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-36/page-3
+              excerpt: "Effective July 1, 2024... The new maximum non-exempt vehicle value limit will be $32,968."
+    versions:
+      - effective_from: '2024-07-01'
+        formula: |-
+          32968
+
+  - name: countable_non_exempt_motor_vehicle_equity_value
+    kind: derived
+    entity: Asset
+    dtype: Money
+    unit: USD
+    period: Month
+    source: All County Letter No. 24-36, Vehicle's Value Increase
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-36/page-3
+              excerpt: "The equity value for each motor vehicle in excess of $32,968 will be counted towards the maximum asset limit for CalWORKs, for applicants and recipients."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value#calworks_non_exempt_vehicle_value_limit
+              output: calworks_non_exempt_vehicle_value_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-07-01'
+        formula: |-
+          if asset_is_non_exempt_motor_vehicle: max(0, motor_vehicle_equity_value - calworks_non_exempt_vehicle_value_limit) else: 0

--- a/us-ca/policies/cdss/calworks/financial-eligibility-income-tests.test.yaml
+++ b/us-ca/policies/cdss/calworks/financial-eligibility-income-tests.test.yaml
@@ -1,0 +1,66 @@
+- name: applicant_and_recipient_income_tests_hold_below_thresholds
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_exemption_change_under_section_11451_5_c: 0
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.employed_person_count: 1
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_income: 200
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_earned_income: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.reasonably_anticipated_income: 400
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.exempt_income: 50
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.disability_based_unearned_income: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.earned_income_exempt_under_section_11451_5: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.maximum_aid_payment_under_section_11450: 300
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_reporting_threshold_under_sections_11265_3_and_11265_47
+    : 500
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 1
+  output:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#earned_income_exemption_per_employed_person: 450
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_minimum_basic_standard_income_test
+    : holds
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_maximum_aid_payment_income_test: holds
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#recipient_family_satisfies_income_reporting_threshold_for_further_aid
+    : holds
+- name: applicant_and_recipient_income_tests_fail_at_or_above_limits
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_exemption_change_under_section_11451_5_c: 0
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.employed_person_count: 1
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_income: 100000
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_earned_income: 0
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.reasonably_anticipated_income: 500
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.exempt_income: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.disability_based_unearned_income: 50
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.earned_income_exempt_under_section_11451_5: 50
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.maximum_aid_payment_under_section_11450: 300
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_reporting_threshold_under_sections_11265_3_and_11265_47
+    : 350
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 1
+  output:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#earned_income_exemption_per_employed_person: 450
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_minimum_basic_standard_income_test
+    : not_holds
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_maximum_aid_payment_income_test: not_holds
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#recipient_family_satisfies_income_reporting_threshold_for_further_aid
+    : not_holds
+- name: subsequent_income_exemption_change_increases_per_employed_person_exemption
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_exemption_change_under_section_11451_5_c: 50
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.employed_person_count: 2
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_income: 700
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.family_earned_income: 1000
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.reasonably_anticipated_income: 900
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.exempt_income: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.disability_based_unearned_income: 100
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.earned_income_exempt_under_section_11451_5: 200
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.maximum_aid_payment_under_section_11450: 600
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#input.income_reporting_threshold_under_sections_11265_3_and_11265_47
+    : 800
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 1
+  output:
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#earned_income_exemption_per_employed_person: 500
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_minimum_basic_standard_income_test
+    : holds
+    us-ca:policies/cdss/calworks/financial-eligibility-income-tests#applicant_family_satisfies_maximum_aid_payment_income_test: holds
+    ? us-ca:policies/cdss/calworks/financial-eligibility-income-tests#recipient_family_satisfies_income_reporting_threshold_for_further_aid
+    : holds

--- a/us-ca/policies/cdss/calworks/financial-eligibility-income-tests.yaml
+++ b/us-ca/policies/cdss/calworks/financial-eligibility-income-tests.yaml
@@ -1,0 +1,148 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11450.12
+  summary: |-
+    (a) An applicant family shall not be eligible unless the family's income, exclusive of the first four hundred fifty dollars ($450) of earned income for each employed person, is less than the minimum basic standard of adequate care. If there are subsequent changes to the income exemption in Section 11451.5(c), the exemption amount changes by an equal amount. (b) Applicant-family reasonably anticipated income, less specified exclusions, must be below the maximum aid payment. (c) Recipient-family reasonably anticipated income, less exempt income, must not exceed the income reporting threshold. (d) Operative July 1, 2022.
+imports:
+  - us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family
+rules:
+  - name: statutory_earned_income_exemption_per_employed_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11450.12(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "first four hundred fifty dollars ($450) of earned income for each employed person"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "This section shall become operative on July 1, 2022."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          450
+
+  - name: earned_income_exemption_per_employed_person
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11450.12(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "the earned income exemption amount specified in this section shall be changed by an equal amount"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/financial-eligibility-income-tests#statutory_earned_income_exemption_per_employed_person
+              output: statutory_earned_income_exemption_per_employed_person
+              hash: sha256:local
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "This section shall become operative on July 1, 2022."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          statutory_earned_income_exemption_per_employed_person + income_exemption_change_under_section_11451_5_c
+
+  - name: applicant_family_satisfies_minimum_basic_standard_income_test
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: 11450.12(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "income, exclusive of the first four hundred fifty dollars ($450) of earned income for each employed person, is less than the minimum basic standard of adequate care"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/financial-eligibility-income-tests#earned_income_exemption_per_employed_person
+              output: earned_income_exemption_per_employed_person
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family
+              output: minimum_basic_standard_schedule_amount_for_family
+              hash: sha256:b074596ebc9236f63f90d1aa6d1c437fe4e4a91130391fba3c7c432edf873a14
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "This section shall become operative on July 1, 2022."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          (family_income - min(family_earned_income, earned_income_exemption_per_employed_person * employed_person_count)) < minimum_basic_standard_schedule_amount_for_family
+
+  - name: applicant_family_satisfies_maximum_aid_payment_income_test
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: 11450.12(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "reasonably anticipated income, less exempt income, and exclusive of amounts of disability-based unearned income and earned income exempt under Section 11451.5, equals or exceeds the maximum aid payment"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "This section shall become operative on July 1, 2022."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          (reasonably_anticipated_income - exempt_income - disability_based_unearned_income - earned_income_exempt_under_section_11451_5) < maximum_aid_payment_under_section_11450
+
+  - name: recipient_family_satisfies_income_reporting_threshold_for_further_aid
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: 11450.12(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "if reasonably anticipated income, less exempt income, exceeds the income reporting threshold"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450.12
+              excerpt: "This section shall become operative on July 1, 2022."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          (reasonably_anticipated_income - exempt_income) <= income_reporting_threshold_under_sections_11265_3_and_11265_47

--- a/us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.test.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.test.yaml
@@ -1,0 +1,32 @@
+- name: exempt_one_person_region_1_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 1
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_persons_on_aid_key: 1
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 809
+- name: non_exempt_four_person_region_1_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 4
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_persons_on_aid_key: 4
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 1416
+- name: exempt_ten_person_region_1_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_persons_on_aid_key: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 3215
+- name: non_exempt_more_than_ten_person_region_1_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 12
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_persons_on_aid_key: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 2876

--- a/us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+  summary: |-
+    CALWORKS PAYMENT STANDARDS CHART EFFECTIVE OCTOBER 1, 2024. Region 1, Exempt MAP and Region 1, Non-Exempt MAP list New MAP amounts by Person(s) on aid, including rows 1 through 9 and 10 or more.
+rules:
+  - name: calworks_region_1_map_largest_persons_on_aid_table_row
+    kind: parameter
+    dtype: Count
+    source: ACL 24-55, Attachment, CalWORKS Payment Standards Chart, Region 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+              excerpt: "10 or more $3,205 $3,215 $10"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          10
+
+  - name: calworks_region_1_exempt_maximum_aid_payment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: calworks_region_1_map_persons_on_aid_key
+    source: ACL 24-55, Attachment, CalWORKS Payment Standards Chart, Region 1, Exempt MAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+              excerpt: "Region 1, Exempt MAP ... New MAP ... 1 $809 ... 10 or more $3,215"
+              table:
+                header: "Region 1, Exempt MAP"
+                row_key: "Person(s) on aid"
+                column_key: "New MAP"
+    versions:
+      - effective_from: '2024-10-01'
+        values:
+          1: 809
+          2: 1039
+          3: 1314
+          4: 1579
+          5: 1850
+          6: 2123
+          7: 2395
+          8: 2669
+          9: 2939
+          10: 3215
+
+  - name: calworks_region_1_non_exempt_maximum_aid_payment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: calworks_region_1_map_persons_on_aid_key
+    source: ACL 24-55, Attachment, CalWORKS Payment Standards Chart, Region 1, Non-Exempt MAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+              excerpt: "Region 1, Non-Exempt MAP ... New MAP ... 1 $734 ... 10 or more $2,876"
+              table:
+                header: "Region 1, Non-Exempt MAP"
+                row_key: "Person(s) on aid"
+                column_key: "New MAP"
+    versions:
+      - effective_from: '2024-10-01'
+        values:
+          1: 734
+          2: 930
+          3: 1175
+          4: 1416
+          5: 1659
+          6: 1902
+          7: 2145
+          8: 2389
+          9: 2631
+          10: 2876
+
+  - name: calworks_region_1_map_persons_on_aid_key
+    kind: derived
+    entity: TanfUnit
+    dtype: Count
+    period: Month
+    source: ACL 24-55, Attachment, CalWORKS Payment Standards Chart, Region 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+              excerpt: "Person(s) on aid ... 10 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_largest_persons_on_aid_table_row
+              output: calworks_region_1_map_largest_persons_on_aid_table_row
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if persons_on_aid >= calworks_region_1_map_largest_persons_on_aid_table_row: calworks_region_1_map_largest_persons_on_aid_table_row else: persons_on_aid
+
+  - name: calworks_region_1_maximum_aid_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: ACL 24-55, Attachment, CalWORKS Payment Standards Chart, Region 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-7
+              excerpt: "Region 1, Exempt MAP ... Region 1, Non-Exempt MAP"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_exempt_maximum_aid_payment
+              output: calworks_region_1_exempt_maximum_aid_payment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_non_exempt_maximum_aid_payment
+              output: calworks_region_1_non_exempt_maximum_aid_payment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_map_persons_on_aid_key
+              output: calworks_region_1_map_persons_on_aid_key
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if assistance_unit_is_exempt: calworks_region_1_exempt_maximum_aid_payment[calworks_region_1_map_persons_on_aid_key] else: calworks_region_1_non_exempt_maximum_aid_payment[calworks_region_1_map_persons_on_aid_key]

--- a/us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.test.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.test.yaml
@@ -1,0 +1,32 @@
+- name: exempt_one_person_region_2_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.persons_on_aid: 1
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.assistance_unit_is_exempt: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_persons_on_aid_key: 1
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment: 770
+- name: non_exempt_four_person_region_2_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.persons_on_aid: 4
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.assistance_unit_is_exempt: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_persons_on_aid_key: 4
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment: 1346
+- name: exempt_ten_person_region_2_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.persons_on_aid: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.assistance_unit_is_exempt: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_persons_on_aid_key: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment: 3054
+- name: non_exempt_more_than_ten_person_region_2_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.persons_on_aid: 12
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.assistance_unit_is_exempt: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_persons_on_aid_key: 10
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment: 2731

--- a/us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+  summary: |-
+    Region 2, Exempt: Person(s) on aid Old MAP New MAP Increase in MAP 1 $768 $770 $2 ... 10 or more $3,045 $3,054 $9. Region 2, Non-Exempt: Person(s) on aid Old MAP New MAP Increase in MAP 1 $693 $695 $2 ... 10 or more $2,723 $2,731 $8.
+rules:
+  - name: calworks_region_2_map_largest_persons_on_aid_table_row
+    kind: parameter
+    dtype: Count
+    source: ACL 24-55, Attachment, CalWORKs Payment Standards Chart, Region 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+              excerpt: "10 or more $3,045 $3,054 $9"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          10
+
+  - name: calworks_region_2_exempt_maximum_aid_payment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: calworks_region_2_map_persons_on_aid_key
+    source: ACL 24-55, Attachment, CalWORKs Payment Standards Chart, Region 2, Exempt
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+              excerpt: "Region 2, Exempt ... 1 $768 $770 $2 2 $984 $987 $3 3 $1,244 $1,248 $4 4 $1,494 $1,498 $4 5 $1,753 $1,758 $5 6 $2,012 $2,018 $6 7 $2,267 $2,274 $7 8 $2,529 $2,537 $8 9 $2,783 $2,791 $8 10 or more $3,045 $3,054 $9"
+              table:
+                header: "Region 2, Exempt"
+                row_key: "Person(s) on aid"
+                column_key: "New MAP"
+    versions:
+      - effective_from: '2024-10-01'
+        values:
+          1: 770
+          2: 987
+          3: 1248
+          4: 1498
+          5: 1758
+          6: 2018
+          7: 2274
+          8: 2537
+          9: 2791
+          10: 3054
+
+  - name: calworks_region_2_non_exempt_maximum_aid_payment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: calworks_region_2_map_persons_on_aid_key
+    source: ACL 24-55, Attachment, CalWORKs Payment Standards Chart, Region 2, Non-Exempt
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+              excerpt: "Region 2, Non-Exempt ... 1 $693 $695 $2 2 $881 $884 $3 3 $1,112 $1,115 $3 4 $1,342 $1,346 $4 5 $1,573 $1,578 $5 6 $1,803 $1,808 $5 7 $2,033 $2,039 $6 8 $2,264 $2,271 $7 9 $2,494 $2,501 $7 10 or more $2,723 $2,731 $8"
+              table:
+                header: "Region 2, Non-Exempt"
+                row_key: "Person(s) on aid"
+                column_key: "New MAP"
+    versions:
+      - effective_from: '2024-10-01'
+        values:
+          1: 695
+          2: 884
+          3: 1115
+          4: 1346
+          5: 1578
+          6: 1808
+          7: 2039
+          8: 2271
+          9: 2501
+          10: 2731
+
+  - name: calworks_region_2_map_persons_on_aid_key
+    kind: derived
+    entity: TanfUnit
+    dtype: Count
+    period: Month
+    source: ACL 24-55, Attachment, CalWORKs Payment Standards Chart, Region 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+              excerpt: "Person(s) on aid ... 10 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_largest_persons_on_aid_table_row
+              output: calworks_region_2_map_largest_persons_on_aid_table_row
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if persons_on_aid >= calworks_region_2_map_largest_persons_on_aid_table_row: calworks_region_2_map_largest_persons_on_aid_table_row else: persons_on_aid
+
+  - name: calworks_region_2_maximum_aid_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: ACL 24-55, Attachment, CalWORKs Payment Standards Chart, Region 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-55/page-8
+              excerpt: "Region 2, Exempt ... Region 2, Non-Exempt"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_exempt_maximum_aid_payment
+              output: calworks_region_2_exempt_maximum_aid_payment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_non_exempt_maximum_aid_payment
+              output: calworks_region_2_non_exempt_maximum_aid_payment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_map_persons_on_aid_key
+              output: calworks_region_2_map_persons_on_aid_key
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if assistance_unit_is_exempt: calworks_region_2_exempt_maximum_aid_payment[calworks_region_2_map_persons_on_aid_key] else: calworks_region_2_non_exempt_maximum_aid_payment[calworks_region_2_map_persons_on_aid_key]

--- a/us-ca/policies/cdss/calworks/maximum-resource-limit.test.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-resource-limit.test.yaml
@@ -1,0 +1,12 @@
+- name: standard_calworks_resource_limit
+  period: 2025-01
+  input:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#input.assistance_unit_includes_member_age_60_or_older_or_disabled: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit: 12137
+- name: higher_limit_for_au_with_member_age_60_or_disabled
+  period: 2025-01
+  input:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#input.assistance_unit_includes_member_age_60_or_older_or_disabled: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit: 18206

--- a/us-ca/policies/cdss/calworks/maximum-resource-limit.yaml
+++ b/us-ca/policies/cdss/calworks/maximum-resource-limit.yaml
@@ -1,0 +1,64 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-54/page-2
+  summary: |-
+    Effective January 1, 2025, the maximum resource limit will increase by 4.32 percent. The new maximum resource limit for CalWORKs applicants and recipients will be $12,137 or $18,206 for Assistance Units (AUs) that include at least one member who is age 60 or older or disabled.
+rules:
+  - name: calworks_standard_maximum_resource_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ACL 24-54, Maximum Asset Limit Increase
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-54/page-2
+              excerpt: "The new maximum resource limit for CalWORKs applicants and recipients will be $12,137"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          12137
+
+  - name: calworks_age_or_disability_maximum_resource_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ACL 24-54, Maximum Asset Limit Increase
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-54/page-2
+              excerpt: "$18,206 for Assistance Units (AUs) that include at least one member who is age 60 or older or disabled"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          18206
+
+  - name: calworks_maximum_resource_limit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: ACL 24-54, Maximum Asset Limit Increase
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/guidance/cdss/acl-2024-24-54/page-2
+              excerpt: "$12,137 or $18,206 for Assistance Units (AUs) that include at least one member who is age 60 or older or disabled"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if assistance_unit_includes_member_age_60_or_older_or_disabled: calworks_age_or_disability_maximum_resource_limit else: calworks_standard_maximum_resource_limit

--- a/us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.test.yaml
+++ b/us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.test.yaml
@@ -1,0 +1,24 @@
+- name: one eligible needy person uses first schedule row
+  period: 1996-07
+  input:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 1
+  output:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family: 341
+- name: ten eligible needy persons uses final schedule row
+  period: 1996-07
+  input:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 10
+  output:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family: 1489
+- name: additional needy persons add fourteen dollars each
+  period: 1996-07
+  input:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 12
+  output:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family: 1517
+- name: below scheduled family size floors schedule amount at zero
+  period: 1996-07
+  input:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#input.eligible_needy_person_count_in_family: 0
+  output:
+    us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care#minimum_basic_standard_schedule_amount_for_family: 0

--- a/us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml
+++ b/us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml
@@ -1,0 +1,155 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11452
+  summary: |-
+    Minimum basic standards of adequate care are based on the schedule in this section, as adjusted for cost-of-living changes under Section 11453. The schedule lists family sizes 1 through 10 at $341, $560, $694, $824, $940, $1,057, $1,160, $1,265, $1,371, and $1,489, plus fourteen dollars ($14) for each additional needy person. Historical COLA provisions state no adjustment for the 1990-91 and 1991-92 fiscal years and a 70 percent COLA for specified later fiscal years through October 31, 1996. The standard also includes special needs amounts specified in Section 11450.
+  deferred_outputs:
+    - output: us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care/11452/a#minimum_basic_standard_of_adequate_care_adjusted
+      reason: The final adjusted standard requires cost-of-living increases or decreases pursuant to Section 11453, which is outside this source unit; this file encodes the source-stated statutory schedule and historical adjustment scalars.
+    - output: us-ca:policies/cdss/calworks/minimum-basic-standard-of-adequate-care/11452/b#minimum_basic_standard_of_adequate_care_including_special_needs
+      reason: The special-needs additions depend on amounts specified in subdivisions (e) and (f) of Section 11450, which are outside this source unit.
+rules:
+  - name: minimum_scheduled_eligible_needy_person_count
+    kind: parameter
+    dtype: Count
+    source: 11452(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "Number of eligible needy persons in the same family ... 1"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          1
+
+  - name: maximum_scheduled_eligible_needy_person_count
+    kind: parameter
+    dtype: Count
+    source: 11452(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "10 ........................ 1,489"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          10
+
+  - name: minimum_basic_standard_schedule_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: eligible_needy_person_count_in_family
+    source: 11452(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              table:
+                header: "Number of eligible needy persons in the same family / Minimum basic standards of adequate care"
+                row_key: eligible_needy_person_count_in_family
+                column_key: minimum_basic_standard_of_adequate_care
+    versions:
+      - effective_from: '1996-06-27'
+        values:
+          1: 341
+          2: 560
+          3: 694
+          4: 824
+          5: 940
+          6: 1057
+          7: 1160
+          8: 1265
+          9: 1371
+          10: 1489
+
+  - name: additional_needy_person_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11452(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "plus fourteen dollars ($14) for each additional needy person"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          14
+
+  - name: cost_of_living_adjustment_fraction_for_suppressed_fiscal_years
+    kind: parameter
+    dtype: Rate
+    source: 11452(a)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "No adjustment shall be made under this section for the 1990-91 and 1991-92 fiscal years"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          0
+
+  - name: historical_cost_of_living_adjustment_fraction
+    kind: parameter
+    dtype: Rate
+    source: 11452(a)(3)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "a cost-of-living adjustment equivalent to 70 percent"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          0.70
+
+  - name: minimum_basic_standard_schedule_amount_for_family
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11452(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "The schedule of minimum basic standards of adequate care is as follows"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452
+              excerpt: "plus fourteen dollars ($14) for each additional needy person"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          if eligible_needy_person_count_in_family < minimum_scheduled_eligible_needy_person_count: 0 else: if eligible_needy_person_count_in_family <= maximum_scheduled_eligible_needy_person_count: minimum_basic_standard_schedule_amount[eligible_needy_person_count_in_family] else: minimum_basic_standard_schedule_amount[maximum_scheduled_eligible_needy_person_count] + ((eligible_needy_person_count_in_family - maximum_scheduled_eligible_needy_person_count) * additional_needy_person_increment)

--- a/us-ca/policies/cdss/calworks/monthly-aid-payment.test.yaml
+++ b/us-ca/policies/cdss/calworks/monthly-aid-payment.test.yaml
@@ -1,0 +1,45 @@
+- name: three_person_income_deducted_with_special_needs
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.eligible_needy_person_count_in_same_home: 3
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.cost_of_living_adjustment_to_monthly_aid_payment_under_section_11453_and_paragraph_2
+    : 0
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.prospective_semiannual_family_income_after_exemptions_and_section_11451_5_calculation
+    : 200
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.special_needs_under_subdivisions_c_e_and_f: 50
+  output:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_person_count_key: 3
+    us-ca:policies/cdss/calworks/monthly-aid-payment#statutory_monthly_aid_payment_schedule_amount: 663
+    us-ca:policies/cdss/calworks/monthly-aid-payment#adjusted_monthly_aid_payment_schedule_amount: 663
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_cap_including_special_needs: 713
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment: 513
+- name: more_than_ten_person_count_uses_final_table_row
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.eligible_needy_person_count_in_same_home: 12
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.cost_of_living_adjustment_to_monthly_aid_payment_under_section_11453_and_paragraph_2
+    : 100
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.prospective_semiannual_family_income_after_exemptions_and_section_11451_5_calculation
+    : 400
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.special_needs_under_subdivisions_c_e_and_f: 0
+  output:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_person_count_key: 10
+    us-ca:policies/cdss/calworks/monthly-aid-payment#statutory_monthly_aid_payment_schedule_amount: 1403
+    us-ca:policies/cdss/calworks/monthly-aid-payment#adjusted_monthly_aid_payment_schedule_amount: 1503
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_cap_including_special_needs: 1503
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment: 1103
+- name: income_above_schedule_preserves_special_needs
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.eligible_needy_person_count_in_same_home: 1
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.cost_of_living_adjustment_to_monthly_aid_payment_under_section_11453_and_paragraph_2
+    : 0
+    ? us-ca:policies/cdss/calworks/monthly-aid-payment#input.prospective_semiannual_family_income_after_exemptions_and_section_11451_5_calculation
+    : 500
+    us-ca:policies/cdss/calworks/monthly-aid-payment#input.special_needs_under_subdivisions_c_e_and_f: 25
+  output:
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_person_count_key: 1
+    us-ca:policies/cdss/calworks/monthly-aid-payment#statutory_monthly_aid_payment_schedule_amount: 326
+    us-ca:policies/cdss/calworks/monthly-aid-payment#adjusted_monthly_aid_payment_schedule_amount: 326
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_cap_including_special_needs: 351
+    us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment: 25

--- a/us-ca/policies/cdss/calworks/monthly-aid-payment.yaml
+++ b/us-ca/policies/cdss/calworks/monthly-aid-payment.yaml
@@ -1,0 +1,204 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+  summary: |-
+    "Aid shall be paid for each needy family" and, in determining the amount, the family's income after stated exclusions and calculations "shall be deducted from the sum specified in the following table, as adjusted for cost-of-living increases." "In no case shall the amount of aid paid for each month exceed" that adjusted sum "plus any special needs." The table lists "Number of eligible needy persons in the same home" and "Maximum aid" from "1 ... $326" through "10 or more ... 1,403."
+rules:
+  - name: monthly_aid_payment_largest_eligible_needy_person_table_row
+    kind: parameter
+    dtype: Count
+    source: WIC 11450(a)(1)(A), maximum aid table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "10 or more ........................ 1,403"
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          10
+
+  - name: statutory_monthly_aid_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: monthly_aid_payment_person_count_key
+    source: WIC 11450(a)(1)(A), maximum aid table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "Maximum aid: 1 $326; 2 $535; 3 $663; 4 $788; 5 $899; 6 $1,010; 7 $1,109; 8 $1,209; 9 $1,306; 10 or more $1,403"
+              table:
+                header: "Number of eligible needy persons in the same home / Maximum aid"
+                row_key: "Number of eligible needy persons in the same home"
+                column_key: "Maximum aid"
+    versions:
+      - effective_from: '1996-06-27'
+        values:
+          1: 326
+          2: 535
+          3: 663
+          4: 788
+          5: 899
+          6: 1010
+          7: 1109
+          8: 1209
+          9: 1306
+          10: 1403
+
+  - name: monthly_aid_payment_person_count_key
+    kind: derived
+    entity: Family
+    dtype: Count
+    period: Month
+    source: WIC 11450(a)(1)(A), maximum aid table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "Number of eligible needy persons in the same home ... 10 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_largest_eligible_needy_person_table_row
+              output: monthly_aid_payment_largest_eligible_needy_person_table_row
+              hash: sha256:local
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          if eligible_needy_person_count_in_same_home >= monthly_aid_payment_largest_eligible_needy_person_table_row: monthly_aid_payment_largest_eligible_needy_person_table_row else: eligible_needy_person_count_in_same_home
+
+  - name: statutory_monthly_aid_payment_schedule_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WIC 11450(a)(1)(A), maximum aid table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "the sum specified in the following table"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#statutory_monthly_aid_payment_amount
+              output: statutory_monthly_aid_payment_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_person_count_key
+              output: monthly_aid_payment_person_count_key
+              hash: sha256:local
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          statutory_monthly_aid_payment_amount[monthly_aid_payment_person_count_key]
+
+  - name: adjusted_monthly_aid_payment_schedule_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WIC 11450(a)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "as adjusted for cost-of-living increases pursuant to Section 11453 and paragraph (2)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#statutory_monthly_aid_payment_schedule_amount
+              output: statutory_monthly_aid_payment_schedule_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          statutory_monthly_aid_payment_schedule_amount + cost_of_living_adjustment_to_monthly_aid_payment_under_section_11453_and_paragraph_2
+
+  - name: monthly_aid_payment_cap_including_special_needs
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WIC 11450(a)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "shall the amount of aid paid for each month exceed the sum specified in the following table ... plus any special needs"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#adjusted_monthly_aid_payment_schedule_amount
+              output: adjusted_monthly_aid_payment_schedule_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          adjusted_monthly_aid_payment_schedule_amount + special_needs_under_subdivisions_c_e_and_f
+
+  - name: monthly_aid_payment
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WIC 11450(a)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "the family's income ... shall be deducted from the sum specified in the following table"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+              excerpt: "In no case shall the amount of aid paid for each month exceed the sum ... plus any special needs"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#adjusted_monthly_aid_payment_schedule_amount
+              output: adjusted_monthly_aid_payment_schedule_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment_cap_including_special_needs
+              output: monthly_aid_payment_cap_including_special_needs
+              hash: sha256:local
+    versions:
+      - effective_from: '1996-06-27'
+        formula: |-
+          min(monthly_aid_payment_cap_including_special_needs, max(0, adjusted_monthly_aid_payment_schedule_amount - prospective_semiannual_family_income_after_exemptions_and_section_11451_5_calculation) + special_needs_under_subdivisions_c_e_and_f)

--- a/us-ca/policies/cdss/calworks/recipient-income-disregard.test.yaml
+++ b/us-ca/policies/cdss/calworks/recipient-income-disregard.test.yaml
@@ -1,0 +1,113 @@
+- name: operative initial threshold with disability income below threshold and earned
+    excess
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.wages: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.salary: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.employer_provided_sick_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.commissions: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.self_employment_business_or_farming_profits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.state_disability_insurance_benefits: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.private_disability_insurance_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.temporary_workers_compensation_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.social_security_disability_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.paid_family_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.veteran_disability_compensation: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.gross_income: 1000
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.not_otherwise_exempt_earned_income: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.section_has_become_operative: true
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_one_year_has_elapsed_since_section_became_operative: false
+    ? us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_two_years_have_elapsed_since_section_became_operative
+    : false
+  output:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#unearned_income: 100
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income_threshold: 500
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_applied_to_disregard_differential: 300
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_excess_over_disregard_differential: 400
+    us-ca:policies/cdss/calworks/recipient-income-disregard#recipient_income_disregard: 700
+- name: one year after operability with disability income above threshold
+  period: 2025-10
+  input:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.wages: 400
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.salary: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.employer_provided_sick_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.commissions: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.self_employment_business_or_farming_profits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.state_disability_insurance_benefits: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.private_disability_insurance_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.temporary_workers_compensation_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.social_security_disability_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.paid_family_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.veteran_disability_compensation: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.gross_income: 1200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.not_otherwise_exempt_earned_income: 300
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.section_has_become_operative: true
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_one_year_has_elapsed_since_section_became_operative: true
+    ? us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_two_years_have_elapsed_since_section_became_operative
+    : false
+  output:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income: 400
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#unearned_income: 100
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income_threshold: 550
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_applied_to_disregard_differential: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_excess_over_disregard_differential: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#recipient_income_disregard: 750
+- name: two years after operability with earned income within differential
+  period: 2026-10
+  input:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.wages: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.salary: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.employer_provided_sick_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.commissions: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.self_employment_business_or_farming_profits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.state_disability_insurance_benefits: 100
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.private_disability_insurance_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.temporary_workers_compensation_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.social_security_disability_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.paid_family_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.veteran_disability_compensation: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.gross_income: 350
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.not_otherwise_exempt_earned_income: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.section_has_become_operative: true
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_one_year_has_elapsed_since_section_became_operative: true
+    ? us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_two_years_have_elapsed_since_section_became_operative
+    : true
+  output:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income: 100
+    us-ca:policies/cdss/calworks/recipient-income-disregard#unearned_income: 50
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income_threshold: 600
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_applied_to_disregard_differential: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_excess_over_disregard_differential: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#recipient_income_disregard: 300
+- name: section not yet operative
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.wages: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.salary: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.employer_provided_sick_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.commissions: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.self_employment_business_or_farming_profits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.state_disability_insurance_benefits: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.private_disability_insurance_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.temporary_workers_compensation_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.social_security_disability_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.paid_family_leave_benefits: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.veteran_disability_compensation: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.gross_income: 1000
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.not_otherwise_exempt_earned_income: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.section_has_become_operative: false
+    us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_one_year_has_elapsed_since_section_became_operative: false
+    ? us-ca:policies/cdss/calworks/recipient-income-disregard#input.at_least_two_years_have_elapsed_since_section_became_operative
+    : false
+  output:
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income: 700
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income: 200
+    us-ca:policies/cdss/calworks/recipient-income-disregard#unearned_income: 100
+    us-ca:policies/cdss/calworks/recipient-income-disregard#disability_based_unearned_income_threshold: 225
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_applied_to_disregard_differential: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#earned_income_excess_over_disregard_differential: 0
+    us-ca:policies/cdss/calworks/recipient-income-disregard#recipient_income_disregard: 0

--- a/us-ca/policies/cdss/calworks/recipient-income-disregard.yaml
+++ b/us-ca/policies/cdss/calworks/recipient-income-disregard.yaml
@@ -1,0 +1,252 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11451.5
+  summary: |-
+    Income exempt from the calculation of family income includes specified disability-based unearned income and earned income disregards. "Earned income means gross income received as wages, salary, employer-provided sick leave benefits, commissions, or profits..." "Disability-based unearned income means state disability insurance benefits..." Each "$225" amount is increased to "$500," "$550," and "$600" on the operative-date schedule. The section becomes operative on "October 1, 2024, or when" SAWS can perform the necessary automation, "whichever is later."
+rules:
+  - name: base_disability_based_unearned_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11451.5(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "two hundred twenty-five dollars ($225)"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          225
+
+  - name: operative_initial_disability_based_unearned_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11451.5(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "to five hundred dollars ($500)"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          500
+
+  - name: one_year_after_operative_disability_based_unearned_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11451.5(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "to five hundred fifty dollars ($550)"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          550
+
+  - name: two_years_after_operative_disability_based_unearned_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 11451.5(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "to six hundred dollars ($600)"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          600
+
+  - name: earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 11451.5(a)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "Fifty percent"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          0.50
+
+  - name: earned_income
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "gross income received as wages, salary, employer-provided sick leave benefits, commissions, or profits"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          wages + salary + employer_provided_sick_leave_benefits + commissions + self_employment_business_or_farming_profits
+
+  - name: disability_based_unearned_income
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "state disability insurance benefits, private disability insurance benefits, temporary workers' compensation benefits, social security disability benefits, paid family leave benefits"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          state_disability_insurance_benefits + private_disability_insurance_benefits + temporary_workers_compensation_benefits + social_security_disability_benefits + paid_family_leave_benefits + veteran_disability_compensation
+
+  - name: unearned_income
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "Unearned income means any income not described in paragraph (1) or (2)."
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          max(0, gross_income - earned_income - disability_based_unearned_income)
+
+  - name: disability_based_unearned_income_threshold
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(c)-(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "Each two-hundred-twenty-five-dollar ($225) amount specified in subdivision (a), shall be increased"
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "October 1, 2024, or when the department notifies the Legislature"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if not section_has_become_operative: base_disability_based_unearned_income_threshold else: if at_least_two_years_have_elapsed_since_section_became_operative: two_years_after_operative_disability_based_unearned_income_threshold else: if at_least_one_year_has_elapsed_since_section_became_operative: one_year_after_operative_disability_based_unearned_income_threshold else: operative_initial_disability_based_unearned_income_threshold
+
+  - name: earned_income_applied_to_disregard_differential
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(a)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "earned income equal to the amount of the difference"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if section_has_become_operative and disability_based_unearned_income <= disability_based_unearned_income_threshold: min(not_otherwise_exempt_earned_income, max(0, disability_based_unearned_income_threshold - disability_based_unearned_income)) else: 0
+
+  - name: earned_income_excess_over_disregard_differential
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(a)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "earned income in excess of the amount applied to meet the differential"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if section_has_become_operative and disability_based_unearned_income <= disability_based_unearned_income_threshold: max(0, not_otherwise_exempt_earned_income - earned_income_applied_to_disregard_differential) else: 0
+
+  - name: recipient_income_disregard
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 11451.5(a)-(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "the following income shall be exempt from the calculation of the income of the family"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "If disability-based unearned income exceeds two hundred twenty-five dollars ($225)"
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11451.5
+              excerpt: "whichever is later"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          if not section_has_become_operative: 0 else: if disability_based_unearned_income <= disability_based_unearned_income_threshold: max(0, disability_based_unearned_income + earned_income_applied_to_disregard_differential + earned_income_disregard_rate * earned_income_excess_over_disregard_differential) else: max(0, disability_based_unearned_income_threshold + earned_income_disregard_rate * earned_income)

--- a/us-ca/policies/cdss/calworks/regional-minimum-basic-standard.test.yaml
+++ b/us-ca/policies/cdss/calworks/regional-minimum-basic-standard.test.yaml
@@ -1,0 +1,33 @@
+- name: region_1_county_has_no_reduction
+  period: 1995-09
+  input:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.county_lowest_quartile_rent_in_1990_decennial_census: 400
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.subdivision_a_of_section_11450_018_is_operative: true
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.minimum_basic_standard_of_adequate_care_as_adjusted: 1000
+  output:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_1_for_minimum_basic_standard: holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_2_for_minimum_basic_standard: not_holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_reduction_rate: 0
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_of_adequate_care: 1000
+- name: region_2_county_gets_4_9_percent_reduction
+  period: 1995-09
+  input:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.county_lowest_quartile_rent_in_1990_decennial_census: 399
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.subdivision_a_of_section_11450_018_is_operative: true
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.minimum_basic_standard_of_adequate_care_as_adjusted: 1000
+  output:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_1_for_minimum_basic_standard: not_holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_2_for_minimum_basic_standard: holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_reduction_rate: 0.049
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_of_adequate_care: 951
+- name: section_inoperative_applies_no_regional_reduction
+  period: 1995-09
+  input:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.county_lowest_quartile_rent_in_1990_decennial_census: 399
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.subdivision_a_of_section_11450_018_is_operative: false
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#input.minimum_basic_standard_of_adequate_care_as_adjusted: 1000
+  output:
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_1_for_minimum_basic_standard: not_holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#county_in_region_2_for_minimum_basic_standard: holds
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_reduction_rate: 0
+    us-ca:policies/cdss/calworks/regional-minimum-basic-standard#regional_minimum_basic_standard_of_adequate_care: 1000

--- a/us-ca/policies/cdss/calworks/regional-minimum-basic-standard.yaml
+++ b/us-ca/policies/cdss/calworks/regional-minimum-basic-standard.yaml
@@ -1,0 +1,164 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11452.018
+  summary: |-
+    "(a) ... the minimum basic standards of adequate care ... shall be changed for each county to reflect regional variations in housing cost based on the lowest quartile rent in each county as reported in the Decennial Census data for 1990."
+    "(b)(1) Region 1 shall include all counties with lowest quartile rents of four hundred dollars ($400) or more. There shall be no reduction..."
+    "(b)(2) Region 2 shall include all counties with lowest quartile rents below four hundred dollars ($400). There shall be a 4.9 percent reduction..."
+    "(c) This section shall be operative during such time as subdivision (a) of Section 11450.018 is operative."
+    "Effective August 3, 1995."
+rules:
+  - name: region_lowest_quartile_rent_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Cal. Welf. & Inst. Code § 11452.018(b)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "lowest quartile rents of four hundred dollars ($400) or more"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          400
+
+  - name: region_2_minimum_basic_standard_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: Cal. Welf. & Inst. Code § 11452.018(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "There shall be a 4.9 percent reduction"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          0.049
+
+  - name: county_in_region_1_for_minimum_basic_standard
+    kind: derived
+    entity: County
+    dtype: Judgment
+    period: Month
+    source: Cal. Welf. & Inst. Code § 11452.018(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Region 1 shall include all counties with lowest quartile rents of four hundred dollars ($400) or more."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          county_lowest_quartile_rent_in_1990_decennial_census >= region_lowest_quartile_rent_threshold
+
+  - name: county_in_region_2_for_minimum_basic_standard
+    kind: derived
+    entity: County
+    dtype: Judgment
+    period: Month
+    source: Cal. Welf. & Inst. Code § 11452.018(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Region 2 shall include all counties with lowest quartile rents below four hundred dollars ($400)."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          county_lowest_quartile_rent_in_1990_decennial_census < region_lowest_quartile_rent_threshold
+
+  - name: regional_minimum_basic_standard_reduction_rate
+    kind: derived
+    entity: County
+    dtype: Rate
+    period: Month
+    source: Cal. Welf. & Inst. Code § 11452.018(b)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "There shall be no reduction ... Region 1 ... There shall be a 4.9 percent reduction ... Region 2."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "operative during such time as subdivision (a) of Section 11450.018 is operative"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          if not subdivision_a_of_section_11450_018_is_operative: 0 else: if county_in_region_1_for_minimum_basic_standard: 0 else: if county_in_region_2_for_minimum_basic_standard: region_2_minimum_basic_standard_reduction_rate else: 0
+
+  - name: regional_minimum_basic_standard_of_adequate_care
+    kind: derived
+    entity: County
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Cal. Welf. & Inst. Code § 11452.018(a)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "the minimum basic standards of adequate care ... shall be changed for each county"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "operative during such time as subdivision (a) of Section 11450.018 is operative"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/wic/11452.018
+              excerpt: "Effective August 3, 1995."
+    versions:
+      - effective_from: '1995-08-03'
+        formula: |-
+          max(0, minimum_basic_standard_of_adequate_care_as_adjusted * (1 - regional_minimum_basic_standard_reduction_rate))


### PR DESCRIPTION
## Summary
- add California CalWORKs RuleSpec encodings for resource limits, vehicle equity, MBSAC/Region tables, income disregard, financial eligibility tests, and monthly aid payment
- include companion tests for each CalWORKs module
- include signed axiom-encode apply manifests for generated files
- bump the rulespec-us validation toolchain to axiom-encode 0.2.817 so CI has the child-corpus source validation fix from TheAxiomFoundation/axiom-encode#760
- bump the rulespec-us validation corpus pin to TheAxiomFoundation/axiom-corpus@992aaf6 so CI has the California WIC/CalWORKs source ingestion

## Encoder notes
- Monthly aid payment initially exposed a validator gap for child corpus citations backed by parent statute rows.
- Fixed and merged TheAxiomFoundation/axiom-encode#760 first; this PR was generated/validated with axiom-encode 0.2.817.
- The first post-bump CI run then exposed that the repo corpus pin predated California WIC ingestion; this PR now pins the merged corpus commit containing those sources.

## Local checks
- uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode validate --skip-reviewers us-ca/policies/cdss/calworks/monthly-aid-payment.yaml
- validated every non-test file in us-ca/policies/cdss/calworks with axiom-encode validate --skip-reviewers
- AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode validate --skip-reviewers us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml us-ca/policies/cdss/calworks/monthly-aid-payment.yaml us-ca/policies/cdss/calworks/recipient-income-disregard.yaml
- uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ca-calworks-20260624 --base-ref origin/main --head-ref HEAD
- uv run --with pytest --with pyyaml pytest tests/
- uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev axiom-encode test us-ca/policies/cdss/calworks --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine