### PR TITLE
Encode Washington SSP eligibility

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1031"
+axiom_encode_version = "0.2.1036"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "6060b1a51da9a1bdb6593291e540dcec3c5ba468"
+axiom_encode_ref = "7cdb1af99c4d692091c6bf8d3ca77a0d2823c85b"
 axiom_corpus_ref = "a2a8eac83b6da1c3130c68e5cff72d1a82df3d57"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-474/388-474-0012.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-474/388-474-0012.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/388/388-474/388-474-0012.yaml",
+      "sha256": "0bde2eab2ca9bc6352c8d49c6781783310c83a2294807ca7b59dbc6196a05a25"
+    },
+    {
+      "path": "regulations/388/388-474/388-474-0012.test.yaml",
+      "sha256": "ea2a14a6df0f4c34e9b4bc9e24c8c0e2d8ae4425e579f82011df09e290b82872"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "c5c1d58acd5af084a04f45635fea2fa417a0e1f4",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1035",
+    "version_commit": "c5c1d58acd5af084a04f45635fea2fa417a0e1f4"
+  },
+  "axiom_encode_version": "0.2.1035",
+  "backend": "codex",
+  "citation": "us-wa:regulations/388/388-474/388-474-0012",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-wa-regulations-388-388-474-388-474-0012/workspace/context-manifest.json",
+  "context_manifest_sha256": "d90e849da1b4696cf8bc0a313fd58bfacc65385e0a25cfbaa7c6dd6d242e2017",
+  "generated_at": "2026-07-01T06:57:42.507800+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/388/388-474/388-474-0012.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "0bde2eab2ca9bc6352c8d49c6781783310c83a2294807ca7b59dbc6196a05a25",
+  "generation_prompt_sha256": "64454db6cd68e12a5f7b0c3d80f9e0091191213c27898977226f227a67a9b80c",
+  "model": "gpt-5.5",
+  "run_id": "26a03b91",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0ff9b1682d62c047ba303123c1d66742240b6264ac9615705ff8a4c6fd208b55"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-wa-regulations-388-388-474-388-474-0012.json",
+  "trace_sha256": "53953929a0e934613c9d9e6b0adc7fc07737ebc28d6e3f7eff69d26ad3257e8a"
+}

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "regulations/388/388-478/388-478-0055.test.yaml",
-      "sha256": "d42335c1545a05f41c791d240004ce16981de83149c909cf60b3ca534e093a99"
+      "sha256": "1ed22aa9daa245b3983c4da529b58580e445e3dca47d6f6440710250aa94c89e"
     }
   ],
   "axiom_encode_git": {
@@ -17,25 +17,25 @@
     "version_commit": "c5c1d58acd5af084a04f45635fea2fa417a0e1f4"
   },
   "axiom_encode_version": "0.2.1035",
-  "backend": "codex",
+  "backend": "deterministic",
   "citation": "us-wa:regulations/388/388-478/388-478-0055",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-wa-regulations-388-388-478-388-478-0055/workspace/context-manifest.json",
-  "context_manifest_sha256": "272a133045f9dbb8b3e5e168164cac67d18cbd0b968b149d6d8d100558b2261c",
-  "generated_at": "2026-07-01T07:29:33.972324+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/388/388-478/388-478-0055.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-01T07:41:26.574445+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmposbby8tj/deterministic-repair/regulations/388/388-478/388-478-0055.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmposbby8tj",
   "generated_output_sha256": "a711a44104d7aca3402f8afad682d3bc04a95a2cbe9bee1f9b4af3f4c0cef6fa",
-  "generation_prompt_sha256": "61818a03b877a388baac4e62784a64d377ebb8306f36cdbdb647b2b216618e95",
-  "model": "gpt-5.5",
-  "run_id": "32fecc02",
-  "runner": "codex-gpt-5.5",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "624ae47c573223756a374fa43fa70e8dad3465f0d487be01de27958ca0aa64a3"
+    "value": "b77110730a1cdff39069880ed3e4350626934155aefea27a1a156380fdf490e4"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-wa-regulations-388-388-478-388-478-0055.json",
-  "trace_sha256": "1a757370d65a61548f4f15079be357d5bf388cd2b9562f29188e191c694479ab"
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
+++ b/us-wa/.axiom/encoding-manifests/regulations/388/388-478/388-478-0055.json
@@ -2,40 +2,40 @@
   "applied_files": [
     {
       "path": "regulations/388/388-478/388-478-0055.yaml",
-      "sha256": "2ec36fbbc76af0c286d984b45831d3c9041e43a2747bf95881ce647392e244d0"
+      "sha256": "a711a44104d7aca3402f8afad682d3bc04a95a2cbe9bee1f9b4af3f4c0cef6fa"
     },
     {
       "path": "regulations/388/388-478/388-478-0055.test.yaml",
-      "sha256": "42a01b05db4bbbf58739bbf339e75f308e680d7993ccbd0c320c271b27d1221f"
+      "sha256": "d42335c1545a05f41c791d240004ce16981de83149c909cf60b3ca534e093a99"
     }
   ],
   "axiom_encode_git": {
-    "commit": "18c2a722081c28215fcb48bbd47b6a1d9a6b0053",
+    "commit": "c5c1d58acd5af084a04f45635fea2fa417a0e1f4",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.991",
-    "version_commit": "18c2a722081c28215fcb48bbd47b6a1d9a6b0053"
+    "version": "0.2.1035",
+    "version_commit": "c5c1d58acd5af084a04f45635fea2fa417a0e1f4"
   },
-  "axiom_encode_version": "0.2.991",
-  "backend": "deterministic",
+  "axiom_encode_version": "0.2.1035",
+  "backend": "codex",
   "citation": "us-wa:regulations/388/388-478/388-478-0055",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-06-30T01:03:50.739922+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz9lgg52e/deterministic-repair/regulations/388/388-478/388-478-0055.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpz9lgg52e",
-  "generated_output_sha256": "2ec36fbbc76af0c286d984b45831d3c9041e43a2747bf95881ce647392e244d0",
-  "generation_prompt_sha256": null,
-  "model": "oracle-parameter-test-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-wa-regulations-388-388-478-388-478-0055/workspace/context-manifest.json",
+  "context_manifest_sha256": "272a133045f9dbb8b3e5e168164cac67d18cbd0b968b149d6d8d100558b2261c",
+  "generated_at": "2026-07-01T07:29:33.972324+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/388/388-478/388-478-0055.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "a711a44104d7aca3402f8afad682d3bc04a95a2cbe9bee1f9b4af3f4c0cef6fa",
+  "generation_prompt_sha256": "61818a03b877a388baac4e62784a64d377ebb8306f36cdbdb647b2b216618e95",
+  "model": "gpt-5.5",
+  "run_id": "32fecc02",
+  "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "41af821c79c60a257ecfb14c0f32f6ff11f506a7e3677e94f6f89c8f530446c8"
+    "value": "624ae47c573223756a374fa43fa70e8dad3465f0d487be01de27958ca0aa64a3"
   },
-  "tool": "axiom-encode repair-oracle-parameter-tests",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-wa-regulations-388-388-478-388-478-0055.json",
+  "trace_sha256": "1a757370d65a61548f4f15079be357d5bf388cd2b9562f29188e191c694479ab"
 }

--- a/us-wa/regulations/388/388-474/388-474-0012.test.yaml
+++ b/us-wa/regulations/388/388-474/388-474-0012.test.yaml
@@ -1,0 +1,49 @@
+- name: ineligible_spouse_status_path
+  period: 2026-07
+  input:
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_has_ineligible_spouse_under_wac_388_474_0001: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_blind_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_disabled_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_ssi_recipient_residing_in_medical_institution: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_ssi_reduced_based_on_institutional_ssi_payment_standard: false
+  output:
+    us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_ineligible_spouse_status: holds
+    us-wa:regulations/388/388-474/388-474-0012#individual_is_eligible_for_ssp_as_described: holds
+- name: developmental_disabilities_administration_path
+  period: 2026-07
+  input:
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : true
+  output:
+    ? us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_developmental_disabilities_administration_determination
+    : holds
+- name: foster_child_brs_path
+  period: 2026-07
+  input:
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+  output:
+    us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_foster_child_brs_services: holds
+- name: foster_child_title_iv_e_reimbursement_blocks_brs_path
+  period: 2026-07
+  input:
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: true
+  output:
+    us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_foster_child_brs_services: not_holds

--- a/us-wa/regulations/388/388-474/388-474-0012.yaml
+++ b/us-wa/regulations/388/388-474/388-474-0012.yaml
@@ -1,0 +1,92 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/regulation/388/388-474/388-474-0012
+  summary: |-
+    SSP is a state-funded cash assistance program for certain clients SSA determines eligible for SSI. A person can get SSP if listed conditions apply, including ineligible spouse status, DDA SSP eligibility, certain foster child BRS service receipt without Title IV-E foster care reimbursement, and other SSI categories.
+rules:
+  - name: ssp_eligibility_based_on_ineligible_spouse_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: us-wa/regulation/388/388-474/388-474-0012(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-474/388-474-0012
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_receives_ssi
+          and individual_has_ineligible_spouse_under_wac_388_474_0001
+
+  - name: ssp_eligibility_based_on_developmental_disabilities_administration_determination
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: us-wa/regulation/388/388-474/388-474-0012(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-474/388-474-0012
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_receives_ssi
+          and developmental_disabilities_administration_determined_individual_eligible_for_ssp
+
+  - name: ssp_eligibility_based_on_foster_child_brs_services
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: us-wa/regulation/388/388-474/388-474-0012(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-474/388-474-0012
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_is_eligible_for_ssi
+          and individual_receives_ssi
+          and individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+          and not individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e
+
+  - name: individual_is_eligible_for_ssp_as_described
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: us-wa/regulation/388/388-474/388-474-0012
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-474/388-474-0012
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (individual_receives_ssi and individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001)
+          or ssp_eligibility_based_on_ineligible_spouse_status
+          or (individual_receives_ssi and individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001)
+          or (individual_receives_ssi and individual_receives_ssi_because_blind_under_wac_388_474_0001)
+          or (individual_receives_ssi and individual_receives_ssi_because_disabled_under_wac_388_474_0001)
+          or ssp_eligibility_based_on_developmental_disabilities_administration_determination
+          or ssp_eligibility_based_on_foster_child_brs_services
+          or (individual_is_ssi_recipient_residing_in_medical_institution and individual_ssi_reduced_based_on_institutional_ssi_payment_standard)

--- a/us-wa/regulations/388/388-478/388-478-0055.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0055.test.yaml
@@ -110,3 +110,15 @@
     us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: holds
     us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
     us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 0
+- name: oracle_parameter_medical_institution_monthly_ssp_base
+  period: 2023-07
+  input:
+    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 0
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
+    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base: 70.0

--- a/us-wa/regulations/388/388-478/388-478-0055.test.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0055.test.yaml
@@ -1,7 +1,20 @@
 - name: fixed SSP rate for aged eligible individual
-  period: 2024-01
+  period: 2026-07
   input:
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_has_ineligible_spouse_under_wac_388_474_0001: false
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_blind_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_disabled_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_ssi_recipient_residing_in_medical_institution: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_ssi_reduced_based_on_institutional_ssi_payment_standard: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
     us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
@@ -14,9 +27,22 @@
     us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
     us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 35.5
 - name: grandfathered SSP amount is clamped to maximum
-  period: 2024-01
+  period: 2026-07
   input:
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_has_ineligible_spouse_under_wac_388_474_0001: false
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_blind_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_disabled_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_ssi_recipient_residing_in_medical_institution: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_ssi_reduced_based_on_institutional_ssi_payment_standard: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: true
     us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 250
@@ -31,7 +57,20 @@
 - name: medical institution SSP base for eligible individual
   period: 2023-07
   input:
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_has_ineligible_spouse_under_wac_388_474_0001: false
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: true
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_blind_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_disabled_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_ssi_recipient_residing_in_medical_institution: true
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_ssi_reduced_based_on_institutional_ssi_payment_standard: true
     us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: true
     us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
     us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
@@ -44,9 +83,22 @@
     us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
     us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 70.0
 - name: no SSP when individual is not eligible under WAC 388-474-0012
-  period: 2024-01
+  period: 2026-07
   input:
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_has_ineligible_spouse_under_wac_388_474_0001: false
+    ? us-wa:regulations/388/388-474/388-474-0012#input.developmental_disabilities_administration_determined_individual_eligible_for_ssp
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_ssi: false
+    ? us-wa:regulations/388/388-474/388-474-0012#input.individual_is_foster_child_receiving_childrens_administration_brs_services_for_part_or_all_of_month
+    : false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_eligible_for_foster_care_reimbursement_under_title_iv_e: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_grandfathered_ssi_recipient_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_age_65_or_older_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_blind_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_receives_ssi_because_disabled_under_wac_388_474_0001: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_is_ssi_recipient_residing_in_medical_institution: false
+    us-wa:regulations/388/388-474/388-474-0012#input.individual_ssi_reduced_based_on_institutional_ssi_payment_standard: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
     us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
     us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 100
@@ -58,16 +110,3 @@
     us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies: holds
     us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard: 0
     us-wa:regulations/388/388-478/388-478-0055#wa_ssp: 0
-- name: oracle_parameter_medical_institution_monthly_ssp_base
-  period: 2023-07
-  input:
-    us-wa:regulations/388/388-478/388-478-0055#input.grandfathered_client_ssp_amount_based_on_federal_requirements: 0
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_has_ineligible_spouse: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_aged_65_or_older: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_blind_as_determined_by_ssa: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_disabled_as_determined_by_ssa: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: false
-    us-wa:regulations/388/388-478/388-478-0055#input.individual_resides_in_medical_institution: false
-  output:
-    us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base: 70.0

--- a/us-wa/regulations/388/388-478/388-478-0055.yaml
+++ b/us-wa/regulations/388/388-478/388-478-0055.yaml
@@ -5,12 +5,14 @@ module:
   source_verification:
     corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
   summary: |-
-    Monthly SSP rate standards are $35.50 for individuals with an ineligible spouse, aged 65 and older, blind as determined by SSA, or disabled as determined by SSA; between $0.54 and $199.77 for grandfathered clients; and $70.00 as of July 2023 for individuals residing in a medical institution, with annual COLA increases starting January 1, 2024.
+    Monthly SSP rate standards are "$35.50 for" individuals with an ineligible spouse, aged 65 and older, blind as determined by SSA, or disabled as determined by SSA; "Between $0.54 and $199.77 for grandfathered clients"; and "$70.00 as of July 2023 for individuals residing in a medical institution." Starting January 1, 2024, the medical-institution payment increases annually by an SSA COLA.
   deferred_outputs:
     - output: us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_rate_after_annual_cola
       reason: The source states that starting January 1, 2024 the medical-institution SSP payment increases annually by a COLA determined by SSA, but the applicable SSA COLA values are not included in the source text or copied RuleSpec context.
       source_values:
         - us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base
+imports:
+  - us-wa:regulations/388/388-474/388-474-0012#individual_is_eligible_for_ssp_as_described
 rules:
   - name: fixed_monthly_ssp_rate_standard
     kind: parameter
@@ -117,7 +119,7 @@ rules:
     entity: Person
     dtype: Judgment
     period: Month
-    source: WAC 388-478-0055(2)(a)
+    source: us-wa/regulation/388/388-478/388-478-0055(a)
     metadata:
       proof:
         atoms:
@@ -170,15 +172,16 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
-              excerpt: "issued to certain individuals who the Social Security Administration (SSA) determines are eligible for supplemental security income (SSI) as described in WAC 388-474-0012."
+            kind: import
+            import:
+              target: us-wa:regulations/388/388-474/388-474-0012#individual_is_eligible_for_ssp_as_described
+              output: individual_is_eligible_for_ssp_as_described
+              hash: sha256:0bde2eab2ca9bc6352c8d49c6781783310c83a2294807ca7b59dbc6196a05a25
           - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us-wa/regulation/388/388-478/388-478-0055
-              excerpt: "Monthly SSP rate standards for eligible persons"
+              excerpt: "Monthly SSP rate standards for eligible persons as described in WAC 388-474-0012"
           - path: versions[0].formula
             kind: amount
             source:
@@ -187,4 +190,4 @@ rules:
     versions:
       - effective_from: '2023-07-01'
         formula: |-
-          if individual_is_eligible_for_ssp_as_described_in_wac_388_474_0012: if individual_resides_in_medical_institution: medical_institution_monthly_ssp_base else: if individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: grandfathered_monthly_ssp_rate_standard else: if fixed_monthly_ssp_rate_standard_applies: fixed_monthly_ssp_rate_standard else: 0 else: 0
+          if individual_is_eligible_for_ssp_as_described: if individual_resides_in_medical_institution: medical_institution_monthly_ssp_base else: if individual_is_grandfathered_client_as_defined_in_wac_388_474_0001: grandfathered_monthly_ssp_rate_standard else: if fixed_monthly_ssp_rate_standard_applies: fixed_monthly_ssp_rate_standard else: 0 else: 0


### PR DESCRIPTION
## Summary
- encode WAC 388-474-0012 SSP eligibility from primary Washington WAC corpus
- update WAC 388-478-0055 to import the WAC 388-474 eligibility concept instead of using a leaf input
- add signed axiom-encode apply manifests for both generated modules

## Validation
- `uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701/us-wa/regulations/388/388-474/388-474-0012.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701/us-wa/regulations/388/388-478/388-478-0055.yaml`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701/us-wa /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701/us-wa/regulations/388/388-474/388-474-0012.test.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701/us-wa/regulations/388/388-478/388-478-0055.test.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-wa-ssp-primary-20260701 --base-ref origin/main --head-ref HEAD --json`
- `git diff --check`

Note: full `axiom-encode validate` with reviewers hit reviewer CLI timeouts on WAC 388-474 locally; the encoder run itself compiled, passed CI, and got generalist review scores of 8/10 for both WAC 388-474 and WAC 388-478.
