### PR TITLE
Add Illinois AABD personal allowance

### DIFF
--- a/us-il/.axiom/encoding-manifests/policies/dhs/csmm/11-01-01/personal-allowance.json
+++ b/us-il/.axiom/encoding-manifests/policies/dhs/csmm/11-01-01/personal-allowance.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dhs/csmm/11-01-01/personal-allowance.yaml",
+      "sha256": "6c2402927d08602cde127a7d78e9b48a0241fa0ceff046159814c512d112acdd"
+    },
+    {
+      "path": "policies/dhs/csmm/11-01-01/personal-allowance.test.yaml",
+      "sha256": "ae7ed402cc36c13b7dc2aa7c224fcd67b0aebaf521940e32d3be1906b2536198"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ad8b58d17fd66544ddbd6c46007e86e4ee2bddbe",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.998",
+    "version_commit": "ad8b58d17fd66544ddbd6c46007e86e4ee2bddbe"
+  },
+  "axiom_encode_version": "0.2.998",
+  "backend": "codex",
+  "citation": "us-il/policies/dhs/csmm/11-01-01/personal-allowance",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-il-policies-dhs-csmm-11-01-01-personal-allowance/workspace/context-manifest.json",
+  "context_manifest_sha256": "fe24ba3b338ef4537c35a51ee1c9ff5e8f68483efb76446c8e05b00604ebc70e",
+  "generated_at": "2026-06-30T05:17:54.492561+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dhs/csmm/11-01-01/personal-allowance.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6c2402927d08602cde127a7d78e9b48a0241fa0ceff046159814c512d112acdd",
+  "generation_prompt_sha256": "c9d6b529ec51e8b0855077d555b8d6488cb15c2bd47ca764bb6f66be1ede8e22",
+  "model": "gpt-5.5",
+  "run_id": "9e24817d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f93f1a8877d18023acf3627e79c2d4e0f9441bd25e04d1c7169d1df31202f76c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-il-policies-dhs-csmm-11-01-01-personal-allowance.json",
+  "trace_sha256": "3db2ff5277dbd9e0d9f97907884c2e9bf48135faf482e61e8897491dab63f719"
+}

--- a/us-il/policies/dhs/csmm/11-01-01/personal-allowance.test.yaml
+++ b/us-il/policies/dhs/csmm/11-01-01/personal-allowance.test.yaml
@@ -1,0 +1,49 @@
+- name: active client eating alone receives active one-person allowance
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active: true
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count: 1
+  output:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#persons_eating_together_band: 0
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance: 62.43
+- name: active client in three through seven row
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active: true
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count: 4
+  output:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance: 53.71
+- name: bedfast client in eight or more row
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast: true
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count: 8
+  output:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance: 39.96
+- name: long term care client receives long term care allowance
+  period: 2024-01
+  input:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care: true
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count: 2
+  output:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance: 30.0
+- name: auto_zero_il_aabd_personal_allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care: false
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count: 0
+  output:
+    us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance: 0

--- a/us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml
+++ b/us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml
@@ -1,0 +1,394 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+  summary: |-
+    Client (Active) personal allowance table by persons eating together: 1 $62.43; 2 $57.25; 3 - 7 $53.71; 8 or more $52.91. Client (Bedfast) table: 1 $48.11; 2 $43.97; 3 through 7 $40.67; 8 or more $39.96. Long Term Care 30.00.
+rules:
+  - name: persons_eating_together_one_person
+    kind: parameter
+    dtype: Count
+    source: Client personal allowance table row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "Persons Eating Together ... 1"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+  - name: persons_eating_together_two_persons
+    kind: parameter
+    dtype: Count
+    source: Client personal allowance table row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "Persons Eating Together ... 2"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+  - name: persons_eating_together_three_to_seven_lower_bound
+    kind: parameter
+    dtype: Count
+    source: Client personal allowance table row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "3 - 7"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+  - name: persons_eating_together_three_to_seven_upper_bound
+    kind: parameter
+    dtype: Count
+    source: Client personal allowance table row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "3 - 7"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          7
+  - name: persons_eating_together_eight_or_more_lower_bound
+    kind: parameter
+    dtype: Count
+    source: Client personal allowance table row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "8 or more"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          8
+  - name: persons_eating_together_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    source: Client personal allowance table rows by persons eating together
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "Persons Eating Together ... 1 ... 2 ... 3 - 7 ... 8 or more"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if persons_eating_together_count == persons_eating_together_one_person: 0 else: if persons_eating_together_count == persons_eating_together_two_persons: 1 else: if persons_eating_together_count >= persons_eating_together_three_to_seven_lower_bound and persons_eating_together_count <= persons_eating_together_three_to_seven_upper_bound: 2 else: if persons_eating_together_count >= persons_eating_together_eight_or_more_lower_bound: 3 else: -1
+  - name: active_client_personal_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Active) personal allowance column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Active) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "personal_allowance"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 62.43
+          1: 57.25
+          2: 53.71
+          3: 52.91
+  - name: active_client_food_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Active) food column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Active) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "food"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 38.68
+          1: 35.47
+          2: 32.25
+          3: 31.70
+  - name: active_client_clothes_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Active) clothes column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Active) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "clothes"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 8.77
+          1: 8.77
+          2: 8.77
+          3: 8.77
+  - name: active_client_household_supplies_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Active) HH Supplies column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Active) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "HH Supplies"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 2.56
+          1: 2.04
+          2: 1.72
+          3: 1.47
+  - name: active_client_personal_needs_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Active) Personal Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Active) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "Personal Needs"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 12.42
+          1: 10.97
+          2: 10.97
+          3: 10.97
+  - name: bedfast_client_personal_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Bedfast) personal allowance column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Bedfast) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "personal_allowance"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 48.11
+          1: 43.97
+          2: 40.67
+          3: 39.96
+  - name: bedfast_client_food_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Bedfast) food column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Bedfast) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "food"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 35.91
+          1: 32.91
+          2: 29.91
+          3: 29.46
+  - name: bedfast_client_clothes_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Bedfast) clothes column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Bedfast) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "clothes"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 4.24
+          1: 4.24
+          2: 4.24
+          3: 4.24
+  - name: bedfast_client_household_supplies_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Bedfast) HH Supplies column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Bedfast) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "HH Supplies"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 2.56
+          1: 2.04
+          2: 1.72
+          3: 1.47
+  - name: bedfast_client_personal_needs_allowance_by_persons_eating_together
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: persons_eating_together_band
+    source: Client (Bedfast) Personal Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              table:
+                header: "Client (Bedfast) Persons Eating Together Personal Allowance Food Clothes HH Supplies Personal Needs"
+                row_key: "persons_eating_together"
+                column_key: "Personal Needs"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 5.40
+          1: 4.79
+          2: 4.79
+          3: 4.79
+  - name: long_term_care_personal_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Long Term Care personal allowance row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "Long Term Care 30.00 -- -- -- --"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30.00
+  - name: il_aabd_personal_allowance
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Client personal allowance tables
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/manual/dhs/csmm/15913/block-2
+              excerpt: "Client (Active) ... Personal Allowance ... Client (Bedfast) ... Personal Allowance ... Long Term Care 30.00"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if client_is_in_long_term_care: long_term_care_personal_allowance else: if persons_eating_together_band == -1: 0 else: if client_is_active: active_client_personal_allowance_by_persons_eating_together[persons_eating_together_band] else: if client_is_bedfast: bedfast_client_personal_allowance_by_persons_eating_together[persons_eating_together_band] else: 0


### PR DESCRIPTION
## Summary
- Adds generated RuleSpec for Illinois AABD personal allowance from DHS CSMM 11-01-01.
- Covers active, bedfast, and long-term-care allowance branches, including table-row selector parameters.
- Includes signed axiom-encode apply manifest from axiom-encode 0.2.998 (merged commit ad8b58d1).

## Validation
- `axiom-encode test --root ... personal-allowance.test.yaml --json`: passed, 5 cases, 0 failures.
- `axiom-encode validate ... personal-allowance.yaml --skip-reviewers --oracle policyengine --json`: passed; PolicyEngine oracle score 1.0 on comparable outputs.
- PE coverage: 6 total outputs, 3 comparable, 3 passed, 0 failed, 0 unmapped, 3 unsupported.
- Unsupported by PE: DHS long-term-care branch and source-level neither-active-nor-bedfast zero branch, which PolicyEngine does not model.
- `axiom-encode guard-generated --repo ... --all --roots policies/dhs/csmm/11-01-01 --json`: passed.
