### PR TITLE
Encode Washington TANF income rules

### DIFF
--- a/.axiom/encoding-manifests/us-wa/regulations/388/388-450/388-450-0170.json
+++ b/.axiom/encoding-manifests/us-wa/regulations/388/388-450/388-450-0170.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-wa/regulations/388/388-450/388-450-0170.yaml",
+      "sha256": "52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d"
+    },
+    {
+      "path": "us-wa/regulations/388/388-450/388-450-0170.test.yaml",
+      "sha256": "5bf8f2cddafb8e554baaa3b9135adfc9cde2e6601a29f9470eb5e9cad9585f62"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f8b0dd7507fa9ede594fd8633583f8afb7cd1f44",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.850",
+    "version_commit": "f8b0dd7507fa9ede594fd8633583f8afb7cd1f44"
+  },
+  "axiom_encode_version": "0.2.850",
+  "backend": "deterministic",
+  "citation": "us-wa:regulations/388/388-450/388-450-0170",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-26T05:24:41.592557+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqq0bipe1/deterministic-repair/us-wa/regulations/388/388-450/388-450-0170.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqq0bipe1",
+  "generated_output_sha256": "52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2e0f04ed766f1ae8152f0c1595dc1703e2d08a4ffd7cee08398176a58dbb58db"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.842"
+axiom_encode_version = "0.2.850"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "138a5749129b18346325891daf8dc9233739ef16"
+axiom_encode_ref = "d7a1e46ba8e77120b886dd5b30dbf99e7fa4d2ed"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-450/388-450-0162.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-450/388-450-0162.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-450/388-450-0162.yaml",
+      "sha256": "5ca9c202c2e525c7868b651ab324c6f4fc3d3c8d8bb97d0e6de747a1c1e5d987"
+    },
+    {
+      "path": "regulations/388/388-450/388-450-0162.test.yaml",
+      "sha256": "a630ee67d4b06d225e6a3d50da1560e85ff34c159fd2600d0a89ac90253b9c15"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f6d466eeb71f65ad07c24e090ed2b4e3e72cfc65",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.848",
+    "version_commit": "f6d466eeb71f65ad07c24e090ed2b4e3e72cfc65"
+  },
+  "axiom_encode_version": "0.2.848",
+  "backend": "codex",
+  "citation": "us-wa/regulation/388/388-450/388-450-0162",
+  "context_manifest_file": "/tmp/wa-388-450-0162-20260626-final-apply-1782449755/_eval_workspaces/codex-gpt-5.5/us-wa-regulation-388-388-450-388-450-0162/workspace/context-manifest.json",
+  "context_manifest_sha256": "351d279df282a25cfa2ec3efebd6cdd28d1a8571c7a452395f2f069f39ad4101",
+  "generated_at": "2026-06-26T04:56:13.494057+00:00",
+  "generated_output_file": "/tmp/wa-388-450-0162-20260626-final-apply-1782449755/codex-gpt-5.5/regulations/388/388-450/388-450-0162.yaml",
+  "generated_output_root": "/tmp/wa-388-450-0162-20260626-final-apply-1782449755",
+  "generated_output_sha256": "5ca9c202c2e525c7868b651ab324c6f4fc3d3c8d8bb97d0e6de747a1c1e5d987",
+  "generation_prompt_sha256": null,
+  "model": "gpt-5.5",
+  "run_id": "wa-388-450-0162-20260626-final-apply-1782449755",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c9744183c0ba4255a1f16fc70003e65a7ffd62bd1bcd8ff47136ae6ff8b98b87"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/wa-388-450-0162-20260626-final-apply-1782449755/traces/codex-gpt-5.5/us-wa-regulation-388-388-450-388-450-0162.json",
+  "trace_sha256": "1aecc53662de4906cd282766995622d2ab5d205ad0b73aefb43d37763c26ef3d"
+}

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-450/388-450-0170.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-450/388-450-0170.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-450/388-450-0170.yaml",
+      "sha256": "52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d"
+    },
+    {
+      "path": "regulations/388/388-450/388-450-0170.test.yaml",
+      "sha256": "62e9d8165e3d86ea04f9265ae37edbde7434ef7d95fbf07550df19a9979bf760"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "81b11cd5b94004ad914c6312b4d439c3b3fc49e3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.846",
+    "version_commit": "dd99ea13685de3fd165ba6e4f6cd01c9b525b61b"
+  },
+  "axiom_encode_version": "0.2.846",
+  "backend": "codex",
+  "citation": "us-wa/regulation/388/388-450/388-450-0170",
+  "context_manifest_file": "/tmp/wa-388-450-0170-20260626-relationfix3/_eval_workspaces/codex-gpt-5.5/us-wa-regulation-388-388-450-388-450-0170/workspace/context-manifest.json",
+  "context_manifest_sha256": "fd0ec1edf8d9133c85906cd4cf4c15192d11e744db9b70380e3868c3c3d8232b",
+  "generated_at": "2026-06-26T03:58:26.757711+00:00",
+  "generated_output_file": "/tmp/wa-388-450-0170-20260626-relationfix3/codex-gpt-5.5/regulations/388/388-450/388-450-0170.yaml",
+  "generated_output_root": "/tmp/wa-388-450-0170-20260626-relationfix3",
+  "generated_output_sha256": "52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d",
+  "generation_prompt_sha256": "f49b6acd22661fa7a7669041df6ef24603de3de871503f2f98d776d90f028ad3",
+  "model": "gpt-5.5",
+  "run_id": "480e6b90",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a6b229fe8c227021b6b2d8adc888f55b5e044f7ad579de1833bfdb712966954d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/wa-388-450-0170-20260626-relationfix3/traces/codex-gpt-5.5/us-wa-regulation-388-388-450-388-450-0170.json",
+  "trace_sha256": "13718428ba53b2dfd119f4624e57b0dca14d7188f81a54e486c34f32fe8a493c"
+}

--- a/us-wa/regulations/388/388-450/388-450-0162.test.yaml
+++ b/us-wa/regulations/388/388-450/388-450-0162.test.yaml
@@ -1,0 +1,33 @@
+- name: three_person_tanf_unit_countable_income_and_benefit
+  period: 2026-01
+  input:
+    us-wa:regulations/388/388-450/388-450-0162#input.assistance_unit_size: 3
+    us-wa:regulations/388/388-450/388-450-0162#relation.dependent_care_recipients: []
+    us-wa:regulations/388/388-450/388-450-0162#input.countable_unearned_income_after_exclusions_and_disregards: 100
+    us-wa:regulations/388/388-450/388-450-0162#input.deemed_or_allocated_income_from_financially_responsible_nonmembers: 50
+    ? us-wa:regulations/388/388-450/388-450-0162#input.other_cash_assistance_deductions_allowed_under_wac_388_450_0177_and_388_450_0178
+    : 50
+    us-wa:regulations/388/388-450/388-450-0162#input.income_allocated_to_persons_outside_assistance_unit: 100
+    us-wa:regulations/388/388-450/388-450-0170#input.household_gross_earned_income: 1100
+  output:
+    us-wa:regulations/388/388-450/388-450-0162#tanf_unit_payment_standard_size_band: 3
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_unit_payment_standard: 706
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_dependent_care_deduction: 0
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_countable_income: 300
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_income_requirement_satisfied: holds
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_monthly_benefit: 406
+- name: countable_income_equal_to_payment_standard_is_ineligible
+  period: 2026-01
+  input:
+    us-wa:regulations/388/388-450/388-450-0162#input.assistance_unit_size: 3
+    us-wa:regulations/388/388-450/388-450-0162#relation.dependent_care_recipients: []
+    us-wa:regulations/388/388-450/388-450-0162#input.countable_unearned_income_after_exclusions_and_disregards: 206
+    us-wa:regulations/388/388-450/388-450-0162#input.deemed_or_allocated_income_from_financially_responsible_nonmembers: 0
+    ? us-wa:regulations/388/388-450/388-450-0162#input.other_cash_assistance_deductions_allowed_under_wac_388_450_0177_and_388_450_0178
+    : 0
+    us-wa:regulations/388/388-450/388-450-0162#input.income_allocated_to_persons_outside_assistance_unit: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.household_gross_earned_income: 1500
+  output:
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_countable_income: 706
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_income_requirement_satisfied: not_holds
+    us-wa:regulations/388/388-450/388-450-0162#cash_assistance_monthly_benefit: 0

--- a/us-wa/regulations/388/388-450/388-450-0162.yaml
+++ b/us-wa/regulations/388/388-450/388-450-0162.yaml
@@ -1,0 +1,224 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+  summary: '"Countable income is all income your assistance unit (AU) has after we
+    subtract" listed exclusions, cash assistance deductions, and allocations outside
+    the AU. For cash assistance, countable income is compared to the payment standard;
+    the AU is not eligible when countable income is equal to or greater than the payment
+    standard, and the benefit level is the payment standard minus countable income.'
+  deferred_outputs:
+  - output: us-wa:regulations/388/388-450/388-450-0162/a#basic_food_income_eligible
+    reason: Generated module encodes the supported rules from this source, but this
+      source subparagraph depends on policy surfaces or entities that are not available
+      in the current RuleSpec context. It is deferred instead of being modeled as
+      a caller-supplied input or an unsupported local entity.
+imports:
+- us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_floor_for_final_row
+- us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard
+- us-wa:regulations/388/388-450/388-450-0170#counted_earned_income_after_work_deductions
+- us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient
+- us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_deduction
+rules:
+- name: tanf_unit_payment_standard_size_band
+  kind: derived
+  entity: TanfUnit
+  dtype: Integer
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0162(3)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: We compare your countable income to the payment standard in WAC
+            388-478-0020
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_floor_for_final_row
+          output: cash_assistance_payment_standard_size_floor_for_final_row
+          hash: sha256:08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if assistance_unit_size >= cash_assistance_payment_standard_size_floor_for_final_row:
+      cash_assistance_payment_standard_size_floor_for_final_row else: assistance_unit_size'
+- name: cash_assistance_unit_payment_standard
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: us-wa/regulation/388/388-450/388-450-0162(3)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: We compare your countable income to the payment standard in WAC
+            388-478-0020
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard
+          output: cash_assistance_maximum_monthly_payment_standard
+          hash: sha256:08acd66f02914850317de18f204c2d7ed551746002bb37af59d5c02453ff5406
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#tanf_unit_payment_standard_size_band
+          output: tanf_unit_payment_standard_size_band
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: cash_assistance_maximum_monthly_payment_standard[tanf_unit_payment_standard_size_band]
+- name: cash_assistance_dependent_care_deduction
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: us-wa/regulation/388/388-450/388-450-0162(1)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: For cash assistance, earned income incentives and deductions allowed
+            for specific programs under WAC 388-450-0170
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_deduction
+          output: dependent_care_recipient_deduction
+          hash: sha256:52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient
+          output: dependent_care_deduction_allowed_for_recipient
+          hash: sha256:52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d
+  versions:
+  - effective_from: '0001-01-01'
+    formula: sum_where(dependent_care_recipients, dependent_care_recipient_deduction,
+      dependent_care_deduction_allowed_for_recipient)
+- name: dependent_care_recipients
+  kind: data_relation
+  data_relation:
+    predicate: dependent_care_recipient_of_tanf_unit
+    arity: 2
+    arguments:
+    - name: dependent_care_recipient
+      entity: Person
+    - name: tanf_unit
+      entity: TanfUnit
+  source: us-wa/regulation/388/388-450/388-450-0162(1)(b)
+- name: cash_assistance_countable_income
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: us-wa/regulation/388/388-450/388-450-0162(1), (2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: Countable income is all income your assistance unit (AU) has after
+            we subtract
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: Countable income includes all income that we must deem or allocate
+            from financially responsible persons who are not members of your AU
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#counted_earned_income_after_work_deductions
+          output: counted_earned_income_after_work_deductions
+          hash: sha256:52ffa27322b17d200234c94b522c742d276f431a76736a3a2a528739ff9b581d
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#cash_assistance_dependent_care_deduction
+          output: cash_assistance_dependent_care_deduction
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, counted_earned_income_after_work_deductions + countable_unearned_income_after_exclusions_and_disregards
+      + deemed_or_allocated_income_from_financially_responsible_nonmembers - cash_assistance_dependent_care_deduction
+      - other_cash_assistance_deductions_allowed_under_wac_388_450_0177_and_388_450_0178
+      - income_allocated_to_persons_outside_assistance_unit)
+- name: cash_assistance_income_requirement_satisfied
+  kind: derived
+  entity: TanfUnit
+  dtype: Judgment
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0162(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: You are not eligible for benefits when your AU's countable income
+            is equal to or greater than the payment standard.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#cash_assistance_countable_income
+          output: cash_assistance_countable_income
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#cash_assistance_unit_payment_standard
+          output: cash_assistance_unit_payment_standard
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: cash_assistance_countable_income < cash_assistance_unit_payment_standard
+- name: cash_assistance_monthly_benefit
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: us-wa/regulation/388/388-450/388-450-0162(3)(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0162
+          excerpt: Your benefit level is the payment standard minus your AU's countable
+            income.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#cash_assistance_countable_income
+          output: cash_assistance_countable_income
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0162#cash_assistance_unit_payment_standard
+          output: cash_assistance_unit_payment_standard
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, cash_assistance_unit_payment_standard - cash_assistance_countable_income)

--- a/us-wa/regulations/388/388-450/388-450-0170.test.yaml
+++ b/us-wa/regulations/388/388-450/388-450-0170.test.yaml
@@ -1,0 +1,90 @@
+- name: earned income deductions subtract first 500 then half remaining
+  period: 2024-06
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.household_gross_earned_income: 1500
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#counted_earned_income_after_work_deductions: 500
+- name: dependent care child under two capped by table and gross income
+  period: 2024-06
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.hours_worked_per_month: 90
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_is_dependent_child_under_two_years_of_age: true
+    us-wa:regulations/388/388-450/388-450-0170#input.care_paid_before_benefit_approval: true
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_gets_cash_assistance_with_person: true
+    us-wa:regulations/388/388-450/388-450-0170#input.care_provider_is_not_parent_or_stepparent: true
+    us-wa:regulations/388/388-450/388-450-0170#input.expense_verified: true
+    us-wa:regulations/388/388-450/388-450-0170#input.gross_monthly_income: 140
+    us-wa:regulations/388/388-450/388-450-0170#input.dependent_care_amount_paid_prorated_to_eligibility_date: 180
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_hours_band: 2
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_monthly_limit: 150
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient: holds
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_deduction: 140
+- name: dependent care age two or incapacitated adult capped by paid amount
+  period: 2024-06
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.hours_worked_per_month: 130
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_is_dependent_child_under_two_years_of_age: false
+    us-wa:regulations/388/388-450/388-450-0170#input.care_paid_before_benefit_approval: true
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_gets_cash_assistance_with_person: true
+    us-wa:regulations/388/388-450/388-450-0170#input.care_provider_is_not_parent_or_stepparent: true
+    us-wa:regulations/388/388-450/388-450-0170#input.expense_verified: true
+    us-wa:regulations/388/388-450/388-450-0170#input.gross_monthly_income: 500
+    us-wa:regulations/388/388-450/388-450-0170#input.dependent_care_amount_paid_prorated_to_eligibility_date: 160
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_hours_band: 3
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_monthly_limit: 175
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient: holds
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_deduction: 160
+- name: dependent care deduction denied when expense not verified
+  period: 2024-06
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.hours_worked_per_month: 30
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_is_dependent_child_under_two_years_of_age: false
+    us-wa:regulations/388/388-450/388-450-0170#input.care_paid_before_benefit_approval: true
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_gets_cash_assistance_with_person: true
+    us-wa:regulations/388/388-450/388-450-0170#input.care_provider_is_not_parent_or_stepparent: true
+    us-wa:regulations/388/388-450/388-450-0170#input.expense_verified: false
+    us-wa:regulations/388/388-450/388-450-0170#input.gross_monthly_income: 500
+    us-wa:regulations/388/388-450/388-450-0170#input.dependent_care_amount_paid_prorated_to_eligibility_date: 40
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_hours_band: 0
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_monthly_limit: 43.75
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient: not_holds
+    us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_deduction: 0
+- name: oracle_parameter_earned_income_initial_deduction
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2019-12-01'
+    end: '2020-11-30'
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.care_paid_before_benefit_approval: false
+    us-wa:regulations/388/388-450/388-450-0170#input.care_provider_is_not_parent_or_stepparent: false
+    us-wa:regulations/388/388-450/388-450-0170#input.dependent_care_amount_paid_prorated_to_eligibility_date: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.expense_verified: false
+    us-wa:regulations/388/388-450/388-450-0170#input.gross_monthly_income: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.hours_worked_per_month: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.household_gross_earned_income: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_gets_cash_assistance_with_person: false
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_is_dependent_child_under_two_years_of_age: false
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#earned_income_initial_deduction: 500
+- name: oracle_parameter_remaining_earned_income_deduction_rate
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2019-12-01'
+    end: '2020-11-30'
+  input:
+    us-wa:regulations/388/388-450/388-450-0170#input.care_paid_before_benefit_approval: false
+    us-wa:regulations/388/388-450/388-450-0170#input.care_provider_is_not_parent_or_stepparent: false
+    us-wa:regulations/388/388-450/388-450-0170#input.dependent_care_amount_paid_prorated_to_eligibility_date: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.expense_verified: false
+    us-wa:regulations/388/388-450/388-450-0170#input.gross_monthly_income: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.hours_worked_per_month: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.household_gross_earned_income: 0
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_gets_cash_assistance_with_person: false
+    us-wa:regulations/388/388-450/388-450-0170#input.recipient_is_dependent_child_under_two_years_of_age: false
+  output:
+    us-wa:regulations/388/388-450/388-450-0170#remaining_earned_income_deduction_rate: 0.5

--- a/us-wa/regulations/388/388-450/388-450-0170.yaml
+++ b/us-wa/regulations/388/388-450/388-450-0170.yaml
@@ -1,0 +1,253 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+  summary: If an individual is working, the department deducts the first $500 of total
+    household earned income, then subtracts 50% of the remaining monthly gross earned
+    income. Pre-approval dependent-care payments may be deducted for dependent children
+    or incapacitated adults getting cash assistance with the person, subject to proration,
+    gross-income cap, per-recipient table limits, non-parent/stepparent care provider,
+    and verification.
+rules:
+- name: earned_income_initial_deduction
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          excerpt: deducting the first $500
+  versions:
+  - effective_from: '2019-12-01'
+    formula: '500'
+- name: remaining_earned_income_deduction_rate
+  kind: parameter
+  dtype: Rate
+  source: us-wa/regulation/388/388-450/388-450-0170(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          excerpt: subtract 50% of the remaining monthly gross earned income
+  versions:
+  - effective_from: '2019-12-01'
+    formula: '0.50'
+- name: counted_earned_income_after_work_deductions
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  unit: USD
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(1)-(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#earned_income_initial_deduction
+          output: earned_income_initial_deduction
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#remaining_earned_income_deduction_rate
+          output: remaining_earned_income_deduction_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2019-12-01'
+    formula: max(0, max(0, household_gross_earned_income - earned_income_initial_deduction)
+      - (remaining_earned_income_deduction_rate * max(0, household_gross_earned_income
+      - earned_income_initial_deduction)))
+- name: dependent_care_hours_band_upper_bound
+  kind: parameter
+  dtype: Decimal
+  indexed_by: dependent_care_hours_band
+  versions:
+  - effective_from: '2019-12-01'
+    values:
+      0: 40
+      1: 80
+      2: 120
+  source: us-wa/regulation/388/388-450/388-450-0170(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          table:
+            header: Dependent Care Maximum Deductions
+            row_key: Hours Worked Per Month
+            column_key: row selector
+- name: dependent_care_hours_band
+  kind: derived
+  entity: Person
+  dtype: Integer
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          table:
+            header: Dependent Care Maximum Deductions
+            row_key: Hours Worked Per Month
+            column_key: row selector
+  versions:
+  - effective_from: '2019-12-01'
+    formula: 'if hours_worked_per_month <= dependent_care_hours_band_upper_bound[0]:
+      0 else: if hours_worked_per_month <= dependent_care_hours_band_upper_bound[1]:
+      1 else: if hours_worked_per_month <= dependent_care_hours_band_upper_bound[2]:
+      2 else: 3'
+- name: dependent_care_child_under_two_monthly_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: dependent_care_hours_band
+  source: us-wa/regulation/388/388-450/388-450-0170(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          table:
+            header: Dependent Care Maximum Deductions
+            row_key: Hours Worked Per Month
+            column_key: Child Under Two Years of Age
+  versions:
+  - effective_from: '2019-12-01'
+    values:
+      0: 50.0
+      1: 100.0
+      2: 150.0
+      3: 200.0
+- name: dependent_care_age_two_or_incapacitated_adult_monthly_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: dependent_care_hours_band
+  source: us-wa/regulation/388/388-450/388-450-0170(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+          table:
+            header: Dependent Care Maximum Deductions
+            row_key: Hours Worked Per Month
+            column_key: Child Two Years of Age and Older or Incapacitated Adult
+  versions:
+  - effective_from: '2019-12-01'
+    values:
+      0: 43.75
+      1: 87.5
+      2: 131.25
+      3: 175.0
+- name: dependent_care_recipient_monthly_limit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_child_under_two_monthly_limit
+          output: dependent_care_child_under_two_monthly_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_age_two_or_incapacitated_adult_monthly_limit
+          output: dependent_care_age_two_or_incapacitated_adult_monthly_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2019-12-01'
+    formula: 'if recipient_is_dependent_child_under_two_years_of_age: dependent_care_child_under_two_monthly_limit[dependent_care_hours_band]
+      else: dependent_care_age_two_or_incapacitated_adult_monthly_limit[dependent_care_hours_band]'
+- name: dependent_care_deduction_allowed_for_recipient
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(4), (b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+  versions:
+  - effective_from: '2019-12-01'
+    formula: 'care_paid_before_benefit_approval
+
+      and recipient_gets_cash_assistance_with_person
+
+      and care_provider_is_not_parent_or_stepparent
+
+      and expense_verified'
+- name: dependent_care_recipient_deduction
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: us-wa/regulation/388/388-450/388-450-0170(4), (a), (b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_recipient_monthly_limit
+          output: dependent_care_recipient_monthly_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wa:regulations/388/388-450/388-450-0170#dependent_care_deduction_allowed_for_recipient
+          output: dependent_care_deduction_allowed_for_recipient
+          hash: sha256:local
+  versions:
+  - effective_from: '2019-12-01'
+    formula: |-
+      if dependent_care_deduction_allowed_for_recipient: min(max(0, gross_monthly_income), min(dependent_care_amount_paid_prorated_to_eligibility_date, dependent_care_recipient_monthly_limit)) else: 0


### PR DESCRIPTION
## Summary
- Encodes WAC 388-450-0162 for Washington cash assistance countable-income and monthly-benefit slices.
- Encodes WAC 388-450-0170 for Washington TANF earned-income and dependent-care deductions.
- Includes signed encoder apply manifests for both generated sections, plus the encoder-repair manifest for the 0170 oracle parameter companion tests.
- Pins the RuleSpec toolchain to `axiom-encode` `0.2.850` (`d7a1e46ba8e77120b886dd5b30dbf99e7fa4d2ed`) so CI sees the WA TANF oracle mappings from TheAxiomFoundation/axiom-encode#789 and #790.

## Validation
- `uv run axiom-encode validate ...388-450-0162.yaml --skip-reviewers`
- `uv run axiom-encode validate ...388-450-0170.yaml --skip-reviewers`
- `uv run axiom-encode test ...388-450-0162.test.yaml --root ...rulespec-us-wa-tanf-income-benefit-20260626`
- `uv run axiom-encode test ...388-450-0170.test.yaml --root ...rulespec-us-wa-tanf-income-benefit-20260626`
- `uv run axiom-encode proof-validate ...388-450-0162.yaml`
- `uv run axiom-encode proof-validate ...388-450-0170.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo ...rulespec-us-wa-tanf-income-benefit-20260626`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode pytest -q tests/test_repository_layout.py tests/test_program_specs.py`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-wa-ci-root-20260626 --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- GitHub Actions `validate` workflow run `28219256366`

## PolicyEngine parity effect
- The WA TANF final-benefit PolicyEngine surface is mapped as `known_not_comparable` because PE exposes a final `wa_tanf` amount while these RuleSpec files encode source-local legal slices.
- The WAC 388-450-0170 earned-income deduction parameters now have comparable PE mappings and companion oracle parameter tests.
- Full local oracle coverage after the toolchain bump reported `Executable outputs: 12967`, `comparable=415`, `known_not_comparable=12552`, and `Untested comparable outputs: 0`.
