### PR TITLE
Add Washington TANF payment and income limits

### DIFF
--- a/.axiom/encoding-manifests/us-wa/regulations/388/388-478/388-478-0020.json
+++ b/.axiom/encoding-manifests/us-wa/regulations/388/388-478/388-478-0020.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-wa/regulations/388/388-478/388-478-0020.yaml",
+      "sha256": "08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406"
+    },
+    {
+      "path": "us-wa/regulations/388/388-478/388-478-0020.test.yaml",
+      "sha256": "553b3237ef1c1b3ded7b303fb547dacf9f9885371abe32bba1f1677048c2d219"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e99860ce78fd0b1e79e41301e6446c9110db2d7c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.840",
+    "version_commit": "e99860ce78fd0b1e79e41301e6446c9110db2d7c"
+  },
+  "axiom_encode_version": "0.2.840",
+  "backend": "deterministic",
+  "citation": "us-wa:regulations/388/388-478/388-478-0020",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-25T21:25:18.461594+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpejkys867/deterministic-repair/us-wa/regulations/388/388-478/388-478-0020.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpejkys867",
+  "generated_output_sha256": "08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a64be27d012a2273ee2c2c350f5b3b6a653a40d1aceb404a38f6e964260b3ac5"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-wa/regulations/388/388-478/388-478-0035.json
+++ b/.axiom/encoding-manifests/us-wa/regulations/388/388-478/388-478-0035.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-wa/regulations/388/388-478/388-478-0035.yaml",
+      "sha256": "54d4c51fca661f913eafaa72d1cf68571f9c8c61df3be28b4c6bc3c4fdd5d860"
+    },
+    {
+      "path": "us-wa/regulations/388/388-478/388-478-0035.test.yaml",
+      "sha256": "8fef1c36275bdd52ffdfaba016aa8baf49f793b0d6b5d2d2d58acca136bd6e38"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e99860ce78fd0b1e79e41301e6446c9110db2d7c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.840",
+    "version_commit": "e99860ce78fd0b1e79e41301e6446c9110db2d7c"
+  },
+  "axiom_encode_version": "0.2.840",
+  "backend": "deterministic",
+  "citation": "us-wa:regulations/388/388-478/388-478-0035",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-25T21:25:26.902910+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3c7jyb2m/deterministic-repair/us-wa/regulations/388/388-478/388-478-0035.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3c7jyb2m",
+  "generated_output_sha256": "54d4c51fca661f913eafaa72d1cf68571f9c8c61df3be28b4c6bc3c4fdd5d860",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fcc23ebd5bbb5e65c99b84d57230e8a0935fabcf9745a85425837dffa69d61f0"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -23,6 +23,7 @@ allowed_root_directories:
   - us-sc
   - us-tn
   - us-tx
+  - us-wa
 allowed_root_files:
   - .gitattributes
   - .gitignore

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.833"
+axiom_encode_version = "0.2.840"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "70cb5bf3dabf68538fb341eb49124a1baf75f63b"
+axiom_encode_ref = "e99860ce78fd0b1e79e41301e6446c9110db2d7c"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0020.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0020.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-478/388-478-0020.yaml",
+      "sha256": "08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406"
+    },
+    {
+      "path": "regulations/388/388-478/388-478-0020.test.yaml",
+      "sha256": "759f7a5eae066afb6ee31df557d48fa7799fb285240670106732d7f91eceb0a1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a8e38e7f5d8846c7a85d5e8c8fc13fb67a33bf83",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.839",
+    "version_commit": "a8e38e7f5d8846c7a85d5e8c8fc13fb67a33bf83"
+  },
+  "axiom_encode_version": "0.2.839",
+  "backend": "codex",
+  "citation": "us-wa/regulation/388/388-478/388-478-0020",
+  "context_manifest_file": "/tmp/axiom-wa-tanf-20260625/388-478-0020-guarded-signed-839/_eval_workspaces/codex-gpt-5.5/us-wa-regulation-388-388-478-388-478-0020/workspace/context-manifest.json",
+  "context_manifest_sha256": "d36630edca6a70bb13498ae7f992e665aca843d3fa2fcf45ac508160f6b7c33e",
+  "generated_at": "2026-06-25T21:02:15.154399+00:00",
+  "generated_output_file": "/tmp/axiom-wa-tanf-20260625/388-478-0020-guarded-signed-839/codex-gpt-5.5/regulations/388/388-478/388-478-0020.yaml",
+  "generated_output_root": "/tmp/axiom-wa-tanf-20260625/388-478-0020-guarded-signed-839",
+  "generated_output_sha256": "08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406",
+  "generation_prompt_sha256": "f52fb70388a0ac10e4a22558a566fe22d6d25026e08ff91aada22a5b90ae72f4",
+  "model": "gpt-5.5",
+  "run_id": "08713649",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "446efdfc09a96dea029ddf9ac11003b6b75a0ab1f759a0cbb9857eb563b70acc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-wa-tanf-20260625/388-478-0020-guarded-signed-839/traces/codex-gpt-5.5/us-wa-regulation-388-388-478-388-478-0020.json",
+  "trace_sha256": "b7e68fa3e04f2f09c04e88d639574a2e11f5831aa49f213fe86578d6742bbb2a"
+}

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0035.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0035.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-478/388-478-0035.yaml",
+      "sha256": "54d4c51fca661f913eafaa72d1cf68571f9c8c61df3be28b4c6bc3c4fdd5d860"
+    },
+    {
+      "path": "regulations/388/388-478/388-478-0035.test.yaml",
+      "sha256": "74e271bb519baedc88be5b08e9825c57f714e65e53906e2420418704e2612208"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a8e38e7f5d8846c7a85d5e8c8fc13fb67a33bf83",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.839",
+    "version_commit": "a8e38e7f5d8846c7a85d5e8c8fc13fb67a33bf83"
+  },
+  "axiom_encode_version": "0.2.839",
+  "backend": "codex",
+  "citation": "us-wa/regulation/388/388-478/388-478-0035",
+  "context_manifest_file": "/tmp/axiom-wa-tanf-20260625/388-478-0035-guarded-signed-839/_eval_workspaces/codex-gpt-5.5/us-wa-regulation-388-388-478-388-478-0035/workspace/context-manifest.json",
+  "context_manifest_sha256": "4eb078b2053059b40b2bcf40636db69c0e4d926af583aa8284ce87d2d9e13e08",
+  "generated_at": "2026-06-25T21:03:20.244003+00:00",
+  "generated_output_file": "/tmp/axiom-wa-tanf-20260625/388-478-0035-guarded-signed-839/codex-gpt-5.5/regulations/388/388-478/388-478-0035.yaml",
+  "generated_output_root": "/tmp/axiom-wa-tanf-20260625/388-478-0035-guarded-signed-839",
+  "generated_output_sha256": "54d4c51fca661f913eafaa72d1cf68571f9c8c61df3be28b4c6bc3c4fdd5d860",
+  "generation_prompt_sha256": "3becc5868d06e8425f62cb6ed307299ae6ec5c9c43ec4d290315535063f78fe6",
+  "model": "gpt-5.5",
+  "run_id": "d93d8ad6",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ec31bddf842a4f26b24be9cc28ce75c41150d59a5edeb14beda7458a17d81e1f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-wa-tanf-20260625/388-478-0035-guarded-signed-839/traces/codex-gpt-5.5/us-wa-regulation-388-388-478-388-478-0035.json",
+  "trace_sha256": "640f270e06ea23c9beed6b172bfded78ebd48fe84ea38c54553da465439b49d5"
+}

--- a/us-wa/regulations/388/388-478/388-478-0020.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0020.test.yaml
@@ -1,0 +1,28 @@
+- name: one_person_assistance_unit_standard
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 1
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 1
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 450
+- name: nine_person_assistance_unit_standard
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 9
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 9
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 1529
+- name: ten_person_assistance_unit_standard
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 10
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 10
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 1662
+- name: more_than_ten_person_assistance_unit_uses_final_row_standard
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 11
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 10
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 1662

--- a/us-wa/regulations/388/388-478/388-478-0020.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0020.test.yaml
@@ -26,3 +26,13 @@
   output:
     us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 10
     us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 1662
+- name: oracle_parameter_cash_assistance_maximum_monthly_payment_standard_1
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 1
+    us-wa:regulations/388/388-478/388-478-0020#input.cash_assistance_payment_standard_size_band: 1
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard: 450

--- a/us-wa/regulations/388/388-478/388-478-0020.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0020.yaml
@@ -1,0 +1,114 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-478/388-478-0020
+  summary: |-
+    "The maximum monthly payment standards for temporary assistance for needy families (TANF), state family assistance (SFA), and refugee cash assistance (RCA) assistance units are:" followed by assistance-unit size standards from 1 ($450) through 10 or more ($1,662).
+rules:
+  - name: cash_assistance_payment_standard_size_floor_for_final_row
+    kind: parameter
+    dtype: Count
+    source: WAC 388-478-0020 payment standard table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0020
+              excerpt: "10 or more 1,662"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: cash_assistance_payment_standard_size_band
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Integer
+    period: Month
+    source: WAC 388-478-0020 payment standard table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0020
+              excerpt: "Assistance unit size Payment standard ... 10 or more 1,662"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_floor_for_final_row
+              output: cash_assistance_payment_standard_size_floor_for_final_row
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if assistance_unit_size >= cash_assistance_payment_standard_size_floor_for_final_row: cash_assistance_payment_standard_size_floor_for_final_row else: assistance_unit_size
+
+  - name: cash_assistance_maximum_monthly_payment_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: cash_assistance_payment_standard_size_band
+    source: WAC 388-478-0020 payment standard table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0020
+              table:
+                header: "Assistance unit size Payment standard"
+                row_key: "Assistance unit size"
+                column_key: "Payment standard"
+              excerpt: "1 $450 6 $1,090 2 570 7 1,258 3 706 8 1,392 4 833 9 1,529 5 959 10 or more 1,662"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 450
+          2: 570
+          3: 706
+          4: 833
+          5: 959
+          6: 1090
+          7: 1258
+          8: 1392
+          9: 1529
+          10: 1662
+
+  - name: cash_assistance_unit_maximum_monthly_payment_standard
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAC 388-478-0020 payment standard table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0020
+              excerpt: "The maximum monthly payment standards ... assistance units are:"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band
+              output: cash_assistance_payment_standard_size_band
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard
+              output: cash_assistance_maximum_monthly_payment_standard
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_maximum_monthly_payment_standard[cash_assistance_payment_standard_size_band]

--- a/us-wa/regulations/388/388-478/388-478-0035.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0035.test.yaml
@@ -25,3 +25,24 @@
     us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band: 10
     us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level: 3824
     us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied: holds
+- name: oracle_parameter_cash_assistance_family_earnings_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 0
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 0
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_earnings_deduction: 500
+- name: oracle_parameter_cash_assistance_maximum_monthly_gross_earned_income_level_1
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 0
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 0
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_earned_income_limit_family_size_band: 1
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_maximum_monthly_gross_earned_income_level: 1400

--- a/us-wa/regulations/388/388-478/388-478-0035.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0035.test.yaml
@@ -1,0 +1,27 @@
+- name: one_member_income_below_limit_satisfies_requirement
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 1
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 1399
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band: 1
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level: 1400
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied: holds
+- name: three_member_income_equal_limit_fails_below_requirement
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 3
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 1912
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band: 3
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level: 1912
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied: not_holds
+- name: ten_or_more_members_use_final_limit
+  period: 2026-06
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 12
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 3823
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band: 10
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level: 3824
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied: holds

--- a/us-wa/regulations/388/388-478/388-478-0035.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0035.yaml
@@ -1,0 +1,158 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+  summary: |-
+    A family's gross earned income must be below the listed maximum monthly earned income levels, which include the $500 family earnings deduction.
+rules:
+  - name: cash_assistance_family_earnings_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "$500 family earnings deduction"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          500
+
+  - name: cash_assistance_earned_income_limit_final_family_size_floor
+    kind: parameter
+    dtype: Count
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "10 or more"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: cash_assistance_earned_income_limit_family_size_band
+    kind: derived
+    entity: Family
+    dtype: Integer
+    period: Month
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "Number of family members ... 10 or more"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_final_family_size_floor
+              output: cash_assistance_earned_income_limit_final_family_size_floor
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if number_of_family_members >= cash_assistance_earned_income_limit_final_family_size_floor: cash_assistance_earned_income_limit_final_family_size_floor else: number_of_family_members
+
+  - name: cash_assistance_maximum_monthly_gross_earned_income_level
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    indexed_by: cash_assistance_earned_income_limit_family_size_band
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "1 $1,400 ... 10 or more 3,824"
+              table:
+                header: "Maximum monthly earned income level by number of family members"
+                row_key: "Number of family members"
+                column_key: "Maximum monthly earned income level"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 1400
+          2: 1640
+          3: 1912
+          4: 2166
+          5: 2418
+          6: 2680
+          7: 3016
+          8: 3284
+          9: 3558
+          10: 3824
+
+  - name: cash_assistance_family_maximum_monthly_gross_earned_income_level
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "Number of family members Maximum monthly earned income level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band
+              output: cash_assistance_earned_income_limit_family_size_band
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_maximum_monthly_gross_earned_income_level
+              output: cash_assistance_maximum_monthly_gross_earned_income_level
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_maximum_monthly_gross_earned_income_level[cash_assistance_earned_income_limit_family_size_band]
+
+  - name: cash_assistance_gross_earned_income_requirement_satisfied
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: WAC 388-478-0035
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0035
+              excerpt: "a family's gross earned income must be below the following levels"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level
+              output: cash_assistance_family_maximum_monthly_gross_earned_income_level
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_family_gross_earned_income < cash_assistance_family_maximum_monthly_gross_earned_income_level


### PR DESCRIPTION
## Summary
- encode WAC 388-478-0020 monthly TANF/SFA/RCA payment standards for assistance-unit sizes 1 through 10-or-more
- encode WAC 388-478-0035 TANF/SFA/RCA/PWA gross earned-income limits and the strict below-limit requirement
- include generated tests and signed axiom-encode apply manifests for both sections

## PolicyEngine coverage
- rulespec-us-wa now reports 10 outputs: 5 comparable, 5 known_not_comparable
- workspace unmapped outputs fell from 23 to 13; remaining unmapped outputs are UK Universal Credit wrappers
- WA TANF final program surface remains pending_rulespec_encoding because this PR covers component WAC tables, not the final wa_tanf amount

## Provenance
- generated with axiom-encode 0.2.839 from TheAxiomFoundation/axiom-encode#779
- traces were scanned for PolicyEngine skill/workflow access; no matches found

## Validation
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us-wa-tanf-20260625/us-wa/regulations/388/388-478/388-478-0020.yaml /Users/maxghenis/TheAxiomFoundation/rulespec-us-wa-tanf-20260625/us-wa/regulations/388/388-478/388-478-0035.yaml --skip-reviewers --json
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us-wa-tanf-20260625/us-wa/regulations/388/388-478/388-478-0020.yaml /Users/maxghenis/TheAxiomFoundation/rulespec-us-wa-tanf-20260625/us-wa/regulations/388/388-478/388-478-0035.yaml --json
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us-wa-tanf-20260625 --base-ref origin/main --head-ref HEAD --json
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --limit 20
