### PR TITLE
Add Massachusetts TAFDC child support disregard

### DIFF
--- a/.axiom/encoding-manifests/us-ma/regulations/106-cmr/704/230/block-1.json
+++ b/.axiom/encoding-manifests/us-ma/regulations/106-cmr/704/230/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ma/regulations/106-cmr/704/230/block-1.yaml",
+      "sha256": "d8227fd4bc3468b6a22e056b1ff1001ca9477444f4d71db5719d6af47e91b3aa"
+    },
+    {
+      "path": "us-ma/regulations/106-cmr/704/230/block-1.test.yaml",
+      "sha256": "a8d0b768e666a5080c663f169b7f2e44581ea8a94550f6abe0a4c60aa23341ef"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "5d4d96783cd0d635609c63b7d04e81bb2d9074f8",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ma-tafdc-child-support-oracle-20260630",
+    "version": "0.2.1000",
+    "version_commit": "5d4d96783cd0d635609c63b7d04e81bb2d9074f8"
+  },
+  "axiom_encode_version": "0.2.1000",
+  "backend": "deterministic",
+  "citation": "us-ma:regulations/106-cmr/704/230/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-06-30T06:19:19.473773+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc8e858c8/deterministic-repair/us-ma/regulations/106-cmr/704/230/block-1.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc8e858c8",
+  "generated_output_sha256": "d8227fd4bc3468b6a22e056b1ff1001ca9477444f4d71db5719d6af47e91b3aa",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "47f498c423968026d302620c61cbd7a864a740dfca046155e6821cdfd7eb985e"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/230/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/230/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/230/block-1.yaml",
+      "sha256": "d8227fd4bc3468b6a22e056b1ff1001ca9477444f4d71db5719d6af47e91b3aa"
+    },
+    {
+      "path": "regulations/106-cmr/704/230/block-1.test.yaml",
+      "sha256": "e18e079b096c88234180c88a2584ecaae9bf7548158a71ea71734b7a92e2da46"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e374d2d3b4d9a3d7d7d127618649ec76bacdb0a5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.999",
+    "version_commit": "63fc87ddb31f8a374d18b3db0e04a2b765b22b38"
+  },
+  "axiom_encode_version": "0.2.999",
+  "backend": "codex",
+  "citation": "us-ma/regulations/106-cmr/704/230/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-230-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "c5d5262407569245eee76fdfe201d5303541befd58786935f2b7eff71691d85f",
+  "generated_at": "2026-06-30T06:08:38.184971+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/106-cmr/704/230/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "d8227fd4bc3468b6a22e056b1ff1001ca9477444f4d71db5719d6af47e91b3aa",
+  "generation_prompt_sha256": "133b6bd46a4eb9729da833c7de611873917d038f2493f9d5d251bc4538ca0ab4",
+  "model": "gpt-5.5",
+  "run_id": "815b151d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "15c6d532e3b9ca7b2448e9c915c6a347217bcde1f6f5ec5adc29e9e48920df75"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-230-block-1.json",
+  "trace_sha256": "28eab5f09036a7d663ac097ce870bdc0be48a839dfb9a08413af5530d203c1c9"
+}

--- a/us-ma/regulations/106-cmr/704/230/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/230/block-1.test.yaml
@@ -1,0 +1,39 @@
+- name: full monthly child support deduction applies
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/230/block-1#input.child_included_in_assistance_unit: true
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_received_directly_by_applicant_or_client: true
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_paid_directly_to_dor: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_for_child_in_assistance_unit: 200
+  output:
+    us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_child_support_deduction: 50
+- name: deduction limited to actual income below monthly disregard
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/230/block-1#input.child_included_in_assistance_unit: true
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_received_directly_by_applicant_or_client: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_paid_directly_to_dor: true
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_for_child_in_assistance_unit: 30
+  output:
+    us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_child_support_deduction: 30
+- name: no deduction when child is not included in assistance unit
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/230/block-1#input.child_included_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_received_directly_by_applicant_or_client: true
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_paid_directly_to_dor: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_for_child_in_assistance_unit: 200
+  output:
+    us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_child_support_deduction: 0
+- name: oracle_parameter_ma_tafdc_monthly_absent_parent_income_disregard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_for_child_in_assistance_unit: 0
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_paid_directly_to_dor: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.absent_parent_income_received_directly_by_applicant_or_client: false
+    us-ma:regulations/106-cmr/704/230/block-1#input.child_included_in_assistance_unit: false
+  output:
+    us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_monthly_absent_parent_income_disregard: 50

--- a/us-ma/regulations/106-cmr/704/230/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/230/block-1.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.230
+  summary: Income from an absent parent for a child included in the assistance unit,
+    received directly by the applicant or client or paid directly to DOR, except for
+    the first $50 received in any month, is countable.
+rules:
+- name: ma_tafdc_monthly_absent_parent_income_disregard
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.230(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.230
+          excerpt: except for the first $50 received in any month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '50'
+- name: ma_tafdc_child_support_deduction
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 106 CMR 704.230(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.230
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.230
+          excerpt: except for the first $50 received in any month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: |-
+      if child_included_in_assistance_unit and (absent_parent_income_received_directly_by_applicant_or_client or absent_parent_income_paid_directly_to_dor): min(max(0, absent_parent_income_for_child_in_assistance_unit), ma_tafdc_monthly_absent_parent_income_disregard) else: 0


### PR DESCRIPTION
## Summary
- Encode 106 CMR 704.230(B)(1) for Massachusetts TAFDC absent-parent income / child-support disregard
- Add the  monthly disregard parameter and conditional TAFDC deduction rule
- Include signed encoder apply manifests and an oracle parameter test mapped to PolicyEngine

## Validation
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630/us-ma/regulations/106-cmr/704/230/block-1.yaml --oracle policyengine --skip-reviewers --json
  - ci_pass=true, policyengine=1.0, comparable=1, passed=1, failed=0
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630/us-ma/regulations/106-cmr/704/230/block-1.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630 --json
  - success=true, cases=4
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630 --oracle policyengine --limit 20
  - untested comparable outputs=0