### PR TITLE
Add Massachusetts TAFDC income test

### DIFF
--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/260/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/260/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/260/block-1.yaml",
+      "sha256": "887fe8a26742548d6227764fe12ebae7e453560a3b2666fa51fed30350cd3346"
+    },
+    {
+      "path": "regulations/106-cmr/704/260/block-1.test.yaml",
+      "sha256": "6747459e1dac02d980d81c6a07985f019d879df1d0363025d56b83d293b135c9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a1eaa3a7e125a3f0250f9e2b1c2630e38430cdb0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1001",
+    "version_commit": "15f97a6158fc28a19a912aeee716b943f2af551b"
+  },
+  "axiom_encode_version": "0.2.1001",
+  "backend": "codex",
+  "citation": "us-ma/regulations/106-cmr/704/260/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-260-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "2e449775d316037518a654438a96cb84ca91c0dbe2cc71b362efed8a4958bccc",
+  "generated_at": "2026-06-30T06:55:42.782179+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/106-cmr/704/260/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "887fe8a26742548d6227764fe12ebae7e453560a3b2666fa51fed30350cd3346",
+  "generation_prompt_sha256": "9df168ca88f55890323182d818d0ff2a0d08a7fbe37efd30c2b57591b24f533d",
+  "model": "gpt-5.5",
+  "run_id": "75fceb70",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0b95ffc550527bc1c3d9b6b98578a6bc81ae652443877d80ee830d2a1434aece"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-260-block-1.json",
+  "trace_sha256": "d71b6a0746c0ff1dc752ff28d55ebd18adb090cbce6cb8358910c9125bfaab10"
+}

--- a/us-ma/regulations/106-cmr/704/260/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/260/block-1.test.yaml
@@ -1,0 +1,22 @@
+- name: eligible_when_excluded_income_brings_unit_to_need_standard
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_total_income: 1200
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_noncountable_income_under_106_cmr_704_250: 100
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_full_employment_program_wages: 50
+    ? us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_disregarded_income_under_106_cmr_704_270_704_275_704_280_and_704_281
+    : 250
+    us-ma:regulations/106-cmr/704/260/block-1#input.applicable_need_standard: 800
+  output:
+    us-ma:regulations/106-cmr/704/260/block-1#ma_tafdc_financial_eligible: holds
+- name: ineligible_when_income_after_exclusions_exceeds_need_standard
+  period: 2024-01
+  input:
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_total_income: 1200
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_noncountable_income_under_106_cmr_704_250: 100
+    us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_full_employment_program_wages: 50
+    ? us-ma:regulations/106-cmr/704/260/block-1#input.filing_unit_disregarded_income_under_106_cmr_704_270_704_275_704_280_and_704_281
+    : 200
+    us-ma:regulations/106-cmr/704/260/block-1#input.applicable_need_standard: 800
+  output:
+    us-ma:regulations/106-cmr/704/260/block-1#ma_tafdc_financial_eligible: not_holds

--- a/us-ma/regulations/106-cmr/704/260/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/260/block-1.yaml
@@ -1,0 +1,31 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.260
+  summary: |-
+    Filing units are financially eligible for TAFDC when total countable income, excluding noncountable income, Full Employment Program wages, and disregarded income under 106 CMR 704.270, 704.275, 704.280, and 704.281, does not exceed the applicable Need Standard.
+rules:
+  - name: ma_tafdc_financial_eligible
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: us-ma/regulation/dta/106-cmr/704/704.260(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.260
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.260
+              excerpt: "the disregarded income as provided in 106 CMR 704.270, 106 CMR 704.275, 106 CMR 704.280 and 106 CMR 704.281"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, filing_unit_total_income - filing_unit_noncountable_income_under_106_cmr_704_250 - filing_unit_full_employment_program_wages - filing_unit_disregarded_income_under_106_cmr_704_270_704_275_704_280_and_704_281) <= applicable_need_standard


### PR DESCRIPTION
## Summary
- Add generated RuleSpec for 106 CMR 704.260(c), Massachusetts TAFDC financial eligibility income test
- Add two generated boundary tests for eligibility at and above the applicable Need Standard
- Include the signed axiom-encode apply manifest for the generated files

## Validation
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode validate us-ma/regulations/106-cmr/704/260/block-1.yaml --oracle policyengine --skip-reviewers --require-oracle-classification --json`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode test us-ma/regulations/106-cmr/704/260/block-1.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-income-test-20260630 --json`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-income-test-20260630`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-income-test-20260630 --oracle policyengine --program tanf --json` -> 350 TANF outputs, 26 comparable, 324 known_not_comparable, 0 untested comparable

## Oracle note
This source-law output is classified as not directly comparable to PolicyEngine: 106 CMR 704.260 tests countable income against the applicable Need Standard with `<=`, while PE `ma_tafdc_financial_eligible` currently uses its own graph and strict `< ma_tafdc_payment_standard`. That should be tracked separately as a PE issue rather than forcing a mismatched oracle comparison.