### PR TITLE
Add Colorado TANF program bridge

### DIFF
--- a/programs/us-co/tanf/fy-2026.yaml
+++ b/programs/us-co/tanf/fy-2026.yaml
@@ -1,0 +1,32 @@
+# Colorado Works TANF -- FY 2026
+#
+# This program spec composes the Colorado Works basic cash assistance rules
+# already encoded under us-co/policies/cdhs/colorado-works. The source module
+# covers the benefit-calculation slice through the grant before pregnancy
+# allowance. Broader demographic, resource, sanction, time-limit, support
+# assignment, pregnancy-allowance, and procedural gates remain incomplete at
+# this top-level surface.
+
+program: us-co/tanf
+period: 2026-01
+
+outputs:
+  - co_tanf
+
+acknowledged_incomplete:
+  - co_tanf
+
+scope:
+  state:
+    - policies/cdhs/colorado-works/basic-cash-assistance
+
+transformations:
+  - pattern: derived_formula
+    name: co_tanf
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-co/tanf/fy-2026 basic-cash-assistance bridge
+    formula: colorado_works_basic_cash_assistance_grant_before_pregnancy_allowance


### PR DESCRIPTION
## Summary
- add a country-level `programs/us-co/tanf/fy-2026.yaml` bridge for Colorado Works TANF
- expose `co_tanf` from the encoded basic cash assistance grant slice
- mark `co_tanf` acknowledged incomplete because broader Colorado Works gates and pregnancy allowance are not yet fully composed

## Validation
- `env -u UV_FROZEN uv --project /Users/maxghenis/TheAxiomFoundation/axiom-encode run --extra dev python -m pytest tests/test_program_specs.py tests/test_repository_layout.py -q` -> 12 passed
- parsed the new YAML with PyYAML from the axiom-encode dev environment

## Notes
This is a bridge over existing country-level Colorado source-law RuleSpec. It does not encode imputed PE amounts or claim full final Colorado Works parity.