### PR TITLE
Encode Indiana TANF benefit calculation

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.853"
+axiom_encode_version = "0.2.857"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "85363e6b4af024d8a0b56751fddfc6482c623f15"
+axiom_encode_ref = "9acf77b15d6f5b671df5a55233fb37ea35a92559"
 axiom_corpus_ref = "6b3ad90909f6c1a598d61ddbd7823a1685058d37"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.yaml",
+      "sha256": "ca4ed7c83b4a055a4023491866a52aac06825f3ab8357a3442f5f97020c95d96"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.test.yaml",
+      "sha256": "31e06d2cdb4396fca90fe265d338e93ee4b7548bfb97e13e08c0bc49c3bdbe3b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fdb884e063553905202646e89c8a2d2823292336",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.854",
+    "version_commit": "fdb884e063553905202646e89c8a2d2823292336"
+  },
+  "axiom_encode_version": "0.2.854",
+  "backend": "codex",
+  "citation": "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626/encode-output/_eval_workspaces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3450-35-05-benefit-calculation-continuation/workspace/context-manifest.json",
+  "context_manifest_sha256": "a7a3526ee5e88645199a3517add5a68c73d8b67da06c92d7db6cb313e8ef9194",
+  "generated_at": "2026-06-26T08:11:28.004604+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626/encode-output/codex-gpt-5.5/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626/encode-output",
+  "generated_output_sha256": "ca4ed7c83b4a055a4023491866a52aac06825f3ab8357a3442f5f97020c95d96",
+  "generation_prompt_sha256": "b8f0e89725c167a6aa40b65bf70c38310215003caaeab6c0117044749c6069cf",
+  "model": "gpt-5.5",
+  "run_id": "af76d3b8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ce9658761880948252c86b4e27b6b276c53d50d4e22f2ff447ee30a92ecf67d2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626/encode-output/traces/codex-gpt-5.5/us-in-policies-dfr-snap-tanf-program-policy-manual-3450-35-05-benefit-calculation-continuation.json",
+  "trace_sha256": "4990dc923de8b53b8fc680ad53c15ef42a37d44a96cdaf172ac7e9516aee4719"
+}

--- a/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.json
+++ b/us-in/.axiom/encoding-manifests/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml",
+      "sha256": "ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99"
+    },
+    {
+      "path": "policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.test.yaml",
+      "sha256": "12f0a1619ea901642f59093518fe57c274fd6dbcb7a5097181a9a836f654be47"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9acf77b15d6f5b671df5a55233fb37ea35a92559",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.857",
+    "version_commit": "9acf77b15d6f5b671df5a55233fb37ea35a92559"
+  },
+  "axiom_encode_version": "0.2.857",
+  "backend": "deterministic",
+  "citation": "us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-26T09:09:06.935327+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5ns5oa9r/deterministic-repair/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5ns5oa9r",
+  "generated_output_sha256": "ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "075670c11a0bc1081f3c6274f454e777453e1369a07c339f5d33c25aed883253"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.test.yaml
@@ -1,0 +1,101 @@
+- name: ongoing benefit below adjusted needs and below 100 percent fpl
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 100
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#input.earned_income_is_sole_factor_for_adjusted_net_income_meeting_or_exceeding_adjusted_needs_and_no_penalties
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement
+    : 148
+- name: ongoing minimum grant when earned income is sole factor
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 300
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#input.earned_income_is_sole_factor_for_adjusted_net_income_meeting_or_exceeding_adjusted_needs_and_no_penalties
+    : true
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement
+    : 10
+- name: ongoing zero grant when adjusted net income exceeds needs without earned income
+    sole factor
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 300
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#input.earned_income_is_sole_factor_for_adjusted_net_income_meeting_or_exceeding_adjusted_needs_and_no_penalties
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement
+    : 0
+- name: ongoing ineligible when countable income is not below 100 percent fpl
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 1400
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#input.assistance_group_size
+    : 1
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#input.earned_income_is_sole_factor_for_adjusted_net_income_meeting_or_exceeding_adjusted_needs_and_no_penalties
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement
+    : 0

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.yaml
@@ -1,0 +1,165 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+  summary: |-
+    "An on-going AG's countable income must be less than 100% of the Federal Poverty Guideline to be eligible for cash assistance, and the benefits are determined as above." If adjusted net income equals or exceeds adjusted needs, an AG with earned income as the sole contributing factor and no sanctions, Voluntary Quit, or fiscal penalties receives a $10 minimum grant; an AG with no earned income receives a $0 grant.
+imports:
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_assistance_group_size_for_100_percent_income_standard
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+rules:
+  - name: tanf_ongoing_minimum_grant_with_earned_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation Continuation, minimum grant
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "a minimum grant of ten dollars ($10)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: tanf_ongoing_countable_income_below_100_percent_fpl
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3450.35.05 Benefit Calculation Continuation, ongoing AG 100% FPG test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "countable income must be less than 100% of the Federal Poverty Guideline"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+              output: tanf_net_countable_income_for_benefit_calculation
+              hash: sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_assistance_group_size_for_100_percent_income_standard
+              output: tanf_assistance_group_size_for_100_percent_income_standard
+              hash: sha256:b3cf35192043c90868ef8ed28681246e999fad5c57806c1e0a6c7c29dc984a69
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards#tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+              output: tanf_100_percent_fpl_countable_net_income_standard_by_ag_size
+              hash: sha256:b3cf35192043c90868ef8ed28681246e999fad5c57806c1e0a6c7c29dc984a69
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          tanf_net_countable_income_for_benefit_calculation < tanf_100_percent_fpl_countable_net_income_standard_by_ag_size[tanf_assistance_group_size_for_100_percent_income_standard]
+
+  - name: tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3450.35.05 Benefit Calculation Continuation, adjusted net income compared with adjusted needs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "If the adjusted net income equals or exceeds the adjusted needs"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+              output: tanf_net_countable_income_for_benefit_calculation
+              hash: sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+              output: tanf_benefit_total_grant_amount_for_participating_ag_members
+              hash: sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          tanf_net_countable_income_for_benefit_calculation >= tanf_benefit_total_grant_amount_for_participating_ag_members
+
+  - name: tanf_ongoing_monthly_benefit_entitlement
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation Continuation, ongoing benefit amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "benefits are determined as above"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "a minimum grant of ten dollars ($10)"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "a zero grant ($0)"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-371
+              excerpt: "earned income and is the sole contributing factor (no sanctions, Voluntary Quit or fiscal penalties)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+              output: tanf_ongoing_countable_income_below_100_percent_fpl
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+              output: tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_minimum_grant_with_earned_income
+              output: tanf_ongoing_minimum_grant_with_earned_income
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+              output: tanf_benefit_total_grant_amount_for_participating_ag_members
+              hash: sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+              output: tanf_net_countable_income_for_benefit_calculation
+              hash: sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99
+    versions:
+      - effective_from: '2026-03-01'
+        formula: |-
+          if tanf_ongoing_countable_income_below_100_percent_fpl: if tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs: if earned_income_is_sole_factor_for_adjusted_net_income_meeting_or_exceeding_adjusted_needs_and_no_penalties: tanf_ongoing_minimum_grant_with_earned_income else: 0 else: max(0, tanf_benefit_total_grant_amount_for_participating_ag_members - tanf_net_countable_income_for_benefit_calculation) else: 0

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.test.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.test.yaml
@@ -1,0 +1,124 @@
+- name: new application benefit for recipient parent children only AG
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : true
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 300
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 50
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 90
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : true
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#input.participating_members
+    : 3
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+    : 513
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_nonexempt_gross_income_for_benefit_calculation
+    : 350
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_and_one_third_earned_income_disregard
+    : 120
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_applicable_earned_income_deductions: 210
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+    : 140
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_financially_eligible_for_benefit_calculation
+    : holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregarded_for_benefit
+    : 225
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_for_benefit
+    : 75
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_countable_income_for_benefit_amount
+    : 125
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_monthly_benefit_entitlement
+    : 388
+- name: new application ineligible when adjusted net income equals or exceeds adjusted
+    needs
+  period: 2026-03
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 900
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#input.participating_members: 1
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+    : 248
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_and_one_third_earned_income_disregard
+    : 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+    : 900
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_financially_eligible_for_benefit_calculation
+    : not_holds
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregarded_for_benefit
+    : 675
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_for_benefit
+    : 225
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_countable_income_for_benefit_amount
+    : 225
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_monthly_benefit_entitlement
+    : 0
+- name: oracle_parameter_tanf_thirty_dollar_earned_income_disregard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
+    : 30
+- name: oracle_parameter_tanf_one_third_earned_income_disregard_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_one_third_earned_income_disregard_rate
+    : '0.3333333333333333333333333333'
+- name: oracle_parameter_tanf_new_application_gross_earned_income_disregard_rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.assistance_group_has_recipient_parent_children_only
+    : false
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.deemed_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.incapacitated_adult_care_expenses: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.monthly_work_expense_disregard_amount
+    : 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_earned_income: 0
+    us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.non_exempt_gross_unearned_income: 0
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#input.tanf_thirty_and_one_third_disregard_applies
+    : false
+  output:
+    ? us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregard_rate
+    : 0.75

--- a/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml
+++ b/us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml
@@ -1,0 +1,370 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+  summary: |-
+    "To determine benefit entitlement for Cash Assistance ... Determine the total grant amount of the participating AG members; Determine the amount of non-exempt gross earned, unearned, and deemed income; Subtract applicable earned income deductions from gross income ... The result is the net countable income." For new applications, adjusted net income at or above adjusted needs makes the AG ineligible; otherwise benefits disregard 75% of gross earned income and apply 25%.
+imports:
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+  - us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+rules:
+  - name: tanf_thirty_dollar_earned_income_disregard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, earned income deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "$30 and 1/3 disregard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: tanf_one_third_earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 3450.35.05 Benefit Calculation, earned income deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "$30 and 1/3 disregard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1 / 3
+
+  - name: tanf_new_application_gross_earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 3450.35.05 Benefit Calculation, new applications
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "disregarding 75% of the gross earned income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.75
+
+  - name: tanf_new_application_gross_earned_income_applied_rate
+    kind: parameter
+    dtype: Rate
+    source: 3450.35.05 Benefit Calculation, new applications
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "applying 25%"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.25
+
+  - name: tanf_benefit_total_grant_amount_for_participating_ag_members
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, total grant amount and 3050.10 maximum benefit reference
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "Determine the total grant amount of the participating AG members"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits#cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+              output: cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+              hash: sha256:e9a1b7a0b2f067e0b8cf338644ae4da6636af195d2784e63406811efa153aa38
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation#cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+              output: cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag
+              hash: sha256:8612ece5dd214dd385fe706f4025fd6da00a40eac454140bf3140a7f2b4bb91c
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          if assistance_group_has_recipient_parent_children_only: cash_assistance_maximum_monthly_benefit_for_recipient_parent_children_only_ag else: cash_assistance_maximum_monthly_benefit_for_recipient_parent_or_caretaker_ag
+
+  - name: tanf_nonexempt_gross_income_for_benefit_calculation
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, non-exempt gross earned, unearned, and deemed income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "Determine the amount of non-exempt gross earned, unearned, and deemed income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, non_exempt_gross_earned_income) + max(0, non_exempt_gross_unearned_income) + max(0, deemed_income)
+
+  - name: tanf_thirty_and_one_third_earned_income_disregard
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, $30 and 1/3 disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "$30 and 1/3 disregard"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
+              output: tanf_thirty_dollar_earned_income_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_one_third_earned_income_disregard_rate
+              output: tanf_one_third_earned_income_disregard_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tanf_thirty_and_one_third_disregard_applies: min(max(0, non_exempt_gross_earned_income), tanf_thirty_dollar_earned_income_disregard) + (tanf_one_third_earned_income_disregard_rate * max(0, non_exempt_gross_earned_income - tanf_thirty_dollar_earned_income_disregard)) else: 0
+
+  - name: tanf_applicable_earned_income_deductions
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, applicable earned income deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "Subtract applicable earned income deductions from gross income, including: work expense disregard, $30 and 1/3 disregard, and incapacitated adult care expenses"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_and_one_third_earned_income_disregard
+              output: tanf_thirty_and_one_third_earned_income_disregard
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, monthly_work_expense_disregard_amount) + tanf_thirty_and_one_third_earned_income_disregard + max(0, incapacitated_adult_care_expenses)
+
+  - name: tanf_net_countable_income_for_benefit_calculation
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, net countable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "The result is the net countable income."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_nonexempt_gross_income_for_benefit_calculation
+              output: tanf_nonexempt_gross_income_for_benefit_calculation
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_applicable_earned_income_deductions
+              output: tanf_applicable_earned_income_deductions
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, tanf_nonexempt_gross_income_for_benefit_calculation - tanf_applicable_earned_income_deductions)
+
+  - name: tanf_new_application_financially_eligible_for_benefit_calculation
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 3450.35.05 Benefit Calculation, new application adjusted net income test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "For new applications, if the adjusted net income equals or exceeds the adjusted needs, the assistance group is ineligible for TANF. If less"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+              output: tanf_net_countable_income_for_benefit_calculation
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+              output: tanf_benefit_total_grant_amount_for_participating_ag_members
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          tanf_net_countable_income_for_benefit_calculation < tanf_benefit_total_grant_amount_for_participating_ag_members
+
+  - name: tanf_new_application_gross_earned_income_disregarded_for_benefit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, new application gross earned income disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "disregarding 75% of the gross earned income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregard_rate
+              output: tanf_new_application_gross_earned_income_disregard_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tanf_new_application_gross_earned_income_disregard_rate * max(0, non_exempt_gross_earned_income)
+
+  - name: tanf_new_application_gross_earned_income_applied_for_benefit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, new application gross earned income applied
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "applying 25%"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_rate
+              output: tanf_new_application_gross_earned_income_applied_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tanf_new_application_gross_earned_income_applied_rate * max(0, non_exempt_gross_earned_income)
+
+  - name: tanf_new_application_countable_income_for_benefit_amount
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, new application benefit amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "benefits are determined by disregarding 75% of the gross earned income and applying 25%"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_for_benefit
+              output: tanf_new_application_gross_earned_income_applied_for_benefit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tanf_new_application_gross_earned_income_applied_for_benefit + max(0, non_exempt_gross_unearned_income) + max(0, deemed_income)
+
+  - name: tanf_new_application_monthly_benefit_entitlement
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 3450.35.05 Benefit Calculation, new application benefit entitlement
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-370
+              excerpt: "If less, the benefits are determined by disregarding 75% of the gross earned income and applying 25%. The maximum benefit amounts are listed at 3050.10."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_financially_eligible_for_benefit_calculation
+              output: tanf_new_application_financially_eligible_for_benefit_calculation
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+              output: tanf_benefit_total_grant_amount_for_participating_ag_members
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_countable_income_for_benefit_amount
+              output: tanf_new_application_countable_income_for_benefit_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-07-01'
+        formula: |-
+          if tanf_new_application_financially_eligible_for_benefit_calculation: max(0, tanf_benefit_total_grant_amount_for_participating_ag_members - tanf_new_application_countable_income_for_benefit_amount) else: 0


### PR DESCRIPTION
## Summary
- encode Indiana TANF 3450.35.05 benefit calculation for new applications
- encode the continuation page for ongoing AG 100% FPG eligibility and $10/$0 grant branches
- update the RuleSpec toolchain pin to axiom-encode 0.2.854 with signed apply manifests

## Validation
- `uv run axiom-encode compile --json .../3450-35-05-benefit-calculation.yaml`
- `uv run axiom-encode compile --json .../3450-35-05-benefit-calculation-continuation.yaml`
- `uv run axiom-encode test --json .../3450-35-05-benefit-calculation.test.yaml .../3450-35-05-benefit-calculation-continuation.test.yaml --root .../rulespec-us/us-in`
- `uv run axiom-encode validate --json --skip-reviewers .../3450-35-05-benefit-calculation.yaml .../3450-35-05-benefit-calculation-continuation.yaml`
- `uv run axiom-encode proof-validate --json .../3450-35-05-benefit-calculation.yaml .../3450-35-05-benefit-calculation-continuation.yaml`
- `uv run axiom-encode guard-generated --root .../rulespec-us/us-in`

## Notes
- This advances Indiana TANF RuleSpec coverage, but `axiom-encode oracle-coverage --program tanf --include-program-surfaces` still reports the PE `in_tanf` surface as `pending_rulespec_encoding` until the oracle registry/mapping is updated.
- The ongoing branch captures the manual's $10 minimum grant and $0 grant language, which appears adjacent rather than identical to PolicyEngine's current `in_tanf` final benefit surface.