### PR TITLE
Encode Medicaid SSI mandatory group

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.868"
+axiom_encode_version = "0.2.871"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "761e49e5c727a596367fae92b57ea53af1a7c765"
+axiom_encode_ref = "5b9cea3fed77ebd1c189b65331ae622aa17b914c"
 axiom_corpus_ref = "0ed2a7d8a5bf3c8ade5919d4079dedbc424593f7"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/regulations/42-cfr/435/120/ssi-mandatory-group.json
+++ b/us/.axiom/encoding-manifests/regulations/42-cfr/435/120/ssi-mandatory-group.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/120/ssi-mandatory-group.yaml",
+      "sha256": "d84ec593f313fc1eeb37c41be5e2503c50ffd709b6c3bd6dac36f2745fde7b2f"
+    },
+    {
+      "path": "regulations/42-cfr/435/120/ssi-mandatory-group.test.yaml",
+      "sha256": "20ab7257974ff370e9b822105f4189e3885a08631270ea670c05a15187b01895"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7249d5fb4dc862f06be3d352f31d3a5347de3207",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.870",
+    "version_commit": "4ede81a5fbfbcc0396cc11a8dbf88db805e1daba"
+  },
+  "axiom_encode_version": "0.2.870",
+  "backend": "codex",
+  "citation": "us/regulation/42/435/120/ssi-mandatory-group",
+  "context_manifest_file": "/tmp/axiom-medicaid-435-120-ssi-apply/_eval_workspaces/codex-gpt-5.5/us-regulation-42-435-120-ssi-mandatory-group/workspace/context-manifest.json",
+  "context_manifest_sha256": "e2d2b473b4cf4e785e1a2ed00f3f2a9d3cb4cdc03fa543a2afcc272c0dd59cd2",
+  "generated_at": "2026-06-26T16:56:58.245387+00:00",
+  "generated_output_file": "/tmp/axiom-medicaid-435-120-ssi-apply/codex-gpt-5.5/regulations/42-cfr/435/120/ssi-mandatory-group.yaml",
+  "generated_output_root": "/tmp/axiom-medicaid-435-120-ssi-apply",
+  "generated_output_sha256": "d84ec593f313fc1eeb37c41be5e2503c50ffd709b6c3bd6dac36f2745fde7b2f",
+  "generation_prompt_sha256": "c21f6b63b883c4448d07921eaab5f2c04d76d2d2aff39890e1f24070f3116b11",
+  "model": "gpt-5.5",
+  "run_id": "f935bcdb",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0277cb9a6ffffe631bfb334cabcd7e29bcdb3e80c5cc7be74afee650e0a72000"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-medicaid-435-120-ssi-apply/traces/codex-gpt-5.5/us-regulation-42-435-120-ssi-mandatory-group.json",
+  "trace_sha256": "45f75926470d18a713618e3a3719643ebe335a4500fde8e14155933edb37fd48"
+}

--- a/us/regulations/42-cfr/435/120/ssi-mandatory-group.test.yaml
+++ b/us/regulations/42-cfr/435/120/ssi-mandatory-group.test.yaml
@@ -1,0 +1,68 @@
+- name: aged_disabled_person_receiving_ssi_must_receive_medicaid
+  period: 2026-01
+  input:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled: true
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi: true
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_pending_final_blindness_or_disability_determination
+    : false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_under_resource_disposal_agreement_with_social_security_administration
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_benefits_under_section_1619_a: false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_in_section_1619_b_status: false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_qualified_severely_impaired_individual_defined_in_section_1905_q
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.section_435_121_allows_other_medicaid_treatment_for_this_person: false
+  output:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group: holds
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group: holds
+- name: section_435_121_exception_blocks_mandatory_group_requirement
+  period: 2026-01
+  input:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled: true
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi: true
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_pending_final_blindness_or_disability_determination
+    : false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_under_resource_disposal_agreement_with_social_security_administration
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_benefits_under_section_1619_a: false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_in_section_1619_b_status: false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_qualified_severely_impaired_individual_defined_in_section_1905_q
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.section_435_121_allows_other_medicaid_treatment_for_this_person: true
+  output:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group: holds
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group: not_holds
+- name: section_1619_b_status_counts_as_receiving_or_deemed_receiving_ssi
+  period: 2026-01
+  input:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled: true
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi: false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_pending_final_blindness_or_disability_determination
+    : false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_under_resource_disposal_agreement_with_social_security_administration
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_benefits_under_section_1619_a: false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_in_section_1619_b_status: true
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_qualified_severely_impaired_individual_defined_in_section_1905_q
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.section_435_121_allows_other_medicaid_treatment_for_this_person: false
+  output:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group: holds
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group: holds
+- name: not_aged_blind_or_disabled_blocks_mandatory_group_requirement
+  period: 2026-01
+  input:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled: false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi: true
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_pending_final_blindness_or_disability_determination
+    : false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_ssi_under_resource_disposal_agreement_with_social_security_administration
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_receives_benefits_under_section_1619_a: false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_in_section_1619_b_status: false
+    ? us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_qualified_severely_impaired_individual_defined_in_section_1905_q
+    : false
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.section_435_121_allows_other_medicaid_treatment_for_this_person: false
+  output:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group: holds
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group: not_holds

--- a/us/regulations/42-cfr/435/120/ssi-mandatory-group.yaml
+++ b/us/regulations/42-cfr/435/120/ssi-mandatory-group.yaml
@@ -1,0 +1,66 @@
+format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/121
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/120
+  summary: |-
+    Except as allowed under § 435.121, the agency must provide Medicaid to aged, blind, and disabled individuals or couples who are receiving or are deemed to be receiving SSI, including SSI pending blindness or disability determination, SSI under resource-disposal agreements, and section 1619(a) or 1619(b) status.
+rules:
+  - name: person_receiving_or_deemed_receiving_ssi_for_mandatory_group
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.120(a)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/42/435/120
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/120
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          person_is_receiving_or_deemed_receiving_ssi
+          or person_receives_ssi_pending_final_blindness_or_disability_determination
+          or person_receives_ssi_under_resource_disposal_agreement_with_social_security_administration
+          or person_receives_benefits_under_section_1619_a
+          or person_is_in_section_1619_b_status
+          or person_is_qualified_severely_impaired_individual_defined_in_section_1905_q
+  - name: medicaid_required_for_ssi_mandatory_group
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.120; exception under 42 CFR 435.121
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/120
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/42/435/120
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group
+              output: person_receiving_or_deemed_receiving_ssi_for_mandatory_group
+              hash: sha256:local
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          person_is_aged_blind_or_disabled
+          and person_receiving_or_deemed_receiving_ssi_for_mandatory_group
+          and not section_435_121_allows_other_medicaid_treatment_for_this_person


### PR DESCRIPTION
## Summary
- encode the 42 CFR 435.120 SSI mandatory Medicaid group prerequisite slice through `axiom-encode --apply`
- add generated tests and signed apply manifest
- bump the RuleSpec validation toolchain to `axiom-encode` `0.2.871` / `5b9cea3f` so CI uses the encoder that classifies the new helper outputs

## PolicyEngine parity impact
- prerequisite Medicaid legal slice for the high-priority PolicyBench Medicaid surface
- the new helper outputs are explicitly classified as not-comparable PolicyEngine intermediates; final `is_medicaid_eligible` parity still needs the PE-facing composite

## Validation
- `env -u UV_FROZEN uv run --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-program-composite-20260626/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-program-composite-20260626/us/regulations/42-cfr/435/120/ssi-mandatory-group.test.yaml --json`
- `env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers --oracle policyengine /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-program-composite-20260626/us/regulations/42-cfr/435/120/ssi-mandatory-group.yaml`
- `env -u UV_FROZEN uv run --extra dev axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-program-composite-20260626/us/regulations/42-cfr/435/120/ssi-mandatory-group.yaml`
- `env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-program-composite-20260626 --base-ref origin/main --head-ref HEAD`
- temporary-root `axiom-encode oracle-coverage --fail-on-unmapped --fail-on-untested-comparable --limit 50` against this PR worktree now passes with `unmapped=0`