### PR TITLE
Add Massachusetts TAFDC work expense deduction

### DIFF
--- a/.axiom/encoding-manifests/us-ma/regulations/106-cmr/704/270/block-1.json
+++ b/.axiom/encoding-manifests/us-ma/regulations/106-cmr/704/270/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ma/regulations/106-cmr/704/270/block-1.yaml",
+      "sha256": "1aa9f862105ffd58bc341b049134dc4b33a466aa2f609597cb7e28ea63079e4a"
+    },
+    {
+      "path": "us-ma/regulations/106-cmr/704/270/block-1.test.yaml",
+      "sha256": "648c0133fad2ddc8c1eb2fa83623227dc5e80efd0186ae667aaaa8d86860eea8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "63fc87ddb31f8a374d18b3db0e04a2b765b22b38",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ma-tafdc-work-expense-oracle-20260630",
+    "version": "0.2.999",
+    "version_commit": "63fc87ddb31f8a374d18b3db0e04a2b765b22b38"
+  },
+  "axiom_encode_version": "0.2.999",
+  "backend": "deterministic",
+  "citation": "us-ma:regulations/106-cmr/704/270/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-30T05:50:20.442302+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0_itjelg/deterministic-repair/us-ma/regulations/106-cmr/704/270/block-1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0_itjelg",
+  "generated_output_sha256": "1aa9f862105ffd58bc341b049134dc4b33a466aa2f609597cb7e28ea63079e4a",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "211e02d4285fece3f1b79f42293d3e280224a023b45ede4d231fac503b24e4ae"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/270/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/270/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/270/block-1.yaml",
+      "sha256": "1aa9f862105ffd58bc341b049134dc4b33a466aa2f609597cb7e28ea63079e4a"
+    },
+    {
+      "path": "regulations/106-cmr/704/270/block-1.test.yaml",
+      "sha256": "51ddb771b672466b692065d0953fff676364c47efee7a8e8f2be523e9392973e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ad8b58d17fd66544ddbd6c46007e86e4ee2bddbe",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.998",
+    "version_commit": "ad8b58d17fd66544ddbd6c46007e86e4ee2bddbe"
+  },
+  "axiom_encode_version": "0.2.998",
+  "backend": "codex",
+  "citation": "us-ma/regulations/106-cmr/704/270/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-270-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "03a5c967e65e1a0574bd31ff04edd5c2fb7b3de3c7eab33fc11a4c4c3eee65bf",
+  "generated_at": "2026-06-30T05:45:58.654755+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/106-cmr/704/270/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "1aa9f862105ffd58bc341b049134dc4b33a466aa2f609597cb7e28ea63079e4a",
+  "generation_prompt_sha256": "c273c53fa2aae36fcbd4969bfbb0d6fbd94d9424bef34149d16519745572e7c5",
+  "model": "gpt-5.5",
+  "run_id": "558a4915",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e5b83e763d5e7f8ebf6d1af7353687707b4c87a63db382b1d1f718ec5177025a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-270-block-1.json",
+  "trace_sha256": "83f215aa18cb2ae938fb6e1287291a1400d88d9dfc28d700a47a139a24b83b1c"
+}

--- a/us-ma/regulations/106-cmr/704/270/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/270/block-1.test.yaml
@@ -1,0 +1,73 @@
+- name: employed client receives monthly work-related expense deduction
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+  output:
+    us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount: 200
+- name: client eligible for earned income disregard receives no deduction
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+  output:
+    us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount: 0
+- name: applicant blocked by EAEDC 704 280 restriction receives no deduction
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+  output:
+    us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount: 0
+- name: required filing unit person outside assistance unit receives no deduction
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: true
+  output:
+    us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount: 0
+- name: oracle_parameter_work_related_expense_deduction_monthly_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+  output:
+    us-ma:regulations/106-cmr/704/270/block-1#work_related_expense_deduction_monthly_amount: 200

--- a/us-ma/regulations/106-cmr/704/270/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/270/block-1.yaml
@@ -1,0 +1,62 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.270
+  summary: An employed applicant is entitled to a $200 monthly work-related-expense
+    deduction from gross wages in determining eligibility. An employed client is entitled
+    to the $200 deduction in determining the grant amount unless eligible for the
+    100% Earned Income Disregard. A person whose income is deemed to the filing unit
+    under the cited EAEDC or TAFDC provisions is also entitled to the $200 deduction.
+    Listed EAEDC categories and persons required in the filing unit but not included
+    in the assistance unit are not eligible.
+rules:
+- name: work_related_expense_deduction_monthly_amount
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.270(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.270
+          excerpt: $200 monthly work-related-expense deduction
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '200'
+- name: ma_tafdc_work_related_expense_deduction_amount
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.270(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.270
+          excerpt: $200 monthly work-related-expense deduction
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.270
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.270
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if person_is_employed and ( employed_applicant_determining_eligibility
+      or ( employed_client_determining_grant_amount and not eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281
+      ) or income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc or income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc
+      ) and not meets_106_cmr_704_280_a_or_b_for_eaedc and not meets_106_cmr_704_286_c_for_eaedc
+      and not required_in_filing_unit_but_not_in_assistance_unit: work_related_expense_deduction_monthly_amount
+      else: 0'


### PR DESCRIPTION
## Summary
- encode 106 CMR 704.270, Massachusetts TAFDC work-related-expense deduction
- preserve the statutory conditional deduction rule and the $200 monthly amount parameter
- include signed encoder apply provenance plus signed deterministic parameter-test repair provenance

## Validation
- `uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630/us-ma/regulations/106-cmr/704/270/block-1.yaml --skip-reviewers --oracle policyengine --json`
  - `ci_pass: true`
  - `oracle_scores.policyengine: 1.0`
  - `comparable: 1`, `passed: 1`, `failed: 0`
- `uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630/us-ma/regulations/106-cmr/704/270/block-1.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630`
  - 5 cases passed
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630`
