### PR TITLE
Encode Medicaid MAGI and child category rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.886"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
 axiom_encode_ref = "5696c9b31e8bf04c3866f76a45983e29a3fd69ce"
-axiom_corpus_ref = "ef558d267db69a7ff0c08a0adccae0e9bb079e68"
+axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.886"
+axiom_encode_version = "0.2.891"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5696c9b31e8bf04c3866f76a45983e29a3fd69ce"
+axiom_encode_ref = "6c20c93342ba44b4c78d969d7eab0a3fa6919454"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/42/1396a/e/14.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1396a/e/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1396a/e/14.yaml",
+      "sha256": "17c6a72e09072273dfeda63802408c7154b760cd38d4e64b08c74121350d1250"
+    },
+    {
+      "path": "statutes/42/1396a/e/14.test.yaml",
+      "sha256": "2bc9d1a6055f3eb546d10e11782f4719f735a2218e9651acafd9e3d71d044cb9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c618cf13820bebf8c3a2b0cd55fd0dc677d85dfb",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.890",
+    "version_commit": "c618cf13820bebf8c3a2b0cd55fd0dc677d85dfb"
+  },
+  "axiom_encode_version": "0.2.890",
+  "backend": "codex",
+  "citation": "42 USC 1396a(e)(14)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/42-USC-1396a-e-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "7783edbd9f28615c29045494352ea200f8bc66e1515f4c93c87e31dd04907f76",
+  "generated_at": "2026-06-27T03:43:38.199658+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/42/1396a/e/14.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "17c6a72e09072273dfeda63802408c7154b760cd38d4e64b08c74121350d1250",
+  "generation_prompt_sha256": "a555490c263b9431af2aa03ad710fc8bda52e7a52e072b2b35080db4f7e6765a",
+  "model": "gpt-5.5",
+  "run_id": "6baf65cb",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d8b8e39cd9e3be8a528999d62683d24af306cfa81435139b295ebd193c8ce9a3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/42-USC-1396a-e-14.json",
+  "trace_sha256": "656ca79e37202efd4a25838968bb524d6bfb3e9b8c3a2dab46860e2b01cdac2e"
+}

--- a/us/.axiom/encoding-manifests/statutes/42/1396a/l.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1396a/l.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/1396a/l.yaml",
+      "sha256": "ec9d6c95899d960bf6ed7acae43954e19bb3d3f1ea5c748f055872b24a57a268"
+    },
+    {
+      "path": "statutes/42/1396a/l.test.yaml",
+      "sha256": "04e2a9746695b237eb7abe1033cc2015b4cb0ffe2fa689c020d445702ad1b54f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c618cf13820bebf8c3a2b0cd55fd0dc677d85dfb",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.890",
+    "version_commit": "c618cf13820bebf8c3a2b0cd55fd0dc677d85dfb"
+  },
+  "axiom_encode_version": "0.2.890",
+  "backend": "codex",
+  "citation": "42 USC 1396a(l)",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/42-USC-1396a-l/workspace/context-manifest.json",
+  "context_manifest_sha256": "00f5cc498a4543a50ff48cb817c6cc70781afa6e3ae8bed744dfd6b78fca56c4",
+  "generated_at": "2026-06-27T03:39:33.816438+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/42/1396a/l.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "ec9d6c95899d960bf6ed7acae43954e19bb3d3f1ea5c748f055872b24a57a268",
+  "generation_prompt_sha256": "10f4be48119323354832bf21f4c932faf4504a35271a155987a54ec97c3b2f13",
+  "model": "gpt-5.5",
+  "run_id": "2216792d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bdfe45080fb2524ad8cd90060f282ef23da4a8a62161d14fe258c1cc5083e943"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/42-USC-1396a-l.json",
+  "trace_sha256": "bbc3fdba3139a3cb5426a94eb13f258c92b31f2a54476f05b4bab3f03f4d1a72"
+}

--- a/us/statutes/42/1396a/e/14.test.yaml
+++ b/us/statutes/42/1396a/e/14.test.yaml
@@ -1,0 +1,49 @@
+- name: magi_rules_apply_when_no_exception
+  period: 2027-04
+  input:
+    us:statutes/42/1396a/e/14#input.income_determination_required_under_state_plan_or_waiver: true
+    us:statutes/42/1396a/e/14#input.eligible_on_basis_not_requiring_income_determination: false
+    us:statutes/42/1396a/e/14#input.individual_has_attained_age_65: false
+    us:statutes/42/1396a/e/14#input.qualifies_on_basis_of_blindness_or_disability: false
+    us:statutes/42/1396a/e/14#input.medically_needy_individual_described_in_subsection_a_10_C: false
+    us:statutes/42/1396a/e/14#input.medicare_cost_sharing_individual_described_in_subsection_a_10_E: false
+    us:statutes/42/1396a/e/14#input.express_lane_agency_income_finding_used: false
+    us:statutes/42/1396a/e/14#input.medicare_prescription_drug_subsidy_determination: false
+    us:statutes/42/1396a/e/14#input.long_term_care_eligibility_determination: false
+  output:
+    us:statutes/42/1396a/e/14#magi_income_determination_applies: holds
+    us:statutes/42/1396a/e/14#income_disregards_prohibited: holds
+    us:statutes/42/1396a/e/14#assets_test_prohibited: holds
+- name: magi_rules_blocked_for_age_65_exception
+  period: 2027-04
+  input:
+    us:statutes/42/1396a/e/14#input.income_determination_required_under_state_plan_or_waiver: true
+    us:statutes/42/1396a/e/14#input.eligible_on_basis_not_requiring_income_determination: false
+    us:statutes/42/1396a/e/14#input.individual_has_attained_age_65: true
+    us:statutes/42/1396a/e/14#input.qualifies_on_basis_of_blindness_or_disability: false
+    us:statutes/42/1396a/e/14#input.medically_needy_individual_described_in_subsection_a_10_C: false
+    us:statutes/42/1396a/e/14#input.medicare_cost_sharing_individual_described_in_subsection_a_10_E: false
+    us:statutes/42/1396a/e/14#input.express_lane_agency_income_finding_used: false
+    us:statutes/42/1396a/e/14#input.medicare_prescription_drug_subsidy_determination: false
+    us:statutes/42/1396a/e/14#input.long_term_care_eligibility_determination: false
+  output:
+    us:statutes/42/1396a/e/14#magi_income_determination_applies: not_holds
+    us:statutes/42/1396a/e/14#income_disregards_prohibited: not_holds
+    us:statutes/42/1396a/e/14#assets_test_prohibited: not_holds
+- name: lottery_lump_sum_counted_over_three_months
+  period: 2027-04
+  input:
+    us:statutes/42/1396a/e/14#input.income_exceeds_applicable_eligibility_threshold_by_application_of_lottery_lump_sum_rule: true
+    us:statutes/42/1396a/e/14#input.state_determines_denial_would_cause_undue_medical_or_financial_hardship: true
+  output:
+    us:statutes/42/1396a/e/14#hardship_exemption_preserves_medical_assistance: holds
+- name: six_month_redetermination_required_for_adult_expansion_enrollee
+  period: 2027-04
+  input:
+    us:statutes/42/1396a/e/14#input.redetermination_scheduled_on_or_after_applicable_start_date: true
+    us:statutes/42/1396a/e/14#input.state_is_one_of_50_states_or_district_of_columbia: true
+    us:statutes/42/1396a/e/14#input.enrolled_under_adult_expansion_group: true
+    us:statutes/42/1396a/e/14#input.enrolled_under_equivalent_minimum_essential_coverage_waiver_for_adult_expansion_group: false
+    us:statutes/42/1396a/e/14#input.individual_exempt_under_subsection_xx_9_A_ii_II: false
+  output:
+    us:statutes/42/1396a/e/14#six_month_redetermination_required: holds

--- a/us/statutes/42/1396a/e/14.yaml
+++ b/us/statutes/42/1396a/e/14.yaml
@@ -1,0 +1,275 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/e/14
+  summary: States must use modified adjusted gross income and household income for
+    Medicaid income determinations, without income disregards or asset tests, except
+    for listed categories. The paragraph defines a 5 percentage-point MAGI reduction,
+    disregard of nominal parent mentor compensation, special counting periods for
+    qualified lottery winnings and qualified lump sum income, and 6-month redeterminations
+    for certain adult expansion enrollees scheduled on or after the first day of the
+    first quarter beginning after December 31, 2026.
+  deferred_outputs:
+  - output: us:statutes/42/1396a/e/14/e#applicable_magi_income_after_disregard
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/42/1396a/e/14/e#magi_standard_increase_percentage_points
+  - output: us:statutes/42/1396a/e/14/e#lottery_lump_sum_income_counting_months
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/42/1396a/e/14/e#magi_standard_increase_percentage_points
+  - output: us:statutes/42/1396a/e/14/e#monthly_lottery_lump_sum_income_installment
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/42/1396a/e/14/e#magi_standard_increase_percentage_points
+  - output: us:statutes/42/1396a/e/14/e#parent_mentor_compensation_disregarded
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/42/1396a/e/14/e#magi_standard_increase_percentage_points
+rules:
+- name: magi_income_determination_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(e)(14)(A), (D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: except as provided in subparagraph (D)
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'income_determination_required_under_state_plan_or_waiver
+
+      and not eligible_on_basis_not_requiring_income_determination
+
+      and not individual_has_attained_age_65
+
+      and not qualifies_on_basis_of_blindness_or_disability
+
+      and not medically_needy_individual_described_in_subsection_a_10_C
+
+      and not medicare_cost_sharing_individual_described_in_subsection_a_10_E
+
+      and not express_lane_agency_income_finding_used
+
+      and not medicare_prescription_drug_subsidy_determination
+
+      and not long_term_care_eligibility_determination'
+- name: income_disregards_prohibited
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(e)(14)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: no type of expense, block, or other income disregard shall be applied
+  versions:
+  - effective_from: '2014-01-01'
+    formula: magi_income_determination_applies
+- name: assets_test_prohibited
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(e)(14)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: shall not apply any assets or resources test
+  versions:
+  - effective_from: '2014-01-01'
+    formula: magi_income_determination_applies
+- name: magi_standard_increase_percentage_points
+  kind: parameter
+  dtype: Rate
+  source: 42 USC 1396a(e)(14)(I)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: increased by 5 percentage points
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '0.05'
+- name: lottery_lump_sum_first_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 42 USC 1396a(e)(14)(K)(i)(I)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: less than $80,000
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '80000'
+- name: lottery_lump_sum_second_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 42 USC 1396a(e)(14)(K)(i)(II)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: greater than or equal to $80,000 but less than $90,000
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '90000'
+- name: lottery_lump_sum_third_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 42 USC 1396a(e)(14)(K)(i)(III)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: greater than or equal to $90,000 but less than $100,000
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '100000'
+- name: lottery_lump_sum_increment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 42 USC 1396a(e)(14)(K)(i)(IV)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: each increment of $10,000
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '10000'
+- name: lottery_lump_sum_maximum_months
+  kind: parameter
+  dtype: Count
+  source: 42 USC 1396a(e)(14)(K)(i)(IV)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: not to exceed a period of 120 months
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '120'
+- name: lottery_lump_sum_maximum_trigger
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 42 USC 1396a(e)(14)(K)(i)(IV)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: for winnings or income of $1,260,000 or more
+  versions:
+  - effective_from: '2018-01-01'
+    formula: '1260000'
+- name: hardship_exemption_preserves_medical_assistance
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(e)(14)(K)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: shall continue to be eligible ... denial ... would cause an undue
+            medical or financial hardship
+  versions:
+  - effective_from: '2018-01-01'
+    formula: 'income_exceeds_applicable_eligibility_threshold_by_application_of_lottery_lump_sum_rule
+
+      and state_determines_denial_would_cause_undue_medical_or_financial_hardship'
+- name: redetermination_interval_months_for_certain_adult_expansion_individuals
+  kind: parameter
+  dtype: Count
+  source: 42 USC 1396a(e)(14)(L)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: once every 6 months
+  versions:
+  - effective_from: '2027-04-01'
+    formula: '6'
+- name: six_month_redetermination_required
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(e)(14)(L)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: scheduled on or after the first day of the first quarter that begins
+            after December 31, 2026
+  versions:
+  - effective_from: '2027-04-01'
+    formula: 'redetermination_scheduled_on_or_after_applicable_start_date
+
+      and state_is_one_of_50_states_or_district_of_columbia
+
+      and (enrolled_under_adult_expansion_group or enrolled_under_equivalent_minimum_essential_coverage_waiver_for_adult_expansion_group)
+
+      and not individual_exempt_under_subsection_xx_9_A_ii_II'

--- a/us/statutes/42/1396a/l.test.yaml
+++ b/us/statutes/42/1396a/l.test.yaml
@@ -1,0 +1,29 @@
+- name: state option to apply resource standard for specified eligibility group
+  period: 2024-01
+  input:
+    us:statutes/42/1396a/l#input.eligible_for_medical_assistance_because_of_specified_subsection: true
+    us:statutes/42/1396a/l#input.state_has_chosen_to_apply_resource_standard: true
+  output:
+    us:statutes/42/1396a/l#resource_standard_application_state_option_applies: holds
+- name: no resource standard option when state has not chosen resource standard
+  period: 2024-01
+  input:
+    us:statutes/42/1396a/l#input.eligible_for_medical_assistance_because_of_specified_subsection: true
+    us:statutes/42/1396a/l#input.state_has_chosen_to_apply_resource_standard: false
+  output:
+    us:statutes/42/1396a/l#resource_standard_application_state_option_applies: not_holds
+- name: waiver state must provide assistance for covered pregnant women infants and
+    children
+  period: 2024-01
+  input:
+    us:statutes/42/1396a/l#input.state_provides_medical_assistance_under_section_1315_waiver: true
+    ? us:statutes/42/1396a/l#input.person_is_pregnant_woman_or_infant_under_subsection_a_10_A_i_IV_or_child_under_subsection_a_10_A_i_VI_or_VII
+    : true
+  output:
+    us:statutes/42/1396a/l#waiver_state_must_provide_assistance_as_if_plan_approved: holds
+- name: territory may substitute any paragraph two a percentage
+  period: 2024-01
+  input:
+    us:statutes/42/1396a/l#input.state_is_not_one_of_the_50_states_or_district_of_columbia: true
+  output:
+    us:statutes/42/1396a/l#non_state_may_substitute_any_percentage_for_paragraph_two_a_minimum: holds

--- a/us/statutes/42/1396a/l.yaml
+++ b/us/statutes/42/1396a/l.yaml
@@ -1,0 +1,280 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/l
+  summary: |-
+    Paragraph (1) describes pregnant women, infants under one year, children ages one through five, and children born after September 30, 1983 who are ages six through eighteen, if not described in specified subsection (a)(10)(A)(i) subclauses and family income does not exceed the State-established paragraph (2) level. Paragraph (2) sets income-level percentages of the official poverty line, including 75 percent after July 1, 1989, 133 percent after April 1, 1990, 185 percent maximum for pregnant women and infants, 133 percent for ages one through five, and 100 percent before 2014 or 133 percent beginning January 1, 2014 for ages six through eighteen.
+  deferred_outputs:
+    - output: us:statutes/42/1396a/l#pregnant_woman_or_infant_income_level
+      reason: The formula depends on the income official poverty line defined by 42 USC 9902(2), and no copied RuleSpec source provides us:statutes/42/9902/2.
+    - output: us:statutes/42/1396a/l#child_age_one_to_five_income_level
+      reason: The formula depends on the income official poverty line defined by 42 USC 9902(2), and no copied RuleSpec source provides us:statutes/42/9902/2.
+    - output: us:statutes/42/1396a/l#older_child_income_level
+      reason: The formula depends on the income official poverty line defined by 42 USC 9902(2), and no copied RuleSpec source provides us:statutes/42/9902/2.
+    - output: us:statutes/42/1396a/l#individual_described_in_paragraph_one
+      reason: The family-income condition depends on the paragraph (2) income levels, which depend on the income official poverty line defined by 42 USC 9902(2), and no copied RuleSpec source provides us:statutes/42/9902/2.
+rules:
+  - name: pregnancy_postpartum_period_days
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "during the 60-day period beginning on the last day of the pregnancy"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          60
+
+  - name: infant_age_ceiling_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "infants under one year of age"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1
+
+  - name: young_child_attainment_age_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "children who have attained one year of age"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1
+
+  - name: young_child_age_ceiling_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "but have not attained 6 years of age"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          6
+
+  - name: older_child_attainment_age_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "have attained 6 years of age"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          6
+
+  - name: older_child_age_ceiling_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(l)(1)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "but have not attained 19 years of age"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          19
+
+  - name: pregnant_woman_or_infant_income_level_maximum_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "not more than 185 percent"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1.85
+
+  - name: pregnant_woman_or_infant_minimum_rate_after_july_1989
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(A)(ii)(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "July 1, 1989, is 75 percent"
+    versions:
+      - effective_from: '1989-07-01'
+        formula: |-
+          0.75
+
+  - name: pregnant_woman_or_infant_minimum_rate_after_april_1990
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(A)(ii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "April 1, 1990, 133 percent"
+    versions:
+      - effective_from: '1990-04-01'
+        formula: |-
+          1.33
+
+  - name: july_1988_state_floor_cap_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(A)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "in no case shall this clause require ... to exceed 100 percent"
+    versions:
+      - effective_from: '1989-07-01'
+        formula: |-
+          1.00
+
+  - name: child_age_one_to_five_income_level_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "equal to 133 percent"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1.33
+
+  - name: older_child_income_level_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1396a(l)(2)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+              excerpt: "equal to 100 percent (or, beginning January 1, 2014, 133 percent)"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          1.00
+      - effective_from: '2014-01-01'
+        formula: |-
+          1.33
+
+  - name: resource_standard_application_state_option_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(l)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          eligible_for_medical_assistance_because_of_specified_subsection
+          and state_has_chosen_to_apply_resource_standard
+
+  - name: waiver_state_must_provide_assistance_as_if_plan_approved
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(l)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          state_provides_medical_assistance_under_section_1315_waiver
+          and person_is_pregnant_woman_or_infant_under_subsection_a_10_A_i_IV_or_child_under_subsection_a_10_A_i_VI_or_VII
+
+  - name: non_state_may_substitute_any_percentage_for_paragraph_two_a_minimum
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(l)(4)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/l
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          state_is_not_one_of_the_50_states_or_district_of_columbia


### PR DESCRIPTION
## Summary\n- encode 42 USC 1396a(l) Medicaid pregnancy/child category age and income-level thresholds through axiom-encode\n- encode 42 USC 1396a(e)(14) MAGI methodology, disregard prohibition, asset-test prohibition, lottery lump-sum thresholds, hardship exception, and 2027 redetermination interval through axiom-encode\n- bump the corpus pin to the merged Medicaid Title XIX corpus slice with 1396u–1 correction\n\n## Notes\n- Parent/caretaker 42 USC 1396u–1(b) was retried but not included: full-section and subsection passes were blocked by source-id/citation-path validation around the USLM en-dash path. No generated output from those failed passes is included.\n\n## Checks\n- AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-title-xix-20260627 env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode validate --skip-reviewers --oracle policyengine us/statutes/42/1396a/l.yaml us/statutes/42/1396a/e/14.yaml\n- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-title-xix-20260627 --base-ref origin/main --head-ref HEAD\n- env -u UV_FROZEN uvx --with pyyaml pytest tests -q