### PR TITLE
Add Michigan SSP RuleSpec

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -18,6 +18,7 @@ allowed_root_directories:
   - us-il
   - us-ma
   - us-md
+  - us-mi
   - us-ks
   - us-la
   - us-nc

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.900"
+axiom_encode_version = "0.2.902"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5eb0779bd9a5b68f001a8d3bc4070e1d1832135b"
-axiom_corpus_ref = "0b5cfe68b72f1938f79b8661c6b5ba98e3baf587"
+axiom_encode_ref = "a92ccf2ac73549c91295f8e803dde776527248b0"
+axiom_corpus_ref = "6d7d88601864f532582bce196e2913ad98ce11d0"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/us-mi/.axiom/encoding-manifests/policies/mdhhs/bridges/bem/660.json
+++ b/us-mi/.axiom/encoding-manifests/policies/mdhhs/bridges/bem/660.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/mdhhs/bridges/bem/660.yaml",
+      "sha256": "4e24ba9549f8221da80c5f63bbfcd8c61610e7a32962fd0024f9b1d250c31cd8"
+    },
+    {
+      "path": "policies/mdhhs/bridges/bem/660.test.yaml",
+      "sha256": "538d6186e2c7195a4f78607bc8c936ce8017595765d3bc20088b8c06aec41519"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5bcb850a50062fc35debd91181c2059975037a02",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.901",
+    "version_commit": "5bcb850a50062fc35debd91181c2059975037a02"
+  },
+  "axiom_encode_version": "0.2.901",
+  "backend": "codex",
+  "citation": "us-mi/manual/mdhhs/bridges/bem/660",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-mi-manual-mdhhs-bridges-bem-660/workspace/context-manifest.json",
+  "context_manifest_sha256": "cb6f8c6f10c78417626fba720d8c502c88045d53caee87853fc7c27a36e5cc3f",
+  "generated_at": "2026-06-27T09:59:57.719134+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/mdhhs/bridges/bem/660.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "4e24ba9549f8221da80c5f63bbfcd8c61610e7a32962fd0024f9b1d250c31cd8",
+  "generation_prompt_sha256": "1cca5b19b7c422b1963b55b10fffed579aebb536da6586452d9de4720281461f",
+  "model": "gpt-5.5",
+  "run_id": "8a7cf4a4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "273c75d6f4aa8e65355d08f33fc88630593cb0310ade15702286a25a7f2557e9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-mi-manual-mdhhs-bridges-bem-660.json",
+  "trace_sha256": "6bf461d43a1c130a4400dc3932e8161348ba77f9bc6d5924935e9efa63e9601f"
+}

--- a/us-mi/.axiom/encoding-manifests/policies/mdhhs/rft/248.json
+++ b/us-mi/.axiom/encoding-manifests/policies/mdhhs/rft/248.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/mdhhs/rft/248.yaml",
+      "sha256": "b428e04570d5cb4d224924736d00bcd1ae8a3fb774a65b908b0480af61175a5c"
+    },
+    {
+      "path": "policies/mdhhs/rft/248.test.yaml",
+      "sha256": "7876087c44d8ac9705ac380e396fc7aeeab89075855405526d61a6a336a3c54c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a92ccf2ac73549c91295f8e803dde776527248b0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.902",
+    "version_commit": "a92ccf2ac73549c91295f8e803dde776527248b0"
+  },
+  "axiom_encode_version": "0.2.902",
+  "backend": "deterministic",
+  "citation": "us-mi:policies/mdhhs/rft/248",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-27T10:28:47.772011+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj3rlo782/deterministic-repair/policies/mdhhs/rft/248.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj3rlo782",
+  "generated_output_sha256": "b428e04570d5cb4d224924736d00bcd1ae8a3fb774a65b908b0480af61175a5c",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c5e63c197b3610e0e88b06efa2a149c397a1a838406f5c9e4ae80d5143c79a9a"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-mi/policies/mdhhs/bridges/bem/660.test.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/660.test.yaml
@@ -1,0 +1,44 @@
+- name: eligible_independent_living_regular_federal_ssi
+  period: 2022-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_ssi_recipient: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_independently: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_regular_first_of_month_federal_ssi_benefit: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_only_retroactive_or_supplemental_federal_ssi_benefit: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_1619_recipient: false
+  output:
+    us-mi:policies/mdhhs/bridges/bem/660#mi_ssp_eligible: holds
+- name: not_eligible_1619_recipient
+  period: 2022-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_ssi_recipient: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_independently: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_regular_first_of_month_federal_ssi_benefit: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_only_retroactive_or_supplemental_federal_ssi_benefit: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_1619_recipient: true
+  output:
+    us-mi:policies/mdhhs/bridges/bem/660#mi_ssp_eligible: not_holds
+- name: not_eligible_only_retroactive_or_supplemental_federal_benefit
+  period: 2022-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_ssi_recipient: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_independently: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_regular_first_of_month_federal_ssi_benefit: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_only_retroactive_or_supplemental_federal_ssi_benefit: true
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_1619_recipient: false
+  output:
+    us-mi:policies/mdhhs/bridges/bem/660#mi_ssp_eligible: not_holds
+- name: not_eligible_missing_ssi_living_arrangement_and_regular_payment
+  period: 2022-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_ssi_recipient: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_independently: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_regular_first_of_month_federal_ssi_benefit: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_received_only_retroactive_or_supplemental_federal_ssi_benefit: false
+    us-mi:policies/mdhhs/bridges/bem/660#input.person_is_1619_recipient: false
+  output:
+    us-mi:policies/mdhhs/bridges/bem/660#mi_ssp_eligible: not_holds

--- a/us-mi/policies/mdhhs/bridges/bem/660.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/660.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+  summary: |-
+    "The Michigan Department of Health and Human Services (MDHHS) issues the State SSI Payment (SSP) to SSI recipients in the following living arrangements: Independent living; Household of another." "Payments are made for only those months the recipient received a regular first of the month federal benefit." "SSPs are not issued for retroactive or supplemental federal benefits." "SSPs are not issued for 1619 Recipients."
+rules:
+  - name: mi_ssp_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: BEM 660, State SSI Payment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+              excerpt: "issues the State SSI Payment (SSP) to SSI recipients"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+              excerpt: "Independent living. Household of another."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+              excerpt: "Payments are made for only those months the recipient received a regular first of the month federal benefit."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+              excerpt: "SSPs are not issued for retroactive or supplemental federal benefits."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/660
+              excerpt: "SSPs are not issued for 1619 Recipients."
+    versions:
+      - effective_from: '2021-10-01'
+        formula: |-
+          person_is_ssi_recipient
+          and (person_lives_independently or person_lives_in_household_of_another)
+          and person_received_regular_first_of_month_federal_ssi_benefit
+          and not person_received_only_retroactive_or_supplemental_federal_ssi_benefit
+          and not person_is_1619_recipient

--- a/us-mi/policies/mdhhs/rft/248.test.yaml
+++ b/us-mi/policies/mdhhs/rft/248.test.yaml
@@ -1,0 +1,260 @@
+- name: independent living individual
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: true
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+  output:
+    us-mi:policies/mdhhs/rft/248#mi_ssp_person: 14.0
+- name: household of another couple member
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: true
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: true
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+  output:
+    us-mi:policies/mdhhs/rft/248#mi_ssp_person: 6.98
+- name: domiciliary care couple member
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: true
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: true
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+  output:
+    us-mi:policies/mdhhs/rft/248#mi_ssp_person: 335.5
+- name: eligible child
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: true
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+  output:
+    us-mi:policies/mdhhs/rft/248#mi_ssp_person: 14.0
+- name: auto_zero_mi_ssp_person
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#mi_ssp_person: 0
+- name: oracle_parameter_independent_living_individual_state_ssi_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#independent_living_individual_state_ssi_payment: 14.0
+- name: oracle_parameter_independent_living_couple_state_ssi_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#independent_living_couple_state_ssi_payment: 10.5
+- name: oracle_parameter_household_of_another_individual_state_ssi_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#household_of_another_individual_state_ssi_payment: 9.33
+- name: oracle_parameter_household_of_another_couple_state_ssi_payment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#household_of_another_couple_state_ssi_payment: 6.98
+- name: oracle_parameter_domiciliary_care_individual_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#domiciliary_care_individual_dhs_supplement: 87.0
+- name: oracle_parameter_domiciliary_care_couple_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#domiciliary_care_couple_dhs_supplement: 671.0
+- name: oracle_parameter_personal_care_individual_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#personal_care_individual_dhs_supplement: 157.5
+- name: oracle_parameter_personal_care_couple_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#personal_care_couple_dhs_supplement: 812.0
+- name: oracle_parameter_home_for_aged_individual_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#home_for_aged_individual_dhs_supplement: 179.3
+- name: oracle_parameter_home_for_aged_couple_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#home_for_aged_couple_dhs_supplement: 855.6
+- name: oracle_parameter_institution_individual_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#institution_individual_dhs_supplement: 7.0
+- name: oracle_parameter_institution_couple_dhs_supplement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/mdhhs/rft/248#input.person_is_eligible_child: false
+    us-mi:policies/mdhhs/rft/248#input.person_is_member_of_intact_couple: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_domiciliary_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_home_for_aged: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_household_of_another: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_institution: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_in_personal_care: false
+    us-mi:policies/mdhhs/rft/248#input.person_lives_independently: false
+  output:
+    us-mi:policies/mdhhs/rft/248#institution_couple_dhs_supplement: 14.0

--- a/us-mi/policies/mdhhs/rft/248.yaml
+++ b/us-mi/policies/mdhhs/rft/248.yaml
@@ -1,0 +1,369 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mi/manual/mdhhs/rft/248
+  summary: |-
+    Effective January 1, 2026: SSI payment levels list State SSI Payment and DHS Supplement amounts for independent living, household of another, eligible child, domiciliary care, personal care, home for aged, and institution. "Multiply the Federal SSI Benefit Rate $994 by 3 to obtain the Extended Care/Waiver income limit $2982." Adult foster care/home for aged recipients retain at least "$44.00 per month for an individual ($88 for a couple)."
+rules:
+  - name: independent_living_individual_state_ssi_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Independent Living/Individual ... State SSI Payment $14.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          14.00
+  - name: independent_living_couple_state_ssi_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Independent Living/Couple ... State SSI Payment $21.00 ($10.50 each)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10.50
+  - name: household_of_another_individual_state_ssi_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Household of Another/Individual ... State SSI Payment $9.33"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          9.33
+  - name: household_of_another_couple_state_ssi_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Household of Another/Couple ... State SSI Payment $13.96 ($6.98 each)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          6.98
+  - name: eligible_child_state_ssi_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Eligible Child Individual ... DHS Supplement $14.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          14.00
+  - name: domiciliary_care_individual_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Domiciliary Care Individual ... DHS Supplement $87.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          87.00
+  - name: domiciliary_care_couple_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Domiciliary Care Couple ... DHS Supplement $671.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          671.00
+  - name: personal_care_individual_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Personal Care Individual ... DHS Supplement $157.50"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          157.50
+  - name: personal_care_couple_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Personal Care Couple ... DHS Supplement $812.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          812.00
+  - name: home_for_aged_individual_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Home for Aged Individual ... DHS Supplement $179.30"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          179.30
+  - name: home_for_aged_couple_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Home for Aged Couple ... DHS Supplement $855.60"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          855.60
+  - name: institution_individual_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Institution Individual ... DHS Supplement $7.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          7.00
+  - name: institution_couple_dhs_supplement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts, effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Institution Couple ... DHS Supplement $14.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          14.00
+  - name: federal_ssi_benefit_rate
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, extended care/waiver income limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Federal SSI Benefit Rate $994"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: extended_care_waiver_income_limit_multiplier
+    kind: parameter
+    dtype: Integer
+    period: Month
+    source: RFT 248, SSI Payment Levels, extended care/waiver income limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "Multiply the Federal SSI Benefit Rate $994 by 3"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          3
+  - name: extended_care_waiver_income_limit
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI Payment Levels, extended care/waiver income limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "obtain the Extended Care/Waiver income limit $2982"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          federal_ssi_benefit_rate * extended_care_waiver_income_limit_multiplier
+  - name: essential_person_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Optional Supplemental Amounts note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "The essential person payment is $498.00."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          498.00
+  - name: adult_foster_care_individual_recipient_retained_allowance
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Adult Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "allowance of at least $44.00 per month for an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          44.00
+  - name: adult_foster_care_couple_recipient_retained_allowance
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, Adult Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "$88 for a couple"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          88.00
+  - name: mi_ssp_person
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: RFT 248, SSI payment levels and optional supplemental amounts effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/rft/248
+              excerpt: "State SSI Payment ... DHS Supplement ... Payment Amounts Effective January 1, 2026"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_is_eligible_child: eligible_child_state_ssi_payment else: if person_lives_independently and person_is_member_of_intact_couple: independent_living_couple_state_ssi_payment else: if person_lives_independently: independent_living_individual_state_ssi_payment else: if person_lives_in_household_of_another and person_is_member_of_intact_couple: household_of_another_couple_state_ssi_payment else: if person_lives_in_household_of_another: household_of_another_individual_state_ssi_payment else: if person_lives_in_domiciliary_care and person_is_member_of_intact_couple: domiciliary_care_couple_dhs_supplement / 2 else: if person_lives_in_domiciliary_care: domiciliary_care_individual_dhs_supplement else: if person_lives_in_personal_care and person_is_member_of_intact_couple: personal_care_couple_dhs_supplement / 2 else: if person_lives_in_personal_care: personal_care_individual_dhs_supplement else: if person_lives_in_home_for_aged and person_is_member_of_intact_couple: home_for_aged_couple_dhs_supplement / 2 else: if person_lives_in_home_for_aged: home_for_aged_individual_dhs_supplement else: if person_lives_in_institution and person_is_member_of_intact_couple: institution_couple_dhs_supplement / 2 else: if person_lives_in_institution: institution_individual_dhs_supplement else: 0


### PR DESCRIPTION
## Summary
- add Michigan RFT 248 State SSI Payment table rules and companion tests
- add BEM 660 bridge eligibility predicate for Michigan SSP
- pin RuleSpec validation to axiom-encode 0.2.902, which classifies the Michigan SSP oracle surface
- add deterministic oracle parameter tests covering all 12 PolicyEngine-comparable Michigan SSP payment cells

## Validation
- `axiom-encode compile .../us-mi/policies/mdhhs/rft/248.yaml` -> 20 rules, passed
- `axiom-encode compile .../us-mi/policies/mdhhs/bridges/bem/660.yaml` -> 1 rule, passed
- `axiom-encode proof-validate us-mi/policies/mdhhs/rft/248.yaml us-mi/policies/mdhhs/bridges/bem/660.yaml` -> 25 atoms, passed
- `axiom-encode test --root .../rulespec-us-mi-ssp-pe-parity-20260627 .../us-mi` -> 2 files / 21 cases, passed
- `axiom-encode validate .../rft/248.yaml .../bem/660.yaml --skip-reviewers --oracle policyengine --require-oracle-classification` -> RFT PolicyEngine 12/12, BEM no unmapped outputs, passed
- `axiom-encode oracle-coverage --fail-on-unmapped --fail-on-untested-comparable` -> `rulespec-us-mi: comparable=12, known_not_comparable=9`, untested comparable outputs 0, passed
- `axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --json` -> passed
- `git diff --check`
