### PR TITLE
Encode Arizona CCAP income and fee schedule

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.829"
-axiom_rules_engine_ref = "0964c8203ae741d285f6835224118b5c6f0da7db"
-axiom_encode_ref = "0c1813b41dcf6a15e592da46422d020ab349bca7"
-axiom_corpus_ref = "8e16988adf25f6ed625540a51c60acda4763acd8"
+axiom_encode_version = "0.2.833"
+axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
+axiom_encode_ref = "70cb5bf3dabf68538fb341eb49124a1baf75f63b"
+axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
-rulespec_us_ref = "39306fd656ae89eea39230d975129975d5be993c"
+rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/us-az/.axiom/encoding-manifests/policies/des/ccap/income-fee-schedule-ffy2026.json
+++ b/us-az/.axiom/encoding-manifests/policies/des/ccap/income-fee-schedule-ffy2026.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/des/ccap/income-fee-schedule-ffy2026.yaml",
+      "sha256": "7535da12265214bd63171ffc27bf8aca6f01403b8fca9674ec3974e2b064459b"
+    },
+    {
+      "path": "policies/des/ccap/income-fee-schedule-ffy2026.test.yaml",
+      "sha256": "b94000cbdf746636c6b8f0200472146d9303fb83bf762392094a71c634835ccc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "70cb5bf3dabf68538fb341eb49124a1baf75f63b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.833",
+    "version_commit": "70cb5bf3dabf68538fb341eb49124a1baf75f63b"
+  },
+  "axiom_encode_version": "0.2.833",
+  "backend": "openai",
+  "citation": "us-az:policies/des/ccap/income-fee-schedule-ffy2026",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/openai-gpt-5.5/us-az-policies-des-ccap-income-fee-schedule-ffy2026/workspace/context-manifest.json",
+  "context_manifest_sha256": "5ce6a853e0e15712bc565b559e37a9cc535eb7984bdb8f3686ca442ffb1ef043",
+  "generated_at": "2026-06-25T15:53:20.239659+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/openai-gpt-5.5/policies/des/ccap/income-fee-schedule-ffy2026.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7535da12265214bd63171ffc27bf8aca6f01403b8fca9674ec3974e2b064459b",
+  "generation_prompt_sha256": "b07119bcdfbbe9576a45783e3bb91e9fe5eaeb163052c6174303e43e8b0acccc",
+  "model": "gpt-5.5",
+  "run_id": "afaea029",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc45606c750b32d47cf710d2fcdd65110e3998d0e4df989f698fdbfea9dfec4d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/openai-gpt-5.5/us-az-policies-des-ccap-income-fee-schedule-ffy2026.json",
+  "trace_sha256": "db10eee8e05bf2fd2c4b48e4d5860eba82b7d1fd6e147df85f500ddfb04affd9"
+}

--- a/us-az/policies/des/ccap/income-fee-schedule-ffy2026.test.yaml
+++ b/us-az/policies/des/ccap/income-fee-schedule-ffy2026.test.yaml
@@ -1,0 +1,54 @@
+- name: family_size_1_initial_boundary_l6_and_copay_level_6
+  period: 2025-10
+  input:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_size: 1
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_gross_monthly_income: 2154
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.children_in_care_count: 1
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_receives_transitional_child_care: false
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.fee_level: false
+  output:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit: 2154
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#initially_income_eligible_for_child_care_assistance: holds
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income: 6
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_daily_copayment_per_child_in_care: 0
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#transitional_child_care_children_with_assigned_copayment_count: 1
+- name: family_size_2_initial_above_l6_not_initially_eligible_but_redetermination_eligible
+  period: 2025-10
+  input:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_size: 2
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_gross_monthly_income: 5202
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.children_in_care_count: 2
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_receives_transitional_child_care: false
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.fee_level: false
+  output:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit: 2909
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_monthly_income_limit: 5202
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#initially_income_eligible_for_child_care_assistance: not_holds
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_income_eligible_for_child_care_assistance: holds
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income: 7
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_daily_copayment_per_child_in_care: 0
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#transitional_child_care_children_with_assigned_copayment_count: 2
+- name: family_size_4_fee_level_4_copay_rate
+  period: 2025-10
+  input:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_size: 4
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_gross_monthly_income: 3886
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.children_in_care_count: 2
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_receives_transitional_child_care: false
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.fee_level: false
+  output:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income: 4
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_daily_copayment_per_child_in_care: 2.5
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#transitional_child_care_children_with_assigned_copayment_count: 2
+- name: transitional_child_care_copayment_assigned_only_first_three_children
+  period: 2025-10
+  input:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_size: 12
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_gross_monthly_income: 6346
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.children_in_care_count: 4
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_receives_transitional_child_care: true
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.fee_level: false
+  output:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income: 2
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_daily_copayment_per_child_in_care: 1.0
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#transitional_child_care_children_with_assigned_copayment_count: 3

--- a/us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml
+++ b/us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml
@@ -1,0 +1,749 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+  summary: 'Child Care Assistance Gross Monthly Income Eligibility Chart and Fee Schedule
+    FFY 2026, effective October 1, 2025. Initial Application: gross monthly income
+    must be at or below 165% FPL / L1-L6. Redetermination: gross monthly income must
+    be at or below 85% SMI / L1-L7. The chart lists monthly income ranges by family
+    size and fee level and minimum required copayment daily rates per child in care.'
+rules:
+- name: initial_application_fpl_ceiling_rate
+  kind: parameter
+  dtype: Rate
+  source: Initial Application threshold statement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Initial Application: A family\u2019s gross monthly income must\
+            \ be at or below 165% of the Federal Poverty Level (FPL) / (L1-L6)."
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1.65'
+- name: redetermination_smi_ceiling_rate
+  kind: parameter
+  dtype: Rate
+  source: Redetermination threshold statement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Redetermination: A family\u2019s gross monthly income must be\
+            \ at or below 85% of the State Median Income (SMI) / (L1-L7)."
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0.85'
+- name: fee_level_1_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 1 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 1 (L1) Income Maximum Equal To or Less Than 85% FPL ...
+            1 0-1,110 ... 12 0-5,395
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 1 (L1) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 1110
+      2: 1499
+      3: 1888
+      4: 2278
+      5: 2668
+      6: 3057
+      7: 3447
+      8: 3837
+      9: 4226
+      10: 4616
+      11: 5005
+      12: 5395
+- name: fee_level_2_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 2 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 2 (L2) Income Maximum Equal To or Less Than 100% FPL
+            ... 1 1,111-1,305 ... 12 5,396-6,346
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 2 (L2) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 1305
+      2: 1763
+      3: 2221
+      4: 2680
+      5: 3138
+      6: 3596
+      7: 4055
+      8: 4513
+      9: 4971
+      10: 5430
+      11: 5888
+      12: 6346
+- name: fee_level_3_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 3 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 3 (L3) Income Maximum Equal To or Less Than 135% FPL
+            ... 1 1,306-1,762 ... 12 6,347-8,568
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 3 (L3) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 1762
+      2: 2381
+      3: 2999
+      4: 3618
+      5: 4237
+      6: 4855
+      7: 5475
+      8: 6093
+      9: 6711
+      10: 7331
+      11: 7949
+      12: 8568
+- name: fee_level_4_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 4 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 4 (L4) Income Maximum Equal To or Less Than 145% FPL
+            ... 1 1,763-1,893 ... 12 8,569-9,202
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 4 (L4) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 1893
+      2: 2557
+      3: 3221
+      4: 3886
+      5: 4551
+      6: 5215
+      7: 5880
+      8: 6544
+      9: 7208
+      10: 7874
+      11: 8538
+      12: 9202
+- name: fee_level_5_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 5 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 5 (L5) Income Maximum Equal To or Less Than 155% FPL
+            ... 1 1,894-2,023 ... 12 9,203-9,837
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 5 (L5) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 2023
+      2: 2733
+      3: 3443
+      4: 4154
+      5: 4864
+      6: 5574
+      7: 6286
+      8: 6996
+      9: 7706
+      10: 8417
+      11: 9127
+      12: 9837
+- name: fee_level_6_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 6 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Fee Level 6 (L6) Income Maximum Equal To or Less Than 165% FPL
+            ... 1 2,024-2,154 ... 12 9,838-10,471
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 6 (L6) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 2154
+      2: 2909
+      3: 3665
+      4: 4422
+      5: 5178
+      6: 5934
+      7: 6691
+      8: 7447
+      9: 8203
+      10: 8960
+      11: 9716
+      12: 10471
+- name: fee_level_7_income_max_by_family_size
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: family_size
+  source: Fee Level 7 income maximum table
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: FEE LEVEL 7 (L7) Income Maximum Equal to or Less Than 85% SMI ...
+            1 3,978 ... 12 11,474
+          table:
+            header: Child Care Assistance Gross Monthly Income Eligibility Chart and
+              Fee Schedule FFY 2026
+            row_key: Family Size
+            column_key: Fee Level 7 (L7) income maximum
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 3978
+      2: 5202
+      3: 6426
+      4: 7649
+      5: 8874
+      6: 10098
+      7: 10327
+      8: 10557
+      9: 10786
+      10: 11015
+      11: 11244
+      12: 11474
+- name: minimum_required_copayment_daily_rate_by_fee_level
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Day
+  indexed_by: fee_level
+  source: Minimum required copayment row
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Minimum Required Copayment Per child in care Daily Rate\u2013\
+            $0.50 Daily Rate\u2013$1.00 Daily Rate\u2013$1.50 Daily Rate\u2013$2.50"
+          table:
+            header: Minimum Required Copayment Per child in care
+            row_key: Fee Level
+            column_key: Daily Rate
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 0.5
+      2: 1.0
+      3: 1.5
+      4: 2.5
+- name: transitional_child_care_copayment_child_count_cap
+  kind: parameter
+  dtype: Count
+  source: Transitional Child Care copayment limitation
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: For families receiving Transitional Child Care (TCC) there is no
+            copay assigned beyond the 3rd child in the family
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '3'
+- name: daily_rate_minimum_time_minutes
+  kind: parameter
+  dtype: Count
+  source: Daily rate time unit statement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Daily rate = 15 minutes or more
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '15'
+- name: initial_application_monthly_income_limit
+  kind: derived
+  entity: Family
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Initial Application L1-L6 income limit
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Initial Application: A family\u2019s gross monthly income must\
+            \ be at or below 165% ... / (L1-L6)."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_6_income_max_by_family_size
+          output: fee_level_6_income_max_by_family_size
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: fee_level_6_income_max_by_family_size[family_size]
+- name: redetermination_monthly_income_limit
+  kind: derived
+  entity: Family
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Redetermination L1-L7 income limit
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Redetermination: A family\u2019s gross monthly income must be\
+            \ at or below 85% ... / (L1-L7)."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_7_income_max_by_family_size
+          output: fee_level_7_income_max_by_family_size
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: fee_level_7_income_max_by_family_size[family_size]
+- name: initially_income_eligible_for_child_care_assistance
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: Initial Application income eligibility statement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Initial Application: A family\u2019s gross monthly income must\
+            \ be at or below 165% ... / (L1-L6)."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit
+          output: initial_application_monthly_income_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: family_gross_monthly_income <= initial_application_monthly_income_limit
+- name: redetermination_income_eligible_for_child_care_assistance
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: Redetermination income eligibility statement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Redetermination: A family\u2019s gross monthly income must be\
+            \ at or below 85% ... / (L1-L7)."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_monthly_income_limit
+          output: redetermination_monthly_income_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: family_gross_monthly_income <= redetermination_monthly_income_limit
+- name: fee_level_for_family_gross_monthly_income_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: Fee level income ranges by family size
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Family Size ... Fee Level 1 (L1) ... Fee Level 6 (L6) ... FEE LEVEL
+            7 (L7)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '4'
+- name: fee_level_for_family_gross_monthly_income_scalar_limit_2
+  kind: parameter
+  dtype: Count
+  source: Fee level income ranges by family size
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Family Size ... Fee Level 1 (L1) ... Fee Level 6 (L6) ... FEE LEVEL
+            7 (L7)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '5'
+- name: fee_level_for_family_gross_monthly_income_scalar_limit_3
+  kind: parameter
+  dtype: Count
+  source: Fee level income ranges by family size
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Family Size ... Fee Level 1 (L1) ... Fee Level 6 (L6) ... FEE LEVEL
+            7 (L7)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '6'
+- name: fee_level_for_family_gross_monthly_income_scalar_limit_4
+  kind: parameter
+  dtype: Count
+  source: Fee level income ranges by family size
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Family Size ... Fee Level 1 (L1) ... Fee Level 6 (L6) ... FEE LEVEL
+            7 (L7)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '7'
+- name: fee_level_for_family_gross_monthly_income
+  kind: derived
+  entity: Family
+  dtype: Integer
+  period: Month
+  source: Fee level income ranges by family size
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: Family Size ... Fee Level 1 (L1) ... Fee Level 6 (L6) ... FEE LEVEL
+            7 (L7)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_1_income_max_by_family_size
+          output: fee_level_1_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_2_income_max_by_family_size
+          output: fee_level_2_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_3_income_max_by_family_size
+          output: fee_level_3_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_4_income_max_by_family_size
+          output: fee_level_4_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_5_income_max_by_family_size
+          output: fee_level_5_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_6_income_max_by_family_size
+          output: fee_level_6_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_7_income_max_by_family_size
+          output: fee_level_7_income_max_by_family_size
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income_scalar_limit
+          output: fee_level_for_family_gross_monthly_income_scalar_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income_scalar_limit_2
+          output: fee_level_for_family_gross_monthly_income_scalar_limit_2
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income_scalar_limit_3
+          output: fee_level_for_family_gross_monthly_income_scalar_limit_3
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income_scalar_limit_4
+          output: fee_level_for_family_gross_monthly_income_scalar_limit_4
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if family_gross_monthly_income <= fee_level_1_income_max_by_family_size[family_size]:
+      1 else: if family_gross_monthly_income <= fee_level_2_income_max_by_family_size[family_size]:
+      2 else: if family_gross_monthly_income <= fee_level_3_income_max_by_family_size[family_size]:
+      3 else: if family_gross_monthly_income <= fee_level_4_income_max_by_family_size[family_size]:
+      fee_level_for_family_gross_monthly_income_scalar_limit else: if family_gross_monthly_income
+      <= fee_level_5_income_max_by_family_size[family_size]: fee_level_for_family_gross_monthly_income_scalar_limit_2
+      else: if family_gross_monthly_income <= fee_level_6_income_max_by_family_size[family_size]:
+      fee_level_for_family_gross_monthly_income_scalar_limit_3 else: if family_gross_monthly_income
+      <= fee_level_7_income_max_by_family_size[family_size]: fee_level_for_family_gross_monthly_income_scalar_limit_4
+      else: -1'
+- name: minimum_required_daily_copayment_per_child_in_care_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: Minimum required copayment per child in care
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Minimum Required Copayment Per child in care Daily Rate\u2013\
+            $0.50 Daily Rate\u2013$1.00 Daily Rate\u2013$1.50 Daily Rate\u2013$2.50"
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '4'
+- name: minimum_required_daily_copayment_per_child_in_care
+  kind: derived
+  entity: Family
+  dtype: Money
+  unit: USD
+  period: Day
+  source: Minimum required copayment per child in care
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: "Minimum Required Copayment Per child in care Daily Rate\u2013\
+            $0.50 Daily Rate\u2013$1.00 Daily Rate\u2013$1.50 Daily Rate\u2013$2.50"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#fee_level_for_family_gross_monthly_income
+          output: fee_level_for_family_gross_monthly_income
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_copayment_daily_rate_by_fee_level
+          output: minimum_required_copayment_daily_rate_by_fee_level
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#minimum_required_daily_copayment_per_child_in_care_scalar_limit
+          output: minimum_required_daily_copayment_per_child_in_care_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if fee_level_for_family_gross_monthly_income <= 0: 0 else: if fee_level_for_family_gross_monthly_income
+      <= minimum_required_daily_copayment_per_child_in_care_scalar_limit: minimum_required_copayment_daily_rate_by_fee_level[fee_level_for_family_gross_monthly_income]
+      else: 0'
+- name: transitional_child_care_children_with_assigned_copayment_count
+  kind: derived
+  entity: Family
+  dtype: Count
+  period: Month
+  source: Transitional Child Care copayment limitation
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+          excerpt: For families receiving Transitional Child Care (TCC) there is no
+            copay assigned beyond the 3rd child in the family
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:policies/des/ccap/income-fee-schedule-ffy2026#transitional_child_care_copayment_child_count_cap
+          output: transitional_child_care_copayment_child_count_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if family_receives_transitional_child_care: min(children_in_care_count,
+      transitional_child_care_copayment_child_count_cap) else: children_in_care_count'


### PR DESCRIPTION
## Summary
- encode Arizona DES CCAP FFY 2026 gross monthly income limits by family size and fee level
- encode initial/redetermination income eligibility limits and minimum daily copayment table
- include signed axiom-encode apply manifest and companion tests

## Tests
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-az /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-az/policies/des/ccap/income-fee-schedule-ffy2026.test.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref origin/main --head-ref HEAD
- git diff --check