### PR TITLE
Add Arizona TANF program surface

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.908"
+axiom_encode_version = "0.2.909"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "12e4e7d6fe27a6f0e31bc86b266f0a2f8094a8a7"
+axiom_encode_ref = "f1dc484cae21a8fcd90f7da9e198d9191e807cab"
 axiom_corpus_ref = "e50a4f00f08e64b7896c828ce1ac672dcab81f2c"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/programs/us-az/tanf/fy-2026.yaml
+++ b/programs/us-az/tanf/fy-2026.yaml
@@ -1,0 +1,79 @@
+# Arizona Cash Assistance -- FY 2026
+#
+# This program spec composes the Arizona DES FAA5 Cash Assistance rules already
+# encoded under us-az/policies/des/faa5. The underlying source modules cover the
+# payment-standard, needy-family, and eligible-no-pay financial path; broader
+# demographic, immigration, resource, time-limit, sanction, and procedural gates
+# remain incomplete at this top-level surface.
+
+program: us-az/tanf
+period: 2026-01
+
+outputs:
+  - az_tanf_payment_standard
+  - az_tanf_countable_income
+  - az_tanf_prospectively_eligible
+  - az_tanf_eligible_no_pay
+  - az_tanf
+
+acknowledged_incomplete:
+  - az_tanf_prospectively_eligible
+  - az_tanf
+
+scope:
+  state:
+    - policies/des/faa5/ca-payment-standard-a1-2fa2
+    - policies/des/faa5/ca-benefit-determination/needy-family-test
+    - policies/des/faa5/ca-benefit-determination/payment-standard-test
+    - policies/des/faa5/ca-benefit-determination/payments-under-10-dollars
+
+transformations:
+  - pattern: derived_formula
+    name: az_tanf_payment_standard
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-az/tanf/fy-2026 payment-standard bridge
+    formula: ca_annual_payment_standard / 12
+
+  - pattern: derived_formula
+    name: az_tanf_countable_income
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-az/tanf/fy-2026 countable-income bridge
+    formula: ca_payment_standard_net_income / 12
+
+  - pattern: derived_formula
+    name: az_tanf_prospectively_eligible
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-az/tanf/fy-2026 prospective-eligibility bridge
+    formula: ca_prospective_eligibility_requirements_met
+
+  - pattern: derived_formula
+    name: az_tanf_eligible_no_pay
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-az/tanf/fy-2026 eligible-no-pay bridge
+    formula: ca_eligible_no_pay_case
+
+  - pattern: conditional_value
+    name: az_tanf
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-az/tanf/fy-2026 benefit amount composition
+    condition: az_tanf_prospectively_eligible and not az_tanf_eligible_no_pay
+    when_true: ca_payment_standard_net_unrounded_payment / 12
+    when_false: 0


### PR DESCRIPTION
## Summary\n- add a FY 2026 Arizona Cash Assistance/TANF program wrapper over existing DES FAA5 legal slices\n- expose payment-standard, countable-income, prospective-eligibility, eligible-no-pay, and final amount bridge outputs\n- bump the validation toolchain to axiom-encode 0.2.909 so PE surface reporting carries the explicit AZ TANF oracle mapping\n\n## Validation\n- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev pytest tests -q\n- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --json\n- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode oracle-coverage --root <tmp rulespec-us symlink> --program tanf --fail-on-unmapped --fail-on-untested-comparable --limit 80\n- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode oracle-coverage --root <tmp rulespec-us symlink> --fail-on-unmapped --fail-on-untested-comparable --limit 80\n- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode oracle-coverage --root <tmp rulespec-us symlink> --include-program-surfaces --json