### PR TITLE
Add Washington SSP rules

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.986"
+axiom_encode_version = "0.2.991"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "22d7a7d87a6568227bbdef45ed4f5bfc79d4e578"
+axiom_encode_ref = "18c2a722081c28215fcb48bbd47b6a1d9a6b0053"
 axiom_corpus_ref = "d6eef2051387ecdf9ab96e8a0046bd45ffb596d5"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
-rulespec_us_ref = "6d5a9d343cdbc1f272d025f591863808c2a093a7"
+rulespec_us_ref = "b316b9462711cd10c558c09d62429a119deaceb0"

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-478/388-478-0055.yaml",
+      "sha256": "2ec36fbbc76af0c286d984b45831d3c9041e43a2747bf95881ce647392e244d0"
+    },
+    {
+      "path": "regulations/388/388-478/388-478-0055.test.yaml",
+      "sha256": "42a01b05db4bbbf58739bbf339e75f308e680d7993ccbd0c320c271b27d1221f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "18c2a722081c28215fcb48bbd47b6a1d9a6b0053",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.991",
+    "version_commit": "18c2a722081c28215fcb48bbd47b6a1d9a6b0053"
+  },
+  "axiom_encode_version": "0.2.991",
+  "backend": "deterministic",
+  "citation": "us-wa:regulations/388/388-478/388-478-0055",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-30T01:03:50.739922+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz9lgg52e/deterministic-repair/regulations/388/388-478/388-478-0055.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz9lgg52e",
+  "generated_output_sha256": "2ec36fbbc76af0c286d984b45831d3c9041e43a2747bf95881ce647392e244d0",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "41af821c79c60a257ecfb14c0f32f6ff11f506a7e3677e94f6f89c8f530446c8"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-wa/regulations/388/388-478/388-478-0055.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0055.test.yaml
@@ -1,0 +1,73 @@
+- name: fixed SSP rate for aged eligible individual
+  period: 2024-01
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: holds
+    us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
+    us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 35.5
+- name: grandfathered SSP amount is clamped to maximum
+  period: 2024-01
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: true
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 250
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: not_holds
+    us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 199.77
+    us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 199.77
+- name: medical institution SSP base for eligible individual
+  period: 2023-07
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: not_holds
+    us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
+    us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 70.0
+- name: no SSP when individual is not eligible under WAC 388-474-0012
+  period: 2024-01
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: true
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: holds
+    us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
+    us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 0
+- name: oracle_parameter_medical_institution_monthly_ssp_base
+  period: 2023-07
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 0
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base: 70.0

--- a/us-wa/regulations/388/388-478/388-478-0055.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0055.yaml
@@ -1,0 +1,190 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+  summary: |-
+    Monthly SSP rate standards are $35.50 for individuals with an ineligible spouse, aged 65 and older, blind as determined by SSA, or disabled as determined by SSA; between $0.54 and $199.77 for grandfathered clients; and $70.00 as of July 2023 for individuals residing in a medical institution, with annual COLA increases starting January 1, 2024.
+  deferred_outputs:
+    - output: us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_rate_after_annual_cola
+      reason: The source states that starting January 1, 2024 the medical-institution SSP payment increases annually by a COLA determined by SSA, but the applicable SSA COLA values are not included in the source text or copied RuleSpec context.
+      source_values:
+        - us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base
+rules:
+  - name: fixed_monthly_ssp_rate_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: us-wa/regulation/388/388-478/388-478-0055(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "$35.50 for: (i) Individuals with an ineligible spouse; (ii) Aged 65 and older; (iii) Blind as determined by SSA; or (iv) Disabled as determined by SSA."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          35.50
+
+  - name: grandfathered_monthly_ssp_minimum
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAC 388-478-0055(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "Between $0.54 and $199.77 for grandfathered clients"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.54
+
+  - name: grandfathered_monthly_ssp_maximum
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAC 388-478-0055(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "Between $0.54 and $199.77 for grandfathered clients"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          199.77
+
+  - name: medical_institution_monthly_ssp_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAC 388-478-0055(2)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "$70.00 as of July 2023 for individuals residing in a medical institution."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "as of July 2023"
+    versions:
+      - effective_from: '2023-07-01'
+        formula: |-
+          70.00
+
+  - name: federal_ssi_personal_needs_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: WAC 388-478-0055(2)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "federal SSI personal needs allowance (PNA) of $30.00"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30.00
+
+  - name: fixed_monthly_ssp_rate_standard_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: WAC 388-478-0055(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "Individuals with an ineligible spouse; Aged 65 and older; Blind as determined by SSA; or Disabled as determined by SSA."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_has_ineligible_spouse
+          or individual_is_aged_65_or_older
+          or individual_is_blind_as_determined_by_ssa
+          or individual_is_disabled_as_determined_by_ssa
+
+  - name: grandfathered_monthly_ssp_rate_standard
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAC 388-478-0055(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "varies by individual based on federal requirements."
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "Between $0.54 and $199.77 for grandfathered clients"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: min(grandfathered_monthly_ssp_maximum, max(grandfathered_monthly_ssp_minimum, grandfathered_client_ssp_amount_based_on_federal_requirements)) else: 0
+
+  - name: wa_ssp
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAC 388-478-0055(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "issued to certain individuals who the Social Security Administration (SSA) determines are eligible for supplemental security income (SSI) as described in WAC 388-474-0012."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "Monthly SSP rate standards for eligible persons"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
+              excerpt: "$70.00 as of July 2023 for individuals residing in a medical institution."
+    versions:
+      - effective_from: '2023-07-01'
+        formula: |-
+          if individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: if individual_resides_in_medical_institution: medical_institution_monthly_ssp_base else: if individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: grandfathered_monthly_ssp_rate_standard else: if fixed_monthly_ssp_rate_standard_applies: fixed_monthly_ssp_rate_standard else: 0 else: 0


### PR DESCRIPTION
## Summary
- add generated Washington SSP RuleSpec for WAC 388-478-0055
- include generated companion tests and signed Axiom manifest
- bump the pinned validation toolchain to axiom-encode 0.2.991 / 18c2a722 so CI sees the WA PE mapping and monthly parameter repair
- defer post-2024 medical-institution COLA output because WAC points to HCA for current values outside the ingested source text

Depends on TheAxiomFoundation/axiom-encode#898, now merged.

## Validation
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode repair-oracle-parameter-tests --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-20260630/us-wa /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-20260630/us-wa/regulations/388/388-478/388-478-0055.yaml
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-20260630/us-wa/regulations/388/388-478/388-478-0055.yaml --skip-reviewers --oracle policyengine --min-match 0.95 --json
- focused SSI coverage: WA has 0 untested comparable outputs; WA no longer appears in active pending SSI state supplement surfaces