### PR TITLE
Add Louisiana FITAP income limits

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -19,6 +19,7 @@ allowed_root_directories:
   - us-ma
   - us-md
   - us-ks
+  - us-la
   - us-nc
   - us-nh
   - us-ny

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.897"
+axiom_encode_version = "0.2.898"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "47900b4bb75d4cee1a195e8bb2db6abc63e89428"
+axiom_encode_ref = "02b6e58338f1980b544164cf59aa955e0c9e3bcc"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-la/.axiom/encoding-manifests/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.json
+++ b/us-la/.axiom/encoding-manifests/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",
+      "sha256": "6030ecff6d5063d305d5fbe31c585b8b41f964d7a0c31ea3cb3dc0ce95371f3a"
+    },
+    {
+      "path": "policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.test.yaml",
+      "sha256": "13ad1dc50094919070de7802dc0590c90829b4c19ae5b8b445dd8f9476eebc5e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "47900b4bb75d4cee1a195e8bb2db6abc63e89428",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.897",
+    "version_commit": "47900b4bb75d4cee1a195e8bb2db6abc63e89428"
+  },
+  "axiom_encode_version": "0.2.897",
+  "backend": "codex",
+  "citation": "us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-la-manual-dcfs-economic-independence-b-640-fitap-income-limits-398921/workspace/context-manifest.json",
+  "context_manifest_sha256": "fd240fae29b33f990a1f974e819b4c7e29debd35f0d5ac961202ebb59deb3e0b",
+  "generated_at": "2026-06-27T06:26:40.864315+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6030ecff6d5063d305d5fbe31c585b8b41f964d7a0c31ea3cb3dc0ce95371f3a",
+  "generation_prompt_sha256": "5004cc56094f7dfbce11ae9dc0d5d5a559238fdc71a3ea7984a774aa4b71b4c8",
+  "model": "gpt-5.5",
+  "run_id": "896a069c",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5955da5d6efb574cb59e403d6547953c4cde8880ed46b6cb80280490a44723e8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-la-manual-dcfs-economic-independence-b-640-fitap-income-limits-398921.json",
+  "trace_sha256": "83115f699a763321c18c79a8e7dcf08abb1571539b8b4c1fe8c7c4ef0f58b82e"
+}

--- a/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.test.yaml
+++ b/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.test.yaml
@@ -1,0 +1,36 @@
+- name: three_person_unit_receives_rounded_deficit
+  period: 2024-01
+  input:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.assistance_unit_size: 3
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.total_countable_income: 450.75
+  output:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount: 484
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_eligible: holds
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#la_fitap: 33
+- name: income_equal_to_flat_grant_is_ineligible_and_no_payment
+  period: 2024-01
+  input:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.assistance_unit_size: 2
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.total_countable_income: 376
+  output:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount: 376
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_eligible: not_holds
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#la_fitap: 0
+- name: eligible_deficit_under_ten_dollars_has_no_paid_grant
+  period: 2024-01
+  input:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.assistance_unit_size: 1
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.total_countable_income: 235.5
+  output:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount: 244
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_eligible: holds
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#la_fitap: 0
+- name: nineteen_person_unit_uses_note_one_formula
+  period: 2024-01
+  input:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.assistance_unit_size: 19
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#input.total_countable_income: 1800
+  output:
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount: 1822
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_eligible: holds
+    us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#la_fitap: 22

--- a/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml
+++ b/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml
@@ -1,0 +1,202 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+  summary: Effective Date January 1, 2023. If total countable income is equal to or
+    greater than the flat grant amount for the assistance unit size, the assistance
+    unit is ineligible. If total countable income is less than the flat grant amount,
+    the deficit rounded down, if $10 or more, is the grant amount. If deficit is less
+    than $10, the assistance unit is FITAP eligible but no grant is paid. Flat grant
+    amounts are listed for 1 through 18 persons; for households exceeding 18 persons,
+    add the flat grant amount for the number in excess of 18 to the flat grant amount
+    for 18 persons and subtract $100.
+rules:
+- name: fitap_flat_grant_amount_by_person_count
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: assistance_unit_size
+  source: B-641-1-1-FITAP - PO Flat Grant Amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: 'Number of Persons / Flat Grant Amount: 1 $244 ... 18 $1,678'
+          table:
+            header: B-641-1-1-FITAP - PO Flat Grant Amount
+            row_key: Number of Persons
+            column_key: Flat Grant Amount
+  versions:
+  - effective_from: '2023-01-01'
+    values:
+      1: 244
+      2: 376
+      3: 484
+      4: 568
+      5: 654
+      6: 732
+      7: 804
+      8: 882
+      9: 954
+      10: 1024
+      11: 1102
+      12: 1180
+      13: 1260
+      14: 1340
+      15: 1424
+      16: 1514
+      17: 1582
+      18: 1678
+- name: fitap_flat_grant_max_listed_persons
+  kind: parameter
+  dtype: Count
+  source: B-641-1-1-FITAP - PO Flat Grant Amount, Note 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: 18+ See Note 1
+  versions:
+  - effective_from: '2023-01-01'
+    formula: '18'
+- name: fitap_large_unit_subtraction
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: B-641-1-1-FITAP - PO Flat Grant Amount, Note 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: subtract $100
+  versions:
+  - effective_from: '2023-01-01'
+    formula: '100'
+- name: fitap_minimum_payable_deficit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: B-641-1-FITAP - PO Determination of Eligibility and Grant Amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: if $10 or more, is the grant amount. If deficit is less than $10
+  versions:
+  - effective_from: '2023-01-01'
+    formula: '10'
+- name: fitap_flat_grant_amount
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: B-641-1-1-FITAP - PO Flat Grant Amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: To determine the amount for households exceeding 18 persons, add
+            the flat grant amount for the number in excess of 18 to the flat grant
+            amount for 18 persons and subtract $100.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount_by_person_count
+          output: fitap_flat_grant_amount_by_person_count
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_max_listed_persons
+          output: fitap_flat_grant_max_listed_persons
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_large_unit_subtraction
+          output: fitap_large_unit_subtraction
+          hash: sha256:local
+  versions:
+  - effective_from: '2023-01-01'
+    formula: 'if assistance_unit_size > fitap_flat_grant_max_listed_persons: fitap_flat_grant_amount_by_person_count[fitap_flat_grant_max_listed_persons]
+      + fitap_flat_grant_amount_by_person_count[assistance_unit_size - fitap_flat_grant_max_listed_persons]
+      - fitap_large_unit_subtraction else: fitap_flat_grant_amount_by_person_count[assistance_unit_size]'
+- name: fitap_eligible
+  kind: derived
+  entity: TanfUnit
+  dtype: Judgment
+  period: Month
+  source: B-641-1-FITAP - PO Determination of Eligibility and Grant Amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: If the total countable income is equal to or greater than the flat
+            grant amount for the assistance unit size, the assistance unit is ineligible.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount
+          output: fitap_flat_grant_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2023-01-01'
+    formula: total_countable_income < fitap_flat_grant_amount
+- name: la_fitap
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: B-641-1-FITAP - PO Determination of Eligibility and Grant Amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921
+          excerpt: If total countable income is less than the flat grant amount ...
+            the deficit rounded down, if $10 or more, is the grant amount. If deficit
+            is less than $10 ... no grant is paid.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_flat_grant_amount
+          output: fitap_flat_grant_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#fitap_minimum_payable_deficit
+          output: fitap_minimum_payable_deficit
+          hash: sha256:local
+  versions:
+  - effective_from: '2023-01-01'
+    formula: "if total_countable_income < fitap_flat_grant_amount:\n  if floor(fitap_flat_grant_amount\
+      \ - total_countable_income) >= fitap_minimum_payable_deficit:\n    floor(fitap_flat_grant_amount\
+      \ - total_countable_income)\n  else:\n    0\nelse:\n  0"


### PR DESCRIPTION
## Summary
- add a generated `us-la` RuleSpec root for Louisiana FITAP B-640 income limits
- encode the flat grant table, 18+ household formula, income eligibility, minimum payable deficit, and final `la_fitap` monthly grant amount
- include signed axiom-encode apply manifest and companion tests

## Validation
- `env -u UV_FROZEN uv run --extra dev axiom-encode compile /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `env -u UV_FROZEN uv run --extra dev axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`
- `env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627 --base-ref origin/main --head-ref HEAD --json`
- `env -u UV_FROZEN uv run --extra dev axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627/us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml --skip-reviewers --json`
- with TheAxiomFoundation/axiom-encode#833: `env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-la-fitap-pe-parity-20260627 --oracle policyengine --include-program-surfaces --json`

Depends on TheAxiomFoundation/axiom-encode#833 for PE oracle coverage classification of the new LA legal IDs.
