### PR TITLE
Repair Medicaid community engagement timing

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1024"
+axiom_encode_version = "0.2.1031"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "6f28b125e8c92b664cbed0965361a37c431f2774"
+axiom_encode_ref = "6060b1a51da9a1bdb6593291e540dcec3c5ba468"
 axiom_corpus_ref = "a2a8eac83b6da1c3130c68e5cff72d1a82df3d57"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -3,7 +3,7 @@
 # file trigger full-repository revalidation.
 [toolchain]
 axiom_encode_version = "0.2.1024"
-axiom_rules_engine_ref = "aa1ff025906c7216c053e9b9c4097cc0dfef1811"
+axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
 axiom_encode_ref = "6f28b125e8c92b664cbed0965361a37c431f2774"
 axiom_corpus_ref = "a2a8eac83b6da1c3130c68e5cff72d1a82df3d57"
 # Canonical-targets checkout for cross-repo validation; bump to the

--- a/us/.axiom/encoding-manifests/statutes/42/1396a/a/10.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1396a/a/10.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/42/1396a/a/10.yaml",
-      "sha256": "dea98af9099b74602e4d9db6838f08f13c401eada245116d4b09bf039979c278"
+      "sha256": "4b0ab9425c5064a50c8584fb7b5a1a854bd280290e032dc6ca6c1c18fecee46b"
     },
     {
       "path": "statutes/42/1396a/a/10.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "89eab4f2c87396c523f34a6768d3fd1858e84f17",
+    "commit": "1d8aff2ffbccc999d1835c42fed0358dee9d3d6a",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1023",
-    "version_commit": "89eab4f2c87396c523f34a6768d3fd1858e84f17"
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicaid-surface-validated-20260701",
+    "version": "0.2.1028",
+    "version_commit": "1d8aff2ffbccc999d1835c42fed0358dee9d3d6a"
   },
-  "axiom_encode_version": "0.2.1023",
+  "axiom_encode_version": "0.2.1028",
   "backend": "deterministic",
   "citation": "us:statutes/42/1396a/a/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-01T00:51:04.284823+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp6bpht_ar/deterministic-repair/statutes/42/1396a/a/10.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp6bpht_ar",
-  "generated_output_sha256": "dea98af9099b74602e4d9db6838f08f13c401eada245116d4b09bf039979c278",
+  "generated_at": "2026-07-01T03:42:38.700347+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8q4dpdo9/deterministic-repair/statutes/42/1396a/a/10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8q4dpdo9",
+  "generated_output_sha256": "4b0ab9425c5064a50c8584fb7b5a1a854bd280290e032dc6ca6c1c18fecee46b",
   "generation_prompt_sha256": null,
-  "model": "medicaid-primary-category-composition-v1",
+  "model": "medicaid-community-engagement-effective-date-v1",
   "run_id": "deterministic-repair",
   "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "29d4f743f4125ff1f4dd2553dc9f0bf497e0e8f8195056c2d43c1821cc85621e"
+    "value": "1fb60ac45edf8622ce4c0392085358f9d6363ddb128785708cca40f1426569fb"
   },
-  "tool": "axiom-encode repair-medicaid-primary-category-composition",
+  "tool": "axiom-encode repair-medicaid-community-engagement-effective-date",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/us/statutes/42/1396a/a/10.yaml
+++ b/us/statutes/42/1396a/a/10.yaml
@@ -420,7 +420,17 @@ rules:
             kind: predicate
             source:
               corpus_citation_path: us/statute/42/1396a/a/10
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+              output: parent_or_caretaker_relative_eligible
+              hash: sha256:e75602f427450e0c901f86624cdf8722311a12fddef730325a649d5f4e6d843f
+          - path: versions[1].formula
             kind: import
             import:
               target: us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
@@ -432,7 +442,19 @@ rules:
               target: us:regulations/42-cfr/435/116#pregnant_woman_eligible
               output: pregnant_woman_eligible
               hash: sha256:279df515adff9b1ea0aed1f926e1f7f2413f6130a35fcd04067cd606cf508314
+          - path: versions[1].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/116#pregnant_woman_eligible
+              output: pregnant_woman_eligible
+              hash: sha256:279df515adff9b1ea0aed1f926e1f7f2413f6130a35fcd04067cd606cf508314
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/118#infants_and_children_eligible
+              output: infants_and_children_eligible
+              hash: sha256:d25d698a533bec85bd82b5dcb1f1a35447a67abcc7e53f2463bf9da0addfd809
+          - path: versions[1].formula
             kind: import
             import:
               target: us:regulations/42-cfr/435/118#infants_and_children_eligible
@@ -444,7 +466,19 @@ rules:
               target: us:regulations/42-cfr/435/119#adult_group_eligible
               output: adult_group_eligible
               hash: sha256:0c9a76599b5604b754e25929deb339f6567f54634acc0acb8a2c60fd31736254
+          - path: versions[1].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/119#adult_group_eligible
+              output: adult_group_eligible
+              hash: sha256:0c9a76599b5604b754e25929deb339f6567f54634acc0acb8a2c60fd31736254
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group
+              output: medicaid_required_for_ssi_mandatory_group
+              hash: sha256:d84ec593f313fc1eeb37c41be5e2503c50ffd709b6c3bd6dac36f2745fde7b2f
+          - path: versions[1].formula
             kind: import
             import:
               target: us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group
@@ -456,7 +490,13 @@ rules:
               target: us:regulations/42-cfr/435/150#former_foster_care_child_medicaid_required
               output: former_foster_care_child_medicaid_required
               hash: sha256:bc9ad27f690d6cebfc3478caec0f209c258a71d0a7d9623c46bc8f27637e6598
-          - path: versions[0].formula
+          - path: versions[1].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/150#former_foster_care_child_medicaid_required
+              output: former_foster_care_child_medicaid_required
+              hash: sha256:bc9ad27f690d6cebfc3478caec0f209c258a71d0a7d9623c46bc8f27637e6598
+          - path: versions[1].formula
             kind: import
             import:
               target: us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
@@ -468,7 +508,19 @@ rules:
               target: us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid
               output: is_optional_senior_or_disabled_for_medicaid
               hash: sha256:845f0dabc5edc2a363c168f49ab3bece26ef00a75851c4666ec09ff60d552e7f
+          - path: versions[1].formula
+            kind: import
+            import:
+              target: us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid
+              output: is_optional_senior_or_disabled_for_medicaid
+              hash: sha256:845f0dabc5edc2a363c168f49ab3bece26ef00a75851c4666ec09ff60d552e7f
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/301#mandatory_medically_needy_medicaid_required
+              output: mandatory_medically_needy_medicaid_required
+              hash: sha256:520073760aa468e2c24cc6308ccd8dba290221ef746c6475cbc4ebd17908295a
+          - path: versions[1].formula
             kind: import
             import:
               target: us:regulations/42-cfr/435/301#mandatory_medically_needy_medicaid_required
@@ -480,8 +532,28 @@ rules:
               target: us:regulations/42-cfr/435/301#optional_medically_needy_medicaid_may_be_provided
               output: optional_medically_needy_medicaid_may_be_provided
               hash: sha256:520073760aa468e2c24cc6308ccd8dba290221ef746c6475cbc4ebd17908295a
+          - path: versions[1].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/301#optional_medically_needy_medicaid_may_be_provided
+              output: optional_medically_needy_medicaid_may_be_provided
+              hash: sha256:520073760aa468e2c24cc6308ccd8dba290221ef746c6475cbc4ebd17908295a
     versions:
       - effective_from: '2014-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or pregnant_woman_eligible
+          or infants_and_children_eligible
+          or adult_group_eligible
+          or medicaid_required_for_ssi_mandatory_group
+          or former_foster_care_child_medicaid_required
+          or is_optional_senior_or_disabled_for_medicaid
+          or optional_ssi_excess_earnings_medicaid_category_eligible
+          or optional_working_disabled_medicaid_category_eligible
+          or optional_youth_medicaid_category_eligible
+          or mandatory_medically_needy_medicaid_required
+          or optional_medically_needy_medicaid_may_be_provided
+      - effective_from: '2026-12-31'
         formula: |-
           parent_or_caretaker_relative_eligible
           or pregnant_woman_eligible


### PR DESCRIPTION
## Summary
- split `is_medicaid_eligible` into pre- and post-community-engagement versions
- keep adult-group Medicaid ungated before the 2026-12-31 community engagement effective date
- add the community-engagement import only to the post-2026 eligibility formula

## Notes
- Generated through `axiom-encode repair-medicaid-community-engagement-effective-date`; no hand-written RuleSpec edits.
- Full Populace parity depends on TheAxiomFoundation/axiom-encode#919 for the Medicaid oracle pregnancy input projection fix.

## Validation
- `uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicaid-surface-validated-20260701 axiom-encode compile /Users/maxghenis/TheAxiomFoundation/rulespec-us/us/statutes/42/1396a/a/10.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701 --json`
- `axiom-encode medicaid-populace-compare --year 2024 --month 1 --populace-year 2024 --program /Users/maxghenis/TheAxiomFoundation/rulespec-us/us/statutes/42/1396a/a/10.yaml --workspace-root /Users/maxghenis/TheAxiomFoundation --axiom-binary /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701/target/debug/axiom-rules-engine --eligibility-only --fail-on-mismatch --min-match-rate 1 --max-differences 20`
  - Compared 160,858 people; matches=160,858; mismatches=0; match_rate=100.00%
