### PR TITLE
Encode Wyoming POWER payment computations

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -25,6 +25,7 @@ allowed_root_directories:
   - us-tn
   - us-tx
   - us-wa
+  - us-wy
 allowed_root_files:
   - .gitattributes
   - .gitignore

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.850"
+axiom_encode_version = "0.2.852"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "d7a1e46ba8e77120b886dd5b30dbf99e7fa4d2ed"
+axiom_encode_ref = "657732db51bb7ed989b91c6d5fd6332981b8af43"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-wy/.axiom/encoding-manifests/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.json
+++ b/us-wy/.axiom/encoding-manifests/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",
+      "sha256": "bd1c59dbe308531b90d232adfda3d95f634e67b074f5124d03ab1ea0f5c04001"
+    },
+    {
+      "path": "policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.test.yaml",
+      "sha256": "fe4955e5b5935574b5cbee2bfbf663b48c487da5d65950e1a75e22285cb7f08a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "208e9aa8ad2589374384b351ee6f092c7d91da6e",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.851",
+    "version_commit": "208e9aa8ad2589374384b351ee6f092c7d91da6e"
+  },
+  "axiom_encode_version": "0.2.851",
+  "backend": "codex",
+  "citation": "us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/wy-power-1101-tight-v3-20260626/_eval_workspaces/codex-gpt-5.5/us-wy-policies-dfs-snap-power-policy-manual-1101-power-payment-tests-computations/workspace/context-manifest.json",
+  "context_manifest_sha256": "ed37bd78a60424a8a4842ee1cfb0ddfad9ce39263a8b4caba6931a7a76d9e32b",
+  "generated_at": "2026-06-26T06:29:09.170717+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/wy-power-1101-tight-v3-20260626/codex-gpt-5.5/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/wy-power-1101-tight-v3-20260626",
+  "generated_output_sha256": "bd1c59dbe308531b90d232adfda3d95f634e67b074f5124d03ab1ea0f5c04001",
+  "generation_prompt_sha256": "94dad864885c468db4cf63f73a1883f1054bf56fb04f97ab369fd98ca6214602",
+  "model": "gpt-5.5",
+  "run_id": "f65ea34d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1131401890753f604d28b5f1be9d3e1e70c5f162f9643ba334dc95ca5ff6992b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/wy-power-1101-tight-v3-20260626/traces/codex-gpt-5.5/us-wy-policies-dfs-snap-power-policy-manual-1101-power-payment-tests-computations.json",
+  "trace_sha256": "d046058dac36743692543a038c1ae0253d69ece98de8ffbf7efee2b41afe8204"
+}

--- a/us-wy/CLAUDE.md
+++ b/us-wy/CLAUDE.md
@@ -1,0 +1,17 @@
+# rulespec-us-wy Agent Notes
+
+This repo stores Wyoming RuleSpec source registry materials and related policy metadata.
+
+## Do
+
+- Keep jurisdiction-administered source slices under `sources/` when source slices are present.
+- Add or update sidecar `.meta.yaml` files with source provenance, relations, and jurisdiction metadata.
+- Add RuleSpec encodings under `statutes/`, `regulations/`, or `policies/` when ready.
+- Keep parameter tables as structured YAML when they are useful reference data.
+- Keep large source payloads outside Git and point to them through metadata or manifests.
+
+## Do Not
+
+- Add singular rule roots, separate parameter/test fixture files, or generated formula artifacts.
+- Put unrelated jurisdiction materials here.
+- Add generated source payloads to Git.

--- a/us-wy/README.md
+++ b/us-wy/README.md
@@ -1,0 +1,15 @@
+# rulespec-us-wy
+
+Wyoming RuleSpec source registry and policy metadata.
+
+## Contents
+
+- `sources/`: source slices, target manifests, and sidecar metadata when available.
+- `statutes/`, `regulations/`, or `policies/`: RuleSpec YAML when encoded rules are added.
+- `.github/workflows/`: wrapper around the shared RuleSpec validation workflow.
+
+## Conventions
+
+Use RuleSpec YAML under `statutes/`, `regulations/`, or `policies/` for encoded rules. Keep source text with matching `.meta.yaml` files that record provenance and relations. Large XML or source payloads belong in object storage, with only registry or manifest metadata in Git.
+
+Jurisdiction-specific materials belong in this repo. Shared federal materials belong in `rulespec-us`.

--- a/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.test.yaml
+++ b/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.test.yaml
@@ -1,0 +1,180 @@
+- name: disqualified person and sponsor computations
+  period: 2026-06
+  input:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_or_net_self_employment
+    : 1500
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income: 100
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_is_citizen: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_has_40_qualifying_quarters_without_government_benefits
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_has_died: false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_income: 800
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_assets: 2000
+  output:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#disqualified_person_available_income_for_power_payment
+    : 1000
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deemed_income_for_immigrant_power
+    : 800
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deemed_assets_for_immigrant_power
+    : 2000
+- name: parent and stepparent available income computations
+  period: 2026-06
+  input:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_or_net_self_employment
+    : 2000
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: true
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_parent_or_stepparent
+    : 300
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_parent_stepparent_and_dependents
+    : 700
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_home
+    : 100
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_child_or_spousal_support_paid_to_persons_not_in_home
+    : 50
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_stepparent
+    : 250
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_stepparent_household
+    : 500
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_household
+    : 75
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_alimony_or_child_support_paid_to_persons_not_in_household
+    : 25
+  output:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#minor_parent_parent_available_income_for_power
+    : 250
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#stepparent_available_income_for_power: 1050
+- name: power maximum benefit level test is met
+  period: 2026-06
+  input:
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income: 1000
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_including_state_assigned_child_or_spousal_support
+    : 100
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.best_estimate_deemed_income: 50
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_power_eligible_individuals
+    : 600
+  output:
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#applicable_power_earned_income_disregard: 600
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_maximum_benefit_level_countable_income
+    : 550
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_maximum_benefit_level_test_met: holds
+- name: performance payment and child support termination
+  period: 2026-06
+  input:
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_of_parent_and_eligible_children
+    : 900
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_excluding_state_assigned_child_or_spousal_support
+    : 50
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.best_estimate_deemed_income: 20
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_power_eligible_individuals
+    : 500
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.nonexempt_child_support_anticipated_to_be_collected
+    : 130
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.child_support_amount_is_anticipated_ongoing
+    : true
+  output:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_performance_payment_countable_income
+    : 370
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_performance_payment_amount: 130
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_case_terminates_for_ongoing_child_support_ineligibility
+    : holds
+- name: auto_zero_sponsor_deemed_income_for_immigrant_power
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_alimony_or_child_support_paid_to_persons_not_in_household
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_child_or_spousal_support_paid_to_persons_not_in_home
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_home
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_household
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_of_parent_and_eligible_children
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_or_net_self_employment
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_parent_or_stepparent
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_stepparent
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_excluding_state_assigned_child_or_spousal_support
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_including_state_assigned_child_or_spousal_support
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.best_estimate_deemed_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.child_support_amount_is_anticipated_ongoing
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_has_40_qualifying_quarters_without_government_benefits
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_is_citizen: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_parent_stepparent_and_dependents
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_power_eligible_individuals
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_stepparent_household
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.nonexempt_child_support_anticipated_to_be_collected
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_assets: 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_income: 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_has_died: false
+  output:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deemed_income_for_immigrant_power
+    : 0
+- name: auto_zero_sponsor_deemed_assets_for_immigrant_power
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_alimony_or_child_support_paid_to_persons_not_in_household
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_child_or_spousal_support_paid_to_persons_not_in_home
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_home
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_dependent_payments_to_persons_not_in_household
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_of_parent_and_eligible_children
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_gross_earned_income_or_net_self_employment
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_parent_or_stepparent
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_available_to_stepparent
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_excluding_state_assigned_child_or_spousal_support
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.anticipated_unearned_income_including_state_assigned_child_or_spousal_support
+    : 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.best_estimate_deemed_income: 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.child_support_amount_is_anticipated_ongoing
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.eligible_married_couple: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_has_40_qualifying_quarters_without_government_benefits
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.immigrant_is_citizen: false
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_parent_stepparent_and_dependents
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_power_eligible_individuals
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.maximum_benefit_level_for_stepparent_household
+    : 0
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.nonexempt_child_support_anticipated_to_be_collected
+    : false
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_assets: 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_and_spouse_income: 0
+    us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#input.sponsor_has_died: false
+  output:
+    ? us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deemed_assets_for_immigrant_power
+    : 0

--- a/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml
+++ b/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml
@@ -1,0 +1,366 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+  summary: |-
+    1101 POWER Payment Tests/Computations: deduct $600, or $1200 for an eligible married couple, as the earned income disregard; compute available income for disqualified persons, parents of a minor parent, and stepparents; require 100% of sponsor and spouse income and assets to be deemed until citizenship, 40 qualifying quarters without government benefits, or sponsor death; compare POWER anticipated income to the maximum benefit level and compute performance payment prospectively.
+rules:
+  - name: power_earned_income_disregard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(A)(2), (B)(3), (C)(4), (E)(3), (F)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Deduct $600"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          600
+
+  - name: power_earned_income_disregard_for_eligible_married_couple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(A)(2), (B)(3), (E)(3), (F)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "$1200 for an eligible married couple"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1200
+
+  - name: sponsor_deeming_rate
+    kind: parameter
+    dtype: Rate
+    source: POWER - ARW, Chapter 1, Section 9, 1101(D)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Require 100% of the income and assets"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.00
+
+  - name: applicable_power_earned_income_disregard
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(A)(2), (B)(3), (E)(3), (F)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "$600 or $1200 earned income disregard"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard
+              output: power_earned_income_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard_for_eligible_married_couple
+              output: power_earned_income_disregard_for_eligible_married_couple
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if eligible_married_couple: power_earned_income_disregard_for_eligible_married_couple else: power_earned_income_disregard
+
+  - name: disqualified_person_available_income_for_power_payment
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(A)(1)-(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Deduct $600, or one $1200 ... Add the anticipated unearned income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard
+              output: power_earned_income_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard_for_eligible_married_couple
+              output: power_earned_income_disregard_for_eligible_married_couple
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, anticipated_gross_earned_income_or_net_self_employment - (if eligible_married_couple: power_earned_income_disregard_for_eligible_married_couple else: power_earned_income_disregard)) + anticipated_unearned_income
+
+  - name: minor_parent_parent_available_income_for_power
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(B)(2)-(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Deduct $600 ($1200 for an eligible married couple) ... Deduct the appropriate maximum benefit level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard
+              output: power_earned_income_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard_for_eligible_married_couple
+              output: power_earned_income_disregard_for_eligible_married_couple
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, anticipated_gross_earned_income_or_net_self_employment - (if eligible_married_couple: power_earned_income_disregard_for_eligible_married_couple else: power_earned_income_disregard) + anticipated_unearned_income_available_to_parent_or_stepparent - maximum_benefit_level_for_parent_stepparent_and_dependents - anticipated_dependent_payments_to_persons_not_in_home - anticipated_child_or_spousal_support_paid_to_persons_not_in_home)
+
+  - name: stepparent_available_income_for_power
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(C)(3)-(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Deduct a flat amount of $600 ... Deduct the appropriate maximum benefit level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_earned_income_disregard
+              output: power_earned_income_disregard
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, anticipated_gross_earned_income_or_net_self_employment - power_earned_income_disregard + anticipated_unearned_income_available_to_stepparent - maximum_benefit_level_for_stepparent_household - anticipated_dependent_payments_to_persons_not_in_household - anticipated_alimony_or_child_support_paid_to_persons_not_in_household)
+
+  - name: sponsor_deemed_income_for_immigrant_power
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(D)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "100% of the income and assets of a sponsor, and the sponsor's spouse"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deeming_rate
+              output: sponsor_deeming_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if immigrant_is_citizen or immigrant_has_40_qualifying_quarters_without_government_benefits or sponsor_has_died: 0 else: sponsor_deeming_rate * sponsor_and_spouse_income
+
+  - name: sponsor_deemed_assets_for_immigrant_power
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(D)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "100% of the income and assets of a sponsor, and the sponsor's spouse"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#sponsor_deeming_rate
+              output: sponsor_deeming_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if immigrant_is_citizen or immigrant_has_40_qualifying_quarters_without_government_benefits or sponsor_has_died: 0 else: sponsor_deeming_rate * sponsor_and_spouse_assets
+
+  - name: power_maximum_benefit_level_countable_income
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(E)(2)-(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Use the anticipated gross earned income ... Allow the $600 or $1200 earned income disregard ... Add the anticipated unearned income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#applicable_power_earned_income_disregard
+              output: applicable_power_earned_income_disregard
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, anticipated_gross_earned_income - applicable_power_earned_income_disregard) + anticipated_unearned_income_including_state_assigned_child_or_spousal_support + best_estimate_deemed_income
+
+  - name: power_maximum_benefit_level_test_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(E)(1), (6)-(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Find the case eligible when the anticipated income is less than the maximum benefit level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_maximum_benefit_level_countable_income
+              output: power_maximum_benefit_level_countable_income
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          power_maximum_benefit_level_countable_income < maximum_benefit_level_for_power_eligible_individuals
+
+  - name: power_performance_payment_countable_income
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(F)(2)-(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Use the anticipated gross earned income ... Exclude state assigned and collected nonexempt child/spousal support"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#applicable_power_earned_income_disregard
+              output: applicable_power_earned_income_disregard
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, anticipated_gross_earned_income_of_parent_and_eligible_children - applicable_power_earned_income_disregard) + anticipated_unearned_income_excluding_state_assigned_child_or_spousal_support + best_estimate_deemed_income
+
+  - name: power_performance_payment_amount
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(F)(6)-(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Subtract all countable anticipated income from the maximum benefit level ... Round ... down to the nearest whole dollar"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_performance_payment_countable_income
+              output: power_performance_payment_countable_income
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor(max(0, maximum_benefit_level_for_power_eligible_individuals - power_performance_payment_countable_income))
+
+  - name: power_case_terminates_for_ongoing_child_support_ineligibility
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: POWER - ARW, Chapter 1, Section 9, 1101(F)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1
+              excerpt: "Terminate the case ... when the performance payment is equal to or less than the nonexempt child support anticipated to be collected"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#power_performance_payment_amount
+              output: power_performance_payment_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          power_performance_payment_amount <= nonexempt_child_support_anticipated_to_be_collected
+          and child_support_amount_is_anticipated_ongoing


### PR DESCRIPTION
## Summary
- add the initial Wyoming RuleSpec jurisdiction scaffold
- encode Wyoming POWER 1101 payment tests/computations from the DFS SNAP/POWER manual
- include generated tests and the signed axiom-encode apply manifest

## Validation
- `uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/wy-power-1101-20260626/rulespec-us/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml --json --skip-reviewers`
- `uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/wy-power-1101-20260626/rulespec-us/us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.test.yaml --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/wy-power-1101-20260626/rulespec-us --base-ref origin/main --head-ref HEAD`
- `/opt/homebrew/bin/python3.13 -m pytest -q tests/test_repository_layout.py tests/test_program_specs.py`

Note: reviewer checks were skipped for the apply run because the default generalist reviewer stalled; deterministic compile/test/manifest gates passed.