### PR TITLE
Record Minnesota MFIP upstream source check

### DIFF
--- a/.axiom/encoding-manifests/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.json
+++ b/.axiom/encoding-manifests/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
+      "sha256": "237f620882efc1190518a584a0010c6b34b174c30061b63410a60f09e1142b9c"
+    },
+    {
+      "path": "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml",
+      "sha256": "18e05ef894308168fd9b7aa83f82646d4f99bb580b474fd6f84cd72c402effe2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b67435dfcb03a19fb6d979b9117521b2f68e7029",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1040",
+    "version_commit": "b67435dfcb03a19fb6d979b9117521b2f68e7029"
+  },
+  "axiom_encode_version": "0.2.1040",
+  "backend": "deterministic",
+  "citation": "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-01T13:17:02.185277+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsaqfy8sy/deterministic-repair/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsaqfy8sy",
+  "generated_output_sha256": "237f620882efc1190518a584a0010c6b34b174c30061b63410a60f09e1142b9c",
+  "generation_prompt_sha256": null,
+  "model": "minnesota-mfip-upstream-source-check-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0249d26f7cec94b54f3dc752f28c2445dc65a5c4e9084f6b3eb2f78ec96b8a48"
+  },
+  "tool": "axiom-encode repair-minnesota-mfip-upstream-source-check",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
+++ b/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
@@ -4,6 +4,19 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-mn/statute/142G.16
+        - us-mn/statute/142G.17
+        - us-mn/statute/256P.03
+      rationale: |-
+        Minnesota statutes define the MFIP income/payment calculation,
+        transitional standard, family wage level, and earned-income disregard.
+        The DHS Combined Manual remains the official implementation source for
+        this module's operational grant procedure, including applicant
+        proration, recoupment, and cash/food issuance against the published
+        standards.
   summary: |-
     The procedure to determine the grant amount differs based upon the types of income the unit receives. If the unit receives no income other than MFIP, the Transitional Standard is the total MFIP grant. For unearned income only, subtract unearned income from the Transitional Standard. For earned income, subtract net earned income from the Family Wage Level and compare the difference to the Transitional Standard. For both earned and unearned income, subtract unearned income from the applicable standard or difference. Applicant cases are prorated, recoupment is subtracted if applicable, the food portion is issued as EBT, and any remaining amount is issued in cash.
 rules:


### PR DESCRIPTION
## Summary
- record the Minnesota MFIP higher-authority source check on the Combined Manual MFIP total-grant module
- cite Minnesota Statutes 142G.16, 142G.17, and 256P.03 as checked upstream authority
- add the signed deterministic repair manifest generated by TheAxiomFoundation/axiom-encode#927

## Validation
- uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode proof-validate --json /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref origin/main --head-ref HEAD --json
- uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode axiom-encode validate --skip-reviewers --json /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml

Note: full validate with reviewers hit two 300s reviewer timeouts, while the non-reviewer CI gate passed.