### PR TITLE
Add Nevada TANF RuleSpec encoding

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -22,6 +22,7 @@ allowed_root_directories:
   - us-la
   - us-nc
   - us-nh
+  - us-nv
   - us-ny
   - us-ok
   - us-sc

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.898"
+axiom_encode_version = "0.2.899"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "02b6e58338f1980b544164cf59aa955e0c9e3bcc"
+axiom_encode_ref = "85c93a47e6fac4a1c6222b46993b7744a1d4b61e"
 axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-nv/.axiom/encoding-manifests/policies/dwss/eligibility-payments/a-600/page-38.json
+++ b/us-nv/.axiom/encoding-manifests/policies/dwss/eligibility-payments/a-600/page-38.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dwss/eligibility-payments/a-600/page-38.yaml",
+      "sha256": "a4cf619436dc48008a26b9257bc2dae2a0692557d6296ea4f30f610d6f442949"
+    },
+    {
+      "path": "policies/dwss/eligibility-payments/a-600/page-38.test.yaml",
+      "sha256": "68df218e6215a93b655d5d11ac3b87c829a7b202dacaed5940fca8f24554ca56"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "02b6e58338f1980b544164cf59aa955e0c9e3bcc",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.898",
+    "version_commit": "02b6e58338f1980b544164cf59aa955e0c9e3bcc"
+  },
+  "axiom_encode_version": "0.2.898",
+  "backend": "codex",
+  "citation": "us-nv/manual/dwss/eligibility-payments/a-600/page-38",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-nv-manual-dwss-eligibility-payments-a-600-page-38/workspace/context-manifest.json",
+  "context_manifest_sha256": "616237bd77ca19eff46aa147d46e73d2f2208f7beb0f500210104a5b14c4cc36",
+  "generated_at": "2026-06-27T07:26:16.299780+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dwss/eligibility-payments/a-600/page-38.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a4cf619436dc48008a26b9257bc2dae2a0692557d6296ea4f30f610d6f442949",
+  "generation_prompt_sha256": "28dddab5b18712cf3ab5b239af1765873ef08ef223fe2de0a7ee912c56ea7848",
+  "model": "gpt-5.5",
+  "run_id": "a301640d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b092d1b563e89c9119b010fe91a5d7104be4985226505335f242e8ed1bb93def"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-nv-manual-dwss-eligibility-payments-a-600-page-38.json",
+  "trace_sha256": "c584f255fe7b12e110f13413e5408de61abd882a7268ce9270eabcb159869505"
+}

--- a/us-nv/policies/dwss/eligibility-payments/a-600/page-38.test.yaml
+++ b/us-nv/policies/dwss/eligibility-payments/a-600/page-38.test.yaml
@@ -1,0 +1,88 @@
+- name: tanf_benefit_rounded_down_and_above_minimum
+  period: 2025-09
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.total_income_for_tanf_gross_income_test: 900
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.federal_poverty_level_for_family_size: 1000
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_payment_allowance_for_household_size: 300.75
+    ? us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_net_income_after_disregards_and_dependent_care_deductions
+    : 250.25
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.supplemental_payment_due: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.payment_after_overpayment_recoupment_processed: false
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_cash_gross_income_test_passes: holds
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#nv_tanf: 50
+- name: tanf_benefit_minimum_applies
+  period: 2025-09
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.total_income_for_tanf_gross_income_test: 900
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.federal_poverty_level_for_family_size: 1000
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_payment_allowance_for_household_size: 100
+    ? us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_net_income_after_disregards_and_dependent_care_deductions
+    : 95
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.supplemental_payment_due: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.payment_after_overpayment_recoupment_processed: false
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_cash_gross_income_test_passes: holds
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#nv_tanf: 10
+- name: tanf_cash_ineligible_over_130_percent_poverty
+  period: 2025-09
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.total_income_for_tanf_gross_income_test: 1310
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.federal_poverty_level_for_family_size: 1000
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_payment_allowance_for_household_size: 300
+    ? us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_net_income_after_disregards_and_dependent_care_deductions
+    : 100
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.supplemental_payment_due: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.payment_after_overpayment_recoupment_processed: false
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_cash_gross_income_test_passes: not_holds
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#nv_tanf: 0
+- name: employment_retention_payment_first_six_months
+  period: 2025-09
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.household_due_to_terminate_for_excess_income: true
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.earned_income_in_terminating_household: 1
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.employment_retention_payment_month_number: 6
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment_eligible: holds
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment: 50
+- name: auto_zero_employment_retention_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.earned_income_in_terminating_household: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.employment_retention_payment_month_number: 7
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.federal_poverty_level_for_family_size: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.household_due_to_terminate_for_excess_income: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.maximum_snap_allotment_for_household_size: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.payment_after_overpayment_recoupment_processed: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.snap_net_income: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.supplemental_payment_due: false
+    ? us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_net_income_after_disregards_and_dependent_care_deductions
+    : 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_payment_allowance_for_household_size: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.total_income_for_tanf_gross_income_test: 0
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment: 0
+- name: auto_output_monthly_snap_allotment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.earned_income_in_terminating_household: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.employment_retention_payment_month_number: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.federal_poverty_level_for_family_size: 1
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.household_due_to_terminate_for_excess_income: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.maximum_snap_allotment_for_household_size: 1
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.payment_after_overpayment_recoupment_processed: false
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.snap_net_income: 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.supplemental_payment_due: false
+    ? us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_net_income_after_disregards_and_dependent_care_deductions
+    : 0
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.tanf_payment_allowance_for_household_size: 1
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#input.total_income_for_tanf_gross_income_test: 0
+  output:
+    us-nv:policies/dwss/eligibility-payments/a-600/page-38#monthly_snap_allotment: 1

--- a/us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml
+++ b/us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml
@@ -1,0 +1,230 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+  summary: '"The benefit amount is determined by comparing the net income after the
+    application of all earned income disregards and dependent care deductions compared
+    to the payment allowance for the household size. A benefit is always a whole dollar
+    amount. Round all amounts down to the nearest dollar. The minimum benefit amount
+    is $10."'
+rules:
+- name: tanf_minimum_issuable_benefit
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: The minimum benefit amount is $10.
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '10'
+- name: employment_retention_payment_amount
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: eligible for a $50 per month Employment Retention Payment
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '50'
+- name: employment_retention_payment_duration_months
+  kind: parameter
+  dtype: Count
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: for six months
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '6'
+- name: earned_income_for_employment_retention_payment_minimum
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: in which at least $1 of the income is earned
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '1'
+- name: snap_net_income_reduction_rate
+  kind: parameter
+  dtype: Rate
+  source: A-660.12 TANF Budgeting Steps
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: multiplying the net income by 0.3
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '0.3'
+- name: tanf_gross_income_poverty_test_rate
+  kind: parameter
+  dtype: Rate
+  source: A-660.12 TANF Budgeting Steps, Step 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: 130% of the Federal Poverty Level
+  versions:
+  - effective_from: '2025-08-11'
+    formula: '1.30'
+- name: tanf_cash_gross_income_test_passes
+  kind: derived
+  entity: TanfUnit
+  dtype: Judgment
+  period: Month
+  source: A-660.12 TANF Budgeting Steps, Step 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: If the Total Income is greater than the 130% of poverty. Case is
+            ineligible for cash benefits.
+  versions:
+  - effective_from: '2025-08-11'
+    formula: total_income_for_tanf_gross_income_test <= tanf_gross_income_poverty_test_rate
+      * federal_poverty_level_for_family_size
+- name: nv_tanf
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: comparing the net income ... to the payment allowance
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_minimum_issuable_benefit
+          output: tanf_minimum_issuable_benefit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-08-11'
+    formula: 'if not tanf_cash_gross_income_test_passes: 0 else: if max(0, floor(tanf_payment_allowance_for_household_size
+      - tanf_net_income_after_disregards_and_dependent_care_deductions)) == 0: 0 else:
+      if supplemental_payment_due or payment_after_overpayment_recoupment_processed:
+      max(0, floor(tanf_payment_allowance_for_household_size - tanf_net_income_after_disregards_and_dependent_care_deductions))
+      else: max(tanf_minimum_issuable_benefit, max(0, floor(tanf_payment_allowance_for_household_size
+      - tanf_net_income_after_disregards_and_dependent_care_deductions)))'
+- name: monthly_snap_allotment
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Budgeting Steps
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: multiplying the net income by 0.3 (round up) and subtracting that
+            amount from the maximum allotment
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nv:policies/dwss/eligibility-payments/a-600/page-38#snap_net_income_reduction_rate
+          output: snap_net_income_reduction_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-08-11'
+    formula: max(0, maximum_snap_allotment_for_household_size - ceil(snap_net_income
+      * snap_net_income_reduction_rate))
+- name: employment_retention_payment_eligible
+  kind: derived
+  entity: TanfUnit
+  dtype: Judgment
+  period: Month
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: If a household is due to terminate for excess income (in which
+            at least $1 of the income is earned)
+  versions:
+  - effective_from: '2025-08-11'
+    formula: 'household_due_to_terminate_for_excess_income
+
+      and earned_income_in_terminating_household >= earned_income_for_employment_retention_payment_minimum
+
+      and employment_retention_payment_month_number <= employment_retention_payment_duration_months'
+- name: employment_retention_payment
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: A-660.12 TANF Benefit Amount/SNAP Allotment note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nv/manual/dwss/eligibility-payments/a-600/page-38
+          excerpt: eligible for a $50 per month Employment Retention Payment (ERP)
+            for six months
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment_amount
+          output: employment_retention_payment_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-08-11'
+    formula: 'if employment_retention_payment_eligible: employment_retention_payment_amount
+      else: 0'


### PR DESCRIPTION
## Summary
- add generated Nevada DWSS A-660.12 TANF RuleSpec encoding and companion tests
- add us-nv to the allowed repository roots
- bump the pinned axiom-encode validation toolchain to 0.2.899 for the merged Nevada TANF oracle metadata

## PolicyEngine parity
- Nevada TANF now has RuleSpec legal slices for minimum issuance, gross income test, whole-dollar benefit rounding, under-$10 exceptions, and Employment Retention Payment
- PolicyEngine does not yet expose the full A-660.12 surface, so oracle coverage classifies the Nevada TANF outputs as known-not-comparable; PE gap tracked in PolicyEngine/policyengine-us#8771

## Local checks
- `axiom-encode compile us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml`
- `axiom-encode test us-nv/policies/dwss/eligibility-payments/a-600/page-38.test.yaml --root <rulespec-us worktree>`
- `axiom-encode guard-generated --repo <rulespec-us worktree> --base-ref origin/main --head-ref HEAD --json`
- `axiom-encode oracle-coverage --root <rulespec-us worktree> --oracle policyengine --include-program-surfaces --json`
- `pytest tests`
- `git diff --check`

Oracle coverage after metadata: 13,409 outputs; 425 comparable; 12,984 known-not-comparable; active pending surfaces 134 (pending_rulespec_encoding 39).
