### PR TITLE
Encode Connecticut SSP statute section

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -11,6 +11,7 @@ allowed_root_directories:
   - us-az
   - us-ca
   - us-co
+  - us-ct
   - us-de
   - us-fl
   - us-ga

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1047"
+axiom_encode_version = "0.2.1050"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "9600c4544020e23f5efc9baa3ceded268c3aec3d"
+axiom_encode_ref = "e0e5353167c4f8330a4c4bb617c797fd7868f652"
 axiom_corpus_ref = "ed1c11a828dbdeb276b10b580e1eb994ff2be37c"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ct/.axiom/encoding-manifests/statutes/17b-600.json
+++ b/us-ct/.axiom/encoding-manifests/statutes/17b-600.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/17b-600.yaml",
+      "sha256": "bc7081e6ffa746770bc05912699de95402515b79df0d059a886b183595697099"
+    },
+    {
+      "path": "statutes/17b-600.test.yaml",
+      "sha256": "fca25c9f4ecaaa74a4591e9f3184f6f7c47383076a26bd6de1d92371daf887ec"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f249cec80fb65aeb6c5db696c12102ea51dc30df",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1049",
+    "version_commit": "41c922a8a16bdd7eb4057ca99bdb1a3dae74962f"
+  },
+  "axiom_encode_version": "0.2.1049",
+  "backend": "codex",
+  "citation": "us-ct/statute/17b-600",
+  "context_manifest_file": "/tmp/axiom-encode-ct-ssp-17b-600.tabCAA/_eval_workspaces/codex-gpt-5.5/us-ct-statute-17b-600/workspace/context-manifest.json",
+  "context_manifest_sha256": "593e4fe0da6dd7de3a3c8b3f8ef37f3beca88965dfde2afe28f44b96b7b508c5",
+  "generated_at": "2026-07-01T22:54:53.278682+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ct-ssp-17b-600.tabCAA/codex-gpt-5.5/statutes/17b-600.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ct-ssp-17b-600.tabCAA",
+  "generated_output_sha256": "bc7081e6ffa746770bc05912699de95402515b79df0d059a886b183595697099",
+  "generation_prompt_sha256": "e8fbb2f9bfa9dbfd370a26e2bd808b5f99835112a257d9531718f5420976177b",
+  "model": "gpt-5.5",
+  "run_id": "7e1a6ff5",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2cfc5937a98dd9f700abb9751639a2d0dfce8d3f0ddb8d475efb2c6711cdb145"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ct-ssp-17b-600.tabCAA/traces/codex-gpt-5.5/us-ct-statute-17b-600.json",
+  "trace_sha256": "06dcfbb735c4db028252098f443d17dc127766c7229aab1911c99f4db5488e2c"
+}

--- a/us-ct/statutes/17b-600.test.yaml
+++ b/us-ct/statutes/17b-600.test.yaml
@@ -1,0 +1,50 @@
+- name: income cap rate equals three hundred percent
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-600#input.individual_resides_in_residential_care_home: true
+    us-ct:statutes/17b-600#input.individual_resides_in_new_horizons_facility: false
+    us-ct:statutes/17b-600#input.available_income: 3200
+    us-ct:statutes/17b-600#input.maximum_ssi_benefit_for_individual: 1000
+    us-ct:statutes/17b-600#input.private_rate_for_residential_care_home_or_new_horizons_facility: 4000
+    us-ct:statutes/17b-600#input.trust_funded_solely_with_excess_income: true
+    us-ct:statutes/17b-600#input.trust_provides_required_state_recovery_after_medicaid_repayment: true
+  output:
+    us-ct:statutes/17b-600#ct_ssp_income_cap_rate: 3.0
+    us-ct:statutes/17b-600#trust_income_disregard_applies: holds
+- name: income below cap prevents trust disregard
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-600#input.individual_resides_in_residential_care_home: true
+    us-ct:statutes/17b-600#input.individual_resides_in_new_horizons_facility: false
+    us-ct:statutes/17b-600#input.available_income: 2900
+    us-ct:statutes/17b-600#input.maximum_ssi_benefit_for_individual: 1000
+    us-ct:statutes/17b-600#input.private_rate_for_residential_care_home_or_new_horizons_facility: 4000
+    us-ct:statutes/17b-600#input.trust_funded_solely_with_excess_income: true
+    us-ct:statutes/17b-600#input.trust_provides_required_state_recovery_after_medicaid_repayment: true
+  output:
+    us-ct:statutes/17b-600#ct_ssp_income_cap_rate: 3.0
+    us-ct:statutes/17b-600#trust_income_disregard_applies: not_holds
+- name: transfer ineligibility applies with extended value
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-600#input.property_disposition_made_within_transfer_lookback_period: true
+    us-ct:statutes/17b-600#input.property_disposed_for_less_than_fair_market_value: true
+    us-ct:statutes/17b-600#input.convincing_evidence_transaction_exclusively_for_other_purpose: false
+    us-ct:statutes/17b-600#input.disposition_made_to_qualifying_trust: false
+    us-ct:statutes/17b-600#input.uncompensated_value_of_disposed_resources: 15000
+  output:
+    us-ct:statutes/17b-600#ct_ssp_income_cap_rate: 3.0
+    us-ct:statutes/17b-600#transfer_ineligibility_applies: holds
+    us-ct:statutes/17b-600#transfer_has_extended_ineligibility_period: holds
+- name: convincing evidence blocks transfer ineligibility
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-600#input.property_disposition_made_within_transfer_lookback_period: true
+    us-ct:statutes/17b-600#input.property_disposed_for_less_than_fair_market_value: true
+    us-ct:statutes/17b-600#input.convincing_evidence_transaction_exclusively_for_other_purpose: true
+    us-ct:statutes/17b-600#input.disposition_made_to_qualifying_trust: false
+    us-ct:statutes/17b-600#input.uncompensated_value_of_disposed_resources: 15000
+  output:
+    us-ct:statutes/17b-600#ct_ssp_income_cap_rate: 3.0
+    us-ct:statutes/17b-600#transfer_ineligibility_applies: not_holds
+    us-ct:statutes/17b-600#transfer_has_extended_ineligibility_period: not_holds

--- a/us-ct/statutes/17b-600.yaml
+++ b/us-ct/statutes/17b-600.yaml
@@ -1,0 +1,163 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-600
+  summary: |-
+    Optional state supplementation may be provided to aged, blind and disabled individuals who receive SSI benefits or would be eligible except for income. A trust exception applies where available income "exceeds three hundred per cent of the maximum Supplemental Security Income program benefit for an individual" and other stated conditions are met. Transfer-related ineligibility applies for dispositions within twenty-four months, with a twelve thousand dollar uncompensated-value threshold for longer ineligibility.
+rules:
+  - name: ct_ssp_income_cap_multiplier
+    kind: parameter
+    dtype: Rate
+    source: Conn. Gen. Stat. § 17b-600, trust income condition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "exceeds three hundred per cent of the maximum Supplemental Security Income program benefit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3.00
+
+  - name: transfer_lookback_period_months
+    kind: parameter
+    dtype: Count
+    source: Conn. Gen. Stat. § 17b-600, transfer lookback
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "within twenty-four months prior to the date of application"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          24
+
+  - name: ordinary_transfer_ineligibility_period_months
+    kind: parameter
+    dtype: Count
+    source: Conn. Gen. Stat. § 17b-600, ordinary transfer ineligibility period
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "twenty-four months after the date of disposition"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          24
+
+  - name: extended_ineligibility_uncompensated_value_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Conn. Gen. Stat. § 17b-600, extended ineligibility threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "uncompensated value of disposed of resources exceeds twelve thousand dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12000
+
+  - name: ct_ssp_income_cap_rate
+    kind: derived
+    entity: Person
+    dtype: Rate
+    period: Month
+    source: Conn. Gen. Stat. § 17b-600, trust income condition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "exceeds three hundred per cent of the maximum Supplemental Security Income program benefit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          ct_ssp_income_cap_multiplier
+
+  - name: trust_income_disregard_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Conn. Gen. Stat. § 17b-600, trust income disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (individual_resides_in_residential_care_home or individual_resides_in_new_horizons_facility)
+          and available_income > ct_ssp_income_cap_rate * maximum_ssi_benefit_for_individual
+          and available_income < private_rate_for_residential_care_home_or_new_horizons_facility
+          and trust_funded_solely_with_excess_income
+          and trust_provides_required_state_recovery_after_medicaid_repayment
+
+  - name: transfer_ineligibility_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Conn. Gen. Stat. § 17b-600, transfer-related ineligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          property_disposition_made_within_transfer_lookback_period
+          and property_disposed_for_less_than_fair_market_value
+          and not convincing_evidence_transaction_exclusively_for_other_purpose
+          and not disposition_made_to_qualifying_trust
+
+  - name: transfer_has_extended_ineligibility_period
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Conn. Gen. Stat. § 17b-600, uncompensated value exceeding twelve thousand dollars
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/17b-600
+              excerpt: "uncompensated value of disposed of resources exceeds twelve thousand dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          transfer_ineligibility_applies
+          and uncompensated_value_of_disposed_resources > extended_ineligibility_uncompensated_value_threshold


### PR DESCRIPTION
## Summary
- Encode Conn. Gen. Stat. § 17b-600 from the official CGA chapter 319mm source as the upstream statutory foundation for Connecticut SSP.
- Add companion tests for the income cap multiplier, trust income disregard, and transfer-ineligibility branches.
- Include the signed axiom-encode apply manifest for the generated RuleSpec files.


## Checks
- AXIOM_CORPUS_REPO=/tmp/axiom-ct-319mm-corpus.LdFrDD uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ct/statutes/17b-600.yaml
- AXIOM_CORPUS_REPO=/tmp/axiom-ct-319mm-corpus.LdFrDD uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ct/statutes/17b-600.yaml
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ct --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ct/statutes/17b-600.test.yaml
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/rulespec-us --base-ref origin/main --head-ref HEAD --json


## Notes
- PolicyEngine references chap_319s.htm#sec_17b-600, but the official current CGA source places § 17b-600 in chapter 319mm. This PR uses the official chap_319mm.htm#sec_17b-600 source slice extracted through axiom-corpus.
