### PR TITLE
Encode CHIP eligibility prerequisite slices

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.871"
+axiom_encode_version = "0.2.873"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5b9cea3fed77ebd1c189b65331ae622aa17b914c"
+axiom_encode_ref = "2e4e6d221667c2356fd24d2ee8554a4c441a5369"
 axiom_corpus_ref = "0ed2a7d8a5bf3c8ade5919d4079dedbc424593f7"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1397jj/b/1.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1397jj/b/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1397jj/b/1.yaml",
+      "sha256": "f0461c712e6d889a0cce78f0abf64f873fc62d7b96513ba6e3bd08615dd6ce74"
+    },
+    {
+      "path": "statutes/42/1397jj/b/1.test.yaml",
+      "sha256": "d9815aeb6571d253ec41cfd432d9ac44f002c404e997e9910f697ef2e5770e2f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5b9cea3fed77ebd1c189b65331ae622aa17b914c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.871",
+    "version_commit": "b97ebf3a42a38017a5fbfe889a55603397298bd2"
+  },
+  "axiom_encode_version": "0.2.871",
+  "backend": "codex",
+  "citation": "42 USC 1397jj(b)(1)",
+  "context_manifest_file": "/tmp/axiom-chip-encode-b1-versionfixed/_eval_workspaces/codex-gpt-5.5/42-USC-1397jj-b-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "040f685b49ca1bd3e7e5bdeefed34be5503d31cc3c1bfdaf2a0fc5b7f2914ad5",
+  "generated_at": "2026-06-26T17:15:06.062401+00:00",
+  "generated_output_file": "/tmp/axiom-chip-encode-b1-versionfixed/codex-gpt-5.5/statutes/42/1397jj/b/1.yaml",
+  "generated_output_root": "/tmp/axiom-chip-encode-b1-versionfixed",
+  "generated_output_sha256": "f0461c712e6d889a0cce78f0abf64f873fc62d7b96513ba6e3bd08615dd6ce74",
+  "generation_prompt_sha256": "91879561d5936591e3c3cff57bf3717b2c7555e7b1d8e9785379ab169f3428b2",
+  "model": "gpt-5.5",
+  "run_id": "9e0fc181",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6590726c090cc1b4d9a4f88bd0b04b3c4dfef43e14de363599d35ab7df50409f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-chip-encode-b1-versionfixed/traces/codex-gpt-5.5/42-USC-1397jj-b-1.json",
+  "trace_sha256": "942cefe81ef463086aee22f804726f44be1b45ed8e54c4740dbc27fafb9fb141"
+}

--- a/us/.axiom/encoding-manifests/statutes/42/1397jj/c/1.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1397jj/c/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1397jj/c/1.yaml",
+      "sha256": "5983f9bd1c30a824da826ee4bc8fc3351cd2c631d4a0ce198b156446493ef9e0"
+    },
+    {
+      "path": "statutes/42/1397jj/c/1.test.yaml",
+      "sha256": "f8d61902d3fa4edb5c5e588ddcfe7bea4d544b5f85d59235193a4c2a72f4d1ae"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "761e49e5c727a596367fae92b57ea53af1a7c765",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.868",
+    "version_commit": "ad586450efedcb083f3afb5da3f1c1c17449d811"
+  },
+  "axiom_encode_version": "0.2.868",
+  "backend": "codex",
+  "citation": "42 USC 1397jj(c)(1)",
+  "context_manifest_file": "/tmp/axiom-chip-encode-c1/_eval_workspaces/codex-gpt-5.5/42-USC-1397jj-c-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "da5e7dd047b65c5fa4ec865c5e31870b10a4c8fe7877236b727284c11dee2057",
+  "generated_at": "2026-06-26T16:34:17.591039+00:00",
+  "generated_output_file": "/tmp/axiom-chip-encode-c1/codex-gpt-5.5/statutes/42/1397jj/c/1.yaml",
+  "generated_output_root": "/tmp/axiom-chip-encode-c1",
+  "generated_output_sha256": "5983f9bd1c30a824da826ee4bc8fc3351cd2c631d4a0ce198b156446493ef9e0",
+  "generation_prompt_sha256": "9822bdc1d6b7778d1146bf20224aa21f3002ab84bc57bec8623a534d971d4350",
+  "model": "gpt-5.5",
+  "run_id": "c25d8e24",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cd98481e56d920f9ac6beb8399d192e7109ee7e277c6bcd595a1f4726cc30890"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-chip-encode-c1/traces/codex-gpt-5.5/42-USC-1397jj-c-1.json",
+  "trace_sha256": "a3ef794b46556e660de98e5907fb56e60a7cb274a1a1456322074e1be94f37a6"
+}

--- a/us/.axiom/encoding-manifests/statutes/42/1397jj/c/4.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1397jj/c/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1397jj/c/4.yaml",
+      "sha256": "1118b9f8721a910e8e67b5df8cea0cf101ff26ca1649492b85eb5971fdbcdfcc"
+    },
+    {
+      "path": "statutes/42/1397jj/c/4.test.yaml",
+      "sha256": "d7323bd65efb48a38ca3e42e26cd9813fdf036a38e6c484e2feff67b59b25d26"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c2ba21e468f27af5974abcfdcd3c0a94754bf293",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.869",
+    "version_commit": "eadda4f0af2db7399f099ebe5c81008e27568335"
+  },
+  "axiom_encode_version": "0.2.869",
+  "backend": "codex",
+  "citation": "42 USC 1397jj(c)(4)",
+  "context_manifest_file": "/tmp/axiom-chip-encode-c4/_eval_workspaces/codex-gpt-5.5/42-USC-1397jj-c-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "309aad6cdab0d57abe4fa57e78d1539002338ede772e7658fb67ec3d8548209e",
+  "generated_at": "2026-06-26T16:42:11.918596+00:00",
+  "generated_output_file": "/tmp/axiom-chip-encode-c4/codex-gpt-5.5/statutes/42/1397jj/c/4.yaml",
+  "generated_output_root": "/tmp/axiom-chip-encode-c4",
+  "generated_output_sha256": "1118b9f8721a910e8e67b5df8cea0cf101ff26ca1649492b85eb5971fdbcdfcc",
+  "generation_prompt_sha256": "00cc199f9b96eeb6c5a893072948e7488c05e2291ae5ae3e55c6c84c7227b2ff",
+  "model": "gpt-5.5",
+  "run_id": "8edee571",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "203379aa4f7595d53e5376ed01590c8e54157f3c239758fb46988c4315749f9a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-chip-encode-c4/traces/codex-gpt-5.5/42-USC-1397jj-c-4.json",
+  "trace_sha256": "4636cd59310c854573b67aa7863c4c32a3b8a9afa408f69e49c9bd33a51234cc"
+}

--- a/us/.axiom/encoding-manifests/statutes/42/1397jj/c/8.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1397jj/c/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1397jj/c/8.yaml",
+      "sha256": "cd27b9c59143217d4a6564eba88ac9f5b49f04f932abd7a9198b1155e6e558b0"
+    },
+    {
+      "path": "statutes/42/1397jj/c/8.test.yaml",
+      "sha256": "d3c69d8bf2bdc242c279efdb0cf616ee3ba57f5c11548cac3d9a762739cf57c4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c2ba21e468f27af5974abcfdcd3c0a94754bf293",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.869",
+    "version_commit": "eadda4f0af2db7399f099ebe5c81008e27568335"
+  },
+  "axiom_encode_version": "0.2.869",
+  "backend": "codex",
+  "citation": "42 USC 1397jj(c)(8)",
+  "context_manifest_file": "/tmp/axiom-chip-encode-c8/_eval_workspaces/codex-gpt-5.5/42-USC-1397jj-c-8/workspace/context-manifest.json",
+  "context_manifest_sha256": "35ce8c25017a471c27c36d8cfc9343742c48783b3cee4319e6be360e615d03da",
+  "generated_at": "2026-06-26T16:38:15.445779+00:00",
+  "generated_output_file": "/tmp/axiom-chip-encode-c8/codex-gpt-5.5/statutes/42/1397jj/c/8.yaml",
+  "generated_output_root": "/tmp/axiom-chip-encode-c8",
+  "generated_output_sha256": "cd27b9c59143217d4a6564eba88ac9f5b49f04f932abd7a9198b1155e6e558b0",
+  "generation_prompt_sha256": "af56a7240c69fa542d4f6225358f81637e80529e8653ea982d610bea60670853",
+  "model": "gpt-5.5",
+  "run_id": "8b4826a0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fc7827b12979ec9ce6df0726971912099ec79c2eab741f95e238a8714e1d5087"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-chip-encode-c8/traces/codex-gpt-5.5/42-USC-1397jj-c-8.json",
+  "trace_sha256": "224c327470a5493829cb5a3d16c0dbce477ffec031bfb5588d52320af0b1d717"
+}

--- a/us/statutes/42/1397jj/b/1.test.yaml
+++ b/us/statutes/42/1397jj/b/1.test.yaml
@@ -1,0 +1,88 @@
+- name: low_income_child_with_state_eligibility_and_no_disqualifying_coverage_is_targeted
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 20000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+    us:statutes/42/1397jj/b/1#input.state_determined_eligible_for_child_health_assistance_under_state_plan: true
+    us:statutes/42/1397jj/b/1#input.family_income_exceeds_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.family_income_percentage_points_above_medicaid_applicable_income_level: 0
+    us:statutes/42/1397jj/b/1#input.family_income_does_not_exceed_substituted_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.child_resides_in_state_without_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.paragraph_2_displaces_targeted_low_income_child_definition: false
+    us:statutes/42/1397jj/b/1#input.found_eligible_for_medical_assistance_under_subchapter_xix: false
+    us:statutes/42/1397jj/b/1#input.paragraph_5_displaces_group_health_or_health_insurance_coverage_disqualification: false
+    us:statutes/42/1397jj/b/1#input.covered_under_group_health_plan: false
+    us:statutes/42/1397jj/b/1#input.covered_under_health_insurance_coverage: false
+  output:
+    us:statutes/42/1397jj/b/1#targeted_low_income_child: holds
+- name: child_with_income_within_50_percentage_points_above_medicaid_level_is_targeted
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 30000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+    us:statutes/42/1397jj/b/1#input.state_determined_eligible_for_child_health_assistance_under_state_plan: true
+    us:statutes/42/1397jj/b/1#input.family_income_exceeds_medicaid_applicable_income_level: true
+    us:statutes/42/1397jj/b/1#input.family_income_percentage_points_above_medicaid_applicable_income_level: 0.25
+    us:statutes/42/1397jj/b/1#input.family_income_does_not_exceed_substituted_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.child_resides_in_state_without_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.paragraph_2_displaces_targeted_low_income_child_definition: false
+    us:statutes/42/1397jj/b/1#input.found_eligible_for_medical_assistance_under_subchapter_xix: false
+    us:statutes/42/1397jj/b/1#input.paragraph_5_displaces_group_health_or_health_insurance_coverage_disqualification: false
+    us:statutes/42/1397jj/b/1#input.covered_under_group_health_plan: false
+    us:statutes/42/1397jj/b/1#input.covered_under_health_insurance_coverage: false
+  output:
+    us:statutes/42/1397jj/b/1#targeted_low_income_child: holds
+- name: paragraph_2_displacement_blocks_otherwise_targeted_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 20000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+    us:statutes/42/1397jj/b/1#input.state_determined_eligible_for_child_health_assistance_under_state_plan: true
+    us:statutes/42/1397jj/b/1#input.family_income_exceeds_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.family_income_percentage_points_above_medicaid_applicable_income_level: 0
+    us:statutes/42/1397jj/b/1#input.family_income_does_not_exceed_substituted_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.child_resides_in_state_without_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.paragraph_2_displaces_targeted_low_income_child_definition: true
+    us:statutes/42/1397jj/b/1#input.found_eligible_for_medical_assistance_under_subchapter_xix: false
+    us:statutes/42/1397jj/b/1#input.paragraph_5_displaces_group_health_or_health_insurance_coverage_disqualification: false
+    us:statutes/42/1397jj/b/1#input.covered_under_group_health_plan: false
+    us:statutes/42/1397jj/b/1#input.covered_under_health_insurance_coverage: false
+  output:
+    us:statutes/42/1397jj/b/1#targeted_low_income_child: not_holds
+- name: group_health_plan_coverage_blocks_unless_paragraph_5_displaces_disqualification
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 20000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+    us:statutes/42/1397jj/b/1#input.state_determined_eligible_for_child_health_assistance_under_state_plan: true
+    us:statutes/42/1397jj/b/1#input.family_income_exceeds_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.family_income_percentage_points_above_medicaid_applicable_income_level: 0
+    us:statutes/42/1397jj/b/1#input.family_income_does_not_exceed_substituted_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.child_resides_in_state_without_medicaid_applicable_income_level: false
+    us:statutes/42/1397jj/b/1#input.paragraph_2_displaces_targeted_low_income_child_definition: false
+    us:statutes/42/1397jj/b/1#input.found_eligible_for_medical_assistance_under_subchapter_xix: false
+    us:statutes/42/1397jj/b/1#input.paragraph_5_displaces_group_health_or_health_insurance_coverage_disqualification: true
+    us:statutes/42/1397jj/b/1#input.covered_under_group_health_plan: true
+    us:statutes/42/1397jj/b/1#input.covered_under_health_insurance_coverage: false
+  output:
+    us:statutes/42/1397jj/b/1#targeted_low_income_child: holds

--- a/us/statutes/42/1397jj/b/1.yaml
+++ b/us/statutes/42/1397jj/b/1.yaml
@@ -1,0 +1,82 @@
+format: rulespec/v1
+imports:
+  - us:statutes/42/1397jj/c/1#child
+  - us:statutes/42/1397jj/c/4#low_income_child
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1397jj/b/1
+  summary: |-
+    Subject to paragraph (2), "targeted low-income child" means a child determined eligible by the State for child health assistance, meeting the low-income or specified Medicaid-income-level alternatives, and not found Medicaid-eligible or covered by group health plan or health insurance coverage subject to paragraph (5).
+rules:
+  - name: medicaid_applicable_income_level_additional_percentage_points
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1397jj(b)(1)(B)(ii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1397jj/b/1
+              excerpt: 50 percentage points above the medicaid applicable income level
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          0.50
+
+  - name: targeted_low_income_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397jj(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/42/1397jj/b/1
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1397jj/c/1#child
+              output: child
+              hash: sha256:5983f9bd1c30a824da826ee4bc8fc3351cd2c631d4a0ce198b156446493ef9e0
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1397jj/c/4#low_income_child
+              output: low_income_child
+              hash: sha256:1118b9f8721a910e8e67b5df8cea0cf101ff26ca1649492b85eb5971fdbcdfcc
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          child
+          and state_determined_eligible_for_child_health_assistance_under_state_plan
+          and (
+            low_income_child
+            or (
+              child
+              and (
+                (
+                  family_income_exceeds_medicaid_applicable_income_level
+                  and family_income_percentage_points_above_medicaid_applicable_income_level <= medicaid_applicable_income_level_additional_percentage_points
+                )
+                or family_income_does_not_exceed_substituted_medicaid_applicable_income_level
+                or child_resides_in_state_without_medicaid_applicable_income_level
+              )
+            )
+          )
+          and not paragraph_2_displaces_targeted_low_income_child_definition
+          and not found_eligible_for_medical_assistance_under_subchapter_xix
+          and (
+            paragraph_5_displaces_group_health_or_health_insurance_coverage_disqualification
+            or (
+              not covered_under_group_health_plan
+              and not covered_under_health_insurance_coverage
+            )
+          )

--- a/us/statutes/42/1397jj/c/1.test.yaml
+++ b/us/statutes/42/1397jj/c/1.test.yaml
@@ -1,0 +1,20 @@
+- name: individual_under_19_is_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+  output:
+    us:statutes/42/1397jj/c/1#child: holds
+- name: individual_age_19_is_not_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 19
+  output:
+    us:statutes/42/1397jj/c/1#child: not_holds

--- a/us/statutes/42/1397jj/c/1.yaml
+++ b/us/statutes/42/1397jj/c/1.yaml
@@ -1,0 +1,43 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1397jj/c/1
+  summary: |-
+    The term "child" means an individual under 19 years of age.
+rules:
+  - name: child_age_limit
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1397jj(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1397jj/c/1
+              excerpt: under 19 years of age
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          19
+
+  - name: child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397jj(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/42/1397jj/c/1
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          age < child_age_limit

--- a/us/statutes/42/1397jj/c/4.test.yaml
+++ b/us/statutes/42/1397jj/c/4.test.yaml
@@ -1,0 +1,36 @@
+- name: child_at_200_percent_poverty_line_is_low_income_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 20000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+  output:
+    us:statutes/42/1397jj/c/4#low_income_child: holds
+- name: child_above_200_percent_poverty_line_is_not_low_income_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/4#input.family_income: 20001
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+  output:
+    us:statutes/42/1397jj/c/4#low_income_child: not_holds
+- name: non_child_below_income_limit_is_not_low_income_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 19
+    us:statutes/42/1397jj/c/4#input.family_income: 10000
+    us:statutes/42/1397jj/c/4#input.poverty_line_for_family_size: 10000
+  output:
+    us:statutes/42/1397jj/c/4#low_income_child: not_holds

--- a/us/statutes/42/1397jj/c/4.yaml
+++ b/us/statutes/42/1397jj/c/4.yaml
@@ -1,0 +1,52 @@
+format: rulespec/v1
+imports:
+  - us:statutes/42/1397jj/c/1#child
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1397jj/c/4
+  summary: |-
+    The term "low-income child" means a child whose family income is at or below 200 percent of the poverty line for a family of the size involved.
+rules:
+  - name: low_income_child_family_income_limit
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1397jj(c)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1397jj/c/4
+              excerpt: 200 percent of the poverty line
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          2.00
+
+  - name: low_income_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397jj(c)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/42/1397jj/c/4
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1397jj/c/1#child
+              output: child
+              hash: sha256:5983f9bd1c30a824da826ee4bc8fc3351cd2c631d4a0ce198b156446493ef9e0
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          child
+          and family_income <= low_income_child_family_income_limit * poverty_line_for_family_size

--- a/us/statutes/42/1397jj/c/8.test.yaml
+++ b/us/statutes/42/1397jj/c/8.test.yaml
@@ -1,0 +1,33 @@
+- name: child_without_creditable_health_coverage_is_uncovered_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/8#input.has_creditable_health_coverage: false
+  output:
+    us:statutes/42/1397jj/c/8#uncovered_child: holds
+- name: child_with_creditable_health_coverage_is_not_uncovered_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 18
+    us:statutes/42/1397jj/c/8#input.has_creditable_health_coverage: true
+  output:
+    us:statutes/42/1397jj/c/8#uncovered_child: not_holds
+- name: covered_status_does_not_make_non_child_uncovered_child
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us:statutes/42/1397jj/c/1#input.age: 19
+    us:statutes/42/1397jj/c/8#input.has_creditable_health_coverage: false
+  output:
+    us:statutes/42/1397jj/c/8#uncovered_child: not_holds

--- a/us/statutes/42/1397jj/c/8.yaml
+++ b/us/statutes/42/1397jj/c/8.yaml
@@ -1,0 +1,35 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1397jj/c/8
+  summary: |-
+    The term "uncovered child" means a child that does not have creditable health coverage.
+imports:
+  - us:statutes/42/1397jj/c/1#child
+rules:
+  - name: uncovered_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397jj(c)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1397jj/c/1#child
+              output: child
+              hash: sha256:5983f9bd1c30a824da826ee4bc8fc3351cd2c631d4a0ce198b156446493ef9e0
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/42/1397jj/c/8
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          child
+          and not has_creditable_health_coverage


### PR DESCRIPTION
## Summary
- encode CHIP targeted low-income child definition at 42 USC 1397jj(b)(1)
- encode CHIP child definition prerequisites at 42 USC 1397jj(c)(1), (c)(4), and (c)(8)
- add generated tests and encoder manifests for all four slices

## PolicyEngine parity
- advances the active PolicyBench CHIP surface: is_chip_eligible
- local oracle coverage for program chip passes with comparable=1, known_not_comparable=7, unmapped=0, untested comparable=0

## Tests
- env -u UV_FROZEN uv run --extra dev axiom-encode test --root .../rulespec-us-chip-pe-parity-20260626/us ...1397jj/b/1.test.yaml ...1397jj/c/1.test.yaml ...1397jj/c/4.test.yaml ...1397jj/c/8.test.yaml --json
- env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers ...1397jj/b/1.yaml ...1397jj/c/1.yaml ...1397jj/c/4.yaml ...1397jj/c/8.yaml
- env -u UV_FROZEN uv run --extra dev axiom-encode proof-validate ...1397jj/b/1.yaml ...1397jj/c/1.yaml ...1397jj/c/4.yaml ...1397jj/c/8.yaml
- env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-chip-root.* --program chip --fail-on-unmapped --fail-on-untested-comparable --limit 20
