### PR TITLE
Encode ACA PTC applicable taxpayer prerequisite

### DIFF
--- a/us/.axiom/encoding-manifests/statutes/26/36B/c/1/A.json
+++ b/us/.axiom/encoding-manifests/statutes/26/36B/c/1/A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/36B/c/1/A.yaml",
+      "sha256": "b1b33c37930a88162b703528d39dd2c81b236076d578b88331ae4b73e245f2fe"
+    },
+    {
+      "path": "statutes/26/36B/c/1/A.test.yaml",
+      "sha256": "30b019528a48dc24e1bbfe972d184611b8ca5aff425b3538a97ce82f1564982f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "761e49e5c727a596367fae92b57ea53af1a7c765",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-rulespec-us-pinned-0.2.868",
+    "version": "0.2.868",
+    "version_commit": "ad586450efedcb083f3afb5da3f1c1c17449d811"
+  },
+  "axiom_encode_version": "0.2.868",
+  "backend": "openai",
+  "citation": "26 USC 36B(c)(1)(A)",
+  "context_manifest_file": "/tmp/axiom-encode-aca-ptc-36b-c-1-a/_eval_workspaces/openai-gpt-5.5/26-USC-36B-c-1-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "de4ee4b2a38fb1bc96bf72b18a6fd289785334780b27ffe1eab679361d3e6aad",
+  "generated_at": "2026-06-26T17:10:21.213291+00:00",
+  "generated_output_file": "/tmp/axiom-encode-aca-ptc-36b-c-1-a/openai-gpt-5.5/statutes/26/36B/c/1/A.yaml",
+  "generated_output_root": "/tmp/axiom-encode-aca-ptc-36b-c-1-a",
+  "generated_output_sha256": "b1b33c37930a88162b703528d39dd2c81b236076d578b88331ae4b73e245f2fe",
+  "generation_prompt_sha256": "c3b6279a71b953c91d941645e2a4076cfb1ebd23bbd8c10dabaacded8822021e",
+  "model": "gpt-5.5",
+  "run_id": "842c47ba",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8d9f671e8af10faf9b35c7a5e46a0938a544386ead76bd30fff69614bd7e257d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-aca-ptc-36b-c-1-a/traces/openai-gpt-5.5/26-USC-36B-c-1-A.json",
+  "trace_sha256": "7fda0ecf8e3dc951b388a17a33201d57092c43e37a604d149e590bbe6550586a"
+}

--- a/us/statutes/26/36B/c/1/A.test.yaml
+++ b/us/statutes/26/36B/c/1/A.test.yaml
@@ -1,0 +1,30 @@
+- name: household_income_between_100_and_400_percent_of_poverty_line
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/36B/c/1/A#input.household_income_for_taxable_year: 25000
+    us:statutes/26/36B/c/1/A#input.poverty_line_for_family_size_involved: 10000
+  output:
+    us:statutes/26/36B/c/1/A#applicable_taxpayer: holds
+- name: household_income_below_100_percent_of_poverty_line
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/36B/c/1/A#input.household_income_for_taxable_year: 9000
+    us:statutes/26/36B/c/1/A#input.poverty_line_for_family_size_involved: 10000
+  output:
+    us:statutes/26/36B/c/1/A#applicable_taxpayer: not_holds
+- name: household_income_above_400_percent_of_poverty_line
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/36B/c/1/A#input.household_income_for_taxable_year: 45000
+    us:statutes/26/36B/c/1/A#input.poverty_line_for_family_size_involved: 10000
+  output:
+    us:statutes/26/36B/c/1/A#applicable_taxpayer: not_holds

--- a/us/statutes/26/36B/c/1/A.yaml
+++ b/us/statutes/26/36B/c/1/A.yaml
@@ -1,0 +1,74 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/36B/c/1/A
+  summary: |-
+    “applicable taxpayer” means a taxpayer whose household income equals or exceeds 100 percent but does not exceed 400 percent of the poverty line for the family size involved.
+rules:
+  - name: applicable_taxpayer_lower_poverty_line_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 36B(c)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/36B/c/1/A
+              excerpt: "equals or exceeds 100 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1.00
+
+  - name: applicable_taxpayer_upper_poverty_line_percentage
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 36B(c)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/36B/c/1/A
+              excerpt: "does not exceed 400 percent"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4.00
+
+  - name: applicable_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 36B(c)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/36B/c/1/A
+              excerpt: "taxpayer whose household income for the taxable year equals or exceeds 100 percent but does not exceed 400 percent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/c/1/A#applicable_taxpayer_lower_poverty_line_percentage
+              output: applicable_taxpayer_lower_poverty_line_percentage
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B/c/1/A#applicable_taxpayer_upper_poverty_line_percentage
+              output: applicable_taxpayer_upper_poverty_line_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          household_income_for_taxable_year >= applicable_taxpayer_lower_poverty_line_percentage * poverty_line_for_family_size_involved
+          and household_income_for_taxable_year <= applicable_taxpayer_upper_poverty_line_percentage * poverty_line_for_family_size_involved


### PR DESCRIPTION
## Summary
- encode the ACA PTC applicable-taxpayer prerequisite at 26 USC 36B(c)(1)(A)
- add generated RuleSpec tests and encoding manifest for the provision slice
- rely on the merged axiom-encode 0.2.873 oracle mappings for non-comparable helper outputs

## Validation
- `env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-aca-ptc-prereq-slice --base-ref origin/main --head-ref HEAD`
- `env -u UV_FROZEN uv run --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-aca-ptc-prereq-slice/us /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-aca-ptc-prereq-slice/us/statutes/26/36B/c/1/A.test.yaml --json`
- `env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-aca-ptc-prereq-slice/us/statutes/26/36B/c/1/A.yaml`
- `env -u UV_FROZEN uv run --extra dev axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-aca-ptc-prereq-slice/us/statutes/26/36B/c/1/A.yaml`
- `env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root <temp-root> --program aca_ptc --fail-on-unmapped --fail-on-untested-comparable --limit 20`
