### PR TITLE
Encode Indiana TANF financial standards

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -14,6 +14,7 @@ allowed_root_directories:
   - us-fl
   - us-ga
   - us-id
+  - us-in
   - us-il
   - us-ma
   - us-md

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.852"
+axiom_encode_version = "0.2.853"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "657732db51bb7ed989b91c6d5fd6332981b8af43"
+axiom_encode_ref = "85363e6b4af024d8a0b56751fddfc6482c623f15"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml",
+      "sha256": "b3cf35192043c90868ef8ed28681246e999fad5c57806c1e0a6c7c29dc984a69"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.test.yaml",
+      "sha256": "3dba55b55ab81b84af7fb0b6a2f731a8d095175f68e9445977aec44d0bc46eea"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "657732db51bb7ed989b91c6d5fd6332981b8af43",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.852",
+    "version_commit": "657732db51bb7ed989b91c6d5fd6332981b8af43"
+  },
+  "axiom_encode_version": "0.2.852",
+  "backend": "codex",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-05-20260626/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3010-15-05-cash-assistance-100-percent-income-standards/workspace/context-manifest.json",
+  "context_manifest_sha256": "859cf7793ff40d933fbe0008bab2fd8969503d39f7aa9048b229f9e93915059b",
+  "generated_at": "2026-06-26T07:22:05.707455+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-05-20260626/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-05-20260626",
+  "generated_output_sha256": "b3cf35192043c90868ef8ed28681246e999fad5c57806c1e0a6c7c29dc984a69",
+  "generation_prompt_sha256": "ef43442bb1bdcd49bfab88aac4a671815bb80a9fc569974b3a5b14cd5f01da09",
+  "model": "gpt-5.5",
+  "run_id": "8aed3784",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fd5993b8ce720c692c3578f7ea62d3b038978e2a1b18c0a7fec685cdfa9f876a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-05-20260626/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3010-15-05-cash-assistance-100-percent-income-standards.json",
+  "trace_sha256": "c010fffed80fee2ee94e82976503466a7bf468e9206df19018e34c583342a5e4"
+}

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",
+      "sha256": "292c95c173111e48ff0e9e5a63986e47069ae108f4a288f7514eb51941437632"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.test.yaml",
+      "sha256": "c447d47c0c0f2d3d42a9d51e0283ee3c9024f5830f0e3bdb63e9d3789bace263"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "657732db51bb7ed989b91c6d5fd6332981b8af43",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.852",
+    "version_commit": "657732db51bb7ed989b91c6d5fd6332981b8af43"
+  },
+  "axiom_encode_version": "0.2.852",
+  "backend": "codex",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-20260626/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3010-15-cash-assistance-income-standards/workspace/context-manifest.json",
+  "context_manifest_sha256": "e3aee221d26806c282d0232053242019cf74b0523bfe1112cca038a21d4120ca",
+  "generated_at": "2026-06-26T07:17:38.824624+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-20260626/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-20260626",
+  "generated_output_sha256": "292c95c173111e48ff0e9e5a63986e47069ae108f4a288f7514eb51941437632",
+  "generation_prompt_sha256": "c0304f2896e5bbcb8ab63f6c87e45d76cdc9586d6161805c91a7fcc7f6ce6ba8",
+  "model": "gpt-5.5",
+  "run_id": "df76348d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a9c56bc53daa95db51e49c5e4bcb113c779fb6610cbdc6c5faab07d035f17945"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3010-15-20260626/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3010-15-cash-assistance-income-standards.json",
+  "trace_sha256": "728331625f93c31de33e10feeeace21e503f4159ae552bd5121a40838ac8993a"
+}

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.yaml",
+      "sha256": "8612ece5dd214dd385fe706f4025fd6da00a40eac454140bf3140a7f2b4bb91c"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.test.yaml",
+      "sha256": "64f7d32921e5d5bcad7030ff9d00c1134db3de634fb86f1c47f6fb1285d3713d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "657732db51bb7ed989b91c6d5fd6332981b8af43",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.852",
+    "version_commit": "657732db51bb7ed989b91c6d5fd6332981b8af43"
+  },
+  "axiom_encode_version": "0.2.852",
+  "backend": "codex",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-page300-20260626/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3050-10-cash-assistance-maximum-benefits-continuation/workspace/context-manifest.json",
+  "context_manifest_sha256": "200ff4c8432277e185c3113da05ccbbdb5c37641bc4676c03bc649f458a09650",
+  "generated_at": "2026-06-26T07:20:31.699206+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-page300-20260626/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-page300-20260626",
+  "generated_output_sha256": "8612ece5dd214dd385fe706f4025fd6da00a40eac454140bf3140a7f2b4bb91c",
+  "generation_prompt_sha256": "c86ddb3e9daac957388fbaed5d187a6402634cb56be0cebc8c7d4cded2cab13b",
+  "model": "gpt-5.5",
+  "run_id": "2e514df3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b9c846547a4578c380401380da991637e512eea4bb61e5984d48cc5742722501"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-page300-20260626/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3050-10-cash-assistance-maximum-benefits-continuation.json",
+  "trace_sha256": "be70a4a65ef6e9826518447a96f70253666469a630bdb42b066f750cb6439cd7"
+}

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml",
+      "sha256": "e9a1b7a0b2f067e0b8cf338644ae4da6636af195d2784e63406811efa153aa38"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.test.yaml",
+      "sha256": "02159b6cd08f5fb9659b2a51c4a0e03e9c87e28c00be31975e271e9895f54e54"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "657732db51bb7ed989b91c6d5fd6332981b8af43",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.852",
+    "version_commit": "657732db51bb7ed989b91c6d5fd6332981b8af43"
+  },
+  "axiom_encode_version": "0.2.852",
+  "backend": "codex",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-20260626/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3050-10-cash-assistance-maximum-benefits/workspace/context-manifest.json",
+  "context_manifest_sha256": "f4d818105da172f6c9af60924f873e19e2d2f77c52be8d89e794c1124bf5c079",
+  "generated_at": "2026-06-26T07:19:14.671752+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-20260626/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-20260626",
+  "generated_output_sha256": "e9a1b7a0b2f067e0b8cf338644ae4da6636af195d2784e63406811efa153aa38",
+  "generation_prompt_sha256": "21644c7e82dfd521b125a29efb032f8375eb17d58662fe1f5017a5865c0ecf62",
+  "model": "gpt-5.5",
+  "run_id": "60cb41c4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dcaa16f0a821b2c54f5a0ea71057cca2c1666b3b3cfc2283d84969940dca3422"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3050-10-20260626/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3050-10-cash-assistance-maximum-benefits.json",
+  "trace_sha256": "44aa50e7f5a7d5dca5ea7a7ea52caa97353a0e6cafc6e66a648e260615565486"
+}

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml",
+      "sha256": "05fdf3ffbfccbba0ab65d66692635d6073b86b2f40dd37e6fa24a2304120a0e7"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.test.yaml",
+      "sha256": "1f56bacf885804307a9343bab89a6ad15fafe4584e4ffc758ea88e309b0ccda8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "657732db51bb7ed989b91c6d5fd6332981b8af43",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.852",
+    "version_commit": "657732db51bb7ed989b91c6d5fd6332981b8af43"
+  },
+  "axiom_encode_version": "0.2.852",
+  "backend": "codex",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation",
+  "context_manifest_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3450-20260626/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3450-financial-eligibility-benefit-calculation/workspace/context-manifest.json",
+  "context_manifest_sha256": "7de503144847c99677c54ac1ebc2d7c9962ada81304be48aeebc2e30a24e0cd7",
+  "generated_at": "2026-06-26T07:11:11.289137+00:00",
+  "generated_output_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3450-20260626/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml",
+  "generated_output_root": "/Users/maxghenis/.axiom/workspace/in-tanf-3450-20260626",
+  "generated_output_sha256": "05fdf3ffbfccbba0ab65d66692635d6073b86b2f40dd37e6fa24a2304120a0e7",
+  "generation_prompt_sha256": "3723d309cd88a904c76152e28105e5df996bd275ab61fda4e0e4f50672111571",
+  "model": "gpt-5.5",
+  "run_id": "b3f582f4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "86cd13fa849377bd4823cec8b6d7e7dce5e6538af80613daf5a5e8e3f83ffef4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/.axiom/workspace/in-tanf-3450-20260626/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3450-financial-eligibility-benefit-calculation.json",
+  "trace_sha256": "ad72039f4ffdc6bacff9e0b5bb88327c4c4bb067f2d08517f98cda126971b0b7"
+}

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.test.yaml
@@ -1,0 +1,42 @@
+- name: net income below standard for AG size 3
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 3
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.countable_net_income
+    : 2276
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_assistance_group_size_for_100_percent_income_standard
+    : 3
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_countable_net_income_below_100_percent_fpl
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_income_standard_maximum_grant
+    : 513
+- name: net income equal to standard loses eligibility for AG size 3
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 3
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.countable_net_income
+    : 2277
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_assistance_group_size_for_100_percent_income_standard
+    : 3
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_countable_net_income_below_100_percent_fpl
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_income_standard_maximum_grant
+    : 513
+- name: AG size 10 table values
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 10
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.countable_net_income
+    : 5589
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_assistance_group_size_for_100_percent_income_standard
+    : 10
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_countable_net_income_below_100_percent_fpl
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_income_standard_maximum_grant
+    : 1241

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml
@@ -1,0 +1,144 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+  summary: |-
+    "The countable net income standard is 100% of the Federal Poverty Level." An AG loses eligibility when countable net income equals or exceeds 100% FPL for the same family size. The chart lists monthly countable net income standards effective 3/1/2026 and maximum grant amounts effective 7/1/2025 for AG sizes 1 through 10.
+rules:
+  - name: tanf_assistance_group_size_for_100_percent_income_standard
+    kind: derived
+    entity: TanfUnit
+    dtype: Count
+    period: Month
+    source: 3010.15.05 100% Income Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+              excerpt: "for a TANF AG"
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          assistance_group_size
+
+  - name: tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_assistance_group_size_for_100_percent_income_standard
+    source: 3010.15.05 Income Standard chart, Countable AG Net Income Standard Effective 3/1/2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+              excerpt: "COUNTABLE AG NET INCOME STANDARD EFFECTIVE 3/1/2026"
+              table:
+                header: "INCOME STANDARD"
+                row_key: "AG SIZE"
+                column_key: "COUNTABLE AG NET INCOME STANDARD EFFECTIVE 3/1/2026"
+    versions:
+      - effective_from: '2026-03-01'
+        values:
+          1: 1330
+          2: 1804
+          3: 2277
+          4: 2750
+          5: 3224
+          6: 3697
+          7: 4170
+          8: 4644
+          9: 5117
+          10: 5590
+
+  - name: tanf_100_percent_income_standard_maximum_grant_by_ag_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_assistance_group_size_for_100_percent_income_standard
+    source: 3010.15.05 Income Standard chart, Maximum Grant Amount Effective 7/1/2025
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+              excerpt: "MAXIMUM GRANT AMOUNT EFFECTIVE 7/1/2025"
+              table:
+                header: "INCOME STANDARD"
+                row_key: "AG SIZE"
+                column_key: "MAXIMUM GRANT AMOUNT EFFECTIVE 7/1/2025"
+    versions:
+      - effective_from: '2025-07-01'
+        values:
+          1: 248
+          2: 409
+          3: 513
+          4: 617
+          5: 721
+          6: 825
+          7: 929
+          8: 1033
+          9: 1137
+          10: 1241
+
+  - name: tanf_countable_net_income_below_100_percent_fpl
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3010.15.05 100% Income Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+              excerpt: "An AG will lose eligibility when its countable net income equals or exceeds 100% of Federal Poverty Level (FPL)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+              output: tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          countable_net_income < tanf_100_percent_fpl_countable_net_income_standard_by_ag_size[tanf_assistance_group_size_for_100_percent_income_standard]
+
+  - name: tanf_100_percent_income_standard_maximum_grant
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3010.15.05 Income Standard chart, Maximum Grant Amount Effective 7/1/2025
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-297
+              excerpt: "MAXIMUM GRANT AMOUNT EFFECTIVE 7/1/2025"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_income_standard_maximum_grant_by_ag_size
+              output: tanf_100_percent_income_standard_maximum_grant_by_ag_size
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          tanf_100_percent_income_standard_maximum_grant_by_ag_size[tanf_assistance_group_size_for_100_percent_income_standard]

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.test.yaml
@@ -1,0 +1,39 @@
+- name: ag_size_1_income_below_both_standards
+  period: 2026-03
+  input:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.assistance_group_size: 1
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.gross_income: 465
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.net_income: 247
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_initial_gross_income_standard_met
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_net_income_standard_met
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_income_standards_met
+    : holds
+- name: ag_size_1_income_equal_standards_fails_less_than_test
+  period: 2026-03
+  input:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.assistance_group_size: 1
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.gross_income: 466
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.net_income: 248
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_initial_gross_income_standard_met
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_net_income_standard_met
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_income_standards_met
+    : not_holds
+- name: ag_size_10_gross_passes_net_fails
+  period: 2026-03
+  input:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.assistance_group_size: 10
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.gross_income: 1956
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#input.net_income: 1241
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_initial_gross_income_standard_met
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_net_income_standard_met
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_income_standards_met
+    : not_holds

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml
@@ -1,0 +1,182 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+  summary: |-
+    "This chart lists the maximum monthly gross income and net income standards for Cash Assistance groups. The gross income standard is used for initial eligibility for all cash assistance groups. For financial eligibility to exist, income must be less than these standards."
+rules:
+  - name: cash_assistance_gross_income_standard_rate
+    kind: parameter
+    dtype: Rate
+    source: 3010.15.00 Gross Income Standards (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              excerpt: "The gross income standard is 35% of the Federal Poverty Level (FPL)"
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          0.35
+  - name: cash_assistance_net_income_standard_rate_of_maximum_grant
+    kind: parameter
+    dtype: Rate
+    source: 3010.15.00 Gross Income Standards (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              excerpt: "the net income standard is 100% of the maximum grant amount"
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          1.00
+  - name: cash_assistance_monthly_gross_income_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: assistance_group_size
+    source: 3010.15.00 Gross Income Standards (C), Gross Income Standard chart effective 3/1/2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              table:
+                header: "GROSS INCOME STANDARD AG Size Gross Income Standard EFFECTIVE 3/1/2026 Net Income Standard"
+                row_key: "AG Size"
+                column_key: "Gross Income Standard"
+    versions:
+      - effective_from: '2026-03-01'
+        values:
+          1: 466
+          2: 632
+          3: 797
+          4: 963
+          5: 1129
+          6: 1294
+          7: 1460
+          8: 1626
+          9: 1791
+          10: 1957
+  - name: cash_assistance_monthly_net_income_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: assistance_group_size
+    source: 3010.15.00 Gross Income Standards (C), Gross Income Standard chart effective 3/1/2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              table:
+                header: "GROSS INCOME STANDARD AG Size Gross Income Standard EFFECTIVE 3/1/2026 Net Income Standard"
+                row_key: "AG Size"
+                column_key: "Net Income Standard"
+    versions:
+      - effective_from: '2026-03-01'
+        values:
+          1: 248
+          2: 409
+          3: 513
+          4: 617
+          5: 721
+          6: 825
+          7: 929
+          8: 1033
+          9: 1137
+          10: 1241
+  - name: cash_assistance_initial_gross_income_standard_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3010.15.00 Gross Income Standards (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              excerpt: "The gross income standard is used for initial eligibility for all cash assistance groups. For financial eligibility to exist, income must be less than these standards."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_monthly_gross_income_standard
+              output: cash_assistance_monthly_gross_income_standard
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          gross_income < cash_assistance_monthly_gross_income_standard[assistance_group_size]
+  - name: cash_assistance_net_income_standard_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3010.15.00 Gross Income Standards (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              excerpt: "For financial eligibility to exist, income must be less than these standards."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_monthly_net_income_standard
+              output: cash_assistance_monthly_net_income_standard
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          net_income < cash_assistance_monthly_net_income_standard[assistance_group_size]
+  - name: cash_assistance_income_standards_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3010.15.00 Gross Income Standards (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+              excerpt: "For financial eligibility to exist, income must be less than these standards."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_initial_gross_income_standard_met
+              output: cash_assistance_initial_gross_income_standard_met
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards#cash_assistance_net_income_standard_met
+              output: cash_assistance_net_income_standard_met
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          cash_assistance_initial_gross_income_standard_met
+          and cash_assistance_net_income_standard_met

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.test.yaml
@@ -1,0 +1,24 @@
+- name: one_participating_member_recipient_parent_children_only_maximum_benefit
+  period: 2025-07
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#input.participating_members
+    : 1
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+    : 248
+- name: six_participating_members_recipient_parent_children_only_maximum_benefit
+  period: 2025-07
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#input.participating_members
+    : 6
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+    : 825
+- name: ten_participating_members_recipient_parent_children_only_maximum_benefit
+  period: 2025-07
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#input.participating_members
+    : 10
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+    : 1241

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-300
+  summary: |-
+    MAXIMUM BENEFITS AG WITH RECIPIENT PARENT CHILDREN ONLY. Participating Members Maximum Benefit EFFECTIVE 7/1/2025: 1 $248, 2 $409, 3 $513, 4 $617, 5 $721, 6 $825, 7 $929, 8 $1033, 9 $1137, 10 $1241.
+rules:
+  - name: cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: participating_members
+    source: DFR SNAP/TANF Program Policy Manual 3050.10, maximum benefits AG with recipient parent children only
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-300
+              excerpt: "Participating Members Maximum Benefit EFFECTIVE 7/1/2025 1 $248 6 $825 2 $409 7 $929 3 $513 8 $1033 4 $617 9 $1137 5 $721 10 $1241"
+              table:
+                header: "MAXIMUM BENEFITS AG WITH RECIPIENT PARENT CHILDREN ONLY"
+                row_key: participating_members
+                column_key: maximum_benefit
+    versions:
+      - effective_from: '2025-07-01'
+        values:
+          1: 248
+          2: 409
+          3: 513
+          4: 617
+          5: 721
+          6: 825
+          7: 929
+          8: 1033
+          9: 1137
+          10: 1241
+  - name: cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DFR SNAP/TANF Program Policy Manual 3050.10, maximum benefits AG with recipient parent children only
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-300
+              excerpt: "Participating Members Maximum Benefit EFFECTIVE 7/1/2025"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag_table
+              output: cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag_table
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag_table[participating_members]

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.test.yaml
@@ -1,0 +1,14 @@
+- name: recipient_parent_or_caretaker_ag_one_participating_member
+  period: 2025-07
+  input:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+    : 248
+- name: recipient_parent_or_caretaker_ag_six_participating_members
+  period: 2025-07
+  input:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 6
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+    : 825

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-299
+  summary: |-
+    "The following charts indicate the maximum monthly Cash Assistance benefits per AG based upon the composition of the AG and number of participating members." For an AG with a recipient parent and/or caretaker, the visible chart entries effective 7/1/2025 show participating members 1: $248 and 6: $825.
+rules:
+  - name: cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: participating_members
+    source: 3050.10.00 Maximum Benefits (C), Maximum Benefits AG with a Recipient Parent and/or Caretaker chart effective 7/1/2025
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-299
+              excerpt: "AG WITH A RECIPIENT PARENT AND/OR CARETAKER Participating Members Maximum Benefit EFFECTIVE 7/1/2025 ... 1 $248 6 $825"
+              table:
+                header: "MAXIMUM BENEFITS AG WITH A RECIPIENT PARENT AND/OR CARETAKER"
+                row_key: "Participating Members"
+                column_key: "Maximum Benefit"
+    versions:
+      - effective_from: '2025-07-01'
+        values:
+          1: 248
+          6: 825
+  - name: cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3050.10.00 Maximum Benefits (C), Maximum Benefits AG with a Recipient Parent and/or Caretaker chart effective 7/1/2025
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-299
+              excerpt: "maximum monthly Cash Assistance benefits per AG based upon the composition of the AG and number of participating members"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag_table
+              output: cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag_table
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag_table[participating_members]

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.test.yaml
@@ -1,0 +1,70 @@
+- name: gross income test met before 2027 threshold change
+  period: 2026-06
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.assistance_group_is_tanf_or_refugee_cash_assistance_applicant
+    : true
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.gross_income: 340
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.federal_income_poverty_level
+    : 1000
+  output:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_limit: 350
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_test_met
+    : holds
+- name: gross income test not met before 2027 threshold change
+  period: 2026-06
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.assistance_group_is_tanf_or_refugee_cash_assistance_applicant
+    : true
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.gross_income: 360
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.federal_income_poverty_level
+    : 1000
+  output:
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_limit: 350
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_test_met
+    : not_holds
+- name: dependent child or woman otherwise qualifies through gross income test
+  period: 2026-06
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_is_dependent_child_or_woman
+    : true
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_otherwise_qualifies_for_assistance
+    : true
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_is_part_of_assistance_group_that_meets_gross_income_test
+    : true
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_assistance_financially_eligible_under_gross_income_test
+    : holds
+- name: work expense disregard for employed nonparticipating member
+  period: 2026-06
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.employed_participating_ag_member
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.employed_nonparticipating_ag_member
+    : true
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#monthly_work_expense_disregard
+    : 90
+- name: auto_zero_monthly_work_expense_disregard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.assistance_group_is_tanf_or_refugee_cash_assistance_applicant
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.employed_nonparticipating_ag_member
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.employed_participating_ag_member
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.federal_income_poverty_level
+    : 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.gross_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_is_dependent_child_or_woman
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_is_part_of_assistance_group_that_meets_gross_income_test
+    : false
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#input.person_otherwise_qualifies_for_assistance
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#monthly_work_expense_disregard
+    : 0

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml
@@ -1,0 +1,176 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+  summary: |-
+    "The Cash Assistance financial eligibility determination is a comparison of the AG's needs to the AG's countable income." TANF and Refugee Cash Assistance applicants must meet a gross income test of not more than 35% of the federal income poverty level, changing after June 30, 2027 to not more than 50%. A monthly $90 work expense disregard is allowed from gross earned income for each employed participating AG member and each employed nonparticipating AG member.
+rules:
+  - name: tanf_gross_income_limit_rate
+    kind: parameter
+    dtype: Rate
+    source: 3450.05.05 Gross Income Test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "not more that thirty-five (35%) percent of the federal income poverty level"
+          - path: versions[1].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "After June 30, 2027"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "not more than fifty (50%) percent of the federal income poverty level"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.35
+      - effective_from: '2027-07-01'
+        formula: |-
+          0.50
+
+  - name: monthly_work_expense_disregard_per_employed_ag_member
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 3450.20.00 Work Expense Disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "A work expense disregard of $90 is allowed as a deduction per each employed participating AG member."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "A work expense disregard of $90 is allowed as a deduction per each employed nonparticipating AG member."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          90
+
+  - name: tanf_gross_income_limit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 3450.05.05 Gross Income Test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "gross income that is not more than thirty-five (35%) percent of the federal income poverty level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_limit_rate
+              output: tanf_gross_income_limit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tanf_gross_income_limit_rate * federal_income_poverty_level
+
+  - name: tanf_gross_income_test_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3450.05.05 Gross Income Test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "The following applies to TANF applicants, and Refugee Cash Assistance applicants."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "has gross income that is not more than thirty-five (35%) percent of the federal income poverty level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#tanf_gross_income_limit
+              output: tanf_gross_income_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          assistance_group_is_tanf_or_refugee_cash_assistance_applicant
+          and gross_income <= tanf_gross_income_limit
+
+  - name: tanf_assistance_financially_eligible_under_gross_income_test
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 3450.05.05 Gross Income Test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "A dependent child and woman who otherwise qualifies for assistance and is part of an assistance group"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "is eligible for TANF assistance"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_is_dependent_child_or_woman
+          and person_otherwise_qualifies_for_assistance
+          and person_is_part_of_assistance_group_that_meets_gross_income_test
+
+  - name: monthly_work_expense_disregard
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 3450.20.00 Work Expense Disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "allowed as a deduction per each employed participating AG member"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-367
+              excerpt: "allowed as a deduction per each employed nonparticipating AG member"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation#monthly_work_expense_disregard_per_employed_ag_member
+              output: monthly_work_expense_disregard_per_employed_ag_member
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if employed_participating_ag_member or employed_nonparticipating_ag_member: monthly_work_expense_disregard_per_employed_ag_member else: 0


### PR DESCRIPTION
## Summary
- Add Indiana (`us-in`) RuleSpec root
- Encode Indiana SNAP/TANF manual financial standards for TANF/Cash Assistance: gross income standards, 100% FPL net-income standards, maximum grant/benefit tables, gross-income test, and work-expense disregard
- Pin validation to axiom-encode 0.2.853, which includes the Indiana PE oracle prefix classification

## PE parity notes
- The generated Indiana outputs are classified as known-not-comparable state manual helper/parameter outputs.
- The `in_tanf` final PolicyEngine surface remains pending because this PR does not yet encode the complete final benefit calculation graph.
- A full benefit-calculation slice was attempted for 3450.35.05, but apply validation blocked the generated candidate on an invalid auto-zero test input (`adjusted_needs: false` for Money). That points to an apply/repair pipeline improvement rather than a hand-editable RuleSpec fix.

## Tests
- `/opt/homebrew/bin/python3.13 -m pytest -q tests/test_repository_layout.py tests/test_program_specs.py`
- `uv run axiom-encode validate <each new us-in RuleSpec file> --skip-reviewers --json`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-3450-20260626/rulespec-us --base-ref origin/main --head-ref HEAD --json`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-pe-parity-root-in-20260626 --include-program-surfaces --json`
