### PR TITLE
Add Kansas TANF program surface

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.909"
+axiom_encode_version = "0.2.910"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "f1dc484cae21a8fcd90f7da9e198d9191e807cab"
+axiom_encode_ref = "a0a2b8989ba3d99b3d65fbbc617874cf41b8847d"
 axiom_corpus_ref = "e50a4f00f08e64b7896c828ce1ac672dcab81f2c"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/programs/us-ks/tanf/fy-2026.yaml
+++ b/programs/us-ks/tanf/fy-2026.yaml
@@ -1,0 +1,68 @@
+# Kansas TANF -- FY 2026
+#
+# This program spec composes the Kansas KEESM 7411 budgetary-standard slice
+# with the KEESM 7401/7402 cash proration and rounding slice already encoded
+# under us-ks/policies/dcf/keesm. The broader TANF financial path in Kansas,
+# including countable income, income/resource eligibility, demographic gates,
+# and immigration gates, is not yet encoded here, so the top-level amount is
+# acknowledged as incomplete.
+
+program: us-ks/tanf
+period: 2026-01
+
+outputs:
+  - ks_tanf_maximum_benefit
+  - ks_tanf_before_proration
+  - ks_tanf_prorated_cash_benefit
+  - ks_tanf
+
+acknowledged_incomplete:
+  - ks_tanf_before_proration
+  - ks_tanf_prorated_cash_benefit
+  - ks_tanf
+
+scope:
+  state:
+    - policies/dcf/keesm/keesm7410
+    - policies/dcf/keesm/keesm7400/cash-proration-rounding
+
+transformations:
+  - pattern: derived_formula
+    name: ks_tanf_before_proration
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ks/tanf/fy-2026 pre-proration bridge
+    formula: ks_tanf_maximum_benefit
+
+  - pattern: derived_formula
+    name: monthly_cash_benefit_before_proration
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ks/tanf/fy-2026 KEESM 7401 input bridge
+    formula: ks_tanf_before_proration
+
+  - pattern: derived_formula
+    name: ks_tanf_prorated_cash_benefit
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ks/tanf/fy-2026 proration bridge
+    formula: cash_benefit_after_proration
+
+  - pattern: derived_formula
+    name: ks_tanf
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ks/tanf/fy-2026 cash payment composition
+    formula: rounded_cash_payment


### PR DESCRIPTION
## Summary
- add the Kansas TANF FY 2026 program wrapper composing KEESM 7411 maximum benefit with KEESM 7401/7402 cash proration and rounding
- acknowledge the final TANF outputs as incomplete because countable income, income/resource eligibility, demographic eligibility, and immigration eligibility are not yet encoded
- bump the rulespec validation toolchain to axiom-encode 0.2.910 at merged ref a0a2b8989ba3d99b3d65fbbc617874cf41b8847d

## Validation
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev pytest tests -q
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode --extra dev axiom-encode guard-generated --json
- TANF oracle coverage with program surfaces: 293 outputs, 22 comparable, 271 known_not_comparable, 0 unmapped, 0 untested comparable

## PE parity note
- This removes the pending/unmapped KS TANF program surface from the PE parity queue, but intentionally does not claim exact PE parity for `ks_tanf` until the missing eligibility and income/resource paths are encoded.