### PR TITLE
Migrate Georgia SNAP categorical eligibility

### DIFF
--- a/us-ga/.axiom/encoding-manifests/policies/dfcs/snap/3210/block-2.json
+++ b/us-ga/.axiom/encoding-manifests/policies/dfcs/snap/3210/block-2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dfcs/snap/3210/block-2.yaml",
+      "sha256": "3c15a5888599a1f765b3941dc018639f139feb6d4217d5eded52a7a19a9bb144"
+    },
+    {
+      "path": "policies/dfcs/snap/3210/block-2.test.yaml",
+      "sha256": "5fb911316cace9eacd97fe55fbc71a46acda3e9007ab8dd2df952f64c0062c34"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a2ef3e7bbc312d1edcaacea0b928d3ed358dd898",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/axiom-encode-ga-medicaid-mappings-20260610",
+    "version": "0.2.646",
+    "version_commit": "a2ef3e7bbc312d1edcaacea0b928d3ed358dd898"
+  },
+  "axiom_encode_version": "0.2.646",
+  "backend": "deterministic",
+  "citation": "us-ga:policies/dfcs/snap/3210/block-2",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-10T18:13:49.472614+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp_7rucy0i/deterministic-semantic-repair/policies/dfcs/snap/3210/block-2.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp_7rucy0i",
+  "generated_output_sha256": "3c15a5888599a1f765b3941dc018639f139feb6d4217d5eded52a7a19a9bb144",
+  "generation_prompt_sha256": null,
+  "model": "semantic-repair",
+  "run_id": "deterministic-semantic-repair",
+  "runner": "deterministic-semantic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5419a12ffb537c60b675d1b46d3cf2035083586258586e8acfc4e23794099229"
+  },
+  "tool": "axiom-encode deterministic semantic repair",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ga/README.md
+++ b/us-ga/README.md
@@ -2,6 +2,10 @@
 
 Georgia RuleSpec source registry and policy metadata.
 
+This directory is the canonical home for Georgia RuleSpec content. It absorbs
+the former standalone `TheAxiomFoundation/rulespec-us-ga` repository, which is
+archived after the move to the country-level `rulespec-us` monorepo.
+
 ## Contents
 
 - `sources/`: source slices, target manifests, and sidecar metadata when available.

--- a/us-ga/policies/dfcs/snap/3210/block-2.test.yaml
+++ b/us-ga/policies/dfcs/snap/3210/block-2.test.yaml
@@ -1,0 +1,90 @@
+- name: all_au_members_receive_tanf_wsp_or_ssi
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#relation.assistance_unit_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: true
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: true
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: true
+    us-ga:policies/dfcs/snap/3210/block-2#relation.household_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap: holds
+- name: au_member_not_receiving_listed_assistance_and_no_tcos
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#relation.assistance_unit_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: true
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    us-ga:policies/dfcs/snap/3210/block-2#relation.household_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap: not_holds
+- name: overlapping_benefits_do_not_double_count_missing_au_member
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#relation.assistance_unit_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: true
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: true
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    us-ga:policies/dfcs/snap/3210/block-2#relation.household_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap: not_holds
+- name: assistance_unit_member_receives_tanf_wsp_or_ssi_when_tanf
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: true
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#assistance_unit_member_receives_tanf_wsp_or_ssi: holds
+- name: assistance_unit_member_does_not_receive_tanf_wsp_or_ssi
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+    us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#assistance_unit_member_receives_tanf_wsp_or_ssi: not_holds
+- name: any_household_member_receives_tcos
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#relation.assistance_unit_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    us-ga:policies/dfcs/snap/3210/block-2#relation.household_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: true
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: false
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: false
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap: holds
+- name: any_household_member_authorized_to_receive_tcos
+  period: 2024-01
+  input:
+    us-ga:policies/dfcs/snap/3210/block-2#relation.assistance_unit_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_work_support_payments: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_supplemental_security_income: false
+    us-ga:policies/dfcs/snap/3210/block-2#relation.household_members:
+    - us-ga:policies/dfcs/snap/3210/block-2#input.member_receives_tanf_community_outreach_services: false
+      us-ga:policies/dfcs/snap/3210/block-2#input.member_authorized_to_receive_tanf_community_outreach_services: true
+  output:
+    us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap: holds

--- a/us-ga/policies/dfcs/snap/3210/block-2.yaml
+++ b/us-ga/policies/dfcs/snap/3210/block-2.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/manual/dfcs/snap/3210/block-2
+  summary: |-
+    Households in which all AU members receive TANF, WSP, or SSI are categorically eligible for SNAP; categorical eligibility is expanded to households in which any member receives or is authorized to receive TCOS.
+rules:
+  - name: assistance_unit_members
+    kind: data_relation
+    data_relation:
+      predicate: assistance_unit_member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
+    source: DFCS SNAP 3210 block 2, first sentence
+
+  - name: household_members
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
+    source: DFCS SNAP 3210 block 2, second sentence
+
+  - name: assistance_unit_member_receives_tanf_wsp_or_ssi
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: DFCS SNAP 3210 block 2, first sentence
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/snap/3210/block-2
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          member_receives_tanf
+          or member_receives_work_support_payments
+          or member_receives_supplemental_security_income
+
+  - name: categorically_eligible_for_snap
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DFCS SNAP 3210 block 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/snap/3210/block-2
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/manual/dfcs/snap/3210/block-2
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            len(assistance_unit_members) > 0
+            and count_where(
+              assistance_unit_members,
+              assistance_unit_member_receives_tanf_wsp_or_ssi
+            ) == len(assistance_unit_members)
+          )
+          or (
+            count_where(household_members, member_receives_tanf_community_outreach_services)
+            + count_where(household_members, member_authorized_to_receive_tanf_community_outreach_services)
+          ) > 0


### PR DESCRIPTION
## Summary
- migrate the missing Georgia SNAP 3210 block 2 categorical-eligibility RuleSpec from archived `rulespec-us-ga` into `rulespec-us/us-ga`
- carry over the companion test and original signed encoder apply manifest
- add a Georgia README note that `rulespec-us/us-ga` is the canonical successor to the archived standalone repo

## Validation
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode validate --skip-reviewers us-ga/policies/dfcs/snap/3210/block-2.yaml`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode test --root . us-ga/policies/dfcs/snap/3210/block-2.test.yaml`
- `env -u UV_FROZEN uv run --with pytest --with pyyaml pytest -q`
- CI runs `guard-generated` with the signing key required to verify the preserved encoder apply manifest.
