### PR TITLE
Encode Illinois SCRETD

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.883"
+axiom_encode_version = "0.2.886"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "21a1fdb57cc647bb48a7aad8116fbe1afcb4a8e0"
-axiom_corpus_ref = "04b0b92b98ad0696b6d2063eb0bc8fa05f73922f"
+axiom_encode_ref = "5696c9b31e8bf04c3866f76a45983e29a3fd69ce"
+axiom_corpus_ref = "2c581691928128f6966533ac6048cfb11620e514"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/programs/us-il/scretd/fy-2026.yaml
+++ b/programs/us-il/scretd/fy-2026.yaml
@@ -1,0 +1,15 @@
+# Illinois Senior Citizens Real Estate Tax Deferral -- tax year 2026
+#
+# Composes the statutory deferral amount from 320 ILCS 30/2 definitions and
+# 320 ILCS 30/3 application, agreement, cap, fund, and equity-cap rules.
+
+program: us-il/scretd
+period: '2026'
+
+outputs:
+  - il_scretd_deferral_amount
+
+scope:
+  state:
+    - statutes/320/30/2
+    - statutes/320/30/3

--- a/us-il/.axiom/encoding-manifests/statutes/320/30/2.json
+++ b/us-il/.axiom/encoding-manifests/statutes/320/30/2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/320/30/2.yaml",
+      "sha256": "934679228fbfd0921adacdb259e9c4711ecc08211e21276ad0b603aefa0d9550"
+    },
+    {
+      "path": "statutes/320/30/2.test.yaml",
+      "sha256": "3519268f59659b5faea45789e4ab8f973f67591f1a23c35bb1bbe3b545ffc177"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2737665ec741f65abf4f48324f2c8361e8d19009",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.884",
+    "version_commit": "2737665ec741f65abf4f48324f2c8361e8d19009"
+  },
+  "axiom_encode_version": "0.2.884",
+  "backend": "codex",
+  "citation": "us-il/statute/320/30/2",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-il-statute-320-30-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "a4b1ab68c898cf69d70009e6786c7ea59835c6bd4903cd8d01034670c0993e21",
+  "generated_at": "2026-06-26T22:21:44.612590+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/320/30/2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "934679228fbfd0921adacdb259e9c4711ecc08211e21276ad0b603aefa0d9550",
+  "generation_prompt_sha256": "c87717346f706dd51645d995eb6bb78f49e0a22a017f78527a0b9b1f638f05aa",
+  "model": "gpt-5.5",
+  "run_id": "2ff66793",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b1c8fbc2b2b3c258efdd58f2b85adf99f0352fbdd37b99ca60680339534ac637"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-il-statute-320-30-2.json",
+  "trace_sha256": "716c5ce28adf0123ade1d7b04566e1cfeda3bf108f39a9d02bec5c22e203b963"
+}

--- a/us-il/.axiom/encoding-manifests/statutes/320/30/3.json
+++ b/us-il/.axiom/encoding-manifests/statutes/320/30/3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/320/30/3.yaml",
+      "sha256": "931a9af9c902eaa2da249aa9993e18f48c8f4bb47563bcbbeffee78ccc2c6120"
+    },
+    {
+      "path": "statutes/320/30/3.test.yaml",
+      "sha256": "46e046d2700ff98e581001eb3c9cf515a61956ebf1d359f203fbda6eeefda143"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2737665ec741f65abf4f48324f2c8361e8d19009",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.884",
+    "version_commit": "2737665ec741f65abf4f48324f2c8361e8d19009"
+  },
+  "axiom_encode_version": "0.2.884",
+  "backend": "codex",
+  "citation": "us-il/statute/320/30/3",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-il-statute-320-30-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "3cc7a214983155f15a9d7a71afb9b4f54008e1aff9470e2b4c190f428662c555",
+  "generated_at": "2026-06-26T22:38:35.718672+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/320/30/3.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "931a9af9c902eaa2da249aa9993e18f48c8f4bb47563bcbbeffee78ccc2c6120",
+  "generation_prompt_sha256": "a099b3f50b58622915b5d830b2ad10e5991f10647217c73cfb79ca61f827cf87",
+  "model": "gpt-5.5",
+  "run_id": "fcb398bd",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bffa4d66df731a019281feaaff4b1ca62f01075fb86515159aa7b3bd1d64ec78"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-il-statute-320-30-3.json",
+  "trace_sha256": "13cb861c4e8c0dfc481e512e207ae31a3f744e6e4fce3114df71b68bec464226"
+}

--- a/us-il/statutes/320/30/2.test.yaml
+++ b/us-il/statutes/320/30/2.test.yaml
@@ -1,0 +1,84 @@
+- name: qualified taxpayer holds for 2025 income at threshold
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-il:statutes/320/30/2#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    ? us-il:statutes/320/30/2#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/2#input.household_income: 75000
+  output:
+    us-il:statutes/320/30/2#household_income_no_greater_than_maximum: holds
+- name: qualified taxpayer holds for 2025 income at threshold_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-il:statutes/320/30/2#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    ? us-il:statutes/320/30/2#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/2#input.household_income: 75000
+  output:
+    us-il:statutes/320/30/2#qualified_taxpayer: holds
+- name: qualified taxpayer fails when income exceeds 2026 maximum
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/320/30/2#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    ? us-il:statutes/320/30/2#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/2#input.household_income: 77001
+  output:
+    us-il:statutes/320/30/2#household_income_no_greater_than_maximum: not_holds
+- name: qualified taxpayer fails when income exceeds 2026 maximum_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/320/30/2#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    ? us-il:statutes/320/30/2#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/2#input.household_income: 77001
+  output:
+    us-il:statutes/320/30/2#qualified_taxpayer: not_holds
+- name: homestead and qualifying property hold for occupied non-income property
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: false
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/2#homestead: holds
+    us-il:statutes/320/30/2#qualifying_property: holds
+- name: qualifying property fails with unpaid real estate tax lien
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: true
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/2#homestead: holds
+    us-il:statutes/320/30/2#qualifying_property: not_holds

--- a/us-il/statutes/320/30/2.yaml
+++ b/us-il/statutes/320/30/2.yaml
@@ -1,0 +1,169 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/320/30/2
+  summary: Definitions include "Qualified Taxpayer", "Tax deferred property", "Homestead",
+    "Real estate taxes", "Department", "Qualifying property", "Equity interest", "Household
+    income", "Collector", and "Maximum household income"; maximum household income
+    is $40,000 through tax year 2005, $50,000 for 2006 through 2011, $55,000 for 2012
+    through 2021, $65,000 for 2022 through 2024, $75,000 for 2025, $77,000 for 2026,
+    and $79,000 for 2027 and thereafter.
+  deferred_outputs:
+  - output: us-il:statutes/320/30/2/30_b#tax_deferred_property
+    reason: The definition identifies property on which taxes are deferred under the
+      Act; the Act-level deferral determination is outside this source slice.
+  - output: us-il:statutes/320/30/2/30_d#real_estate_taxes
+    reason: The definition depends on liability under the Property Tax Code, special
+      service area taxes, and local-government special assessments, none of which
+      are supplied in this source.
+  - output: us-il:statutes/320/30/2/30_e#department
+    reason: Institutional definition only; no computable amount, condition, or membership
+      relation is created.
+  - output: us-il:statutes/320/30/2/30_g#equity_interest
+    reason: The formula requires current assessed valuation, conversion to full market
+      value, appraised value fallback, and outstanding debts or liens; valuation and
+      appraisal mechanics are not supplied in this source slice.
+  - output: us-il:statutes/320/30/2/30_h#household_income
+    reason: The term is defined by cross-reference to the Senior Citizens and Persons
+      with Disabilities Property Tax Relief Act, which is not supplied here.
+rules:
+- name: maximum_household_income
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 30(j)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $40,000 through tax year 2005
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $50,000 for tax years 2006 through 2011
+      - path: versions[2].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $55,000 for tax years 2012 through 2021
+      - path: versions[3].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $65,000 for tax years 2022 through 2024
+      - path: versions[4].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $75,000 for tax year 2025
+      - path: versions[5].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $77,000 for tax year 2026
+      - path: versions[6].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: $79,000 for tax years 2027 and thereafter
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '40000'
+  - effective_from: '2006-01-01'
+    formula: '50000'
+  - effective_from: '2012-01-01'
+    formula: '55000'
+  - effective_from: '2022-01-01'
+    formula: '65000'
+  - effective_from: '2025-01-01'
+    formula: '75000'
+  - effective_from: '2026-01-01'
+    formula: '77000'
+  - effective_from: '2027-01-01'
+    formula: '79000'
+- name: household_income_no_greater_than_maximum
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Year
+  source: 30(j)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+          excerpt: '"Maximum household income" means'
+  versions:
+  - effective_from: '0001-01-01'
+    formula: household_income <= maximum_household_income
+- name: homestead
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 30(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'property_is_land_and_buildings_or_covered_dwelling_unit
+
+      and (taxpayer_occupies_property_as_residence or taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility)'
+- name: qualifying_property
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 30(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'homestead
+
+      and taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+
+      and not property_is_income_producing
+
+      and not property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed
+
+      and property_not_disqualified_by_trust_rule'
+- name: qualified_taxpayer
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 30(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-il/statute/320/30/2
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year
+
+      and taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+
+      and household_income_no_greater_than_maximum'

--- a/us-il/statutes/320/30/3.test.yaml
+++ b/us-il/statutes/320/30/3.test.yaml
@@ -1,0 +1,156 @@
+- name: deferral amount limited by 2024 annual cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/320/30/3#input.application_on_or_before_march_1: true
+    us-il:statutes/320/30/3#input.application_filed_with_appropriate_collector_or_designated_official: true
+    us-il:statutes/320/30/3#input.application_on_department_prescribed_form_furnished_by_collector: true
+    us-il:statutes/320/30/3#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    us-il:statutes/320/30/3#input.taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption: false
+    ? us-il:statutes/320/30/3#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/3#input.application_specifies_deferral_scope_and_amount_if_partial: true
+    us-il:statutes/320/30/3#input.property_has_separate_assessed_valuation: true
+    us-il:statutes/320/30/3#input.taxpayer_filed_required_appraisal_and_appraiser_certificate: false
+    us-il:statutes/320/30/3#input.tax_deferral_and_recovery_agreement_entered: true
+    us-il:statutes/320/30/3#input.all_joint_owners_gave_written_prior_approval_for_agreement: true
+    ? us-il:statutes/320/30/3#input.taxpayer_or_agent_provided_sufficient_fire_or_casualty_insurance_evidence_for_total_deferred_taxes
+    : true
+    us-il:statutes/320/30/3#input.requested_deferral_amount: 9000
+    us-il:statutes/320/30/3#input.real_estate_taxes_or_special_assessment_installments_payable_during_year: 10000
+    us-il:statutes/320/30/3#input.senior_citizens_real_estate_deferred_tax_revolving_fund_available_amount: 20000
+    us-il:statutes/320/30/3#input.taxpayer_equity_interest_in_property: 100000
+    us-il:statutes/320/30/3#input.total_deferred_taxes_plus_interest_before_current_deferral: 1000
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: false
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/3#application_requirements_satisfied: holds
+    us-il:statutes/320/30/3#tax_deferral_and_recovery_agreement_requirements_satisfied: holds
+    us-il:statutes/320/30/3#remaining_equity_deferral_capacity: 79000
+    us-il:statutes/320/30/3#il_scretd_deferral_amount: 7500
+- name: deferral denied when application is late
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/320/30/3#input.application_on_or_before_march_1: false
+    us-il:statutes/320/30/3#input.application_filed_with_appropriate_collector_or_designated_official: true
+    us-il:statutes/320/30/3#input.application_on_department_prescribed_form_furnished_by_collector: true
+    us-il:statutes/320/30/3#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    us-il:statutes/320/30/3#input.taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption: false
+    ? us-il:statutes/320/30/3#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/3#input.application_specifies_deferral_scope_and_amount_if_partial: true
+    us-il:statutes/320/30/3#input.property_has_separate_assessed_valuation: true
+    us-il:statutes/320/30/3#input.taxpayer_filed_required_appraisal_and_appraiser_certificate: false
+    us-il:statutes/320/30/3#input.tax_deferral_and_recovery_agreement_entered: true
+    us-il:statutes/320/30/3#input.all_joint_owners_gave_written_prior_approval_for_agreement: true
+    ? us-il:statutes/320/30/3#input.taxpayer_or_agent_provided_sufficient_fire_or_casualty_insurance_evidence_for_total_deferred_taxes
+    : true
+    us-il:statutes/320/30/3#input.requested_deferral_amount: 4000
+    us-il:statutes/320/30/3#input.real_estate_taxes_or_special_assessment_installments_payable_during_year: 6000
+    us-il:statutes/320/30/3#input.senior_citizens_real_estate_deferred_tax_revolving_fund_available_amount: 20000
+    us-il:statutes/320/30/3#input.taxpayer_equity_interest_in_property: 100000
+    us-il:statutes/320/30/3#input.total_deferred_taxes_plus_interest_before_current_deferral: 1000
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: false
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/3#application_requirements_satisfied: not_holds
+    us-il:statutes/320/30/3#tax_deferral_and_recovery_agreement_requirements_satisfied: holds
+    us-il:statutes/320/30/3#remaining_equity_deferral_capacity: 79000
+    us-il:statutes/320/30/3#il_scretd_deferral_amount: 0
+- name: low income freeze qualification satisfies age and occupancy certification
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/320/30/3#input.application_on_or_before_march_1: true
+    us-il:statutes/320/30/3#input.application_filed_with_appropriate_collector_or_designated_official: true
+    us-il:statutes/320/30/3#input.application_on_department_prescribed_form_furnished_by_collector: true
+    us-il:statutes/320/30/3#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: false
+    us-il:statutes/320/30/3#input.taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption: true
+    ? us-il:statutes/320/30/3#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : false
+    us-il:statutes/320/30/3#input.application_specifies_deferral_scope_and_amount_if_partial: true
+    us-il:statutes/320/30/3#input.property_has_separate_assessed_valuation: true
+    us-il:statutes/320/30/3#input.taxpayer_filed_required_appraisal_and_appraiser_certificate: false
+    us-il:statutes/320/30/3#input.tax_deferral_and_recovery_agreement_entered: true
+    us-il:statutes/320/30/3#input.all_joint_owners_gave_written_prior_approval_for_agreement: true
+    ? us-il:statutes/320/30/3#input.taxpayer_or_agent_provided_sufficient_fire_or_casualty_insurance_evidence_for_total_deferred_taxes
+    : true
+    us-il:statutes/320/30/3#input.requested_deferral_amount: 3000
+    us-il:statutes/320/30/3#input.real_estate_taxes_or_special_assessment_installments_payable_during_year: 6000
+    us-il:statutes/320/30/3#input.senior_citizens_real_estate_deferred_tax_revolving_fund_available_amount: 20000
+    us-il:statutes/320/30/3#input.taxpayer_equity_interest_in_property: 100000
+    us-il:statutes/320/30/3#input.total_deferred_taxes_plus_interest_before_current_deferral: 1000
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: false
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/3#application_requirements_satisfied: holds
+    us-il:statutes/320/30/3#tax_deferral_and_recovery_agreement_requirements_satisfied: holds
+    us-il:statutes/320/30/3#remaining_equity_deferral_capacity: 79000
+    us-il:statutes/320/30/3#il_scretd_deferral_amount: 3000
+- name: deferral amount limited by remaining equity capacity
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/320/30/3#input.application_on_or_before_march_1: true
+    us-il:statutes/320/30/3#input.application_filed_with_appropriate_collector_or_designated_official: true
+    us-il:statutes/320/30/3#input.application_on_department_prescribed_form_furnished_by_collector: true
+    us-il:statutes/320/30/3#input.taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year: true
+    us-il:statutes/320/30/3#input.taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption: false
+    ? us-il:statutes/320/30/3#input.taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence
+    : true
+    us-il:statutes/320/30/3#input.application_specifies_deferral_scope_and_amount_if_partial: true
+    us-il:statutes/320/30/3#input.property_has_separate_assessed_valuation: false
+    us-il:statutes/320/30/3#input.taxpayer_filed_required_appraisal_and_appraiser_certificate: true
+    us-il:statutes/320/30/3#input.tax_deferral_and_recovery_agreement_entered: true
+    us-il:statutes/320/30/3#input.all_joint_owners_gave_written_prior_approval_for_agreement: true
+    ? us-il:statutes/320/30/3#input.taxpayer_or_agent_provided_sufficient_fire_or_casualty_insurance_evidence_for_total_deferred_taxes
+    : true
+    us-il:statutes/320/30/3#input.requested_deferral_amount: 5000
+    us-il:statutes/320/30/3#input.real_estate_taxes_or_special_assessment_installments_payable_during_year: 6000
+    us-il:statutes/320/30/3#input.senior_citizens_real_estate_deferred_tax_revolving_fund_available_amount: 20000
+    us-il:statutes/320/30/3#input.taxpayer_equity_interest_in_property: 10000
+    us-il:statutes/320/30/3#input.total_deferred_taxes_plus_interest_before_current_deferral: 7000
+    us-il:statutes/320/30/2#input.property_is_land_and_buildings_or_covered_dwelling_unit: true
+    us-il:statutes/320/30/2#input.taxpayer_occupies_property_as_residence: true
+    ? us-il:statutes/320/30/2#input.taxpayer_temporarily_unoccupied_property_because_residing_not_more_than_one_year_in_licensed_nursing_home_care_act_facility
+    : false
+    ? us-il:statutes/320/30/2#input.taxpayer_or_taxpayer_and_spouse_own_or_are_purchasing_property_in_fee_simple_under_recorded_instrument
+    : true
+    us-il:statutes/320/30/2#input.property_is_income_producing: false
+    us-il:statutes/320/30/2#input.property_subject_to_unpaid_real_estate_tax_lien_when_claim_filed: false
+    us-il:statutes/320/30/2#input.property_not_disqualified_by_trust_rule: true
+  output:
+    us-il:statutes/320/30/3#application_requirements_satisfied: holds
+    us-il:statutes/320/30/3#tax_deferral_and_recovery_agreement_requirements_satisfied: holds
+    us-il:statutes/320/30/3#remaining_equity_deferral_capacity: 1000
+    us-il:statutes/320/30/3#il_scretd_deferral_amount: 1000

--- a/us-il/statutes/320/30/3.yaml
+++ b/us-il/statutes/320/30/3.yaml
@@ -1,0 +1,227 @@
+format: rulespec/v1
+imports:
+  - us-il:statutes/320/30/2#qualifying_property
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/320/30/3
+  summary: |-
+    A taxpayer may apply on or before March 1 for deferral of all or part of real estate taxes or special assessment installments on qualifying property. The collector shall grant the deferral if funds are available and the owners enter a tax deferral and recovery agreement; total deferred taxes plus interest may not exceed 80% of the taxpayer's equity interest, annual deferral is capped at $5,000 through the 2021 tax year and $7,500 for 2022 and later, and interest is 6% before tax year 2023 and 3% for 2023 and later.
+rules:
+  - name: equity_interest_limit_rate
+    kind: parameter
+    dtype: Rate
+    source: Sec. 3(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: may not exceed 80% of the taxpayer's equity interest
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.80
+
+  - name: annual_per_taxpayer_deferral_cap
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 3(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: through the 2021 tax year, the total amount of any such deferral shall not exceed $5,000 per taxpayer in each tax year
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: For the 2022 tax year and every tax year after, the total amount of any such deferral shall not exceed $7,500 per taxpayer in each tax year
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          5000
+      - effective_from: '2022-01-01'
+        formula: |-
+          7500
+
+  - name: tax_deferred_interest_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Sec. 3(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: If the taxes deferred are for a tax year prior to 2023, then interest shall accrue at the rate of 6% per year.
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: If the taxes deferred are for the 2023 tax year or any tax year thereafter, then interest shall accrue at the rate of 3% per year.
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.06
+      - effective_from: '2023-01-01'
+        formula: |-
+          0.03
+
+  - name: surviving_spouse_minimum_age_within_death_window
+    kind: parameter
+    dtype: Count
+    source: Sec. 3(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: surviving spouse if the spouse is 55 years of age or older within 6 months
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          55
+
+  - name: estate_recovery_deadline_years_after_death
+    kind: parameter
+    dtype: Count
+    source: Sec. 3(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: recovered from the estate of the taxpayer within one year of the date of his death
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: nonqualifying_property_due_deadline_days
+    kind: parameter
+    dtype: Count
+    source: Sec. 3(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: due within 90 days after any tax deferred property ceases to be qualifying property
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          90
+
+  - name: application_requirements_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Sec. 3, application paragraph
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:statutes/320/30/2#qualifying_property
+              output: qualifying_property
+              hash: sha256:934679228fbfd0921adacdb259e9c4711ecc08211e21276ad0b603aefa0d9550
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          application_on_or_before_march_1
+          and application_filed_with_appropriate_collector_or_designated_official
+          and application_on_department_prescribed_form_furnished_by_collector
+          and (taxpayer_will_be_65_or_older_by_june_1_of_tax_deferral_year or taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption)
+          and qualifying_property
+          and (taxpayer_certifies_owned_and_occupied_property_or_other_qualifying_property_in_state_for_at_least_last_3_years_except_temporary_nursing_or_sheltered_care_home_residence or taxpayer_eligible_for_low_income_senior_citizens_assessment_freeze_homestead_exemption)
+          and application_specifies_deferral_scope_and_amount_if_partial
+          and (property_has_separate_assessed_valuation or taxpayer_filed_required_appraisal_and_appraiser_certificate)
+
+  - name: tax_deferral_and_recovery_agreement_requirements_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Sec. 3, agreement paragraph and clauses (5), (7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_deferral_and_recovery_agreement_entered
+          and all_joint_owners_gave_written_prior_approval_for_agreement
+          and taxpayer_or_agent_provided_sufficient_fire_or_casualty_insurance_evidence_for_total_deferred_taxes
+
+  - name: remaining_equity_deferral_capacity
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 3(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: total amount of taxes deferred under this Act, plus interest ... may not exceed 80% of the taxpayer's equity interest
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, equity_interest_limit_rate * taxpayer_equity_interest_in_property - total_deferred_taxes_plus_interest_before_current_deferral)
+
+  - name: il_scretd_deferral_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 3, application paragraph and clause (1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: The collector shall grant the tax deferral provided such deferral does not exceed funds available
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/statute/320/30/3
+              excerpt: For the 2022 tax year and every tax year after, the total amount of any such deferral shall not exceed $7,500 per taxpayer in each tax year.
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          if application_requirements_satisfied and tax_deferral_and_recovery_agreement_requirements_satisfied: min(requested_deferral_amount, real_estate_taxes_or_special_assessment_installments_payable_during_year, senior_citizens_real_estate_deferred_tax_revolving_fund_available_amount, annual_per_taxpayer_deferral_cap, remaining_equity_deferral_capacity) else: 0


### PR DESCRIPTION
## Summary
- encode 320 ILCS 30/2 definitions for Illinois Senior Citizens Real Estate Tax Deferral
- encode 320 ILCS 30/3 deferral amount, application/agreement gates, annual cap, interest rate, fund availability, and equity-cap mechanics
- add a 2026 Illinois SCRETD program spec exposing il_scretd_deferral_amount
- bump the RuleSpec toolchain to axiom-encode 0.2.885 and axiom-corpus 2c581691

## Oracle status
The PolicyEngine surface is now known-not-comparable rather than pending. Axiom follows the current statute's qualifying-property, application, agreement, requested-amount, fund-availability, special-assessment, and 80% equity-cap constraints; PolicyEngine's adjacent variable only applies age/income eligibility and the annual cap.

## Tests
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode test --root . statutes/320/30/2.test.yaml statutes/320/30/3.test.yaml
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode validate --skip-reviewers us-il/statutes/320/30/2.yaml us-il/statutes/320/30/3.yaml
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --repo . --base-ref origin/main --head-ref HEAD --json
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-il-scretd-root --program il_scretd --include-program-surfaces --limit 100
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev pytest tests/test_program_specs.py tests/test_repository_layout.py