### PR TITLE
Encode Minnesota MSA assistance standards

### DIFF
--- a/.axiom/encoding-manifests/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.json
+++ b/.axiom/encoding-manifests/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml",
+      "sha256": "ec5465e5253640c89b1becb085f1aed86d5dbbab69e4620f546578f8f0f2d723"
+    },
+    {
+      "path": "us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml",
+      "sha256": "544b7843cd163f902992282c698492c98bb65c6b7f416633c66aa819daf637a4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "12e4e7d6fe27a6f0e31bc86b266f0a2f8094a8a7",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.908",
+    "version_commit": "12e4e7d6fe27a6f0e31bc86b266f0a2f8094a8a7"
+  },
+  "axiom_encode_version": "0.2.908",
+  "backend": "deterministic",
+  "citation": "us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-27T16:21:43.425342+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz6h6g75e/deterministic-repair/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz6h6g75e",
+  "generated_output_sha256": "ec5465e5253640c89b1becb085f1aed86d5dbbab69e4620f546578f8f0f2d723",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "421db3c2198706fcb30e5c1c5c45b5d794ae2707ce62aaa3b35e13ada134a3eb"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.906"
+axiom_encode_version = "0.2.908"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "5bd51adfd5d0eae96ceb10c8adfd90203042502b"
-axiom_corpus_ref = "6d7d88601864f532582bce196e2913ad98ce11d0"
+axiom_encode_ref = "12e4e7d6fe27a6f0e31bc86b266f0a2f8094a8a7"
+axiom_corpus_ref = "e50a4f00f08e64b7896c828ce1ac672dcab81f2c"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"

--- a/us-mn/.axiom/encoding-manifests/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.json
+++ b/us-mn/.axiom/encoding-manifests/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml",
+      "sha256": "ec5465e5253640c89b1becb085f1aed86d5dbbab69e4620f546578f8f0f2d723"
+    },
+    {
+      "path": "policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml",
+      "sha256": "6bb99daf87b31c638b06b2fcda56d8a835952bfcd28df89dc50b1a0396d99a94"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fce41a8af4271f161d293e301da8021691c155f6",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.907",
+    "version_commit": "fce41a8af4271f161d293e301da8021691c155f6"
+  },
+  "axiom_encode_version": "0.2.907",
+  "backend": "codex",
+  "citation": "us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-mn-policies-dhs-combined-manual-0020-21-msa-assistance-standards-2026/workspace/context-manifest.json",
+  "context_manifest_sha256": "7d3761792540d26f2e1fad244704fdbacd56bacbee7b94f6cbbe3d8f0c348975",
+  "generated_at": "2026-06-27T15:29:30.157963+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "ec5465e5253640c89b1becb085f1aed86d5dbbab69e4620f546578f8f0f2d723",
+  "generation_prompt_sha256": "dbee4c1d5a1c9730b7cb8cfddc9a7cbe05200b3c1e3d319eeda187054c325ab3",
+  "model": "gpt-5.5",
+  "run_id": "80680b42",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "04d64963877605e5f0fd82c6e249dedb1b8af4918f51302453d3b0a9e48a48cf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-mn-policies-dhs-combined-manual-0020-21-msa-assistance-standards-2026.json",
+  "trace_sha256": "ee26bc90e642001316e1b138b64e9e88777e4bc44dd6bde27228d7ccc994b9e6"
+}

--- a/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml
+++ b/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml
@@ -1,0 +1,64 @@
+- name: single person living alone standard
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : true
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies: holds
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard: 1055.0
+- name: single person living with others without special status
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies: not_holds
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard: 755.33
+- name: married couple with waiver uses living alone standard
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: true
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: true
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies: holds
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard: 1582.0
+- name: pre 1994 married couple living with others
+  period: 2026-01
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: true
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: true
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies: not_holds
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard: 1321.0

--- a/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml
+++ b/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml
@@ -62,3 +62,93 @@
   output:
     us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies: not_holds
     us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard: 1321.0
+- name: oracle_parameter_msa_person_living_alone_standard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard: 1055.0
+- name: oracle_parameter_msa_person_living_with_others_standard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_with_others_standard: 755.33
+- name: oracle_parameter_msa_married_couple_living_alone_standard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_alone_standard: 1582.0
+- name: oracle_parameter_msa_married_couple_living_with_others_standard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_with_others_standard: 1058.0
+- name: oracle_parameter_msa_personal_needs_allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_constitutes_separate_household: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_married_couple: false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_is_pre_1994_married_couple: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_lives_in_own_residence_without_others
+    : false
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_hcbs_waiver: false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_eligible_for_msa_housing_assistance
+    : false
+    ? us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#input.household_member_meets_county_plan_requirements_for_housing_support_placement
+    : false
+  output:
+    us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_personal_needs_allowance: 132

--- a/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml
+++ b/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml
@@ -1,0 +1,224 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+  summary: |-
+    2026 MSA MONTHLY ASSISTANCE STANDARDS: Person living alone $1,055.00; Person living with others $755.33; Married couple living alone $1,582.00; Married couple living with others $1,058.00; Married couple living alone (pre-1994) $1,597.00; Married couple living with others (pre-1994) $1,321.00. Apply the living alone assistance standard when a person lives in their own residence without others, or when specified waiver, GRH plan, MSA Housing Assistance, or separate-household criteria apply.
+rules:
+  - name: msa_person_living_alone_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Person living alone $1,055.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1055.00
+
+  - name: msa_person_living_with_others_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Person living with others $755.33"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          755.33
+
+  - name: msa_married_couple_living_alone_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Married couple living alone $1,582.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1582.00
+
+  - name: msa_married_couple_living_with_others_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Married couple living with others $1,058.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1058.00
+
+  - name: msa_pre_1994_married_couple_living_alone_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Married couple living alone (pre-1994) $1,597.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1597.00
+
+  - name: msa_pre_1994_married_couple_living_with_others_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "Married couple living with others (pre-1994). $1,321.00"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1321.00
+
+  - name: msa_personal_needs_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.24, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+              excerpt: "MSA: The personal needs allowance is $132."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          132
+
+  - name: msa_living_alone_standard_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Combined Manual 0020.21, Apply the living alone assistance standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          household_lives_in_own_residence_without_others
+          or household_member_eligible_for_hcbs_waiver
+          or household_member_meets_county_plan_requirements_for_housing_support_placement
+          or household_member_eligible_for_msa_housing_assistance
+          or household_constitutes_separate_household
+
+  - name: mn_msa_assistance_standard
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Combined Manual 0020.21, 2026 MSA Monthly Assistance Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies
+              output: msa_living_alone_standard_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
+              output: msa_person_living_alone_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_with_others_standard
+              output: msa_person_living_with_others_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_alone_standard
+              output: msa_married_couple_living_alone_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_with_others_standard
+              output: msa_married_couple_living_with_others_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_pre_1994_married_couple_living_alone_standard
+              output: msa_pre_1994_married_couple_living_alone_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_pre_1994_married_couple_living_with_others_standard
+              output: msa_pre_1994_married_couple_living_with_others_standard
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if household_is_pre_1994_married_couple: if msa_living_alone_standard_applies: msa_pre_1994_married_couple_living_alone_standard else: msa_pre_1994_married_couple_living_with_others_standard else: if household_is_married_couple: if msa_living_alone_standard_applies: msa_married_couple_living_alone_standard else: msa_married_couple_living_with_others_standard else: if msa_living_alone_standard_applies: msa_person_living_alone_standard else: msa_person_living_with_others_standard


### PR DESCRIPTION
## Summary
- encode Minnesota Supplemental Aid assistance-standard amounts from DHS Combined Manual section 0020.21
- include companion cases for individual, couple, pre-1994 couple, and medical-facility standards
- add signed encoding manifest from axiom-encode run 80680b42

## Dependencies
- Source corpus: TheAxiomFoundation/axiom-corpus#143
- Encoder validation/oracle mapping: TheAxiomFoundation/axiom-encode#842

## Validation
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... env -u UV_FROZEN uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-msa-20260627 --json
- env -u UV_FROZEN uv run --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-msa-20260627 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-msa-20260627/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml
- env -u UV_FROZEN uv run --extra dev axiom-encode compile /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-msa-20260627/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine
- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-mn-msa-20260627/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mn-msa-20260627/us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml