### PR TITLE
Encode Texas TANF grant tables

### DIFF
--- a/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.json
+++ b/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml",
+      "sha256": "be50092ec1be11e3f8be4dd980f3e7c33a028786d6c81cc06d0a7391c7893249"
+    },
+    {
+      "path": "policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.test.yaml",
+      "sha256": "33cbd8753bfcafdc6abcb821ef7cd1a9de5a37d79e50cf86b7fd50023d1956ad"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9600c4544020e23f5efc9baa3ceded268c3aec3d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1047",
+    "version_commit": "c8758927dd045c55d94781ed2667290bd8fd8ee4"
+  },
+  "axiom_encode_version": "0.2.1047",
+  "backend": "codex",
+  "citation": "us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-a-1340-income-limits-block-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "8b64946fb0440108320bd72d637aa9cadf6a85a9be15bb8439325f0307f65753",
+  "generated_at": "2026-07-01T20:48:16.439627+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "be50092ec1be11e3f8be4dd980f3e7c33a028786d6c81cc06d0a7391c7893249",
+  "generation_prompt_sha256": "e8ab41459117df488a0290aaa07de069efc2df43d75888b2cf4abe111fa3f0ca",
+  "model": "gpt-5.5",
+  "run_id": "60a85f59",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "282785cfd3cf9d00856c98a062884c00b34f580e4454c00c88671a278127b0ac"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-a-1340-income-limits-block-16.json",
+  "trace_sha256": "72c9a638cdb86560063998717fb0add5b1b4c4d773aade009318e8191f4e8ac8"
+}

--- a/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/c-110-tanf/block-2.json
+++ b/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/c-110-tanf/block-2.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml",
+      "sha256": "6341abf0027a5807566b3da92fad782ce36b223f2fbe1a35f89625481a588958"
+    },
+    {
+      "path": "policies/hhs/texas-works-handbook/c-110-tanf/block-2.test.yaml",
+      "sha256": "864e4e0d9d6ee71307e9c136ad99e3f21277943e0a6b6d5d55dbf33760d661b4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9600c4544020e23f5efc9baa3ceded268c3aec3d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1047",
+    "version_commit": "c8758927dd045c55d94781ed2667290bd8fd8ee4"
+  },
+  "axiom_encode_version": "0.2.1047",
+  "backend": "codex",
+  "citation": "us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-c-110-tanf-block-2/workspace/context-manifest.json",
+  "context_manifest_sha256": "b08d300124f78c72d5d2d228bdacd6049c19984274b67de4f7f94e2439991283",
+  "generated_at": "2026-07-01T20:36:18.713136+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "6341abf0027a5807566b3da92fad782ce36b223f2fbe1a35f89625481a588958",
+  "generation_prompt_sha256": "31a6e2e8fdb77207f19d312e950d4e4901909125f5c15e443b91c1c2c4a3c4bc",
+  "model": "gpt-5.5",
+  "run_id": "1fb8b6a1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e241d764cdbaf4bbd258a6c3ebfbb01971b8230435ae0a76b19d8cdf8cc030c5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-c-110-tanf-block-2.json",
+  "trace_sha256": "31fa53e6d021cff84fcf86ecbf9edb1597c266c03580e995d572abcf53b89425"
+}

--- a/us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.test.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.test.yaml
@@ -1,0 +1,56 @@
+- name: regular_grant_uses_recommended_amount_when_at_least_minimum
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_passes_recognizable_needs_test: true
+    ? us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.maximum_grant_amount_allowed_for_household_size_and_composition
+    : 159
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_adjusted_gross_income: 33.75
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_is_supplemental: false
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_made_after_processing_recoupment: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#recommended_tanf_grant_amount: 126
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#tx_tanf: 126
+- name: regular_grant_below_minimum_is_raised_to_minimum
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_passes_recognizable_needs_test: true
+    ? us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.maximum_grant_amount_allowed_for_household_size_and_composition
+    : 100
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_adjusted_gross_income: 95.25
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_is_supplemental: false
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_made_after_processing_recoupment: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#tx_tanf: 10
+- name: supplemental_payment_may_issue_below_minimum
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_passes_recognizable_needs_test: true
+    ? us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.maximum_grant_amount_allowed_for_household_size_and_composition
+    : 100
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_adjusted_gross_income: 95.25
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_is_supplemental: true
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_made_after_processing_recoupment: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#tx_tanf: 5
+- name: recoupment_processed_payment_may_issue_below_minimum
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_passes_recognizable_needs_test: true
+    ? us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.maximum_grant_amount_allowed_for_household_size_and_composition
+    : 100
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_adjusted_gross_income: 95.25
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_is_supplemental: false
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_made_after_processing_recoupment: true
+  output:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#tx_tanf: 5
+- name: recognizable_needs_test_not_passed_no_grant
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_passes_recognizable_needs_test: false
+    ? us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.maximum_grant_amount_allowed_for_household_size_and_composition
+    : 159
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.household_adjusted_gross_income: 33.75
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_is_supplemental: false
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#input.payment_made_after_processing_recoupment: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/a-1340-income-limits/block-16#tx_tanf: 0

--- a/us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml
@@ -1,0 +1,109 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us-tx/statute/hr/31.003
+        - us-tx/statute/hr/31.043
+      rationale: The Texas Human Resources Code delegates TANF financial assistance amount rules and fill-the-gap budgeting mechanics to the executive commissioner and commission; this Texas Works Handbook source is the operative HHSC delegated source for the grant calculation and minimum grant rule encoded here.
+  summary: |-
+    "The TANF grant amount is the amount of the monthly benefit. The TANF grant is approximately 17 percent of the Federal Poverty Level (FPL)." "Subtract the household's adjusted gross income, rounded down to the nearest dollar, from the maximum grant amount allowed for the household's size and composition." "The minimum grant amount is $10."
+rules:
+  - name: approximate_tanf_grant_fpl_rate
+    kind: parameter
+    dtype: Rate
+    source: Texas Works Handbook A-1340, block 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "approximately 17 percent of the Federal Poverty Level (FPL)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.17
+
+  - name: tanf_minimum_grant_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Texas Works Handbook A-1340, block 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "The minimum grant amount is $10."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+
+  - name: recommended_tanf_grant_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Texas Works Handbook A-1340, block 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "Subtract the household's adjusted gross income, rounded down to the nearest dollar, from the maximum grant amount allowed for the household's size and composition."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, maximum_grant_amount_allowed_for_household_size_and_composition - floor(household_adjusted_gross_income))
+
+  - name: tx_tanf
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Texas Works Handbook A-1340, block 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "After the household passes the recognizable needs test"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "The minimum grant amount is $10."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/a-1340-income-limits/block-16
+              excerpt: "Benefits of less than $10 are issued only for: supplemental payments; and payments made after processing a recoupment."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if household_passes_recognizable_needs_test:
+            if recommended_tanf_grant_amount < tanf_minimum_grant_amount:
+              if payment_is_supplemental or payment_made_after_processing_recoupment:
+                recommended_tanf_grant_amount
+              else:
+                tanf_minimum_grant_amount
+            else:
+              recommended_tanf_grant_amount
+          else:
+            0

--- a/us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.test.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.test.yaml
@@ -1,0 +1,48 @@
+- name: non_caretaker_family_size_1_max_grant
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_family_size: 1
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_non_caretaker: true
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_without_second_parent: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_with_second_parent: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#tx_tanf_payment_standard: 130
+- name: caretaker_without_second_parent_family_size_12_max_grant
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_family_size: 12
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_non_caretaker: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_without_second_parent: true
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_with_second_parent: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#tx_tanf_payment_standard: 1004
+- name: caretaker_with_second_parent_family_size_2_max_grant
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_family_size: 2
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_non_caretaker: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_without_second_parent: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_with_second_parent: true
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#tx_tanf_payment_standard: 253
+- name: non_caretaker_family_size_16_uses_additional_person_increment
+  period: 2024-01
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_family_size: 16
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_non_caretaker: true
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_without_second_parent: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_with_second_parent: false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#tx_tanf_payment_standard: 1192
+- name: auto_zero_tx_tanf_payment_standard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_with_second_parent: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_caretaker_without_second_parent: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_case_is_non_caretaker: false
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#input.tanf_family_size: 0
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#tx_tanf_payment_standard: 0

--- a/us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml
@@ -1,0 +1,513 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us-tx/statute/hr/31.003
+        - us-tx/statute/hr/31.043
+      rationale: Texas Human Resources Code delegates TANF financial assistance amount rules and fill-the-gap budgeting methods to the executive commissioner and HHSC; this Texas Works Handbook table is the operative delegated HHSC source for the current TANF budgetary needs, recognizable needs, and maximum grant amounts.
+  summary: |-
+    TANF Budgetary Allowances table lists, by family size and case composition, Bud Needs (100%), Rec Needs (25%), and Max Grant amounts. Rows cover family sizes 1 through 15 and "Each additional person"; footnotes identify SSI caretaker cases for selected recognizable-needs cells.
+rules:
+  - name: budgetary_need_percentage
+    kind: parameter
+    dtype: Rate
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, column header "Bud Needs (100%)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Bud Needs (100%)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.00
+
+  - name: recognizable_need_percentage
+    kind: parameter
+    dtype: Rate
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, column header "Rec Needs (25%)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Rec Needs (25%)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.25
+
+  - name: maximum_listed_family_size
+    kind: parameter
+    dtype: Count
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, final listed family size row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "15 $2174 $544 $1,104 $2356 $589 $1,197 $2423 $606 $1,230"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          15
+
+  - name: caretaker_with_second_parent_minimum_family_size
+    kind: parameter
+    dtype: Count
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, caretaker cases with second parent first numeric row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "2 $369 $92 $188 $650 $163 $331 $498 $125** $253"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: non_caretaker_budgetary_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Non-Caretaker Cases Bud Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Non-Caretaker Cases"
+                row_key: "Family Size"
+                column_key: "Bud Needs (100%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 256
+          2: 369
+          3: 518
+          4: 617
+          5: 793
+          6: 856
+          7: 1068
+          8: 1173
+          9: 1346
+          10: 1450
+          11: 1623
+          12: 1726
+          13: 1899
+          14: 2003
+          15: 2174
+
+  - name: non_caretaker_recognizable_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Non-Caretaker Cases Rec Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Non-Caretaker Cases"
+                row_key: "Family Size"
+                column_key: "Rec Needs (25%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 64
+          2: 92
+          3: 130
+          4: 154
+          5: 198
+          6: 214
+          7: 267
+          8: 293
+          9: 337
+          10: 363
+          11: 406
+          12: 432
+          13: 475
+          14: 501
+          15: 544
+
+  - name: non_caretaker_maximum_grant_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Non-Caretaker Cases Max Grant column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Non-Caretaker Cases"
+                row_key: "Family Size"
+                column_key: "Max Grant"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 130
+          2: 188
+          3: 263
+          4: 314
+          5: 403
+          6: 435
+          7: 543
+          8: 596
+          9: 684
+          10: 737
+          11: 824
+          12: 877
+          13: 965
+          14: 1017
+          15: 1104
+
+  - name: caretaker_without_second_parent_budgetary_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases Without Second Parent Bud Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases Without Second Parent"
+                row_key: "Family Size"
+                column_key: "Bud Needs (100%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 313
+          2: 650
+          3: 751
+          4: 903
+          5: 1003
+          6: 1153
+          7: 1252
+          8: 1425
+          9: 1528
+          10: 1701
+          11: 1804
+          12: 1977
+          13: 2080
+          14: 2253
+          15: 2356
+
+  - name: caretaker_without_second_parent_recognizable_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases Without Second Parent Rec Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases Without Second Parent"
+                row_key: "Family Size"
+                column_key: "Rec Needs (25%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 78
+          2: 163
+          3: 188
+          4: 226
+          5: 251
+          6: 288
+          7: 313
+          8: 356
+          9: 382
+          10: 425
+          11: 451
+          12: 494
+          13: 520
+          14: 563
+          15: 589
+
+  - name: caretaker_without_second_parent_maximum_grant_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases Without Second Parent Max Grant column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases Without Second Parent"
+                row_key: "Family Size"
+                column_key: "Max Grant"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 159
+          2: 331
+          3: 382
+          4: 459
+          5: 510
+          6: 586
+          7: 636
+          8: 724
+          9: 776
+          10: 864
+          11: 916
+          12: 1004
+          13: 1057
+          14: 1144
+          15: 1197
+
+  - name: caretaker_with_second_parent_budgetary_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases With Second Parent Bud Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases With Second Parent"
+                row_key: "Family Size"
+                column_key: "Bud Needs (100%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          2: 498
+          3: 824
+          4: 925
+          5: 1073
+          6: 1176
+          7: 1319
+          8: 1422
+          9: 1595
+          10: 1698
+          11: 1871
+          12: 1975
+          13: 2147
+          14: 2251
+          15: 2423
+
+  - name: caretaker_with_second_parent_recognizable_need_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases With Second Parent Rec Needs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases With Second Parent"
+                row_key: "Family Size"
+                column_key: "Rec Needs (25%)"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          2: 125
+          3: 206
+          4: 231
+          5: 268
+          6: 294
+          7: 330
+          8: 356
+          9: 399
+          10: 425
+          11: 468
+          12: 494
+          13: 537
+          14: 563
+          15: 606
+
+  - name: caretaker_with_second_parent_maximum_grant_by_family_size
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: tanf_family_size
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Caretaker Cases With Second Parent Max Grant column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              table:
+                header: "Caretaker Cases With Second Parent"
+                row_key: "Family Size"
+                column_key: "Max Grant"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          2: 253
+          3: 418
+          4: 470
+          5: 545
+          6: 597
+          7: 670
+          8: 722
+          9: 810
+          10: 862
+          11: 950
+          12: 1003
+          13: 1090
+          14: 1143
+          15: 1230
+
+  - name: budgetary_need_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Each additional person Bud Needs cells
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Each additional person $173 $43 $88 $173 $43 $88 $173 $43 $88"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          173
+
+  - name: recognizable_need_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Each additional person Rec Needs cells
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Each additional person $173 $43 $88 $173 $43 $88 $173 $43 $88"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          43
+
+  - name: maximum_grant_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Each additional person Max Grant cells
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Each additional person $173 $43 $88 $173 $43 $88 $173 $43 $88"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          88
+
+  - name: tx_tanf_payment_standard
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-110 TANF Budgetary Allowances, Max Grant columns
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf/block-2
+              excerpt: "Max Grant ... Each additional person $173 $43 $88"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#non_caretaker_maximum_grant_by_family_size
+              output: non_caretaker_maximum_grant_by_family_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#caretaker_without_second_parent_maximum_grant_by_family_size
+              output: caretaker_without_second_parent_maximum_grant_by_family_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#caretaker_with_second_parent_maximum_grant_by_family_size
+              output: caretaker_with_second_parent_maximum_grant_by_family_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf/block-2#maximum_grant_additional_person
+              output: maximum_grant_additional_person
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if tanf_family_size <= 0: 0 else: if tanf_case_is_non_caretaker: if tanf_family_size <= maximum_listed_family_size: non_caretaker_maximum_grant_by_family_size[tanf_family_size] else: non_caretaker_maximum_grant_by_family_size[maximum_listed_family_size] + ((tanf_family_size - maximum_listed_family_size) * maximum_grant_additional_person) else: if tanf_case_is_caretaker_without_second_parent: if tanf_family_size <= maximum_listed_family_size: caretaker_without_second_parent_maximum_grant_by_family_size[tanf_family_size] else: caretaker_without_second_parent_maximum_grant_by_family_size[maximum_listed_family_size] + ((tanf_family_size - maximum_listed_family_size) * maximum_grant_additional_person) else: if tanf_case_is_caretaker_with_second_parent: if tanf_family_size < caretaker_with_second_parent_minimum_family_size: 0 else: if tanf_family_size <= maximum_listed_family_size: caretaker_with_second_parent_maximum_grant_by_family_size[tanf_family_size] else: caretaker_with_second_parent_maximum_grant_by_family_size[maximum_listed_family_size] + ((tanf_family_size - maximum_listed_family_size) * maximum_grant_additional_person) else: 0


### PR DESCRIPTION
## Summary
- encode Texas Works Handbook A-1340 TANF grant amount/minimum grant rule
- encode Texas Works Handbook C-110 TANF budgetary needs, recognizable needs, and max-grant table
- ground both delegated HHSC sources against official Texas Human Resources Code §§ 31.003 and 31.043 via upstream source checks

## Validation
- uv run --extra dev axiom-encode validate --skip-reviewers ...block-16.yaml ...block-2.yaml
- uv run --extra dev axiom-encode proof-validate ...block-16.yaml ...block-2.yaml
- uv run --extra dev axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260701/us-tx ...block-16.test.yaml ...block-2.test.yaml
- uv run --extra dev axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260701/us-tx --base-ref origin/main --head-ref HEAD --json

## Parity note
This is source-law coverage for the Texas TANF grant amount/table layer, not a full Populace/PolicyEngine final tx_tanf parity claim yet. Remaining TX TANF parity work is to encode/compose income, recognizable/budgetary needs tests, resource eligibility, assistance-unit membership, and OTTANF before running a meaningful Populace final-benefit comparison.