### PR TITLE
Add Massachusetts TAFDC payment standard

### DIFF
--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/410-420-table/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/410-420-table/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/410-420-table/block-1.yaml",
+      "sha256": "d128bff83dfe781b465af5f290172eec06a092c6254a25fa98ca24bca5cd7c82"
+    },
+    {
+      "path": "regulations/106-cmr/704/410-420-table/block-1.test.yaml",
+      "sha256": "7f776b0fa845dd688754aac9129a5629da8fcbf4cb03b269573b4a91eb359d3f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "22d7a7d87a6568227bbdef45ed4f5bfc79d4e578",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.986",
+    "version_commit": "22d7a7d87a6568227bbdef45ed4f5bfc79d4e578"
+  },
+  "axiom_encode_version": "0.2.986",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/704/410-420-table/block-1",
+  "context_manifest_file": "/tmp/ma-tafdc-payment-standard-encode-apply-signed/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-410-420-table-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "13014342246b80a8d44b66a39a379be64c74ba2ab7fabe03611529828692a822",
+  "generated_at": "2026-06-29T22:54:21.068654+00:00",
+  "generated_output_file": "/tmp/ma-tafdc-payment-standard-encode-apply-signed/codex-gpt-5.5/regulations/106-cmr/704/410-420-table/block-1.yaml",
+  "generated_output_root": "/tmp/ma-tafdc-payment-standard-encode-apply-signed",
+  "generated_output_sha256": "d128bff83dfe781b465af5f290172eec06a092c6254a25fa98ca24bca5cd7c82",
+  "generation_prompt_sha256": "ef856bb6415824cb2b7c10a2595c05a501ec88d21f57d8883b41feab3b9bfe65",
+  "model": "gpt-5.5",
+  "run_id": "8b97453b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ac057a50043f9fe235ffe25503a045864f8db17fcade88c42113f9ba61dce7a5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/ma-tafdc-payment-standard-encode-apply-signed/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-410-420-table-block-1.json",
+  "trace_sha256": "7a0ad2c758374416eaa7264ae0f8c52389d4e98e890c1bb29905b4b71c5c0939"
+}

--- a/us-ma/regulations/106-cmr/704/410-420-table/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/410-420-table/block-1.test.yaml
@@ -1,0 +1,30 @@
+- name: no rent allowance listed unit size
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_size: 3
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_has_rent_allowance: false
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.month_is_temporary_clothing_allowance_period: true
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.eligible_applicant_or_client_under_clothing_allowance_age_count: 1
+  output:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard: 783
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_temporary_clothing_allowance: 500
+- name: with rent allowance listed unit size
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_size: 4
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_has_rent_allowance: true
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.month_is_temporary_clothing_allowance_period: false
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.eligible_applicant_or_client_under_clothing_allowance_age_count: 2
+  output:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard: 952
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_temporary_clothing_allowance: 0
+- name: incremental amount above ten with rent allowance
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_size: 11
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_has_rent_allowance: true
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.month_is_temporary_clothing_allowance_period: true
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.eligible_applicant_or_client_under_clothing_allowance_age_count: 2
+  output:
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard: 1893
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_temporary_clothing_allowance: 1000

--- a/us-ma/regulations/106-cmr/704/410-420-table/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/410-420-table/block-1.yaml
@@ -1,0 +1,191 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+  summary: From September 1, 2024, to September 30, 2024, inclusive, the appropriate
+    Need and Payment Standard shall be increased by $500 for each eligible applicant
+    and client under age 19. Assistance Unit Size table lists Need and Payment Standard
+    with no rent allowance, with rent allowance, and an incremental amount.
+rules:
+- name: ma_tafdc_payment_standard_no_rent_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  indexed_by: assistance_unit_size
+  source: 106 CMR 704.410 and 106 CMR 704.420 table, column A
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          table:
+            header: Assistance Unit Size Need and Payment Standard table
+            row_key: Assistance Unit Size
+            column_key: A. Need and Payment Standard No Rent Allowance
+  versions:
+  - effective_from: '2024-09-01'
+    values:
+      1: 513
+      2: 648
+      3: 783
+      4: 912
+      5: 1045
+      6: 1183
+      7: 1316
+      8: 1448
+      9: 1580
+      10: 1714
+- name: ma_tafdc_payment_standard_with_rent_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  indexed_by: assistance_unit_size
+  source: 106 CMR 704.410 and 106 CMR 704.420 table, column B
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          table:
+            header: Assistance Unit Size Need and Payment Standard table
+            row_key: Assistance Unit Size
+            column_key: B. Need and Payment Standard With Rent Allowance
+  versions:
+  - effective_from: '2024-09-01'
+    values:
+      1: 553
+      2: 688
+      3: 823
+      4: 952
+      5: 1085
+      6: 1223
+      7: 1356
+      8: 1488
+      9: 1620
+      10: 1754
+- name: maximum_listed_assistance_unit_size
+  kind: parameter
+  dtype: Count
+  source: 106 CMR 704.410 and 106 CMR 704.420 table, assistance unit size rows
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: Assistance Unit Size ... 10
+  versions:
+  - effective_from: '2024-09-01'
+    formula: '10'
+- name: ma_tafdc_payment_standard_incremental_amount
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.410 and 106 CMR 704.420 table, incremental row
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: Incremental 139.00 139.00
+  versions:
+  - effective_from: '2024-09-01'
+    formula: '139'
+- name: temporary_clothing_allowance_amount
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: September 2024 nonrecurring clothing allowance note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: nonrecurring $500 clothing allowance in September 2024
+  versions:
+  - effective_from: '2024-09-01'
+    formula: '500'
+- name: temporary_clothing_allowance_age_upper_bound
+  kind: parameter
+  dtype: Count
+  source: September 2024 clothing allowance age condition
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: under age 19
+  versions:
+  - effective_from: '2024-09-01'
+    formula: '19'
+- name: ma_tafdc_payment_standard
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.410 and 106 CMR 704.420 table, Need and Payment Standard
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: Need and Payment Standard No Rent Allowance ... With Rent Allowance
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: Incremental 139.00 139.00
+  versions:
+  - effective_from: '2024-09-01'
+    formula: "if assistance_unit_size <= maximum_listed_assistance_unit_size:\n  if\
+      \ assistance_unit_has_rent_allowance:\n    ma_tafdc_payment_standard_with_rent_allowance[assistance_unit_size]\n\
+      \  else:\n    ma_tafdc_payment_standard_no_rent_allowance[assistance_unit_size]\n\
+      else:\n  if assistance_unit_has_rent_allowance:\n    ma_tafdc_payment_standard_with_rent_allowance[maximum_listed_assistance_unit_size]\
+      \ + ((assistance_unit_size - maximum_listed_assistance_unit_size) * ma_tafdc_payment_standard_incremental_amount)\n\
+      \  else:\n    ma_tafdc_payment_standard_no_rent_allowance[maximum_listed_assistance_unit_size]\
+      \ + ((assistance_unit_size - maximum_listed_assistance_unit_size) * ma_tafdc_payment_standard_incremental_amount)"
+- name: ma_tafdc_temporary_clothing_allowance
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: September 2024 nonrecurring clothing allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: From September 1, 2024, to September 30, 2024, inclusive
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/410-420-table/block-1
+          excerpt: increased by $500 for each eligible applicant and client under
+            age 19
+  versions:
+  - effective_from: '2024-09-01'
+    formula: 'if month_is_temporary_clothing_allowance_period: eligible_applicant_or_client_under_clothing_allowance_age_count
+      * temporary_clothing_allowance_amount else: 0'


### PR DESCRIPTION
## Summary
- encode the Massachusetts TAFDC 106 CMR 704.410/704.420 September 2024 need and payment standard table
- include no-rent and with-rent tables, the size-10 cap, and the incremental amount above listed sizes
- keep the September 2024 temporary clothing allowance as a separate RuleSpec output from the recurring payment standard

## Validation
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/axiom-encode compile /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260630/us-ma/regulations/106-cmr/704/410-420-table/block-1.yaml --json`
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260630 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260630/us-ma/regulations/106-cmr/704/410-420-table/block-1.test.yaml --json`
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260630/us-ma/regulations/106-cmr/704/410-420-table/block-1.yaml --skip-reviewers --oracle policyengine --min-match 1.0 --json`
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/axiom-encode guard-generated --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260630`

PolicyEngine oracle: 3/3 comparable `ma_tafdc_payment_standard` outputs passed; 3 unsupported outputs are the separate temporary clothing allowance surface.