### PR TITLE
Add Kansas TANF budgetary standards

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -18,6 +18,7 @@ allowed_root_directories:
   - us-il
   - us-ma
   - us-md
+  - us-ks
   - us-nc
   - us-nh
   - us-ny

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.895"
+axiom_encode_version = "0.2.896"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5a2787c19ff9c37f979717e02a8ab8044caa4c35"
+axiom_encode_ref = "55b6461fe2e5e489c3a3a5c0f0c176e76abcd755"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.891"
+axiom_encode_version = "0.2.895"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "6c20c93342ba44b4c78d969d7eab0a3fa6919454"
+axiom_encode_ref = "5a2787c19ff9c37f979717e02a8ab8044caa4c35"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.896"
+axiom_encode_version = "0.2.897"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "55b6461fe2e5e489c3a3a5c0f0c176e76abcd755"
+axiom_encode_ref = "47900b4bb75d4cee1a195e8bb2db6abc63e89428"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7410.json
+++ b/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7410.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dcf/keesm/keesm7410.yaml",
+      "sha256": "b22e10b5ac5627af9e609b4296afecce97c50ba335e5f8c421f8862646e50acf"
+    },
+    {
+      "path": "policies/dcf/keesm/keesm7410.test.yaml",
+      "sha256": "0e82ff0dae5c166e7da05cae23a40ab118fac52c4258034b804a44c9433bd08f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5a2787c19ff9c37f979717e02a8ab8044caa4c35",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.895",
+    "version_commit": "5a2787c19ff9c37f979717e02a8ab8044caa4c35"
+  },
+  "axiom_encode_version": "0.2.895",
+  "backend": "codex",
+  "citation": "us-ks/manual/dcf/keesm/keesm7410",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ks-manual-dcf-keesm-keesm7410/workspace/context-manifest.json",
+  "context_manifest_sha256": "1b1ff2611f93a7c95469e0c812d2c247c84846986bee753e0aa1b49ab0f52f24",
+  "generated_at": "2026-06-27T05:24:28.160101+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dcf/keesm/keesm7410.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b22e10b5ac5627af9e609b4296afecce97c50ba335e5f8c421f8862646e50acf",
+  "generation_prompt_sha256": "a3b66219978d0a1977828f3a3f730d4300ea21cc7951b6e6eec279fead2899aa",
+  "model": "gpt-5.5",
+  "run_id": "a3a8a757",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8389d092a784345980d4908c45a73ccfc87cfe15e23ea8fc455f90748729215e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ks-manual-dcf-keesm-keesm7410.json",
+  "trace_sha256": "7a235cb2ab7963a99c839394c7f03e6d01c80290f7147e48946cec482a48c54e"
+}

--- a/us-ks/policies/dcf/keesm/keesm7410.test.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7410.test.yaml
@@ -1,0 +1,206 @@
+- name: table_i_group_v_three_person_unit
+  period: 2024-01
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 3
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: true
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: true
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#ks_tanf_maximum_benefit: 429
+- name: table_ii_group_iii_two_person_shared_living
+  period: 2024-01
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 2
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: true
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: true
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#ks_tanf_maximum_benefit: 265.5
+- name: table_ii_six_or_more_group_i_additional_persons
+  period: 2024-01
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 6
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: true
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: true
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#ks_tanf_maximum_benefit: 502.4
+- name: auto_zero_tanf_shelter_allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 0
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_shelter_allowance: 0
+- name: auto_zero_ks_tanf_maximum_benefit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 5
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#ks_tanf_maximum_benefit: 0
+- name: auto_output_tanf_shelter_group_index
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 1
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_shelter_group_index: -1
+- name: auto_output_tanf_table_ii_shelter_percentage_person_count_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 1
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_table_ii_shelter_percentage_person_count_band: 1
+- name: auto_output_tanf_basic_allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 1
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_basic_allowance: 132
+- name: auto_output_tanf_table_i_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 1
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_table_i_applies: not_holds
+- name: auto_output_tanf_table_ii_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.assistance_plan_person_count: 1
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_i_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_ii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iii_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_iv_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shelter_group_v_applies: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_table_ii_applies: not_holds
+- name: auto_positive_tanf_table_i_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: true
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: true
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: true
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: true
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_table_i_applies: holds
+- name: auto_positive_tanf_table_ii_applies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ks:policies/dcf/keesm/keesm7410#input.all_persons_in_home_in_same_assistance_plan: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_with_person_not_in_budget_plan: true
+    us-ks:policies/dcf/keesm/keesm7410#input.only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child: false
+    us-ks:policies/dcf/keesm/keesm7410#input.shared_living_arrangement_is_commercial_bona_fide_landlord_tenant: false
+    us-ks:policies/dcf/keesm/keesm7410#input.specialized_living_commercial_board_room_or_room_only_arrangement: false
+  output:
+    us-ks:policies/dcf/keesm/keesm7410#tanf_table_ii_applies: holds

--- a/us-ks/policies/dcf/keesm/keesm7410.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7410.yaml
@@ -1,0 +1,317 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+  summary: |-
+    7411 Budgetary Standards (TANF): Basic allowances are $132 for one, $217 for two, $294 for three, $362 for four, and $61 for each additional person. Shelter allowances are $92 for Groups I and II, $97 for Group III, $109 for Group IV, and $135 for Group V. Table I represents 100% of basic and shelter allowances. Table II represents 100% of basic allowance plus shelter reductions of 60% for one, 50% for two, 40% for three, 35% for four, 30% for five, and 20% for six or more persons.
+rules:
+  - name: tanf_basic_allowance_by_person_count
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: assistance_plan_person_count
+    source: KEE SM 7411, basic allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$132 for one, $217 for two, $294 for three, $362 for four"
+              table:
+                header: basic allowances
+                row_key: assistance_plan_person_count
+                column_key: monthly_basic_allowance
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 132
+          2: 217
+          3: 294
+          4: 362
+
+  - name: tanf_basic_allowance_final_listed_person_count
+    kind: parameter
+    dtype: Count
+    source: KEE SM 7411, basic allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$362 for four"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          4
+
+  - name: tanf_basic_allowance_each_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: KEE SM 7411, basic allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$61 for each additional person"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          61
+
+  - name: tanf_energy_supplement_per_person_in_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: KEE SM 7411, energy supplement
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$18 per person for the purpose of being an energy supplement"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          18
+
+  - name: tanf_shelter_allowance_by_group
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_shelter_group_index
+    source: KEE SM 7411, shelter allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$92 for Groups I and II, $97 for Group III, $109 for Group IV, and $135 for Group V"
+              table:
+                header: shelter allowances
+                row_key: shelter_group
+                column_key: monthly_shelter_allowance
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 92
+          2: 92
+          3: 97
+          4: 109
+          5: 135
+
+  - name: tanf_table_i_shelter_percentage
+    kind: parameter
+    dtype: Rate
+    source: KEE SM 7411, Table I
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "Table I - This table represents l00% of the basic and shelter allowances."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.00
+
+  - name: tanf_table_ii_shelter_percentage_by_person_count
+    kind: parameter
+    dtype: Rate
+    indexed_by: tanf_table_ii_shelter_percentage_person_count_band
+    source: KEE SM 7411, Table II
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "60% for one, 50% for two, 40% for three, 35% for four, 30% for five, and 20% for six or more persons"
+              table:
+                header: Table II shelter allowance percentage reduction
+                row_key: assistance_plan_person_count_band
+                column_key: shelter_percentage
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 0.60
+          2: 0.50
+          3: 0.40
+          4: 0.35
+          5: 0.30
+          6: 0.20
+
+  - name: tanf_table_ii_six_or_more_person_count
+    kind: parameter
+    dtype: Count
+    source: KEE SM 7411, Table II
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "20% for six or more persons"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6
+
+  - name: tanf_shelter_group_index
+    kind: derived
+    entity: TanfUnit
+    dtype: Integer
+    period: Month
+    source: KEE SM 7411, shelter groups
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "Groups I and II ... Group III ... Group IV ... Group V"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if shelter_group_i_applies: 1 else: if shelter_group_ii_applies: 2 else: if shelter_group_iii_applies: 3 else: if shelter_group_iv_applies: 4 else: if shelter_group_v_applies: 5 else: -1
+
+  - name: tanf_table_ii_shelter_percentage_person_count_band
+    kind: derived
+    entity: TanfUnit
+    dtype: Integer
+    period: Month
+    source: KEE SM 7411, Table II person-count rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "60% for one, 50% for two, 40% for three, 35% for four, 30% for five, and 20% for six or more persons"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if assistance_plan_person_count >= tanf_table_ii_six_or_more_person_count: tanf_table_ii_six_or_more_person_count else: assistance_plan_person_count
+
+  - name: tanf_basic_allowance
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: KEE SM 7411, basic allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$132 for one, $217 for two, $294 for three, $362 for four, and $61 for each additional person"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if assistance_plan_person_count <= tanf_basic_allowance_final_listed_person_count: tanf_basic_allowance_by_person_count[assistance_plan_person_count] else: tanf_basic_allowance_by_person_count[tanf_basic_allowance_final_listed_person_count] + ((assistance_plan_person_count - tanf_basic_allowance_final_listed_person_count) * tanf_basic_allowance_each_additional_person)
+
+  - name: tanf_shelter_allowance
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: KEE SM 7411, shelter allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "$92 for Groups I and II, $97 for Group III, $109 for Group IV, and $135 for Group V"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tanf_shelter_group_index == -1: 0 else: tanf_shelter_allowance_by_group[tanf_shelter_group_index]
+
+  - name: tanf_table_i_applies
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: KEE SM 7411, Table I use cases
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          all_persons_in_home_in_same_assistance_plan
+          or only_excluded_person_is_qualifying_ssi_recipient_or_joint_custody_child
+          or shared_living_arrangement_is_commercial_bona_fide_landlord_tenant
+          or specialized_living_commercial_board_room_or_room_only_arrangement
+
+  - name: tanf_table_ii_applies
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: KEE SM 7411, Table II use cases
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          shared_living_arrangement_with_person_not_in_budget_plan
+          and not tanf_table_i_applies
+
+  - name: ks_tanf_maximum_benefit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: KEE SM 7411, standardized tables for TANF eligibility and payment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7410
+              excerpt: "Table I ... 100% of the basic and shelter allowances. Table II ... 100% of the basic allowance plus a percentage reduction of the shelter allowance"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tanf_table_i_applies: tanf_basic_allowance + (tanf_shelter_allowance * tanf_table_i_shelter_percentage) else: if tanf_table_ii_applies: tanf_basic_allowance + (tanf_shelter_allowance * tanf_table_ii_shelter_percentage_by_person_count[tanf_table_ii_shelter_percentage_person_count_band]) else: 0


### PR DESCRIPTION
## Summary
- add generated Kansas KEESM 7411 TANF budgetary/payment-standard RuleSpec and companion tests
- add the signed axiom-encode apply manifest for the generated module
- allow the new us-ks root and bump the RuleSpec encoder pin to 0.2.895, matching the manifest producer

## Validation
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode validate --skip-reviewers us-ks/policies/dcf/keesm/keesm7410.yaml
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode compile /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ks-tanf-payment-standard-20260627/us-ks/policies/dcf/keesm/keesm7410.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ks-tanf-payment-standard-20260627/us-ks --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine policies/dcf/keesm/keesm7410.test.yaml
- env -u UV_FROZEN uv run --with pytest --with pyyaml python -m pytest tests/test_repository_layout.py tests/test_program_specs.py
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ks-tanf-payment-standard-20260627 --base-ref origin/main --head-ref HEAD --json