### PR TITLE
Encode Illinois TANF earned income deduction

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -14,6 +14,7 @@ allowed_root_directories:
   - us-fl
   - us-ga
   - us-id
+  - us-il
   - us-ma
   - us-md
   - us-nc

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.840"
+axiom_encode_version = "0.2.842"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "e99860ce78fd0b1e79e41301e6446c9110db2d7c"
+axiom_encode_ref = "138a5749129b18346325891daf8dc9233739ef16"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-il/.axiom/encoding-manifests/policies/dhs/csmm/15232/block-1.json
+++ b/us-il/.axiom/encoding-manifests/policies/dhs/csmm/15232/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhs/csmm/15232/block-1.yaml",
+      "sha256": "3f04e4d33f45853df712e0592e309b75a036816029568561f5110d9199c8f188"
+    },
+    {
+      "path": "policies/dhs/csmm/15232/block-1.test.yaml",
+      "sha256": "b34928a3ac02b913ac070a00184383d234d6a9a46da6da3ee7a8f56fcff6cdb0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "bf1cdf8facbecc964278a8644b6cf8956884d3d7",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.841",
+    "version_commit": "bf1cdf8facbecc964278a8644b6cf8956884d3d7"
+  },
+  "axiom_encode_version": "0.2.841",
+  "backend": "deterministic",
+  "citation": "us-il:policies/dhs/csmm/15232/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-26T02:22:58.721525+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpg2i6nm8d/deterministic-repair/policies/dhs/csmm/15232/block-1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpg2i6nm8d",
+  "generated_output_sha256": "3f04e4d33f45853df712e0592e309b75a036816029568561f5110d9199c8f188",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6a4736518d78eb2a302c9e24bdd0baaeb9b589d574587dc78fc814d414f1b5d7"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-il/.axiom/encoding-manifests/policies/dhs/csmm/15820/block-1.json
+++ b/us-il/.axiom/encoding-manifests/policies/dhs/csmm/15820/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhs/csmm/15820/block-1.yaml",
+      "sha256": "77145006065099457165b8461310454d703fc392150ecca10f55924e032e6a8e"
+    },
+    {
+      "path": "policies/dhs/csmm/15820/block-1.test.yaml",
+      "sha256": "07e0e40cc710664b809d87b27baed521dfe49ec9ef5fd8e6d060e71c6a256a56"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "bf1cdf8facbecc964278a8644b6cf8956884d3d7",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.841",
+    "version_commit": "bf1cdf8facbecc964278a8644b6cf8956884d3d7"
+  },
+  "axiom_encode_version": "0.2.841",
+  "backend": "codex",
+  "citation": "us-il/manual/dhs/csmm/15820/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-il-tanf-minimum-payment/_eval_workspaces/codex-gpt-5.5/us-il-manual-dhs-csmm-15820-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "e61472c7b2ef85b48455704928b06049685bf7af798c99e64ca9bbb2506ca939",
+  "generated_at": "2026-06-26T02:44:10.776108+00:00",
+  "generated_output_file": "/tmp/axiom-encode-il-tanf-minimum-payment/codex-gpt-5.5/policies/dhs/csmm/15820/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-il-tanf-minimum-payment",
+  "generated_output_sha256": "77145006065099457165b8461310454d703fc392150ecca10f55924e032e6a8e",
+  "generation_prompt_sha256": "923010b4e8fe91d1ffbe73ff5c199fd9c304bdd8d90b267220932a461833168a",
+  "model": "gpt-5.5",
+  "run_id": "7822b802",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "692a17236544f4defdb36387e6a82ac29f31defc9e2b6d895006e95bcd71550b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-il-tanf-minimum-payment/traces/codex-gpt-5.5/us-il-manual-dhs-csmm-15820-block-1.json",
+  "trace_sha256": "ef581707c01b53ae4ac1bfdf13742d8e3f28efcf4ce78296b484ff81cbf89aaa"
+}

--- a/us-il/policies/dhs/csmm/15232/block-1.test.yaml
+++ b/us-il/policies/dhs/csmm/15232/block-1.test.yaml
@@ -1,0 +1,77 @@
+- name: employed_active_case_gets_three_quarters_deduction
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15232/block-1#input.person_is_employed: true
+    us-il:policies/dhs/csmm/15232/block-1#input.active_case: true
+    us-il:policies/dhs/csmm/15232/block-1#input.intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test: false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+    : false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+    : false
+    us-il:policies/dhs/csmm/15232/block-1#input.person_failed_without_good_cause_to_report_income_timely: false
+    us-il:policies/dhs/csmm/15232/block-1#input.gross_earned_income: 400
+  output:
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed: holds
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_amount: 300
+- name: quit_or_reduced_earnings_without_good_cause_blocks_deduction
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15232/block-1#input.person_is_employed: true
+    us-il:policies/dhs/csmm/15232/block-1#input.active_case: true
+    us-il:policies/dhs/csmm/15232/block-1#input.intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test: false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+    : true
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+    : false
+    us-il:policies/dhs/csmm/15232/block-1#input.person_failed_without_good_cause_to_report_income_timely: false
+    us-il:policies/dhs/csmm/15232/block-1#input.gross_earned_income: 400
+  output:
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed: not_holds
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_amount: 0
+- name: refused_employment_without_good_cause_blocks_deduction
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15232/block-1#input.person_is_employed: true
+    us-il:policies/dhs/csmm/15232/block-1#input.active_case: true
+    us-il:policies/dhs/csmm/15232/block-1#input.intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test: false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+    : false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+    : true
+    us-il:policies/dhs/csmm/15232/block-1#input.person_failed_without_good_cause_to_report_income_timely: false
+    us-il:policies/dhs/csmm/15232/block-1#input.gross_earned_income: 400
+  output:
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed: not_holds
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_amount: 0
+- name: untimely_income_reporting_without_good_cause_blocks_deduction
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15232/block-1#input.person_is_employed: true
+    us-il:policies/dhs/csmm/15232/block-1#input.active_case: true
+    us-il:policies/dhs/csmm/15232/block-1#input.intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test: false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+    : false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+    : false
+    us-il:policies/dhs/csmm/15232/block-1#input.person_failed_without_good_cause_to_report_income_timely: true
+    us-il:policies/dhs/csmm/15232/block-1#input.gross_earned_income: 400
+  output:
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed: not_holds
+    us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_amount: 0
+- name: oracle_parameter_earned_income_deduction_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:policies/dhs/csmm/15232/block-1#input.active_case: false
+    us-il:policies/dhs/csmm/15232/block-1#input.gross_earned_income: 0
+    us-il:policies/dhs/csmm/15232/block-1#input.intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test: false
+    us-il:policies/dhs/csmm/15232/block-1#input.person_failed_without_good_cause_to_report_income_timely: false
+    us-il:policies/dhs/csmm/15232/block-1#input.person_is_employed: false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+    : false
+    ? us-il:policies/dhs/csmm/15232/block-1#input.person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+    : false
+  output:
+    us-il:policies/dhs/csmm/15232/block-1#earned_income_deduction_rate: 0.75

--- a/us-il/policies/dhs/csmm/15232/block-1.yaml
+++ b/us-il/policies/dhs/csmm/15232/block-1.yaml
@@ -1,0 +1,83 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/manual/dhs/csmm/15232/block-1
+  summary: |-
+    "determine eligibility and benefit amount by applying the 3/4 earned income deduction to the client's gross earned income"; "Allow this deduction for each employed person"; "Do not allow" it after specified job quit/reduction, employment refusal, or untimely income reporting without good cause.
+rules:
+  - name: earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: WAG 08-01-02-c
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15232/block-1
+              excerpt: "3/4 earned income deduction"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3 / 4
+
+  - name: three_quarters_earned_income_deduction_allowed
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: WAG 08-01-02-c
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15232/block-1
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15232/block-1
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_is_employed
+          and (active_case or intake_or_swaps_medical_to_cash_and_family_eligible_after_first_test)
+          and not person_quit_job_or_reduced_earnings_without_good_cause_within_30_day_period_before_month
+          and not person_refused_bona_fide_or_job_service_employment_without_good_cause_within_30_day_period_before_month
+          and not person_failed_without_good_cause_to_report_income_timely
+
+  - name: three_quarters_earned_income_deduction_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAG 08-01-02-c
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15232/block-1
+              excerpt: "deduct 3/4 of the gross earned income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15232/block-1#earned_income_deduction_rate
+              output: earned_income_deduction_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed
+              output: three_quarters_earned_income_deduction_allowed
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if three_quarters_earned_income_deduction_allowed: earned_income_deduction_rate * max(0, gross_earned_income) else: 0

--- a/us-il/policies/dhs/csmm/15820/block-1.test.yaml
+++ b/us-il/policies/dhs/csmm/15820/block-1.test.yaml
@@ -1,0 +1,39 @@
+- name: income_at_least_one_dollar_less_than_payment_level_eligible
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15820/block-1#input.payment_level: 500
+    us-il:policies/dhs/csmm/15820/block-1#input.nonexempt_income: 499
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_regular_monthly_tanf_benefit: 37.95
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_initial_prorated_entitlement_payment: 12.4
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_non_regular_roll_check_amount: 3.25
+  output:
+    us-il:policies/dhs/csmm/15820/block-1#tanf_cash_eligible: holds
+    us-il:policies/dhs/csmm/15820/block-1#regular_monthly_tanf_benefit: 37
+    us-il:policies/dhs/csmm/15820/block-1#initial_prorated_entitlement_payment: 12
+    us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_check_amount: 3.25
+- name: income_equal_to_payment_level_not_cash_eligible
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15820/block-1#input.payment_level: 500
+    us-il:policies/dhs/csmm/15820/block-1#input.nonexempt_income: 500
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_regular_monthly_tanf_benefit: 0.99
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_initial_prorated_entitlement_payment: 0.75
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_non_regular_roll_check_amount: 0.99
+  output:
+    us-il:policies/dhs/csmm/15820/block-1#tanf_cash_eligible: not_holds
+    us-il:policies/dhs/csmm/15820/block-1#regular_monthly_tanf_benefit: 0
+    us-il:policies/dhs/csmm/15820/block-1#initial_prorated_entitlement_payment: 0
+    us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_check_amount: 0
+- name: income_greater_than_payment_level_not_cash_eligible
+  period: 2026-06
+  input:
+    us-il:policies/dhs/csmm/15820/block-1#input.payment_level: 500
+    us-il:policies/dhs/csmm/15820/block-1#input.nonexempt_income: 501
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_regular_monthly_tanf_benefit: 1.99
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_initial_prorated_entitlement_payment: 1.01
+    us-il:policies/dhs/csmm/15820/block-1#input.unrounded_non_regular_roll_check_amount: 1
+  output:
+    us-il:policies/dhs/csmm/15820/block-1#tanf_cash_eligible: not_holds
+    us-il:policies/dhs/csmm/15820/block-1#regular_monthly_tanf_benefit: 1
+    us-il:policies/dhs/csmm/15820/block-1#initial_prorated_entitlement_payment: 1
+    us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_check_amount: 1

--- a/us-il/policies/dhs/csmm/15820/block-1.yaml
+++ b/us-il/policies/dhs/csmm/15820/block-1.yaml
@@ -1,0 +1,164 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+  summary: |-
+    A family qualifies for TANF benefits if nonexempt income is at least $1 less than the Payment Level. TANF payments of less than $1 are not made. Non-regular roll checks must be at least $1. Regular monthly TANF benefits and IPE payments are rounded down to the nearest whole dollar.
+rules:
+  - name: tanf_minimum_cash_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "TANF payments of less than $1 are not made."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: non_regular_roll_minimum_check_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "Non-regular roll (Mercury) checks must be at least $1."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: tanf_cash_eligible
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "nonexempt income is at least $1 less than the Payment Level"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "If nonexempt income is equal to or greater than the Payment Level, eligibility for cash benefits under the TANF program does not exist."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15820/block-1#tanf_minimum_cash_payment_amount
+              output: tanf_minimum_cash_payment_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payment_level - nonexempt_income >= tanf_minimum_cash_payment_amount
+
+  - name: regular_monthly_tanf_benefit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "Regular monthly TANF benefits ... are rounded down to the nearest whole dollar."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "TANF payments of less than $1 are not made."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15820/block-1#tanf_minimum_cash_payment_amount
+              output: tanf_minimum_cash_payment_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if floor(unrounded_regular_monthly_tanf_benefit) >= tanf_minimum_cash_payment_amount: floor(unrounded_regular_monthly_tanf_benefit) else: 0
+
+  - name: initial_prorated_entitlement_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "Initial Prorated Entitlement (IPE) payments are rounded down to the nearest whole dollar."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "TANF payments of less than $1 are not made."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15820/block-1#tanf_minimum_cash_payment_amount
+              output: tanf_minimum_cash_payment_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if floor(unrounded_initial_prorated_entitlement_payment) >= tanf_minimum_cash_payment_amount: floor(unrounded_initial_prorated_entitlement_payment) else: 0
+
+  - name: non_regular_roll_check_amount
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAG 10-01-02
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15820/block-1
+              excerpt: "Non-regular roll (Mercury) checks must be at least $1."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_minimum_check_amount
+              output: non_regular_roll_minimum_check_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if unrounded_non_regular_roll_check_amount >= non_regular_roll_minimum_check_amount: unrounded_non_regular_roll_check_amount else: 0


### PR DESCRIPTION
## Summary
- add the Illinois RuleSpec root to repository metadata
- encode PM/WAG 08-01-02-c 3/4 earned income deduction for IL TANF
- include signed encoder manifest and companion tests, including a PolicyEngine parameter oracle case

## Checks
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-il/policies/dhs/csmm/15232/block-1.yaml --skip-reviewers
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-il --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-il/policies/dhs/csmm/15232/block-1.test.yaml
- uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-il/policies/dhs/csmm/15232/block-1.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- uv run --with pytest --with pyyaml python -m pytest tests/test_repository_layout.py tests/test_program_specs.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --include-program-surfaces --limit 80

Draft until this gets an independent review cycle.