### PR TITLE
Add Minnesota MFIP total grant rules

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -19,6 +19,7 @@ allowed_root_directories:
   - us-ma
   - us-md
   - us-mi
+  - us-mn
   - us-ks
   - us-la
   - us-nc

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.904"
+axiom_encode_version = "0.2.906"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5399093c4430fdc47f2ec63ca76e367499efff5c"
+axiom_encode_ref = "5bd51adfd5d0eae96ceb10c8adfd90203042502b"
 axiom_corpus_ref = "6d7d88601864f532582bce196e2913ad98ce11d0"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-mn/.axiom/encoding-manifests/policies/dhs/combined-manual/0022-12/mfip-total-grant.json
+++ b/us-mn/.axiom/encoding-manifests/policies/dhs/combined-manual/0022-12/mfip-total-grant.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
+      "sha256": "7b8ced9dae4cd57ff2347dfdb4aaa0c5be0a08d8ac13aa9e45c9d5f855e7d6c7"
+    },
+    {
+      "path": "policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml",
+      "sha256": "18e05ef894308168fd9b7aa83f82646d4f99bb580b474fd6f84cd72c402effe2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "63373bdc0fb03c11b5c5409243c23938ead4f08d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.905",
+    "version_commit": "63373bdc0fb03c11b5c5409243c23938ead4f08d"
+  },
+  "axiom_encode_version": "0.2.905",
+  "backend": "codex",
+  "citation": "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-mn-policies-dhs-combined-manual-0022-12-mfip-total-grant/workspace/context-manifest.json",
+  "context_manifest_sha256": "e1f3a1d558a2d34095e5d1f142ef2c5a87e998122998c57bfd4c641962a83744",
+  "generated_at": "2026-06-27T13:47:19.330786+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7b8ced9dae4cd57ff2347dfdb4aaa0c5be0a08d8ac13aa9e45c9d5f855e7d6c7",
+  "generation_prompt_sha256": "55683b5258b7da3d7ee19dd1f69771fa40e19a8ccef585c0f72edbd4413a22af",
+  "model": "gpt-5.5",
+  "run_id": "e72ebee3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8f81ba3a5c3b9fdd74bf5e4b87231a13de8496cb5f7819dc7b64e2638b4b72e6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-mn-policies-dhs-combined-manual-0022-12-mfip-total-grant.json",
+  "trace_sha256": "7dd87320395599a9e492d1978e89a1604854ade2100fcea73f1f5f6a3e3c83fd"
+}

--- a/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml
+++ b/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml
@@ -1,0 +1,100 @@
+- name: no_income_uses_transitional_standard
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_no_income_other_than_mfip: true
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_unearned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_earned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_both_earned_and_unearned_income: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.transitional_standard_for_corresponding_payment_month: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.family_wage_level_for_corresponding_payment_month: 925
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.net_earned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unearned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_is_applicant_case: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.prorated_benefit_under_section_0022_12_03: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.recoupment_amount_if_applicable: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.mfip_food_portion_amount_under_section_0020_09: 304
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#total_mfip_grant_before_proration: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#final_total_mfip_grant: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_food_portion_issued_as_ebt: 304
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_cash_portion_issued_as_cash: 537
+- name: unearned_income_only_subtracts_unearned_and_recoupment
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_no_income_other_than_mfip: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_unearned_income_only: true
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_earned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_both_earned_and_unearned_income: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.transitional_standard_for_corresponding_payment_month: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.family_wage_level_for_corresponding_payment_month: 925
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.net_earned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unearned_income_in_budget_month: 200
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_is_applicant_case: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.prorated_benefit_under_section_0022_12_03: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.recoupment_amount_if_applicable: 50
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.mfip_food_portion_amount_under_section_0020_09: 304
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#total_mfip_grant_before_proration: 641
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#final_total_mfip_grant: 591
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_food_portion_issued_as_ebt: 304
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_cash_portion_issued_as_cash: 287
+- name: earned_income_only_uses_family_wage_difference_capped_by_transitional_standard
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_no_income_other_than_mfip: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_unearned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_earned_income_only: true
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_both_earned_and_unearned_income: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.transitional_standard_for_corresponding_payment_month: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.family_wage_level_for_corresponding_payment_month: 925
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.net_earned_income_in_budget_month: 300
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unearned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_is_applicant_case: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.prorated_benefit_under_section_0022_12_03: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.recoupment_amount_if_applicable: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.mfip_food_portion_amount_under_section_0020_09: 304
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#total_mfip_grant_before_proration: 625
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#final_total_mfip_grant: 625
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_food_portion_issued_as_ebt: 304
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_cash_portion_issued_as_cash: 321
+- name: earned_and_unearned_income_with_applicant_proration
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_no_income_other_than_mfip: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_unearned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_earned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_both_earned_and_unearned_income: true
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.transitional_standard_for_corresponding_payment_month: 841
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.family_wage_level_for_corresponding_payment_month: 1200
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.net_earned_income_in_budget_month: 100
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unearned_income_in_budget_month: 100
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_is_applicant_case: true
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.prorated_benefit_under_section_0022_12_03: 500
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.recoupment_amount_if_applicable: 50
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.mfip_food_portion_amount_under_section_0020_09: 304
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#total_mfip_grant_before_proration: 741
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#final_total_mfip_grant: 450
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_food_portion_issued_as_ebt: 304
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#mfip_cash_portion_issued_as_cash: 146
+- name: auto_zero_total_mfip_grant_before_proration
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.family_wage_level_for_corresponding_payment_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.mfip_food_portion_amount_under_section_0020_09: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.net_earned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.prorated_benefit_under_section_0022_12_03: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.recoupment_amount_if_applicable: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.transitional_standard_for_corresponding_payment_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unearned_income_in_budget_month: 0
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_both_earned_and_unearned_income: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_has_earned_income_only: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_is_applicant_case: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_no_income_other_than_mfip: false
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#input.unit_receives_unearned_income_only: false
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#total_mfip_grant_before_proration: 0

--- a/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
+++ b/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
@@ -1,0 +1,108 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+  summary: |-
+    The procedure to determine the grant amount differs based upon the types of income the unit receives. If the unit receives no income other than MFIP, the Transitional Standard is the total MFIP grant. For unearned income only, subtract unearned income from the Transitional Standard. For earned income, subtract net earned income from the Family Wage Level and compare the difference to the Transitional Standard. For both earned and unearned income, subtract unearned income from the applicable standard or difference. Applicant cases are prorated, recoupment is subtracted if applicable, the food portion is issued as EBT, and any remaining amount is issued in cash.
+rules:
+  - name: total_mfip_grant_before_proration
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Combined Manual 0022.12, MFIP grant calculation before applicant proration and recoupment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "If the unit receives NO INCOME (other than MFIP), the Transitional Standard is the total MFIP grant."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "If the unit receives UNEARNED INCOME ONLY, subtract the amount of unearned income in the budget month from the Transitional Standard"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "Subtract the net earned income in the budget month from the Family Wage Level for the corresponding payment month."
+    versions:
+      - effective_from: '2015-01-01'
+        formula: |-
+          if unit_receives_no_income_other_than_mfip: transitional_standard_for_corresponding_payment_month else: if unit_receives_unearned_income_only: max(0, transitional_standard_for_corresponding_payment_month - unearned_income_in_budget_month) else: if unit_has_earned_income_only: max(0, min(transitional_standard_for_corresponding_payment_month, family_wage_level_for_corresponding_payment_month - net_earned_income_in_budget_month)) else: if unit_has_both_earned_and_unearned_income: max(0, min(transitional_standard_for_corresponding_payment_month, family_wage_level_for_corresponding_payment_month - net_earned_income_in_budget_month) - unearned_income_in_budget_month) else: 0
+  - name: final_total_mfip_grant
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Combined Manual 0022.12, applicant proration and recoupment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "For applicant cases, prorate the benefit."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "Subtract the recoupment if applicable."
+    versions:
+      - effective_from: '2015-01-01'
+        formula: |-
+          if unit_is_applicant_case: max(0, prorated_benefit_under_section_0022_12_03 - recoupment_amount_if_applicable) else: max(0, total_mfip_grant_before_proration - recoupment_amount_if_applicable)
+  - name: mfip_food_portion_issued_as_ebt
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Combined Manual 0022.12, food portion issuance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "Issue the food portion of the grant as EBT."
+    versions:
+      - effective_from: '2015-01-01'
+        formula: |-
+          min(final_total_mfip_grant, mfip_food_portion_amount_under_section_0020_09)
+  - name: mfip_cash_portion_issued_as_cash
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Combined Manual 0022.12, remaining cash issuance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+              excerpt: "Issue any remaining amount in cash."
+    versions:
+      - effective_from: '2015-01-01'
+        formula: |-
+          max(0, final_total_mfip_grant - mfip_food_portion_issued_as_ebt)


### PR DESCRIPTION
## Summary
- add Minnesota Combined Manual 0022.12 MFIP total grant calculation
- split final total grant into food portion issued as EBT and cash portion issued as cash
- include generated companion tests and signed encoding manifest
- bump RuleSpec validation toolchain to axiom-encode 0.2.906 so MFIP oracle mappings are available

## PolicyEngine parity
- comparable output: `mfip_cash_portion_issued_as_cash` -> PE `mn_mfip`
- known non-comparable helpers: total grant before proration, final total grant before food split, capped food portion issued as EBT

## Tests
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode validate --skip-reviewers us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-mfip-benefit-20260627 us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-mfip-benefit-20260627 --base-ref origin/main --head-ref HEAD --json`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-mfip-benefit-20260627 --fail-on-unmapped`
- `git diff --check`