### PR TITLE
Encode Medicare ALS eligibility prerequisite

### DIFF
--- a/us/.axiom/encoding-manifests/statutes/42/426/h/1.json
+++ b/us/.axiom/encoding-manifests/statutes/42/426/h/1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/426/h/1.yaml",
+      "sha256": "dac48283e3a11a6b6eb84ca0f08307e8f381ecbd470b184c13b27da34f58f49f"
+    },
+    {
+      "path": "statutes/42/426/h/1.test.yaml",
+      "sha256": "83620daf9fde1e1be801184dc3766a44841011e1a3ed50a0db38c15e7ea8deb2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b97ebf3a42a38017a5fbfe889a55603397298bd2",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.871",
+    "version_commit": "b97ebf3a42a38017a5fbfe889a55603397298bd2"
+  },
+  "axiom_encode_version": "0.2.871",
+  "backend": "codex",
+  "citation": "42 USC 426(h)(1)",
+  "context_manifest_file": "/tmp/axiom-encode-medicare-426h1-20260626/_eval_workspaces/codex-gpt-5.5/42-USC-426-h-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "412f034af177aa4dc35f805542f57d7eaa1f6cec7fe04c9e8b8cbdfce6ab6b4b",
+  "generated_at": "2026-06-26T17:10:46.550152+00:00",
+  "generated_output_file": "/tmp/axiom-encode-medicare-426h1-20260626/codex-gpt-5.5/statutes/42/426/h/1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-medicare-426h1-20260626",
+  "generated_output_sha256": "dac48283e3a11a6b6eb84ca0f08307e8f381ecbd470b184c13b27da34f58f49f",
+  "generation_prompt_sha256": "ad583a9af2ab0ef5df2bc121048665954848a1020cbc7fcbe2ac9edb82ec4dc3",
+  "model": "gpt-5.5",
+  "run_id": "2d9809dd",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7c68f6c2efe8b5f48de2dcbf93cb567b42c5354c40545b2f564df334ad1c4e84"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-medicare-426h1-20260626/traces/codex-gpt-5.5/42-USC-426-h-1.json",
+  "trace_sha256": "237b62697f7ca150bd7aad73897bfafff5c6cd4235d39976e2a1ddc339c22d80"
+}

--- a/us/statutes/42/426/h/1.test.yaml
+++ b/us/statutes/42/426/h/1.test.yaml
@@ -1,0 +1,12 @@
+- name: one_month_satisfies_subsection_h_period_requirement
+  period: 2024-01
+  input:
+    us:statutes/42/426/h/1#input.months_of_entitlement_to_benefits_or_status_for_applying_subsection_b: 1
+  output:
+    us:statutes/42/426/h/1#entitlement_or_status_period_requirement_satisfied_under_subsection_h: holds
+- name: no_months_do_not_satisfy_subsection_h_period_requirement
+  period: 2024-01
+  input:
+    us:statutes/42/426/h/1#input.months_of_entitlement_to_benefits_or_status_for_applying_subsection_b: 0
+  output:
+    us:statutes/42/426/h/1#entitlement_or_status_period_requirement_satisfied_under_subsection_h: not_holds

--- a/us/statutes/42/426/h/1.yaml
+++ b/us/statutes/42/426/h/1.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/426/h/1
+  summary: |-
+    Subsection (b) shall be applied as if there were no requirement for any entitlement to benefits, or status, for a period longer than 1 month.
+rules:
+  - name: maximum_entitlement_or_status_month_requirement_under_subsection_h
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 426(h)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426/h/1
+              excerpt: "no requirement for any entitlement to benefits, or status, for a period longer than 1 month"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1
+
+  - name: entitlement_or_status_period_requirement_satisfied_under_subsection_h
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 U.S.C. 426(h)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/h/1
+              excerpt: "Subsection (b) shall be applied"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/42/426/h/1
+              excerpt: "as if there were no requirement ... for a period longer than 1 month"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/426/h/1#maximum_entitlement_or_status_month_requirement_under_subsection_h
+              output: maximum_entitlement_or_status_month_requirement_under_subsection_h
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          months_of_entitlement_to_benefits_or_status_for_applying_subsection_b >= maximum_entitlement_or_status_month_requirement_under_subsection_h


### PR DESCRIPTION
## Summary
- encode the Medicare ALS waiting-period prerequisite at 42 USC 426(h)(1)
- add generated tests and encoder manifest

## PolicyEngine parity
- advances the active PolicyBench Medicare surface: is_medicare_eligible
- local oracle coverage for program medicare passes with comparable=3, known_not_comparable=38, unmapped=0, untested comparable=0

## Tests
- env -u UV_FROZEN uv run --extra dev axiom-encode test --root .../rulespec-us-medicare-pe-parity-20260626/us ...426/h/1.test.yaml --json
- env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers ...426/h/1.yaml
- env -u UV_FROZEN uv run --extra dev axiom-encode proof-validate ...426/h/1.yaml
- env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-medicare-root.* --program medicare --fail-on-unmapped --fail-on-untested-comparable --limit 20
