### PR TITLE
Add Illinois AABD grant adjustment

### DIFF
--- a/.axiom/encoding-manifests/us-il/policies/dhs/csmm/25-06-01.json
+++ b/.axiom/encoding-manifests/us-il/policies/dhs/csmm/25-06-01.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-il/policies/dhs/csmm/25-06-01.yaml",
+      "sha256": "1911bb789f2167b8ced8e17d7a3e8ecd447db4bdee9f38be7b12fbdd200b1594"
+    },
+    {
+      "path": "us-il/policies/dhs/csmm/25-06-01.test.yaml",
+      "sha256": "fca8ca45b782161463d404c8e2851470a79c7115fcce77ff61b1c8b53c506e1a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f5bb75b09053719e7a4cb197675192ebc34ef3c3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.993",
+    "version_commit": "f5bb75b09053719e7a4cb197675192ebc34ef3c3"
+  },
+  "axiom_encode_version": "0.2.993",
+  "backend": "deterministic",
+  "citation": "us-il:policies/dhs/csmm/25-06-01",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-30T01:47:44.810812+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpff5pr77o/deterministic-repair/us-il/policies/dhs/csmm/25-06-01.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpff5pr77o",
+  "generated_output_sha256": "1911bb789f2167b8ced8e17d7a3e8ecd447db4bdee9f38be7b12fbdd200b1594",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bfb42c19b6a16dab79db13b0b94b09d6b08176f0e74634e4845681e14dbd29c5"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.991"
+axiom_encode_version = "0.2.993"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "18c2a722081c28215fcb48bbd47b6a1d9a6b0053"
+axiom_encode_ref = "f5bb75b09053719e7a4cb197675192ebc34ef3c3"
 axiom_corpus_ref = "d6eef2051387ecdf9ab96e8a0046bd45ffb596d5"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
-rulespec_us_ref = "b316b9462711cd10c558c09d62429a119deaceb0"
+rulespec_us_ref = "aab946374e5463ba502fc53f02dd79fc02ba09ea"

--- a/us-il/policies/dhs/csmm/25-06-01.test.yaml
+++ b/us-il/policies/dhs/csmm/25-06-01.test.yaml
@@ -1,0 +1,24 @@
+- name: certified AABD cash case receives 2024 grant adjustment
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/25-06-01#input.certified_aabd_cash_case: true
+  output:
+    us-il:policies/dhs/csmm/25-06-01#il_aabd_grant_amount: 764.9
+- name: non-certified case after July 1982 receives no grant adjustment
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/25-06-01#input.certified_aabd_cash_case: false
+  output:
+    us-il:policies/dhs/csmm/25-06-01#il_aabd_grant_amount: 0
+- name: pre-July 1982 grant adjustment does not require certified AABD cash case
+  period: 1981-07
+  input:
+    us-il:policies/dhs/csmm/25-06-01#input.certified_aabd_cash_case: false
+  output:
+    us-il:policies/dhs/csmm/25-06-01#il_aabd_grant_amount: 96.9
+- name: oracle_parameter_aabd_grant_adjustment_amount
+  period: 2025-01
+  input:
+    us-il:policies/dhs/csmm/25-06-01#input.certified_aabd_cash_case: false
+  output:
+    us-il:policies/dhs/csmm/25-06-01#aabd_grant_adjustment_amount: 788.9

--- a/us-il/policies/dhs/csmm/25-06-01.yaml
+++ b/us-il/policies/dhs/csmm/25-06-01.yaml
@@ -1,0 +1,236 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/manual/dhs/csmm/19812
+  summary: |-
+    WAG 25-06-01: Use the grant adjustment chart when computing past overpayments. Beginning on 07/01/82 only certified AABD Cash cases are allowed the grant adjustment. Retrospective budgeting was implemented effective August 1983 and stopped effective January 2002.
+rules:
+  - name: aabd_grant_adjustment_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAG 25-06-01 grant adjustment chart
+    metadata:
+      proof:
+        atoms:
+          - path: versions
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/19812
+              excerpt: "Dates Grant Adjustment ... 01/01/2025-12/31/2025 788.90 ... 07/01/77 - 06/30/78 10.00"
+              table:
+                header: "Dates Grant Adjustment"
+                row_key: "date period"
+                column_key: "grant adjustment"
+    versions:
+      - effective_from: '1977-07-01'
+        formula: |-
+          10.00
+      - effective_from: '1978-07-01'
+        formula: |-
+          21.60
+      - effective_from: '1979-07-01'
+        formula: |-
+          40.40
+      - effective_from: '1980-07-01'
+        formula: |-
+          70.20
+      - effective_from: '1981-07-01'
+        formula: |-
+          96.90
+      - effective_from: '1982-07-01'
+        formula: |-
+          116.50
+      - effective_from: '1983-09-01'
+        formula: |-
+          126.20
+      - effective_from: '1984-03-01'
+        formula: |-
+          135.90
+      - effective_from: '1985-03-01'
+        formula: |-
+          146.90
+      - effective_from: '1986-03-01'
+        formula: |-
+          157.90
+      - effective_from: '1987-03-01'
+        formula: |-
+          161.90
+      - effective_from: '1988-03-01'
+        formula: |-
+          175.90
+      - effective_from: '1989-03-01'
+        formula: |-
+          189.90
+      - effective_from: '1990-03-01'
+        formula: |-
+          207.90
+      - effective_from: '1991-03-01'
+        formula: |-
+          228.90
+      - effective_from: '1993-03-01'
+        formula: |-
+          255.90
+      - effective_from: '1994-03-01'
+        formula: |-
+          267.90
+      - effective_from: '1995-03-01'
+        formula: |-
+          279.90
+      - effective_from: '1996-03-01'
+        formula: |-
+          291.90
+      - effective_from: '1997-03-01'
+        formula: |-
+          305.90
+      - effective_from: '1998-03-01'
+        formula: |-
+          315.90
+      - effective_from: '1999-03-01'
+        formula: |-
+          321.90
+      - effective_from: '2000-03-01'
+        formula: |-
+          333.90
+      - effective_from: '2001-03-01'
+        formula: |-
+          351.90
+      - effective_from: '2001-10-01'
+        formula: |-
+          352.90
+      - effective_from: '2002-03-01'
+        formula: |-
+          366.90
+      - effective_from: '2003-03-01'
+        formula: |-
+          373.90
+      - effective_from: '2004-03-01'
+        formula: |-
+          385.90
+      - effective_from: '2005-03-01'
+        formula: |-
+          400.90
+      - effective_from: '2006-03-01'
+        formula: |-
+          424.90
+      - effective_from: '2007-03-01'
+        formula: |-
+          444.90
+      - effective_from: '2008-03-01'
+        formula: |-
+          458.90
+      - effective_from: '2009-03-01'
+        formula: |-
+          495.90
+      - effective_from: '2012-03-01'
+        formula: |-
+          519.90
+      - effective_from: '2013-03-01'
+        formula: |-
+          531.90
+      - effective_from: '2014-03-01'
+        formula: |-
+          542.90
+      - effective_from: '2015-03-01'
+        formula: |-
+          554.90
+      - effective_from: '2017-03-01'
+        formula: |-
+          556.90
+      - effective_from: '2018-01-01'
+        formula: |-
+          571.90
+      - effective_from: '2019-01-01'
+        formula: |-
+          592.90
+      - effective_from: '2020-01-01'
+        formula: |-
+          604.90
+      - effective_from: '2021-01-01'
+        formula: |-
+          615.90
+      - effective_from: '2022-01-01'
+        formula: |-
+          662.90
+      - effective_from: '2023-01-01'
+        formula: |-
+          735.90
+      - effective_from: '2024-01-01'
+        formula: |-
+          764.90
+      - effective_from: '2025-01-01'
+        formula: |-
+          788.90
+
+  - name: aabd_grant_adjustment_requires_certified_cash_case
+    kind: parameter
+    dtype: Integer
+    period: Month
+    source: WAG 25-06-01 grant adjustment footnote
+    metadata:
+      proof:
+        atoms:
+          - path: versions
+            kind: condition
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/19812
+              excerpt: "Beginning on 07/01/82 only certified AABD Cash cases are allowed the grant adjustment."
+    versions:
+      - effective_from: '1977-07-01'
+        formula: |-
+          0
+      - effective_from: '1982-07-01'
+        formula: |-
+          1
+
+  - name: aabd_retrospective_budgeting_procedure_indicator
+    kind: parameter
+    dtype: Integer
+    period: Month
+    source: WAG 25-06-01 retrospective budgeting note
+    metadata:
+      proof:
+        atoms:
+          - path: versions
+            kind: effective_period
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/19812
+              excerpt: "retrospective budgeting procedure was implemented effective August 1983 and stopped effective January 2002"
+    versions:
+      - effective_from: '1977-07-01'
+        formula: |-
+          0
+      - effective_from: '1983-08-01'
+        formula: |-
+          1
+      - effective_from: '2002-01-01'
+        formula: |-
+          0
+
+  - name: il_aabd_grant_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: WAG 25-06-01 grant adjustment chart and footnote
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/19812
+              excerpt: "Use the following chart when computing past overpayments: Dates Grant Adjustment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/19812
+              excerpt: "Beginning on 07/01/82 only certified AABD Cash cases are allowed the grant adjustment."
+    versions:
+      - effective_from: '1977-07-01'
+        formula: |-
+          if aabd_grant_adjustment_requires_certified_cash_case == 1: if certified_aabd_cash_case: aabd_grant_adjustment_amount else: 0 else: aabd_grant_adjustment_amount


### PR DESCRIPTION
## Summary
- add Illinois DHS CDB/WAG 25-06-01 AABD grant adjustment parameter table and certified-cash-case grant amount rule
- add companion tests including a PolicyEngine oracle parameter case for the 2025 monthly grant amount
- update the validation toolchain pin to axiom-encode 0.2.993 after the oracle-parameter repair fix

## Source
- us-il/manual/dhs/csmm/19812

## Validation
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630/us-il/policies/dhs/csmm/25-06-01.test.yaml
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630/us-il/policies/dhs/csmm/25-06-01.yaml
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630/us-il/policies/dhs/csmm/25-06-01.yaml --skip-reviewers --oracle policyengine --min-match 0.95 --json
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630 --include-program-surfaces --program ssi_state_supplement --limit 80
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-grant-20260630 --base-ref origin/main --json