### PR TITLE
Add Massachusetts TAFDC infant benefit

### DIFF
--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/705/600/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/705/600/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/705/600/block-1.yaml",
+      "sha256": "86327dbdd99c7ff8c15a85f3b6c4fa2891de25f31c0966bb16c5181b8bdf3098"
+    },
+    {
+      "path": "regulations/106-cmr/705/600/block-1.test.yaml",
+      "sha256": "c0d179c57cd5d7bdf2a5fc950f4474f42a559515afaa31202d8af8b88161f710"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6d7821077099039662a114ba1dc805dac784fef0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.987",
+    "version_commit": "6d7821077099039662a114ba1dc805dac784fef0"
+  },
+  "axiom_encode_version": "0.2.987",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/705/600/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-ma-tafdc-infant-1/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-705-600-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "6cb18e517e02a5483b8ea19fd0b6ce496dc2c1821c965c8159acb6a7272e61ba",
+  "generated_at": "2026-06-29T23:39:01.514042+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ma-tafdc-infant-1/codex-gpt-5.5/regulations/106-cmr/705/600/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ma-tafdc-infant-1",
+  "generated_output_sha256": "86327dbdd99c7ff8c15a85f3b6c4fa2891de25f31c0966bb16c5181b8bdf3098",
+  "generation_prompt_sha256": "7f726c9416951a660e9fe7358abc110c36d98a5675d1433380f440c1ae96a8e1",
+  "model": "gpt-5.5",
+  "run_id": "d21087c9",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c171b584a6caa9c92aa29f6875aac3fb0740d68b28d0ca944bc4f7c6f8ab2d41"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ma-tafdc-infant-1/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-705-600-block-1.json",
+  "trace_sha256": "fba33cdc3459c32456899e2dccf4b8d39786b583e3805d73cc398c5f91280a7a"
+}

--- a/us-ma/regulations/106-cmr/705/600/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/705/600/block-1.test.yaml
@@ -1,0 +1,44 @@
+- name: crib mattress and layette authorized
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/705/600/block-1#input.infant_equipment_not_available_from_any_other_source: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.payment_requested_within_six_months_following_birth_of_eligible_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.crib_or_mattress_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.layette_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_crib_or_mattress_rate: 200
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_layette_rate: 100
+  output:
+    us-ma:regulations/106-cmr/705/600/block-1#ma_tafdc_infant_benefit: 300
+- name: equipment available from another source blocks payment
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/705/600/block-1#input.infant_equipment_not_available_from_any_other_source: false
+    us-ma:regulations/106-cmr/705/600/block-1#input.payment_requested_within_six_months_following_birth_of_eligible_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.crib_or_mattress_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.layette_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_crib_or_mattress_rate: 200
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_layette_rate: 100
+  output:
+    us-ma:regulations/106-cmr/705/600/block-1#ma_tafdc_infant_benefit: 0
+- name: request outside six months blocks payment
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/705/600/block-1#input.infant_equipment_not_available_from_any_other_source: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.payment_requested_within_six_months_following_birth_of_eligible_infant: false
+    us-ma:regulations/106-cmr/705/600/block-1#input.crib_or_mattress_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.layette_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_crib_or_mattress_rate: 200
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_layette_rate: 100
+  output:
+    us-ma:regulations/106-cmr/705/600/block-1#ma_tafdc_infant_benefit: 0
+- name: only layette requested
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/705/600/block-1#input.infant_equipment_not_available_from_any_other_source: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.payment_requested_within_six_months_following_birth_of_eligible_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.crib_or_mattress_requested_for_newborn_infant: false
+    us-ma:regulations/106-cmr/705/600/block-1#input.layette_requested_for_newborn_infant: true
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_crib_or_mattress_rate: 200
+    us-ma:regulations/106-cmr/705/600/block-1#input.department_set_layette_rate: 100
+  output:
+    us-ma:regulations/106-cmr/705/600/block-1#ma_tafdc_infant_benefit: 100

--- a/us-ma/regulations/106-cmr/705/600/block-1.yaml
+++ b/us-ma/regulations/106-cmr/705/600/block-1.yaml
@@ -1,0 +1,41 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/705/705.600
+  summary: Infant Benefits provide a one-time payment for equipment needed to care
+    for an infant when equipment is unavailable from any other source and payment
+    is requested within six months following birth.
+rules:
+- name: ma_tafdc_infant_benefit
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 705.600
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/705/705.600
+          excerpt: equipment is not available ... from any other source
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/705/705.600
+          excerpt: requested within the six months following the birth
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/705/705.600
+          excerpt: payment for a crib or mattress ... and ... a layette
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if infant_equipment_not_available_from_any_other_source and payment_requested_within_six_months_following_birth_of_eligible_infant:
+      (if crib_or_mattress_requested_for_newborn_infant: department_set_crib_or_mattress_rate
+      else: 0) + (if layette_requested_for_newborn_infant: department_set_layette_rate
+      else: 0) else: 0'


### PR DESCRIPTION
## Summary
- add 106 CMR 705.600 Massachusetts TAFDC infant benefit RuleSpec
- include generated tests for equipment availability, six-month request timing, and crib/mattress/layette components
- include signed axiom-encode apply manifest

## Validation
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-grant-20260630/us-ma/regulations/106-cmr/705/600/block-1.yaml --skip-reviewers --oracle policyengine --min-match 1.0 --json

PolicyEngine oracle result: 1.0. Coverage: 4 outputs, 2 comparable and passed, 2 unsupported because PE models a flat MA TAFDC infant amount and lacks the 106 CMR 705.600 equipment-source/component-request conditions.