### PR TITLE
Add Alabama SSP payment standards

### DIFF
--- a/.axiom/encoding-manifests/us-al/policies/dhr/ssp/state-supplement-payment-standard.json
+++ b/.axiom/encoding-manifests/us-al/policies/dhr/ssp/state-supplement-payment-standard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml",
+      "sha256": "7b01b5c6d088f862c89bb661f25ed6120fdbbaab713be5d7d56c564bda67b87f"
+    },
+    {
+      "path": "us-al/policies/dhr/ssp/state-supplement-payment-standard.test.yaml",
+      "sha256": "63128ef0091b5fc9c66d3357baac44fb53e127ba9c490888dbe14ee6f3dc55ae"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8f8d2f1c9f77ef2d96ec4cc619a22bddd1776df3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-al-ssp-oracle-20260630",
+    "version": "0.2.996",
+    "version_commit": "8f8d2f1c9f77ef2d96ec4cc619a22bddd1776df3"
+  },
+  "axiom_encode_version": "0.2.996",
+  "backend": "deterministic",
+  "citation": "us-al:policies/dhr/ssp/state-supplement-payment-standard",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-30T04:20:39.022916+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzfqrb6t9/deterministic-repair/us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzfqrb6t9",
+  "generated_output_sha256": "7b01b5c6d088f862c89bb661f25ed6120fdbbaab713be5d7d56c564bda67b87f",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "283df8c0b8eda84b54a757913fdc69fda49c82e5c963a59c2f2a12a57ae4eabb"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.995"
+axiom_encode_version = "0.2.996"
 axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
-axiom_encode_ref = "848e1fecb883424ac31f77266e45fbef3176fb0b"
-axiom_corpus_ref = "7ee8c575e2b1f923cca9c9cdc2e24674e25579f6"
+axiom_encode_ref = "b3dbba5989e245fb5bef07c9052116ee9217080e"
+axiom_corpus_ref = "a2a8eac83b6da1c3130c68e5cff72d1a82df3d57"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
-rulespec_us_ref = "aab946374e5463ba502fc53f02dd79fc02ba09ea"
+rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/us-al/.axiom/encoding-manifests/policies/dhr/ssp/state-supplement-payment-standard.json
+++ b/us-al/.axiom/encoding-manifests/policies/dhr/ssp/state-supplement-payment-standard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhr/ssp/state-supplement-payment-standard.yaml",
+      "sha256": "7b01b5c6d088f862c89bb661f25ed6120fdbbaab713be5d7d56c564bda67b87f"
+    },
+    {
+      "path": "policies/dhr/ssp/state-supplement-payment-standard.test.yaml",
+      "sha256": "4a81271e37158a9d934f3926d5cbac24ab5a00836f47b947ea1e2cfc2c492d84"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "848e1fecb883424ac31f77266e45fbef3176fb0b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.995",
+    "version_commit": "848e1fecb883424ac31f77266e45fbef3176fb0b"
+  },
+  "axiom_encode_version": "0.2.995",
+  "backend": "codex",
+  "citation": "us-al/policies/dhr/ssp/state-supplement-payment-standard",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-al-policies-dhr-ssp-state-supplement-payment-standard/workspace/context-manifest.json",
+  "context_manifest_sha256": "c0e7439d710ca9b78599e508ca4b4b1aa8253e966fdeaf8365ddab62e1206abd",
+  "generated_at": "2026-06-30T04:07:11.760990+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dhr/ssp/state-supplement-payment-standard.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "7b01b5c6d088f862c89bb661f25ed6120fdbbaab713be5d7d56c564bda67b87f",
+  "generation_prompt_sha256": "bcfdcc59e4eead07e5a342b49836105f5926b80e7e6413ad45b62807063169ea",
+  "model": "gpt-5.5",
+  "run_id": "56e525a2",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2ec680ee7efb78d57a8b8ba644e2d593b9c51858db9223637e5f8ded9504a7ae"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-al-policies-dhr-ssp-state-supplement-payment-standard.json",
+  "trace_sha256": "e130ec10e07d85a3268bf2fb84de2a99695e46b08c75a5fd9489126a72e9f642"
+}

--- a/us-al/policies/dhr/ssp/state-supplement-payment-standard.test.yaml
+++ b/us-al/policies/dhr/ssp/state-supplement-payment-standard.test.yaml
@@ -1,0 +1,143 @@
+- name: fcmp nursing care required
+  period: 2024-01
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: true
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp: 100.0
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted: 60.0
+- name: nursing care supplement
+  period: 2024-01
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: true
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp: 60.0
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted: 60.0
+- name: personal care level b supplement
+  period: 2024-01
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: true
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp: 56.0
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted: 56.0
+- name: cerebral palsy treatment center care
+  period: 2024-01
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: true
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp: 196.0
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted: 196.0
+- name: auto_zero_al_ssp
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp: 0
+- name: auto_zero_al_ssp_maximum_budgeted
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted: 0
+- name: oracle_parameter_fcmp_nursing_care_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_payment_monthly_amount: 100.0
+- name: oracle_parameter_nursing_care_supplement_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_payment_monthly_amount: 60.0
+- name: oracle_parameter_personal_care_level_a_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_payment_monthly_amount: 60.0
+- name: oracle_parameter_personal_care_level_b_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_payment_monthly_amount: 56.0
+- name: oracle_parameter_foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    ? us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+    : 110.0
+- name: oracle_parameter_cerebral_palsy_treatment_center_care_payment_monthly_amount
+  period: 1995-04
+  input:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.cerebral_palsy_treatment_center_care_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.fcmp_nursing_care_required: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.foster_care_personal_or_nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.nursing_care_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_a_supplement_applies: false
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#input.personal_care_level_b_supplement_applies: false
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_payment_monthly_amount: 196.0

--- a/us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml
+++ b/us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml
@@ -1,0 +1,335 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+  summary: |-
+    Attachment 660-2-4-.19a lists Special Needs payment rows with "Payment Monthly Amount" and "Maximum Budgeted" amounts: FCMP Nursing Care when required, Nursing Care Supplement, Personal Care Supplement Levels A and B, Personal Care or Nursing Care Supplement in Foster Care, and Care in a Cerebral Palsy Treatment Center (APTD).
+rules:
+  - name: fcmp_nursing_care_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, FCMP Nursing Care row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'FCMP Nursing Care (when required) $100.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          100.00
+  - name: fcmp_nursing_care_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, FCMP Nursing Care row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'FCMP Nursing Care (when required) $100.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          60.00
+  - name: nursing_care_supplement_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Nursing Care Supplement row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Nursing Care Supplement $60.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          60.00
+  - name: nursing_care_supplement_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Nursing Care Supplement row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Nursing Care Supplement $60.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          60.00
+  - name: personal_care_level_a_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Personal Care Supplement Level A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care Supplement - Level Of Independence "A" $60.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          60.00
+  - name: personal_care_level_a_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Personal Care Supplement Level A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care Supplement - Level Of Independence "A" $60.00 $60.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          60.00
+  - name: personal_care_level_b_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Personal Care Supplement Level B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care Supplement - Level of Independence "B" $56.00 $56.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          56.00
+  - name: personal_care_level_b_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Personal Care Supplement Level B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care Supplement - Level of Independence "B" $56.00 $56.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          56.00
+  - name: foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Foster Care supplement row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care or Nursing Care Supplement in Foster Care $110.00 $110.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          110.00
+  - name: foster_care_personal_or_nursing_care_supplement_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Foster Care supplement row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Personal Care or Nursing Care Supplement in Foster Care $110.00 $110.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          110.00
+  - name: cerebral_palsy_treatment_center_care_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Cerebral Palsy Treatment Center row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Care in a Cerebral Palsy Treatment Center (APTD) $196.00 $196.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          196.00
+  - name: cerebral_palsy_treatment_center_care_maximum_budgeted
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Cerebral Palsy Treatment Center row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Care in a Cerebral Palsy Treatment Center (APTD) $196.00 $196.00'
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          196.00
+  - name: al_ssp
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Payment Monthly Amount column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Payment Monthly Amount To Be Maximum Budgeted'
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_payment_monthly_amount
+              output: fcmp_nursing_care_payment_monthly_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_payment_monthly_amount
+              output: nursing_care_supplement_payment_monthly_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_payment_monthly_amount
+              output: personal_care_level_a_payment_monthly_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_payment_monthly_amount
+              output: personal_care_level_b_payment_monthly_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+              output: foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_payment_monthly_amount
+              output: cerebral_palsy_treatment_center_care_payment_monthly_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          if fcmp_nursing_care_required: fcmp_nursing_care_payment_monthly_amount else: if nursing_care_supplement_applies: nursing_care_supplement_payment_monthly_amount else: if personal_care_level_a_supplement_applies: personal_care_level_a_payment_monthly_amount else: if personal_care_level_b_supplement_applies: personal_care_level_b_payment_monthly_amount else: if foster_care_personal_or_nursing_care_supplement_applies: foster_care_personal_or_nursing_care_supplement_payment_monthly_amount else: if cerebral_palsy_treatment_center_care_applies: cerebral_palsy_treatment_center_care_payment_monthly_amount else: 0
+  - name: al_ssp_maximum_budgeted
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Attachment 660-2-4-.19a, Special Needs table, Maximum Budgeted column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/regulation/alabama-administrative-code/660/2/4/page-24
+              excerpt: 'Payment Monthly Amount To Be Maximum Budgeted'
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_maximum_budgeted
+              output: fcmp_nursing_care_maximum_budgeted
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_maximum_budgeted
+              output: nursing_care_supplement_maximum_budgeted
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_maximum_budgeted
+              output: personal_care_level_a_maximum_budgeted
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_maximum_budgeted
+              output: personal_care_level_b_maximum_budgeted
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_maximum_budgeted
+              output: foster_care_personal_or_nursing_care_supplement_maximum_budgeted
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_maximum_budgeted
+              output: cerebral_palsy_treatment_center_care_maximum_budgeted
+              hash: sha256:local
+    versions:
+      - effective_from: '1995-03-31'
+        formula: |-
+          if fcmp_nursing_care_required: fcmp_nursing_care_maximum_budgeted else: if nursing_care_supplement_applies: nursing_care_supplement_maximum_budgeted else: if personal_care_level_a_supplement_applies: personal_care_level_a_maximum_budgeted else: if personal_care_level_b_supplement_applies: personal_care_level_b_maximum_budgeted else: if foster_care_personal_or_nursing_care_supplement_applies: foster_care_personal_or_nursing_care_supplement_maximum_budgeted else: if cerebral_palsy_treatment_center_care_applies: cerebral_palsy_treatment_center_care_maximum_budgeted else: 0


### PR DESCRIPTION
## Summary
- add Alabama SSP payment-standard amounts from Alabama Administrative Code chapter 660-2-4 attachment 660-2-4-.19a
- include generated selector tests plus oracle parameter tests for the six PolicyEngine-comparable amount cells
- pin the validation toolchain to the merged encoder/corpus refs that add Alabama SSP oracle mappings and corpus source support

This covers the PE-comparable monthly amount cells for Alabama SSP. The source-local maximum-budgeted amounts and final `al_ssp` selector remain marked known non-comparable in the oracle mapping because PolicyEngine's final `al_ssp` also composes SSI eligibility, payment category, grandfathering, waiver, and skilled-nursing-facility predicates.

## Checks
- `AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630 AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-al-ssp-20260630/data/corpus AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-al-ssp-20260630 uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630/us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml --skip-reviewers --json`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630/us-al /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630/us-al/policies/dhr/ssp/state-supplement-payment-standard.test.yaml --json`
- `AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630 uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630 --fail-on-unmapped --fail-on-untested-comparable --limit 80`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-al-ssp-20260630 --base-ref origin/main --head-ref HEAD --json`
