### PR TITLE
Add Kansas TANF cash proration rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.902"
+axiom_encode_version = "0.2.904"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "a92ccf2ac73549c91295f8e803dde776527248b0"
+axiom_encode_ref = "5399093c4430fdc47f2ec63ca76e367499efff5c"
 axiom_corpus_ref = "6d7d88601864f532582bce196e2913ad98ce11d0"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7400/cash-proration-rounding.json
+++ b/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7400/cash-proration-rounding.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml",
-      "sha256": "7e9cce576bfd1386ea11360f0629f6776d7ae3408a4f3839a174209b5338aee1"
+      "sha256": "e48c3ba82e41f81673a2e354d56c9aa825cd4c1a20c97a7fdc09f8acc3fe1c1b"
     },
     {
       "path": "policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml",
-      "sha256": "777530f03c2e3ab80978daf28f3612033f681891a3354192a4eb64d99f68d54d"
+      "sha256": "c35849e97d64c9457cc3641efc67d90b0bdd7ff851463a2a1d7ab8a5de75199b"
     }
   ],
   "axiom_encode_git": {
-    "commit": "362916c7990c6e9787d00fd2d9d91f8121528267",
+    "commit": "5399093c4430fdc47f2ec63ca76e367499efff5c",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.903",
-    "version_commit": "362916c7990c6e9787d00fd2d9d91f8121528267"
+    "version": "0.2.904",
+    "version_commit": "5399093c4430fdc47f2ec63ca76e367499efff5c"
   },
-  "axiom_encode_version": "0.2.903",
+  "axiom_encode_version": "0.2.904",
   "backend": "codex",
   "citation": "us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ks-policies-dcf-keesm-keesm7400-cash-proration-rounding/workspace/context-manifest.json",
-  "context_manifest_sha256": "c490d648f594591bc46d3396c536e946a73183a68674a9c917fe150ecd41bc0f",
-  "generated_at": "2026-06-27T12:51:42.789452+00:00",
+  "context_manifest_sha256": "c9ce3892e8d9eabe7591683233f2ac1ac279dd7aa09a7cf28af538a7cda0242d",
+  "generated_at": "2026-06-27T13:17:01.240106+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "7e9cce576bfd1386ea11360f0629f6776d7ae3408a4f3839a174209b5338aee1",
-  "generation_prompt_sha256": "69375f8b1844dd9f0a8189b114f1d55b604f17b2ac0b40c520a50decff6a5ed1",
+  "generated_output_sha256": "e48c3ba82e41f81673a2e354d56c9aa825cd4c1a20c97a7fdc09f8acc3fe1c1b",
+  "generation_prompt_sha256": "fa82c5a9dd66b3fe3981d42720d9fd60b13a77a630f23a0dd8660fd90174570d",
   "model": "gpt-5.5",
-  "run_id": "493d821f",
+  "run_id": "d0ae0383",
   "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "a2f7a0fbbd837c594cb2a58628e0bd53a39f26fadb552e11ba64efb366d129f0"
+    "value": "d6e8afea4b2238ab8f50b24b55caf6d8fc41ab9e99c7da486476075473011097"
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ks-policies-dcf-keesm-keesm7400-cash-proration-rounding.json",
-  "trace_sha256": "8a108fbdeab0dcfe0e185d038f48dc29a1b029d2fc3a7845a1ef3e8e2177b7f5"
+  "trace_sha256": "28e66bd1370e2bbdc9d1a02a205e47cf709b5fb908f981fc857f40cfb9413ab4"
 }

--- a/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7400/cash-proration-rounding.json
+++ b/us-ks/.axiom/encoding-manifests/policies/dcf/keesm/keesm7400/cash-proration-rounding.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml",
+      "sha256": "7e9cce576bfd1386ea11360f0629f6776d7ae3408a4f3839a174209b5338aee1"
+    },
+    {
+      "path": "policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml",
+      "sha256": "777530f03c2e3ab80978daf28f3612033f681891a3354192a4eb64d99f68d54d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "362916c7990c6e9787d00fd2d9d91f8121528267",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.903",
+    "version_commit": "362916c7990c6e9787d00fd2d9d91f8121528267"
+  },
+  "axiom_encode_version": "0.2.903",
+  "backend": "codex",
+  "citation": "us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ks-policies-dcf-keesm-keesm7400-cash-proration-rounding/workspace/context-manifest.json",
+  "context_manifest_sha256": "c490d648f594591bc46d3396c536e946a73183a68674a9c917fe150ecd41bc0f",
+  "generated_at": "2026-06-27T12:51:42.789452+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7e9cce576bfd1386ea11360f0629f6776d7ae3408a4f3839a174209b5338aee1",
+  "generation_prompt_sha256": "69375f8b1844dd9f0a8189b114f1d55b604f17b2ac0b40c520a50decff6a5ed1",
+  "model": "gpt-5.5",
+  "run_id": "493d821f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a2f7a0fbbd837c594cb2a58628e0bd53a39f26fadb552e11ba64efb366d129f0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ks-policies-dcf-keesm-keesm7400-cash-proration-rounding.json",
+  "trace_sha256": "8a108fbdeab0dcfe0e185d038f48dc29a1b029d2fc3a7845a1ef3e8e2177b7f5"
+}

--- a/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml
@@ -1,24 +1,3 @@
-- name: cash_application_on_first_day_gets_full_month_rounded_down
-  period: 2026-01
-  input:
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 500.75
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 31
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 1
-    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
-    : false
-    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
-    : false
-    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
-    : false
-    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
-    : false
-    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
-    : false
-  output:
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 31
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 500.75
-    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 500
 - name: cash_application_after_first_day_is_prorated_and_rounded_down
   period: 2026-04
   input:
@@ -40,7 +19,91 @@
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 200
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 200
-- name: cash_sanction_notice_exception_blocks_proration
+- name: cash_application_on_first_day_gets_full_month_rounded_down
+  period: 2026-01
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 500.75
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 31
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 1
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 31
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 500.75
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 500
+- name: suspension_reinstatement_exception_blocks_cash_proration
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : true
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 300
+- name: required_information_or_cooperation_reinstatement_exception_blocks_cash_proration
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : true
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 300
+- name: review_or_application_returned_exception_blocks_cash_proration
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : true
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 300
+- name: sanction_notice_cooperation_exception_blocks_cash_proration
   period: 2026-04
   input:
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
@@ -56,6 +119,27 @@
     : true
     ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
     : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 300
+- name: tanf_reopened_exception_blocks_cash_proration
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : true
   output:
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
     us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20

--- a/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml
@@ -1,0 +1,63 @@
+- name: cash_application_on_first_day_gets_full_month_rounded_down
+  period: 2026-01
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 500.75
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 31
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 1
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 31
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 500.75
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 500
+- name: cash_application_after_first_day_is_prorated_and_rounded_down
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 200
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 200
+- name: cash_sanction_notice_exception_blocks_proration
+  period: 2026-04
+  input:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.monthly_cash_benefit_before_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.days_in_month: 30
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.application_day_of_month: 11
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_review_or_application_returned_in_month_following_end_of_review_period
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+    : true
+    ? us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#input.tanf_case_reopened_in_month_following_effective_date_of_closure
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies: not_holds
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month: 20
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration: 300
+    us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#rounded_cash_payment: 300

--- a/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
@@ -5,12 +5,12 @@ module:
   source_verification:
     corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
   summary: |-
-    7401 Proration: For applications filed on the first of the month, assistance will be provided for the full month. For applications filed after the first of the month, the amount of assistance is to be prorated from the date of application. To compute the prorated amount, divide the monthly benefit by the number of days in the month, multiply by the remaining days in the month, and determine remaining days by subtracting the date of application from the number of days in the month and adding one day. 7402 Rounding: For cash, rounding is permitted in determining the pro rata standards and the amount of payment only. All money payments shall be rounded down to the next lowest dollar.
+    7401 Proration: For applications filed on the first of the month, assistance will be provided for the full month; for applications filed after the first of the month, assistance is prorated from the date of application. The prorated amount is the monthly benefit divided by the number of days in the month and multiplied by the remaining days in the month. 7401.2 lists cases where proration is not applicable. 7402 Rounding: For cash, rounding is permitted in determining the pro rata standards and amount of payment only, and all money payments are rounded down to the next lowest dollar.
 rules:
   - name: first_day_of_month
     kind: parameter
     dtype: Count
-    source: KEEsm 7401, Proration
+    source: KEESM 7401, Proration
     metadata:
       proof:
         atoms:
@@ -27,7 +27,7 @@ rules:
   - name: inclusive_application_day_count
     kind: parameter
     dtype: Count
-    source: KEEsm 7401, Proration computation
+    source: KEESM 7401, Proration computation
     metadata:
       proof:
         atoms:
@@ -46,7 +46,7 @@ rules:
     entity: Household
     dtype: Count
     period: Month
-    source: KEEsm 7401, Proration computation
+    source: KEESM 7401, Proration computation
     metadata:
       proof:
         atoms:
@@ -71,7 +71,7 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: KEEsm 7401 and 7401.2, Cash proration applicability
+    source: KEESM 7401 and 7401.2, Cash proration applicability
     metadata:
       proof:
         atoms:
@@ -84,7 +84,27 @@ rules:
             kind: exception
             source:
               corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
-              excerpt: "Proration is not applicable to: ... Cash Only"
+              excerpt: "Proration is not applicable to: All programs: Persons whose assistance has been suspended and reinstated in the month following a one month suspension"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "Persons who are reinstated when required information/cooperation or the interim report or 12-month report form is provided in the month following the effective date of closure"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "Cash and Child Care Only - When an application or review form is returned in the month following the end of the review period"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "Cash Only - When an application is filed in response to a notice of sanction and cooperation is established within 45 days"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "When a TANF case is being reopened in the month following the effective date of closure."
           - path: versions[0].formula
             kind: import
             import:
@@ -107,7 +127,7 @@ rules:
     dtype: Money
     period: Month
     unit: USD
-    source: KEEsm 7401, Cash proration computation
+    source: KEESM 7401, Cash proration computation
     metadata:
       proof:
         atoms:
@@ -144,7 +164,7 @@ rules:
     dtype: Money
     period: Month
     unit: USD
-    source: KEEsm 7402, Cash rounding
+    source: KEESM 7402, Cash rounding
     metadata:
       proof:
         atoms:

--- a/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
@@ -1,0 +1,165 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+  summary: |-
+    7401 Proration: For applications filed on the first of the month, assistance will be provided for the full month. For applications filed after the first of the month, the amount of assistance is to be prorated from the date of application. To compute the prorated amount, divide the monthly benefit by the number of days in the month, multiply by the remaining days in the month, and determine remaining days by subtracting the date of application from the number of days in the month and adding one day. 7402 Rounding: For cash, rounding is permitted in determining the pro rata standards and the amount of payment only. All money payments shall be rounded down to the next lowest dollar.
+rules:
+  - name: first_day_of_month
+    kind: parameter
+    dtype: Count
+    source: KEEsm 7401, Proration
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "applications filed on the first of the month"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: inclusive_application_day_count
+    kind: parameter
+    dtype: Count
+    source: KEEsm 7401, Proration computation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "add one day"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: remaining_days_in_application_month
+    kind: derived
+    entity: Household
+    dtype: Count
+    period: Month
+    source: KEEsm 7401, Proration computation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "subtract the date of application from the number of days in the month and add one day"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#inclusive_application_day_count
+              output: inclusive_application_day_count
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          days_in_month - application_day_of_month + inclusive_application_day_count
+
+  - name: cash_proration_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: KEEsm 7401 and 7401.2, Cash proration applicability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "For applications filed after the first of the month, the amount of assistance is to be prorated from the date of application."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "Proration is not applicable to: ... Cash Only"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#first_day_of_month
+              output: first_day_of_month
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          application_day_of_month > first_day_of_month
+          and not assistance_suspended_and_reinstated_in_month_following_one_month_suspension
+          and not assistance_reinstated_after_required_information_or_cooperation_provided_in_month_following_closure
+          and not cash_review_or_application_returned_in_month_following_end_of_review_period
+          and not cash_application_filed_in_response_to_sanction_notice_with_cooperation_within_45_days_and_received_in_month_following_closure
+          and not tanf_case_reopened_in_month_following_effective_date_of_closure
+
+  - name: cash_benefit_after_proration
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: KEEsm 7401, Cash proration computation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "divide the monthly benefit by the number of days in the month. Multiply that figure by the remaining days in the month."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "For applications filed on the first of the month, assistance will be provided for the full month."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_proration_applies
+              output: cash_proration_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#remaining_days_in_application_month
+              output: remaining_days_in_application_month
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if cash_proration_applies: max(0, monthly_cash_benefit_before_proration / days_in_month * remaining_days_in_application_month) else: max(0, monthly_cash_benefit_before_proration)
+
+  - name: rounded_cash_payment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: KEEsm 7402, Cash rounding
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7400/block-1
+              excerpt: "All money payments shall be rounded down to the next lowest dollar."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#cash_benefit_after_proration
+              output: cash_benefit_after_proration
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor(cash_benefit_after_proration)


### PR DESCRIPTION
## Summary
- adds a corpus-backed KS KEESM 7400 RuleSpec slice for TANF/cash proration and cash payment rounding
- includes companion tests for full-month, prorated, and proration-exception cases
- records the signed axiom-encode apply manifest

## Validation
- axiom-encode validate --skip-reviewers us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
- axiom-encode compile us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
- axiom-encode test --root . us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.test.yaml
- axiom-encode guard-generated --repo . --base-ref origin/main --head-ref HEAD --json
- axiom-encode oracle-coverage --root . --program tanf --fail-on-unmapped
- env -u UV_FROZEN uv run --with pytest --with pyyaml pytest -q