### PR TITLE
Encode CMS Medicare eligibility surface

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.883"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
 axiom_encode_ref = "21a1fdb57cc647bb48a7aad8116fbe1afcb4a8e0"
-axiom_corpus_ref = "0ed2a7d8a5bf3c8ade5919d4079dedbc424593f7"
+axiom_corpus_ref = "04b0b92b98ad0696b6d2063eb0bc8fa05f73922f"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/us/.axiom/encoding-manifests/policies/cms/original-medicare-part-a-b.json
+++ b/us/.axiom/encoding-manifests/policies/cms/original-medicare-part-a-b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/cms/original-medicare-part-a-b.yaml",
+      "sha256": "e2fae9e3903727709a7f6fbd4d6ea3d5456552be54c916ee25da9a11fefdcbf0"
+    },
+    {
+      "path": "policies/cms/original-medicare-part-a-b.test.yaml",
+      "sha256": "0dfc2d96f64c041894dbf856f21dfb0c870d82f88beafaade5d4dbe4dbd6ed7b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1bde801e631e199a1832ab757a0bd0f241abdc15",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/medicare-pe-encode-20260626",
+    "version": "0.2.877",
+    "version_commit": "1bde801e631e199a1832ab757a0bd0f241abdc15"
+  },
+  "axiom_encode_version": "0.2.877",
+  "backend": "deterministic",
+  "citation": "us:policies/cms/original-medicare-part-a-b",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-26T18:55:48.949416+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5sno8og2/deterministic-repair/policies/cms/original-medicare-part-a-b.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5sno8og2",
+  "generated_output_sha256": "e2fae9e3903727709a7f6fbd4d6ea3d5456552be54c916ee25da9a11fefdcbf0",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8d9cd11740279c39653ac3d266bc97e42fbcd1dd4af9033097c9b7f795f2acdb"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/policies/cms/original-medicare-part-a-b.test.yaml
+++ b/us/policies/cms/original-medicare-part-a-b.test.yaml
@@ -1,0 +1,68 @@
+- name: coverage begins month after IEP enrollment
+  period: 2024-01
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: true
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: true
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 0
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 0
+  output:
+    us:policies/cms/original-medicare-part-a-b#enrolled_during_initial_enrollment_period_coverage_begins_next_month: holds
+    us:policies/cms/original-medicare-part-a-b#disabled_individual_automatically_enrolled: not_holds
+    us:policies/cms/original-medicare-part-a-b#is_medicare_eligible: holds
+- name: IEP enrollment without next-month coverage month
+  period: 2024-01
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: true
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: false
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 0
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 0
+  output:
+    us:policies/cms/original-medicare-part-a-b#enrolled_during_initial_enrollment_period_coverage_begins_next_month: not_holds
+    us:policies/cms/original-medicare-part-a-b#disabled_individual_automatically_enrolled: not_holds
+    us:policies/cms/original-medicare-part-a-b#is_medicare_eligible: not_holds
+- name: disability automatic enrollment after 24 months
+  period: 2024-01
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: false
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: false
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 24
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 0
+  output:
+    us:policies/cms/original-medicare-part-a-b#enrolled_during_initial_enrollment_period_coverage_begins_next_month: not_holds
+    us:policies/cms/original-medicare-part-a-b#disabled_individual_automatically_enrolled: holds
+    us:policies/cms/original-medicare-part-a-b#is_medicare_eligible: holds
+- name: disability entitlement begins in 25th month
+  period: 2024-01
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: false
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: false
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 0
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 25
+  output:
+    us:policies/cms/original-medicare-part-a-b#enrolled_during_initial_enrollment_period_coverage_begins_next_month: not_holds
+    us:policies/cms/original-medicare-part-a-b#disabled_individual_automatically_enrolled: not_holds
+    us:policies/cms/original-medicare-part-a-b#is_medicare_eligible: holds
+- name: oracle_parameter_medicare_age_trigger_years
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: false
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: false
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 0
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 0
+  output:
+    us:policies/cms/original-medicare-part-a-b#medicare_age_trigger_years: 65
+- name: oracle_parameter_disability_auto_enrollment_months
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment: false
+    us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period: false
+    us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement: 0
+    us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits: 0
+  output:
+    us:policies/cms/original-medicare-part-a-b#disability_auto_enrollment_months: 24

--- a/us/policies/cms/original-medicare-part-a-b.yaml
+++ b/us/policies/cms/original-medicare-part-a-b.yaml
@@ -1,0 +1,168 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+  summary: |-
+    The IEP is a 7-month period beginning 3 months before the month a person turns 65, including the birthday month, and ending 3 months after. For disability-based Medicare under age 65, entitlement begins with the 25th month of disability benefit entitlement; disabled individuals are automatically enrolled in Part A and Part B after 24 months of Social Security disability benefits. Coverage begins the month after enrollment during the IEP.
+rules:
+  - name: initial_enrollment_period_total_months
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, initial enrollment period
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "The IEP is a 7-month period"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          7
+
+  - name: months_before_trigger_month_in_initial_enrollment_period
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, initial enrollment period
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "begins 3 months before"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: months_after_trigger_month_in_initial_enrollment_period
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, initial enrollment period
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "ends 3 months after"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: medicare_age_trigger_years
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, age-based IEP trigger
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "the month a person turns 65"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+
+  - name: disability_entitlement_trigger_month
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, disability entitlement trigger
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "entitlement begins with the 25th month"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          25
+
+  - name: disability_auto_enrollment_months
+    kind: parameter
+    dtype: Count
+    source: CMS Original Medicare Part A/B guidance, disability automatic enrollment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "after they have received disability benefits from Social Security for 24 months"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          24
+
+  - name: enrolled_during_initial_enrollment_period_coverage_begins_next_month
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: CMS Original Medicare Part A/B guidance, IEP coverage start
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          enrolled_during_initial_enrollment_period
+          and coverage_month_is_month_after_enrollment
+
+  - name: disabled_individual_automatically_enrolled
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: CMS Original Medicare Part A/B guidance, disability automatic enrollment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+              excerpt: "Disabled individuals are automatically enrolled in Medicare Part A and Part B after they have received disability benefits from Social Security for 24 months."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          months_received_social_security_disability_benefits >= disability_auto_enrollment_months
+
+  - name: is_medicare_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: CMS Original Medicare Part A/B guidance, Medicare entitlement and coverage
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/guidance/cms/original-medicare-part-a-b/block-11
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          enrolled_during_initial_enrollment_period_coverage_begins_next_month
+          or disabled_individual_automatically_enrolled
+          or months_of_disability_benefit_entitlement >= disability_entitlement_trigger_month


### PR DESCRIPTION
## Summary
- add RuleSpec for the simplified PE-facing Medicare eligibility surface from CMS Original Medicare Part A and B
- encode age-65 eligibility and 24-month disability auto-enrollment/entitlement paths
- add oracle parameter tests for the comparable Medicare age and disability-month thresholds

## Dependency
- Depends on corpus source PR: https://github.com/TheAxiomFoundation/axiom-corpus/pull/135

## Checks
- AXIOM_CORPUS_REPO=/Users/maxghenis/_axiom-worktrees/medicare-pe-corpus-20260626 uv run --project /Users/maxghenis/_axiom-worktrees/medicare-pe-encode-20260626 axiom-encode validate --skip-reviewers policies/cms/original-medicare-part-a-b.yaml
- uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/medicare-pe-rulespec-20260626/us/policies/cms/original-medicare-part-a-b.yaml
- uv run axiom-encode test --root /Users/maxghenis/_axiom-worktrees/medicare-pe-rulespec-20260626/us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine /Users/maxghenis/_axiom-worktrees/medicare-pe-rulespec-20260626/us/policies/cms/original-medicare-part-a-b.test.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/_axiom-worktrees/medicare-pe-rulespec-20260626 --base-ref origin/main --head-ref HEAD --roots us --json