### PR TITLE
Add Massachusetts TAFDC dependent criteria and deductions

### DIFF
--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/703/200/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/703/200/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/703/200/block-1.yaml",
+      "sha256": "24c09fac371f06614cb0b74c74dfa5f11925d352630d96dc501466817119d295"
+    },
+    {
+      "path": "regulations/106-cmr/703/200/block-1.test.yaml",
+      "sha256": "6d632a6659a9e3ba490154d3eb81309483b05b9870cc79acaefe1649cce0543b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e7abb3690646e7074575fe3df8594b114dd402ad",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.915",
+    "version_commit": "1f3fa15978b57540ad4ae376bc072d5ad290b132"
+  },
+  "axiom_encode_version": "0.2.915",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/703/200/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-ma-tafdc-703200/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-703-200-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "affe83fb91dbdc5e00cb4832869be1e26cd8d0db4f8f7f93fbb2ab5a46378988",
+  "generated_at": "2026-06-27T21:00:19.923213+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ma-tafdc-703200/codex-gpt-5.5/regulations/106-cmr/703/200/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ma-tafdc-703200",
+  "generated_output_sha256": "24c09fac371f06614cb0b74c74dfa5f11925d352630d96dc501466817119d295",
+  "generation_prompt_sha256": "82abf980f7375f932db1f501d5cbcb051a0c3f938fbc330ba189ee8b9e7c5626",
+  "model": "gpt-5.5",
+  "run_id": "f476b62f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6321d9241cf6d0f2a79d2955524b5eaa785352a807dc91bad72f959cd652b5b6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ma-tafdc-703200/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-703-200-block-1.json",
+  "trace_sha256": "22a4c1aca79842f3fc593925a29ca80e7cc72f97e7e9ed0ee0e74869179f8427"
+}

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/703/210/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/703/210/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/703/210/block-1.yaml",
+      "sha256": "d6417075e17557dc6916f0433e3d214329a4129832750b2f8d5df821cbaa62af"
+    },
+    {
+      "path": "regulations/106-cmr/703/210/block-1.test.yaml",
+      "sha256": "f0835b6d0dd44c7f50a00c0b1f2ae0cbb9120bc7590c7c5de789c04478b1434c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e7abb3690646e7074575fe3df8594b114dd402ad",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.915",
+    "version_commit": "1f3fa15978b57540ad4ae376bc072d5ad290b132"
+  },
+  "axiom_encode_version": "0.2.915",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/703/210/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-ma-tafdc-703210/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-703-210-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "5dfc9c3447d87ec379ad08a51ae193cea9a95a97d850a5e0901b311e1bda943c",
+  "generated_at": "2026-06-27T20:59:37.100004+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ma-tafdc-703210/codex-gpt-5.5/regulations/106-cmr/703/210/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ma-tafdc-703210",
+  "generated_output_sha256": "d6417075e17557dc6916f0433e3d214329a4129832750b2f8d5df821cbaa62af",
+  "generation_prompt_sha256": "a47f9199608a6817e3a22d178230259f331952a003d416f3ffdbbae6aea33993",
+  "model": "gpt-5.5",
+  "run_id": "039e3462",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "43b6623f925489b31567d4d8e3564ed6ab1cbf6f4448bb4eb798e6e8b4aa9c43"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ma-tafdc-703210/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-703-210-block-1.json",
+  "trace_sha256": "828bdc9db02715d532bd5066fb5f80e6aa42b14fbc638b8fcf5722612672d260"
+}

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/275/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/275/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/275/block-1.yaml",
+      "sha256": "9f91a2e2926ff439e47e760dd65a9c70b6b0f29ccd336e700bd9e34c47865e93"
+    },
+    {
+      "path": "regulations/106-cmr/704/275/block-1.test.yaml",
+      "sha256": "a8db89c3ff2b8425b5db2286c9e24ddd007a97637d6aba1a4e999c5731564bc6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e7abb3690646e7074575fe3df8594b114dd402ad",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.915",
+    "version_commit": "1f3fa15978b57540ad4ae376bc072d5ad290b132"
+  },
+  "axiom_encode_version": "0.2.915",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/704/275/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-ma-tafdc-704275-final/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-275-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "648032f0ba4416752159f097973057701e54a6d9567bc79917a2a3c2e02bac9c",
+  "generated_at": "2026-06-27T20:43:31.303677+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ma-tafdc-704275-final/codex-gpt-5.5/regulations/106-cmr/704/275/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ma-tafdc-704275-final",
+  "generated_output_sha256": "9f91a2e2926ff439e47e760dd65a9c70b6b0f29ccd336e700bd9e34c47865e93",
+  "generation_prompt_sha256": "6dee80997c001d561eefb8d154889c09179767a26b1f99d7a759fdbbfb7bd95c",
+  "model": "gpt-5.5",
+  "run_id": "6c24a98a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3d8489061527cb1b44f943b9d47bc9ec58afb7c77d5268d6e82e0fb0614b0085"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ma-tafdc-704275-final/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-275-block-1.json",
+  "trace_sha256": "363e5731bc69d7d756e97c89ac38779c0822170a97d90e2f0024c50d542f277b"
+}

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/280/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/280/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/280/block-1.yaml",
+      "sha256": "d244dcbf00050a040c7b048d638734a5c41c4241606d4cb4cd13371c12128314"
+    },
+    {
+      "path": "regulations/106-cmr/704/280/block-1.test.yaml",
+      "sha256": "9ef48b2c0cf0bd9c6b9c0627129669011cc24771ee6780abd701a77a8adc85dc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e7abb3690646e7074575fe3df8594b114dd402ad",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.915",
+    "version_commit": "1f3fa15978b57540ad4ae376bc072d5ad290b132"
+  },
+  "axiom_encode_version": "0.2.915",
+  "backend": "codex",
+  "citation": "us-ma:regulations/106-cmr/704/280/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-ma-tafdc-704280/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-280-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "29afc4d4fa22aafe1e771715b6ac51f04b0467a9349927ebefd3040ef482d629",
+  "generated_at": "2026-06-27T20:49:53.284599+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ma-tafdc-704280/codex-gpt-5.5/regulations/106-cmr/704/280/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ma-tafdc-704280",
+  "generated_output_sha256": "d244dcbf00050a040c7b048d638734a5c41c4241606d4cb4cd13371c12128314",
+  "generation_prompt_sha256": "c64ddb57c73b06be5c9a655d0affca163f30f3df695e247d0dba45cbf5793720",
+  "model": "gpt-5.5",
+  "run_id": "d8747563",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "99d5aabc74503f5c8c4d4163236a298fabef0a6b7e706861a16950c7fda9525d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ma-tafdc-704280/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-280-block-1.json",
+  "trace_sha256": "0cbbc580f542c6c79e323c20ca40fb81b39ad1ec190bba07a4bf9ea50885e809"
+}

--- a/us-ma/regulations/106-cmr/703/200/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/703/200/block-1.test.yaml
@@ -1,0 +1,49 @@
+- name: child_under_18_is_dependent_child
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_child: true
+    us-ma:regulations/106-cmr/703/200/block-1#input.age_years: 17
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_full_time_student: false
+    us-ma:regulations/106-cmr/703/200/block-1#input.current_grade_level: 11
+    ? us-ma:regulations/106-cmr/703/200/block-1#input.person_is_in_equivalent_vocational_or_technical_training_program_designed_to_lead_to_gainful_employment
+    : false
+    us-ma:regulations/106-cmr/703/200/block-1#input.expected_age_at_graduation_or_completion_years: 18
+  output:
+    us-ma:regulations/106-cmr/703/200/block-1#dependent_child: holds
+- name: full_time_grade_12_student_expected_to_complete_before_19_is_dependent_child
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_child: true
+    us-ma:regulations/106-cmr/703/200/block-1#input.age_years: 18
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_full_time_student: true
+    us-ma:regulations/106-cmr/703/200/block-1#input.current_grade_level: 12
+    ? us-ma:regulations/106-cmr/703/200/block-1#input.person_is_in_equivalent_vocational_or_technical_training_program_designed_to_lead_to_gainful_employment
+    : false
+    us-ma:regulations/106-cmr/703/200/block-1#input.expected_age_at_graduation_or_completion_years: 18
+  output:
+    us-ma:regulations/106-cmr/703/200/block-1#dependent_child: holds
+- name: student_not_expected_to_complete_before_19_is_not_dependent_child
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_child: true
+    us-ma:regulations/106-cmr/703/200/block-1#input.age_years: 18
+    us-ma:regulations/106-cmr/703/200/block-1#input.person_is_full_time_student: true
+    us-ma:regulations/106-cmr/703/200/block-1#input.current_grade_level: 12
+    ? us-ma:regulations/106-cmr/703/200/block-1#input.person_is_in_equivalent_vocational_or_technical_training_program_designed_to_lead_to_gainful_employment
+    : false
+    us-ma:regulations/106-cmr/703/200/block-1#input.expected_age_at_graduation_or_completion_years: 19
+  output:
+    us-ma:regulations/106-cmr/703/200/block-1#dependent_child: not_holds
+- name: tafdc_unit_with_dependent_child_meets_primary_nonfinancial_requirement
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/703/200/block-1#relation.member_of_tafdc_unit:
+    - us-ma:regulations/106-cmr/703/200/block-1#input.person_is_child: true
+      us-ma:regulations/106-cmr/703/200/block-1#input.age_years: 17
+      us-ma:regulations/106-cmr/703/200/block-1#input.person_is_full_time_student: false
+      us-ma:regulations/106-cmr/703/200/block-1#input.current_grade_level: 10
+      ? us-ma:regulations/106-cmr/703/200/block-1#input.person_is_in_equivalent_vocational_or_technical_training_program_designed_to_lead_to_gainful_employment
+      : false
+      us-ma:regulations/106-cmr/703/200/block-1#input.expected_age_at_graduation_or_completion_years: 18
+  output:
+    us-ma:regulations/106-cmr/703/200/block-1#tafdc_dependent_child_requirement_met: holds

--- a/us-ma/regulations/106-cmr/703/200/block-1.yaml
+++ b/us-ma/regulations/106-cmr/703/200/block-1.yaml
@@ -1,0 +1,105 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+  summary: '"The primary nonfinancial TAFDC requirement is the presence of a dependent
+    child. A dependent child is a child who is under the age of 18" and certain full-time
+    students expected to complete school or training before the 19th birthday.'
+rules:
+- name: dependent_child_under_age_limit
+  kind: parameter
+  dtype: Count
+  source: 106 CMR 703.200 dependent child age limit
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+          excerpt: under the age of 18
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '18'
+- name: dependent_child_grade_level_limit
+  kind: parameter
+  dtype: Count
+  source: 106 CMR 703.200 student grade level limit
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+          excerpt: grade 12 or below
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '12'
+- name: dependent_child_completion_age_limit
+  kind: parameter
+  dtype: Count
+  source: 106 CMR 703.200 student completion age limit
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+          excerpt: before his or her 19th birthday
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '19'
+- name: dependent_child
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 106 CMR 703.200 dependent child definition
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "person_is_child\nand (\n  age_years < dependent_child_under_age_limit\n\
+      \  or (\n    person_is_full_time_student\n    and (\n      current_grade_level\
+      \ <= dependent_child_grade_level_limit\n      or person_is_in_equivalent_vocational_or_technical_training_program_designed_to_lead_to_gainful_employment\n\
+      \    )\n    and expected_age_at_graduation_or_completion_years < dependent_child_completion_age_limit\n\
+      \  )\n)"
+- name: member_of_tafdc_unit
+  kind: data_relation
+  data_relation:
+    predicate: member_of_tafdc_unit
+    arity: 2
+    arguments:
+    - name: member_of_tafdc_unit
+      entity: Person
+    - name: tanf_unit
+      entity: TanfUnit
+- name: tafdc_dependent_child_requirement_met
+  kind: derived
+  entity: TanfUnit
+  dtype: Judgment
+  period: Month
+  source: 106 CMR 703.200 primary nonfinancial TAFDC requirement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.200
+  versions:
+  - effective_from: '0001-01-01'
+    formula: count_where(member_of_tafdc_unit, dependent_child) > 0

--- a/us-ma/regulations/106-cmr/703/210/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/703/210/block-1.test.yaml
@@ -1,0 +1,48 @@
+- name: within_120_days_qualifies
+  period: 2024-03
+  input:
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_pregnant_woman: true
+    us-ma:regulations/106-cmr/703/210/block-1#input.otherwise_eligible_pregnant_woman: true
+    ? us-ma:regulations/106-cmr/703/210/block-1#input.child_if_born_and_living_with_her_would_meet_tafdc_nonfinancial_and_financial_requirements
+    : true
+    us-ma:regulations/106-cmr/703/210/block-1#input.days_until_expected_birth_from_application_date: 90
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_teen_parent_under_106_cmr_701_600_kk: false
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_meets_school_attendance_requirements_under_106_cmr_703_181: false
+  output:
+    us-ma:regulations/106-cmr/703/210/block-1#tafdc_pregnancy_dependent_child_requirement_met: holds
+- name: outside_120_days_without_teen_parent_school_path_does_not_qualify
+  period: 2024-03
+  input:
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_pregnant_woman: true
+    us-ma:regulations/106-cmr/703/210/block-1#input.otherwise_eligible_pregnant_woman: true
+    ? us-ma:regulations/106-cmr/703/210/block-1#input.child_if_born_and_living_with_her_would_meet_tafdc_nonfinancial_and_financial_requirements
+    : true
+    us-ma:regulations/106-cmr/703/210/block-1#input.days_until_expected_birth_from_application_date: 150
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_teen_parent_under_106_cmr_701_600_kk: false
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_meets_school_attendance_requirements_under_106_cmr_703_181: false
+  output:
+    us-ma:regulations/106-cmr/703/210/block-1#tafdc_pregnancy_dependent_child_requirement_met: not_holds
+- name: teen_parent_meeting_school_attendance_qualifies_at_any_pregnancy_stage
+  period: 2024-03
+  input:
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_pregnant_woman: true
+    us-ma:regulations/106-cmr/703/210/block-1#input.otherwise_eligible_pregnant_woman: true
+    ? us-ma:regulations/106-cmr/703/210/block-1#input.child_if_born_and_living_with_her_would_meet_tafdc_nonfinancial_and_financial_requirements
+    : true
+    us-ma:regulations/106-cmr/703/210/block-1#input.days_until_expected_birth_from_application_date: 200
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_teen_parent_under_106_cmr_701_600_kk: true
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_meets_school_attendance_requirements_under_106_cmr_703_181: true
+  output:
+    us-ma:regulations/106-cmr/703/210/block-1#tafdc_pregnancy_dependent_child_requirement_met: holds
+- name: unborn_child_requirements_block_eligibility
+  period: 2024-03
+  input:
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_pregnant_woman: true
+    us-ma:regulations/106-cmr/703/210/block-1#input.otherwise_eligible_pregnant_woman: true
+    ? us-ma:regulations/106-cmr/703/210/block-1#input.child_if_born_and_living_with_her_would_meet_tafdc_nonfinancial_and_financial_requirements
+    : false
+    us-ma:regulations/106-cmr/703/210/block-1#input.days_until_expected_birth_from_application_date: 90
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_is_teen_parent_under_106_cmr_701_600_kk: false
+    us-ma:regulations/106-cmr/703/210/block-1#input.person_meets_school_attendance_requirements_under_106_cmr_703_181: false
+  output:
+    us-ma:regulations/106-cmr/703/210/block-1#tafdc_pregnancy_dependent_child_requirement_met: not_holds

--- a/us-ma/regulations/106-cmr/703/210/block-1.yaml
+++ b/us-ma/regulations/106-cmr/703/210/block-1.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.210
+  summary: |-
+    Assistance may be provided for an otherwise eligible pregnant woman when verified that the child is expected to be born within 120 days of application, or for a teen parent at any time during pregnancy if meeting school attendance requirements, and if the child would meet TAFDC requirements if born and living with her.
+rules:
+  - name: tafdc_pregnancy_expected_birth_days_limit
+    kind: parameter
+    dtype: Count
+    source: 106 CMR 703.210(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.210
+              excerpt: "within 120 days of the date of application"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          120
+
+  - name: tafdc_pregnancy_dependent_child_requirement_met
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 703.210(A)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/703/703.210
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/703/210/block-1#tafdc_pregnancy_expected_birth_days_limit
+              output: tafdc_pregnancy_expected_birth_days_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_is_pregnant_woman
+          and otherwise_eligible_pregnant_woman
+          and child_if_born_and_living_with_her_would_meet_tafdc_nonfinancial_and_financial_requirements
+          and (
+            days_until_expected_birth_from_application_date <= tafdc_pregnancy_expected_birth_days_limit
+            or (
+              person_is_teen_parent_under_106_cmr_701_600_kk
+              and person_meets_school_attendance_requirements_under_106_cmr_703_181
+            )
+          )

--- a/us-ma/regulations/106-cmr/704/275/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/275/block-1.test.yaml
@@ -1,0 +1,110 @@
+- name: full_time_child_under_two_capped_at_200
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 160
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 250
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: true
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_monthly_hours_band: 4
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_restriction_applies: not_holds
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction_available: holds
+    us-ma:regulations/106-cmr/704/275/block-1#applicable_dependent_care_maximum_deduction: 200
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction: 200
+- name: full_time_child_two_or_over_or_incapacitated_capped_at_175
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 160
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 300
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_monthly_hours_band: 4
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_restriction_applies: not_holds
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction_available: holds
+    us-ma:regulations/106-cmr/704/275/block-1#applicable_dependent_care_maximum_deduction: 175
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction: 175
+- name: part_time_actual_expense_below_cap
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 50
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 70
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_monthly_hours_band: 2
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_restriction_applies: not_holds
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction_available: holds
+    us-ma:regulations/106-cmr/704/275/block-1#applicable_dependent_care_maximum_deduction: 88
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction: 70
+- name: restriction_disallows_dependent_care_deduction
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 160
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 120
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : true
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_monthly_hours_band: 4
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_restriction_applies: holds
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction_available: not_holds
+    us-ma:regulations/106-cmr/704/275/block-1#applicable_dependent_care_maximum_deduction: 0
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction: 0
+- name: no_eligible_hours_zero_band_and_zero_maximum
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 0
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 120
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: true
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_monthly_hours_band: 0
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_restriction_applies: not_holds
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction_available: holds
+    us-ma:regulations/106-cmr/704/275/block-1#applicable_dependent_care_maximum_deduction: 0
+    us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction: 0

--- a/us-ma/regulations/106-cmr/704/275/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/275/block-1.yaml
@@ -1,0 +1,260 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+  summary: |-
+    An employed applicant or client may receive a dependent-care deduction equal to actual dependent-care expenditure, including transportation, but not more than the applicable monthly maximum. The maximum is $175 per dependent child age two or older or incapacitated individual, $200 for children under two, and prorated by hours for less than full-time employment. The deduction is unavailable under specified TAFDC/EAEDC provisions, for a filing-unit member excluded from the assistance unit, and is not applied to renter, roomer, or boarder income.
+rules:
+  - name: dependent_care_monthly_hours_lower_bound
+    kind: parameter
+    dtype: Decimal
+    period: Month
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction hours table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: MONTHLY HOURS lower bounds
+                column_key: MONTHLY HOURS
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 1
+          2: 44
+          3: 88
+          4: 131
+
+  - name: dependent_care_monthly_hours_upper_bound
+    kind: parameter
+    dtype: Decimal
+    period: Month
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction hours table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: MONTHLY HOURS upper bounds
+                column_key: MONTHLY HOURS
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 43
+          2: 87
+          3: 130
+
+  - name: dependent_care_weekly_hours_lower_bound
+    kind: parameter
+    dtype: Decimal
+    period: Week
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction hours table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: WEEKLY HOURS lower bounds
+                column_key: WEEKLY HOURS
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 1
+          2: 11
+          3: 21
+          4: 31
+
+  - name: dependent_care_weekly_hours_upper_bound
+    kind: parameter
+    dtype: Decimal
+    period: Week
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction hours table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: WEEKLY HOURS upper bounds
+                column_key: WEEKLY HOURS
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 10
+          2: 20
+          3: 30
+
+  - name: dependent_care_maximum_deduction_child_two_or_over_or_incapacitated
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction maximum table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: MONTHLY HOURS
+                column_key: TWO OR OVER
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 44
+          2: 88
+          3: 132
+          4: 175
+
+  - name: dependent_care_maximum_deduction_child_under_two
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    indexed_by: dependent_care_monthly_hours_band
+    source: 106 CMR 704.275(A), dependent-care deduction maximum table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              table:
+                header: WEEKLY HOURS | MONTHLY HOURS | MAXIMUM DEDUCTIONS DEPENDENT CHILD
+                row_key: MONTHLY HOURS
+                column_key: UNDER TWO
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 50
+          2: 100
+          3: 150
+          4: 200
+
+  - name: dependent_care_monthly_hours_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    source: 106 CMR 704.275(A), monthly-hours standards for dependent-care deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              excerpt: "MONTHLY HOURS: 1 - 43; 44 - 87; 88 - 130; 131 - above"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if monthly_employment_hours < dependent_care_monthly_hours_lower_bound[1]: 0 else: if monthly_employment_hours <= dependent_care_monthly_hours_upper_bound[1]: 1 else: if monthly_employment_hours <= dependent_care_monthly_hours_upper_bound[2]: 2 else: if monthly_employment_hours <= dependent_care_monthly_hours_upper_bound[3]: 3 else: 4
+
+  - name: dependent_care_restriction_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.275(B), Restrictions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+          or applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+          or applicant_or_client_meets_106_cmr_704_285_c_for_eaedc
+          or applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit
+          or income_is_from_renter_roomer_or_boarder
+
+  - name: dependent_care_deduction_available
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.275(A)-(B), dependent-care deduction requirements and restrictions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          applicant_or_client_is_employed
+          and dependent_is_dependent_child_or_incapacitated_individual_requiring_care
+          and dependent_is_member_of_assistance_unit
+          and not dependent_care_restriction_applies
+
+  - name: applicable_dependent_care_maximum_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.275(A), maximum allowable dependent-care deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              excerpt: "the amount allowed ... shall not exceed $175 ... For children under the age of two ... $200"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if not dependent_care_deduction_available: 0 else: if dependent_care_monthly_hours_band == 0: 0 else: if dependent_is_child_under_two: dependent_care_maximum_deduction_child_under_two[dependent_care_monthly_hours_band] else: dependent_care_maximum_deduction_child_two_or_over_or_incapacitated[dependent_care_monthly_hours_band]
+
+  - name: dependent_care_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.275(A)-(B), dependent-care deduction amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.275
+              excerpt: "the amount allowed for dependent care is the actual expenditure ... or the maximum allowable deduction, whichever is less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if dependent_care_deduction_available: min(max(0, actual_dependent_care_expenditure_including_transportation), applicable_dependent_care_maximum_deduction) else: 0

--- a/us-ma/regulations/106-cmr/704/280/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/280/block-1.test.yaml
@@ -1,0 +1,144 @@
+- name: eligible_applicant_receives_half_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 500
+- name: no_recent_tafdc_receipt_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: reduced_income_or_terminated_employment_exception_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : true
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: refused_bona_fide_job_offer_exception_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: untimely_income_report_exception_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : true
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: full_employment_program_exception_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: support_liable_noncase_member_exception_blocks_disregard
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : 1000
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0
+- name: eligible_applicant_negative_remaining_earnings_gets_zero
+  period: 2026-06
+  input:
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_received_tafdc_within_last_four_calendar_months: true
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+    : false
+    us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_employed_in_full_employment_program: false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+    : false
+    ? us-ma:regulations/106-cmr/704/280/block-1#input.remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions
+    : -100
+  output:
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified: not_holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible: holds
+    us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_amount: 0

--- a/us-ma/regulations/106-cmr/704/280/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/280/block-1.yaml
@@ -1,0 +1,104 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.280
+  summary: |-
+    An applicant who has received TAFDC within the last four calendar months is eligible to have 50 per cent of remaining gross earned income disregarded after work-related expenses and before dependent care deductions, unless one of the listed disqualifying conditions exists.
+rules:
+  - name: tafdc_application_earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 106 CMR 704.280
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.280
+              excerpt: "50 per cent of the remaining gross earned income disregarded"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.50
+
+  - name: tafdc_application_earned_income_disregard_disqualified
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.280(A)-(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.280
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          applicant_reduced_income_or_terminated_employment_without_good_cause_before_grant_calculation_month
+          or applicant_refused_bona_fide_job_offer_without_good_cause_in_same_period
+          or applicant_failed_without_good_cause_to_make_timely_report_of_income_received
+          or applicant_is_employed_in_full_employment_program
+          or applicant_is_not_included_in_case_but_legally_liable_to_support_dependent_child
+
+  - name: tafdc_application_earned_income_disregard_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.280
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.280
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_disqualified
+              output: tafdc_application_earned_income_disregard_disqualified
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          applicant_received_tafdc_within_last_four_calendar_months
+          and not tafdc_application_earned_income_disregard_disqualified
+
+  - name: tafdc_application_earned_income_disregard_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.280
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.280
+              excerpt: "remaining gross earned income disregarded, after work-related-expenses, but before dependent care deductions"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_rate
+              output: tafdc_application_earned_income_disregard_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/280/block-1#tafdc_application_earned_income_disregard_eligible
+              output: tafdc_application_earned_income_disregard_eligible
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tafdc_application_earned_income_disregard_eligible: tafdc_application_earned_income_disregard_rate * max(0, remaining_gross_earned_income_after_work_related_expenses_before_dependent_care_deductions) else: 0


### PR DESCRIPTION
## Summary
- Add generated RuleSpec encodings for 106 CMR 703.200 dependent-child criteria and 703.210 pregnancy criteria.
- Add generated RuleSpec encodings for 106 CMR 704.275 dependent-care deductions and 704.280 applicant earned-income disregard.
- Carry over the encoder apply manifests for each added module.

## Notes
- This is split out of the older stale MA TAFDC scratch worktree. I intentionally did not carry forward its 704.260, 704.270, 704.281, 704.410/420, 704.500, or program-bridge files because those were generated before later merged TAFDC modules and reference obsolete rule IDs.

## Checks
- `uv run --with pytest --with pyyaml python -m pytest -q tests`
- `axiom-encode validate ... --skip-reviewers`
- `axiom-encode proof-validate ...`
- `axiom-encode test --root ... --axiom-rules-engine-path ...` (4 files, 21 cases)
- `axiom-encode guard-generated --repo ... --base-ref origin/main --head-ref HEAD --roots us-ma`
- changed oracle coverage filter: 22 outputs, all `known_not_comparable`
