### PR TITLE
Encode Massachusetts TAFDC grant calculation

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1046"
+axiom_encode_version = "0.2.1047"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "018a559bdef454589b89e8bbf86907a76db8c843"
+axiom_encode_ref = "9600c4544020e23f5efc9baa3ceded268c3aec3d"
 axiom_corpus_ref = "ed1c11a828dbdeb276b10b580e1eb994ff2be37c"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/500/block-1.json
+++ b/us-ma/.axiom/encoding-manifests/regulations/106-cmr/704/500/block-1.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/106-cmr/704/500/block-1.yaml",
+      "sha256": "e9c72b0bd8b4ef58f1d42af4ecf089c4ea6d49f132a2f48385690a473842368b"
+    },
+    {
+      "path": "regulations/106-cmr/704/500/block-1.test.yaml",
+      "sha256": "fb203da47082f40469ad2e0a983bdbafcee46ce1a98c1cd6ee70006f2f30cbce"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "018a559bdef454589b89e8bbf86907a76db8c843",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1046",
+    "version_commit": "0744772846790370ecff4aef464b6bfdd9a7607d"
+  },
+  "axiom_encode_version": "0.2.1046",
+  "backend": "codex",
+  "citation": "us-ma/regulations/106-cmr/704/500/block-1",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-500-block-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "b444bc27503c860cca341c75aaf3278440b3ed83f4b230cdea439c92f73612d2",
+  "generated_at": "2026-07-01T17:25:32.447955+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/106-cmr/704/500/block-1.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "e9c72b0bd8b4ef58f1d42af4ecf089c4ea6d49f132a2f48385690a473842368b",
+  "generation_prompt_sha256": "512ca998841eff0dbab7435f6fdb66112b9ce6e3d39757112f0d714cefa5e4ff",
+  "model": "gpt-5.5",
+  "run_id": "96b802fe",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2e2c8e7b11099a931cd5e360f3a3f34cd814a1b526cfb960a2528a796b5e8cde"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ma-regulations-106-cmr-704-500-block-1.json",
+  "trace_sha256": "49335dc7470e6e584b2a472df7dfd7b5ade694e75302b624540359ac8f48e4ae"
+}

--- a/us-ma/regulations/106-cmr/704/500/block-1.test.yaml
+++ b/us-ma/regulations/106-cmr/704/500/block-1.test.yaml
@@ -1,0 +1,116 @@
+- name: tafdc person countable earned income with fifty percent disregard
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_gross_earned_income: 1000
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_earned_income_noncountable_under_106_cmr_704_250: 0
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_full_employment_program_income: 0
+    ? us-ma:regulations/106-cmr/704/500/block-1#input.member_dependent_child_full_time_student_earned_income_used_in_financial_eligibility_test
+    : 0
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_100_percent_earned_income_disregard: false
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_50_percent_earned_income_disregard: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: true
+    us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 160
+    us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 100
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+    us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+    : false
+    ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+    : false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+    us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_member_remaining_gross_earned_income_after_exclusions: 1000
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_member_countable_earned_income: 300
+- name: tafdc grant result below payment standard is paid
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/500/block-1#input.applicable_need_standard: 900
+    ? us-ma:regulations/106-cmr/704/500/block-1#input.filing_unit_gross_unearned_and_other_income_not_excluded_under_106_cmr_704_250_including_deemed_and_excluded_assistance_unit_members
+    : 50
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_size: 3
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_has_rent_allowance: false
+    us-ma:regulations/106-cmr/704/500/block-1#relation.tafdc_filing_unit_members:
+    - us-ma:regulations/106-cmr/704/500/block-1#input.filing_unit_member_included_in_grant_calculation: true
+      us-ma:regulations/106-cmr/704/500/block-1#input.member_gross_earned_income: 1000
+      us-ma:regulations/106-cmr/704/500/block-1#input.member_earned_income_noncountable_under_106_cmr_704_250: 0
+      us-ma:regulations/106-cmr/704/500/block-1#input.member_full_employment_program_income: 0
+      ? us-ma:regulations/106-cmr/704/500/block-1#input.member_dependent_child_full_time_student_earned_income_used_in_financial_eligibility_test
+      : 0
+      us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_100_percent_earned_income_disregard: false
+      us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_50_percent_earned_income_disregard: true
+      us-ma:regulations/106-cmr/704/270/block-1#input.person_is_employed: true
+      us-ma:regulations/106-cmr/704/270/block-1#input.employed_applicant_determining_eligibility: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.employed_client_determining_grant_amount: true
+      us-ma:regulations/106-cmr/704/270/block-1#input.eligible_for_100_percent_earned_income_disregard_under_106_cmr_704_281: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_335_for_eaedc: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.income_deemed_to_filing_unit_and_meets_106_cmr_704_210_d_for_tafdc: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_280_a_or_b_for_eaedc: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.meets_106_cmr_704_286_c_for_eaedc: false
+      us-ma:regulations/106-cmr/704/270/block-1#input.required_in_filing_unit_but_not_in_assistance_unit: false
+      us-ma:regulations/106-cmr/704/275/block-1#input.monthly_employment_hours: 160
+      us-ma:regulations/106-cmr/704/275/block-1#input.actual_dependent_care_expenditure_including_transportation: 100
+      us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_is_employed: true
+      us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_dependent_child_or_incapacitated_individual_requiring_care: true
+      us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_member_of_assistance_unit: true
+      us-ma:regulations/106-cmr/704/275/block-1#input.dependent_is_child_under_two: false
+      ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_280_a_or_b_for_tafdc
+      : false
+      ? us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_applicable_provisions_of_106_cmr_704_281_a_or_b_for_tafdc
+      : false
+      us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_meets_106_cmr_704_285_c_for_eaedc: false
+      us-ma:regulations/106-cmr/704/275/block-1#input.applicant_or_client_must_be_in_filing_unit_but_not_in_assistance_unit: false
+      us-ma:regulations/106-cmr/704/275/block-1#input.income_is_from_renter_roomer_or_boarder: false
+  output:
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_filing_unit_countable_earned_income: 300
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_filing_unit_total_countable_income: 350
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_rounded_need_standard_deficit: 550
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_financially_eligible_after_grant_calculation: holds
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_monthly_grant_amount: 550
+- name: tafdc negative result is financially ineligible
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/500/block-1#input.applicable_need_standard: 900
+    ? us-ma:regulations/106-cmr/704/500/block-1#input.filing_unit_gross_unearned_and_other_income_not_excluded_under_106_cmr_704_250_including_deemed_and_excluded_assistance_unit_members
+    : 1000
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_size: 3
+    us-ma:regulations/106-cmr/704/410-420-table/block-1#input.assistance_unit_has_rent_allowance: false
+    us-ma:regulations/106-cmr/704/500/block-1#relation.tafdc_filing_unit_members: []
+    us-ma:regulations/106-cmr/704/500/block-1#input.filing_unit_member_included_in_grant_calculation: false
+    ? us-ma:regulations/106-cmr/704/500/block-1#input.member_dependent_child_full_time_student_earned_income_used_in_financial_eligibility_test
+    : 0
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_earned_income_noncountable_under_106_cmr_704_250: 0
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_100_percent_earned_income_disregard: false
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_eligible_for_50_percent_earned_income_disregard: false
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_full_employment_program_income: 0
+    us-ma:regulations/106-cmr/704/500/block-1#input.member_gross_earned_income: 0
+  output:
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_filing_unit_countable_earned_income: 0
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_filing_unit_total_countable_income: 1000
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_rounded_need_standard_deficit: -100
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_financially_eligible_after_grant_calculation: not_holds
+    us-ma:regulations/106-cmr/704/500/block-1#tafdc_monthly_grant_amount: 0
+- name: eaedc thirty and one third disregard leaves assistance unit eligible
+  period: 2024-09
+  input:
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_countable_earned_income_before_grant_deductions: 300
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_work_related_expenses: 30
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_thirty_and_one_third_disregard_applies: true
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_thirty_dollar_disregard_applies: false
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_dependent_care_deduction: 20
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_gross_unearned_income: 100
+    us-ma:regulations/106-cmr/704/500/block-1#input.eaedc_standard_of_assistance: 300
+  output:
+    us-ma:regulations/106-cmr/704/500/block-1#eaedc_countable_income_after_grant_deductions: 240
+    us-ma:regulations/106-cmr/704/500/block-1#eaedc_financially_eligible_after_grant_calculation: holds

--- a/us-ma/regulations/106-cmr/704/500/block-1.yaml
+++ b/us-ma/regulations/106-cmr/704/500/block-1.yaml
@@ -1,0 +1,302 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+  summary: |-
+    The TAFDC grant amount calculation identifies countable earned income, applies the 100% or 50% earned-income disregards, subtracts dependent care, totals countable earned and countable unearned income, and subtracts that total from the applicable Need Standard. If the rounded result is $10 or greater but less than the applicable Payment Standard, that result is paid monthly; if greater than the Payment Standard, the Payment Standard is paid; if zero through less than $10, assistance is considered received but no monthly grant is paid; if less than zero, the assistance unit is financially ineligible. The EAEDC grant amount calculation subtracts work expenses, applicable $30 and one-third or $30 disregards, and dependent care from earned income, adds gross unearned income, and compares the result with the standard of assistance.
+imports:
+  - us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard
+  - us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount
+  - us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction
+rules:
+  - name: tafdc_full_earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 106 CMR 704.500, TAFDC Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "100% Earned Income Disregard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: tafdc_half_earned_income_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 106 CMR 704.500, TAFDC Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "50 per cent of the remainder"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.50
+
+  - name: tafdc_minimum_monthly_grant_threshold
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Step 7
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "if $10 or greater"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: eaedc_thirty_dollar_disregard_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, EAEDC Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "$30 and one-third disregard or $30 disregard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30
+
+  - name: eaedc_one_third_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 106 CMR 704.500, EAEDC Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "$30 and one-third disregard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1 / 3
+
+  - name: tafdc_filing_unit_members
+    kind: data_relation
+    source: 106 CMR 704.500, TAFDC Steps 1 through 4
+    data_relation:
+      predicate: tafdc_filing_unit_members
+      arity: 2
+      arguments:
+        - Person
+        - TanfUnit
+
+  - name: tafdc_member_remaining_gross_earned_income_after_exclusions
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Step 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, member_gross_earned_income - member_earned_income_noncountable_under_106_cmr_704_250 - member_full_employment_program_income - member_dependent_child_full_time_student_earned_income_used_in_financial_eligibility_test)
+
+  - name: tafdc_member_countable_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Steps 2 and 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount
+              output: ma_tafdc_work_related_expense_deduction_amount
+              hash: sha256:1aa9f862105ffd58bc341b049134dc4b33a466aa2f609597cb7e28ea63079e4a
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/275/block-1#dependent_care_deduction
+              output: dependent_care_deduction
+              hash: sha256:9f91a2e2926ff439e47e760dd65a9c70b6b0f29ccd336e700bd9e34c47865e93
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if member_eligible_for_100_percent_earned_income_disregard: max(0, tafdc_member_remaining_gross_earned_income_after_exclusions - (tafdc_full_earned_income_disregard_rate * tafdc_member_remaining_gross_earned_income_after_exclusions)) else: if member_eligible_for_50_percent_earned_income_disregard: max(0, max(0, tafdc_member_remaining_gross_earned_income_after_exclusions - ma_tafdc_work_related_expense_deduction_amount) - (tafdc_half_earned_income_disregard_rate * max(0, tafdc_member_remaining_gross_earned_income_after_exclusions - ma_tafdc_work_related_expense_deduction_amount)) - dependent_care_deduction) else: max(0, tafdc_member_remaining_gross_earned_income_after_exclusions - dependent_care_deduction)
+
+  - name: tafdc_filing_unit_countable_earned_income
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Step 4
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          sum_where(tafdc_filing_unit_members, tafdc_member_countable_earned_income, filing_unit_member_included_in_grant_calculation)
+
+  - name: tafdc_filing_unit_total_countable_income
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Steps 5 and 6
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tafdc_filing_unit_countable_earned_income + filing_unit_gross_unearned_and_other_income_not_excluded_under_106_cmr_704_250_including_deemed_and_excluded_assistance_unit_members
+
+  - name: tafdc_rounded_need_standard_deficit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Step 7
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "Subtract the result of Step 6 from the applicable Need Standard ... Round this amount down to the next whole dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor(applicable_need_standard - tafdc_filing_unit_total_countable_income)
+
+  - name: tafdc_financially_eligible_after_grant_calculation
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.500, TAFDC Step 7
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "If the result is less than zero, the assistance unit is financially ineligible."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tafdc_rounded_need_standard_deficit >= 0
+
+  - name: tafdc_monthly_grant_amount
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, TAFDC Step 7
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard
+              output: ma_tafdc_payment_standard
+              hash: sha256:d128bff83dfe781b465af5f290172eec06a092c6254a25fa98ca24bca5cd7c82
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if not tafdc_financially_eligible_after_grant_calculation: 0 else: if tafdc_rounded_need_standard_deficit < tafdc_minimum_monthly_grant_threshold: 0 else: if tafdc_rounded_need_standard_deficit < ma_tafdc_payment_standard: tafdc_rounded_need_standard_deficit else: ma_tafdc_payment_standard
+
+  - name: eaedc_countable_income_after_grant_deductions
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 106 CMR 704.500, EAEDC Steps 1 and 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "Subtract work-related-expenses ... the $30 and one-third disregard or $30 disregard ... dependent care deduction, from earned income, and add the result to the gross unearned income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (if eaedc_thirty_and_one_third_disregard_applies: max(0, max(0, eaedc_countable_earned_income_before_grant_deductions - eaedc_work_related_expenses) - eaedc_thirty_dollar_disregard_amount - (eaedc_one_third_disregard_rate * max(0, max(0, eaedc_countable_earned_income_before_grant_deductions - eaedc_work_related_expenses) - eaedc_thirty_dollar_disregard_amount)) - eaedc_dependent_care_deduction) else: if eaedc_thirty_dollar_disregard_applies: max(0, max(0, eaedc_countable_earned_income_before_grant_deductions - eaedc_work_related_expenses) - eaedc_thirty_dollar_disregard_amount - eaedc_dependent_care_deduction) else: max(0, max(0, eaedc_countable_earned_income_before_grant_deductions - eaedc_work_related_expenses) - eaedc_dependent_care_deduction)) + eaedc_gross_unearned_income
+
+  - name: eaedc_financially_eligible_after_grant_calculation
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: 106 CMR 704.500, EAEDC Step 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/regulation/dta/106-cmr/704/704.500
+              excerpt: "If the result is greater than or equal to zero, the assistance unit is financially eligible."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          eaedc_standard_of_assistance - eaedc_countable_income_after_grant_deductions >= 0


### PR DESCRIPTION
## Summary
- add generated RuleSpec for 106 CMR 704.500 TAFDC monthly grant calculation, including earned-income disregards, dependent-care deduction interaction, need-standard deficit, payment-standard cap, and under-$10 no-grant behavior
- add companion tests covering 50% earned-income disregard, paid grant below payment standard, negative-deficit ineligibility, and the EAEDC grant-calculation slice in the same source section
- bump rulespec-us validation toolchain to axiom-encode 0.2.1047 / 9600c454 so oracle coverage classifies Massachusetts TAFDC as encoded but known-not-comparable to PE final ma_tafdc

## Validation
- uv run --extra dev axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260701/us-ma/regulations/106-cmr/704/500/block-1.yaml --skip-reviewers
- uv run --extra dev axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260701/us-ma/regulations/106-cmr/704/500/block-1.yaml
- uv run --extra dev axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260701/us-ma/regulations/106-cmr/704/500/block-1.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260701
- uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-20260701 --base-ref origin/main --head-ref HEAD --all --json
- uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-ma-tafdc-parent --include-program-surfaces --json

Coverage result: pending program surfaces 36 -> 35; Massachusetts TAFDC is known_not_comparable with legal ID us-ma:regulations/106-cmr/704/500/block-1#tafdc_monthly_grant_amount.
