### PR TITLE
Encode Connecticut SSP UPM standards

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1050"
+axiom_encode_version = "0.2.1051"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "e0e5353167c4f8330a4c4bb617c797fd7868f652"
-axiom_corpus_ref = "ed1c11a828dbdeb276b10b580e1eb994ff2be37c"
+axiom_encode_ref = "a0304b74d67c5447cbb97b17ef6bc23105633224"
+axiom_corpus_ref = "61021509a5659f954726d9ecf66440c1d07f6852"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode retire",
+  "reason": "Replaced broad DSS Program Standards chart module with child modules for unearned-disregards, personal-needs, shelter, and special-needs to avoid parent/child re-encoding of chart-local inputs.",
+  "axiom_encode_git": {
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+    "dirty_tracked": false
+  },
+  "applied_files": [
+    {
+      "path": "policies/dss/program-standards/2026-01-01.yaml",
+      "deleted": true
+    },
+    {
+      "path": "policies/dss/program-standards/2026-01-01.test.yaml",
+      "deleted": true
+    }
+  ],
+  "retired_manifest": {
+    "applied_files": [
+      {
+        "path": "policies/dss/program-standards/2026-01-01.yaml",
+        "sha256": "aff54a6bb15d079e83ba8638ba02568e739f27b883f9fbda267384971134fad0"
+      },
+      {
+        "path": "policies/dss/program-standards/2026-01-01.test.yaml",
+        "sha256": "86835c646afef716dc0d8e711d7bdd39f8da960ac46a2b47f96ee55d88d45014"
+      }
+    ],
+    "axiom_encode_git": {
+      "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+      "dirty_tracked": false,
+      "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1050",
+      "version_commit": "e0e5353167c4f8330a4c4bb617c797fd7868f652"
+    },
+    "axiom_encode_version": "0.2.1050",
+    "backend": "codex",
+    "citation": "us-ct/policies/dss/program-standards/2026-01-01",
+    "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ct-policies-dss-program-standards-2026-01-01/workspace/context-manifest.json",
+    "context_manifest_sha256": "ad5de454983725cb6e8ac7bc45324face23597cc4f0c367f83b292786e10f660",
+    "generated_at": "2026-07-02T00:32:02.504520+00:00",
+    "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/program-standards/2026-01-01.yaml",
+    "generated_output_root": "/tmp/axiom-encode-encodings",
+    "generated_output_sha256": "aff54a6bb15d079e83ba8638ba02568e739f27b883f9fbda267384971134fad0",
+    "generation_prompt_sha256": "1badc89e1003b196e1040f6fe13075a5cad25936417179091c830783a3f43a9e",
+    "model": "gpt-5.5",
+    "run_id": "44dc490e",
+    "runner": "codex-gpt-5.5",
+    "schema_version": "axiom-encode/applied-rulespec/v1",
+    "signature": {
+      "algorithm": "hmac-sha256",
+      "key_id": "axiom-encode-apply-v1",
+      "value": "74c1589ed39323c8b7675a6926331b13dcb8c8878b86ebbba7fcf66848bbcf55"
+    },
+    "tool": "axiom-encode encode --apply",
+    "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ct-policies-dss-program-standards-2026-01-01.json",
+    "trace_sha256": "4ed3975fe6f7f87a7c45950cad8602907b2c5fb075a415a5220817e635e65ffd"
+  },
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d0125f511c10b19109cd76794f9e1efc5fbe89768fec092362b1dd0e957e39aa"
+  }
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/personal-needs.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/personal-needs.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/program-standards/2026-01-01/personal-needs.yaml",
+      "sha256": "f639efd68742b27562d892c6a7dc163295fbd664fd4021ba028723e11287a04c"
+    },
+    {
+      "path": "policies/dss/program-standards/2026-01-01/personal-needs.test.yaml",
+      "sha256": "7e57be8e13c0de86c54e88d7e1a3579cd8c8d1984974731a89453911e688a5f2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ct-ssp-oracles-20260702",
+    "version": "0.2.1051",
+    "version_commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d"
+  },
+  "axiom_encode_version": "0.2.1051",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/program-standards/2026-01-01/personal-needs",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T01:09:17.459100+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5xn61otc/deterministic-repair/policies/dss/program-standards/2026-01-01/personal-needs.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp5xn61otc",
+  "generated_output_sha256": "f639efd68742b27562d892c6a7dc163295fbd664fd4021ba028723e11287a04c",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b3d905863547eb9f15e67bfa98267c3a63e069dece69374d1044fdba3143b28c"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/shelter.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/shelter.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/program-standards/2026-01-01/shelter.yaml",
+      "sha256": "473a8ebf068a53c0d773f452b2b267be5f220f839c93b192d32ea0925a591c96"
+    },
+    {
+      "path": "policies/dss/program-standards/2026-01-01/shelter.test.yaml",
+      "sha256": "1397e1cbd253dd6e2ec6a481602ea89a9c64b0693a4a949ffb4c9a79ec65b6b9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ct-ssp-oracles-20260702",
+    "version": "0.2.1051",
+    "version_commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d"
+  },
+  "axiom_encode_version": "0.2.1051",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/program-standards/2026-01-01/shelter",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T01:09:20.898084+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4gwz91xg/deterministic-repair/policies/dss/program-standards/2026-01-01/shelter.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4gwz91xg",
+  "generated_output_sha256": "473a8ebf068a53c0d773f452b2b267be5f220f839c93b192d32ea0925a591c96",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f4c4019745c5ccf15618c6a39300ec940f6b6cc7b9a1eb5b73565108a9270217"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/special-needs.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/special-needs.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/program-standards/2026-01-01/special-needs.yaml",
+      "sha256": "1239e0a8da1465c37575228022040c5ee64093d785eb6d10ce4287f3b4ace4ee"
+    },
+    {
+      "path": "policies/dss/program-standards/2026-01-01/special-needs.test.yaml",
+      "sha256": "990390d84c7a396c723f41a1ec31a7043995b16bf0ab191c79ab2db4ba29f943"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ct-ssp-oracles-20260702",
+    "version": "0.2.1051",
+    "version_commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d"
+  },
+  "axiom_encode_version": "0.2.1051",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/program-standards/2026-01-01/special-needs",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T01:09:24.216221+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsw_elpqr/deterministic-repair/policies/dss/program-standards/2026-01-01/special-needs.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpsw_elpqr",
+  "generated_output_sha256": "1239e0a8da1465c37575228022040c5ee64093d785eb6d10ce4287f3b4ace4ee",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2545c02582f8ad5f36c839289ce887f02bc26bade2345a1d3ae3c1c077ffa3ba"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/unearned-disregards.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/program-standards/2026-01-01/unearned-disregards.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/program-standards/2026-01-01/unearned-disregards.yaml",
+      "sha256": "062559ffb00cdad2d221663a682994ebdc1ee94606e2251e84eb592e6ca9a68c"
+    },
+    {
+      "path": "policies/dss/program-standards/2026-01-01/unearned-disregards.test.yaml",
+      "sha256": "02cddaa5e35de5af94c5d9d4154e2b8ea9382a1f5e67bb483a3ab5b895059fa7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1050",
+    "version_commit": "e0e5353167c4f8330a4c4bb617c797fd7868f652"
+  },
+  "axiom_encode_version": "0.2.1050",
+  "backend": "codex",
+  "citation": "us-ct/policies/dss/program-standards/2026-01-01/unearned-disregards",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ct-policies-dss-program-standards-2026-01-01-unearned-disregards/workspace/context-manifest.json",
+  "context_manifest_sha256": "513205f524c769bbd9d2551d0555c1249165e38982fafba2fd95737a122dbdb9",
+  "generated_at": "2026-07-02T00:45:48.634356+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/program-standards/2026-01-01/unearned-disregards.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "062559ffb00cdad2d221663a682994ebdc1ee94606e2251e84eb592e6ca9a68c",
+  "generation_prompt_sha256": "bff854720160fde6e434f399ee5245d73a36b00ee8aac12cb17076920df06d7f",
+  "model": "gpt-5.5",
+  "run_id": "d88f1543",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2f8582436295288883ae012fe72569704377085c221b88928dd90fca591ebc04"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ct-policies-dss-program-standards-2026-01-01-unearned-disregards.json",
+  "trace_sha256": "b6b06093ee05c64a3539b1de508ae9d91a82d0f164e6a92feb4134a462e21182"
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/upm/4005-10.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/upm/4005-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/upm/4005-10.yaml",
+      "sha256": "c67fdbf7a46c3a9079b91020e46bc02bce7d60da1aa621cf82d02b77e8fd8437"
+    },
+    {
+      "path": "policies/dss/upm/4005-10.test.yaml",
+      "sha256": "46e6fbc4f8fb1f3fd621b8fd8dfdc36ddcc39e01a4faa4c1f7785b813ea995e4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ct-ssp-oracles-20260702",
+    "version": "0.2.1051",
+    "version_commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d"
+  },
+  "axiom_encode_version": "0.2.1051",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/upm/4005-10",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T01:09:28.544118+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmptj5dpgma/deterministic-repair/policies/dss/upm/4005-10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmptj5dpgma",
+  "generated_output_sha256": "c67fdbf7a46c3a9079b91020e46bc02bce7d60da1aa621cf82d02b77e8fd8437",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8afbf67344c901f13c0e4b984a822ed0c3649f808c289753a9e2ac130b2eee81"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/upm/4520-10.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/upm/4520-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/upm/4520-10.yaml",
+      "sha256": "b64de3cf5a9d1a526af9c6a11a7a71f5d10b026f25c3b80f2c4343d43239f110"
+    },
+    {
+      "path": "policies/dss/upm/4520-10.test.yaml",
+      "sha256": "f024cb74b40bf8dbe70fe2f44841cfacc3922199b8b72c6f6399aacc24c277f4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1050",
+    "version_commit": "e0e5353167c4f8330a4c4bb617c797fd7868f652"
+  },
+  "axiom_encode_version": "0.2.1050",
+  "backend": "codex",
+  "citation": "us-ct/policies/dss/upm/4520-10",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ct-policies-dss-upm-4520-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "7ee9a45149de20e137aba174fc2b63114b415bf7aa1d914710cebc8a868c9a64",
+  "generated_at": "2026-07-02T00:25:04.018891+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/upm/4520-10.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "b64de3cf5a9d1a526af9c6a11a7a71f5d10b026f25c3b80f2c4343d43239f110",
+  "generation_prompt_sha256": "006ac116b9f2b31d0d42326bae70fb083d8a2cb7c28190a066536c7e6f9fa536",
+  "model": "gpt-5.5",
+  "run_id": "408352f7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2439dfc4d94a3a372f3e3cd3f03d7a3d614693288afc3f8d576b9face21132d1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ct-policies-dss-upm-4520-10.json",
+  "trace_sha256": "722269f3839c317ff72b40c0930af84af5505facb5a8d0f53406180a1cd7f1b6"
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/upm/4520-20.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/upm/4520-20.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/upm/4520-20.yaml",
+      "sha256": "df56f2200c84c1bb5538a5ad5410b91e5b08bd681953cf4d9c9cefa7c12d752f"
+    },
+    {
+      "path": "policies/dss/upm/4520-20.test.yaml",
+      "sha256": "430fad585be3201f893e1e07d556ec4da23580e263696b98e6cc8164b5dcce2d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1050",
+    "version_commit": "e0e5353167c4f8330a4c4bb617c797fd7868f652"
+  },
+  "axiom_encode_version": "0.2.1050",
+  "backend": "codex",
+  "citation": "us-ct/policies/dss/upm/4520-20",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ct-policies-dss-upm-4520-20/workspace/context-manifest.json",
+  "context_manifest_sha256": "fb0784bd6765b2c54cf00c3052ab795cf733a196dab086ff7012e1f954266ca4",
+  "generated_at": "2026-07-02T00:27:16.884511+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/upm/4520-20.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "df56f2200c84c1bb5538a5ad5410b91e5b08bd681953cf4d9c9cefa7c12d752f",
+  "generation_prompt_sha256": "d02d51de952722a01afec5c8851b13f243fc22a97c846ef966fedb29e78a52ad",
+  "model": "gpt-5.5",
+  "run_id": "0998a1e7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e7bd684a7d624b6a9b15b4d8ee652ce4db331da0b06703228c71d5c3e5c0db96"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ct-policies-dss-upm-4520-20.json",
+  "trace_sha256": "dc10779193e295b2efe0840d3e7bdf8c9f1f5446a85487f2526fb942399d17a9"
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/upm/5030-10.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/upm/5030-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/upm/5030-10.yaml",
+      "sha256": "d246238f1aedf5aa7be5f3f7f0a54ee211d5190dedf328070413cf6788a760fe"
+    },
+    {
+      "path": "policies/dss/upm/5030-10.test.yaml",
+      "sha256": "64e3ec61be6051195c7fa9212ce645a0b58c778b62680182ae27a7a0565bd11a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ct-ssp-oracles-20260702",
+    "version": "0.2.1051",
+    "version_commit": "159d4d69a7c14ddc3a20fb987ed504a1bdbd4a0d"
+  },
+  "axiom_encode_version": "0.2.1051",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/upm/5030-10",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T01:09:32.200236+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp21pm9rif/deterministic-repair/policies/dss/upm/5030-10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp21pm9rif",
+  "generated_output_sha256": "d246238f1aedf5aa7be5f3f7f0a54ee211d5190dedf328070413cf6788a760fe",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d803fe5bce4fc49c95304a3abfa1511964eb60761d0cfeefdd2b4e1d539d563f"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ct/.axiom/encoding-manifests/policies/dss/upm/5030-15.json
+++ b/us-ct/.axiom/encoding-manifests/policies/dss/upm/5030-15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dss/upm/5030-15.yaml",
+      "sha256": "3c73d171a7948bf37c1d14c6f51da1b6a2ca186e0a2e2753376ac48ee6eb100b"
+    },
+    {
+      "path": "policies/dss/upm/5030-15.test.yaml",
+      "sha256": "7adf37c025c10e3738d4182bec3052984cb26b3303065032b951515e71575084"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "ed41b6092b5404e1edaf2e14de1413008777cb8b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1050",
+    "version_commit": "e0e5353167c4f8330a4c4bb617c797fd7868f652"
+  },
+  "axiom_encode_version": "0.2.1050",
+  "backend": "codex",
+  "citation": "us-ct/policies/dss/upm/5030-15",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ct-policies-dss-upm-5030-15/workspace/context-manifest.json",
+  "context_manifest_sha256": "630248db2b69135b84df8365fe1480ae470538563bbfe0af0316b531c6d3572c",
+  "generated_at": "2026-07-02T00:02:15.110532+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/upm/5030-15.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "3c73d171a7948bf37c1d14c6f51da1b6a2ca186e0a2e2753376ac48ee6eb100b",
+  "generation_prompt_sha256": "4cca8cac16cf5c579d28c070087f444afb9818a4dabf6f08cf2c3805d4f97694",
+  "model": "gpt-5.5",
+  "run_id": "af81a646",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "282eb59bdcd8a407c2f6b521ff2c29dfe4ad27cb302524adee21ea2cfe3e6f05"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ct-policies-dss-upm-5030-15.json",
+  "trace_sha256": "c21fe59a588f7f45de7a20fb8834030d0df836e56f200c26319a3bd62817de51"
+}

--- a/us-ct/policies/dss/program-standards/2026-01-01/personal-needs.test.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/personal-needs.test.yaml
@@ -1,0 +1,80 @@
+- name: individual_community_personal_needs_allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance: 197.35
+- name: married_community_personal_needs_allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: true
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance: 198.55
+- name: boarding_home_personal_needs_allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: true
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance: 34.75
+- name: waiver_w01_personal_needs_allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: true
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance: 2609
+- name: oracle_parameter_ct_ssp_personal_needs_allowance_married
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_married: 198.55
+- name: oracle_parameter_ct_ssp_personal_needs_allowance_individual
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_individual: 197.35
+- name: oracle_parameter_ct_ssp_personal_needs_allowance_boarding_home
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_boarding_home: 34.75
+- name: oracle_parameter_ct_ssp_personal_needs_allowance_snf
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_new_horizons: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_snf: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_in_waiver_w01: false
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#input.person_is_married: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_snf: 75

--- a/us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml
@@ -1,0 +1,181 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - Conn. Gen. Stat. section 17b-600
+        - Conn. Gen. Stat. section 17b-10
+        - Regulations of Connecticut State Agencies section 17b-10-1
+        - Regulations of Connecticut State Agencies section 17b-198-2
+      rationale: |-
+        Connecticut statutes and regulations establish DSS administration of AABD/SSP and the Uniform Policy Manual/program standards as the implementing source for current assistance standards. The DSS Program Standards Chart is the official current parameter source for the personal needs allowance amounts encoded here.
+  summary: |-
+    DSS Program Standards Chart as of 1/1/2026: AABD / MAABD / LTSS Personal Needs Allowance: Married $198.55; Individual $197.35; Boarding Home $34.75; New Horizons $156.82; SNF $75; Waiver (W01) PNA Amount $2,609 effective 3/1/25.
+rules:
+  - name: ct_ssp_personal_needs_allowance_married
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance Married $198.55"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          198.55
+  - name: ct_ssp_personal_needs_allowance_individual
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance Individual $197.35"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          197.35
+  - name: ct_ssp_personal_needs_allowance_boarding_home
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance Boarding Home $34.75"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          34.75
+  - name: ct_ssp_personal_needs_allowance_new_horizons
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance New Horizons $156.82"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          156.82
+  - name: ct_ssp_personal_needs_allowance_snf
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance SNF $75"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          75
+  - name: ct_ssp_personal_needs_allowance_waiver_w01
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Waiver (W01) PNA Amount $2,609 eff. 3/1/25"
+    versions:
+      - effective_from: '2025-03-01'
+        formula: |-
+          2609
+  - name: ct_ssp_personal_needs_allowance
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Personal Needs Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Personal Needs Allowance Married $198.55 Individual $197.35 Boarding Home $34.75 New Horizons $156.82 SNF $75 Waiver (W01) PNA Amount $2,609"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_married
+              output: ct_ssp_personal_needs_allowance_married
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_individual
+              output: ct_ssp_personal_needs_allowance_individual
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_boarding_home
+              output: ct_ssp_personal_needs_allowance_boarding_home
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_new_horizons
+              output: ct_ssp_personal_needs_allowance_new_horizons
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_snf
+              output: ct_ssp_personal_needs_allowance_snf
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/personal-needs#ct_ssp_personal_needs_allowance_waiver_w01
+              output: ct_ssp_personal_needs_allowance_waiver_w01
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_is_in_waiver_w01: ct_ssp_personal_needs_allowance_waiver_w01 else: if person_is_in_snf: ct_ssp_personal_needs_allowance_snf else: if person_is_in_new_horizons: ct_ssp_personal_needs_allowance_new_horizons else: if person_is_in_boarding_home: ct_ssp_personal_needs_allowance_boarding_home else: if person_is_married: ct_ssp_personal_needs_allowance_married else: ct_ssp_personal_needs_allowance_individual

--- a/us-ct/policies/dss/program-standards/2026-01-01/shelter.test.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/shelter.test.yaml
@@ -1,0 +1,35 @@
+- name: community individual shelter allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_individual_shelter_arrangement: true
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_shared_shelter_arrangement: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance: 400
+- name: community shared shelter allowance
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_individual_shelter_arrangement: false
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_shared_shelter_arrangement: true
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance: 200
+- name: no covered shelter arrangement
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_individual_shelter_arrangement: false
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_shared_shelter_arrangement: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance: 0
+- name: oracle_parameter_ct_ssp_shelter_allowance_community_individual
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_individual_shelter_arrangement: false
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_shared_shelter_arrangement: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance_community_individual: 400
+- name: oracle_parameter_ct_ssp_shelter_allowance_community_shared
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_individual_shelter_arrangement: false
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#input.person_has_aabd_community_shared_shelter_arrangement: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance_community_shared: 200

--- a/us-ct/policies/dss/program-standards/2026-01-01/shelter.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/shelter.yaml
@@ -1,0 +1,85 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - Conn. Gen. Stat. section 17b-600
+        - Conn. Gen. Stat. section 17b-10
+        - Regulations of Connecticut State Agencies section 17b-10-1
+        - Regulations of Connecticut State Agencies section 17b-198-2
+      rationale: |-
+        Connecticut statutes and regulations establish DSS administration of AABD/SSP and the Uniform Policy Manual/program standards as the implementing source for current assistance standards. The DSS Program Standards Chart is the official current parameter source for the shelter allowance amounts encoded here.
+  summary: |-
+    DSS Program Standards Chart as of 1/1/2026: AABD Shelter Allowances: Community Individual $400; Community Shared $200.
+rules:
+  - name: ct_ssp_shelter_allowance_community_individual
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, AABD Shelter Allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "AABD Shelter Allowances Community Individual $400"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          400
+  - name: ct_ssp_shelter_allowance_community_shared
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, AABD Shelter Allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "AABD Shelter Allowances Community Shared $200"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          200
+  - name: ct_ssp_shelter_allowance
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, AABD Shelter Allowances
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "AABD Shelter Allowances Community Individual $400 Community Shared $200"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance_community_individual
+              output: ct_ssp_shelter_allowance_community_individual
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/shelter#ct_ssp_shelter_allowance_community_shared
+              output: ct_ssp_shelter_allowance_community_shared
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_has_aabd_community_individual_shelter_arrangement: ct_ssp_shelter_allowance_community_individual else: if person_has_aabd_community_shared_shelter_arrangement: ct_ssp_shelter_allowance_community_shared else: 0

--- a/us-ct/policies/dss/program-standards/2026-01-01/special-needs.test.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/special-needs.test.yaml
@@ -1,0 +1,18 @@
+- name: therapeutic_diet_special_need
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#input.person_has_therapeutic_diet_special_need: true
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#ct_ssp_special_needs: 36.2
+- name: no_therapeutic_diet_special_need
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#input.person_has_therapeutic_diet_special_need: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#ct_ssp_special_needs: 0
+- name: oracle_parameter_ct_ssp_therapeutic_diet_special_needs_amount
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#input.person_has_therapeutic_diet_special_need: false
+  output:
+    us-ct:policies/dss/program-standards/2026-01-01/special-needs#ct_ssp_therapeutic_diet_special_needs_amount: 36.2

--- a/us-ct/policies/dss/program-standards/2026-01-01/special-needs.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/special-needs.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - Conn. Gen. Stat. section 17b-600
+        - Conn. Gen. Stat. section 17b-10
+        - Regulations of Connecticut State Agencies section 17b-10-1
+        - Regulations of Connecticut State Agencies section 17b-198-2
+      rationale: |-
+        Connecticut statutes and regulations establish DSS administration of AABD/SSP and the Uniform Policy Manual/program standards as the implementing source for current assistance standards. The DSS Program Standards Chart is the official current parameter source for the special-needs therapeutic diet amount encoded here.
+  summary: |-
+    DSS Program Standards Chart as of 1/1/2026: AABD / MAABD / LTSS Special Needs: Therapeutic Diet $36.20.
+rules:
+  - name: ct_ssp_therapeutic_diet_special_needs_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, AABD / MAABD / LTSS Special Needs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Special Needs Therapeutic Diet $36.20"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          36.20
+  - name: ct_ssp_special_needs
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, AABD / MAABD / LTSS Special Needs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Special Needs Therapeutic Diet $36.20"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/special-needs#ct_ssp_therapeutic_diet_special_needs_amount
+              output: ct_ssp_therapeutic_diet_special_needs_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_has_therapeutic_diet_special_need: ct_ssp_therapeutic_diet_special_needs_amount else: 0

--- a/us-ct/policies/dss/program-standards/2026-01-01/unearned-disregards.test.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/unearned-disregards.test.yaml
@@ -1,0 +1,27 @@
+- name: standard_unearned_income_disregard
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_shared_living: false
+  output:
+    ? us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard_living_arrangement_index
+    : 0
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard: 562
+- name: shared_living_unearned_income_disregard
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_boarding_home: false
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_shared_living: true
+  output:
+    ? us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard_living_arrangement_index
+    : 1
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard: 629.9
+- name: boarding_home_unearned_income_disregard
+  period: 2026-01
+  input:
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_boarding_home: true
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#input.person_is_in_shared_living: false
+  output:
+    ? us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard_living_arrangement_index
+    : 2
+    us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard: 469.7

--- a/us-ct/policies/dss/program-standards/2026-01-01/unearned-disregards.yaml
+++ b/us-ct/policies/dss/program-standards/2026-01-01/unearned-disregards.yaml
@@ -1,0 +1,92 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - Conn. Gen. Stat. section 17b-600
+        - Conn. Gen. Stat. section 17b-10
+        - Regulations of Connecticut State Agencies section 17b-10-1
+        - Regulations of Connecticut State Agencies section 17b-198-2
+      rationale: |-
+        Connecticut statutes and regulations establish DSS administration of AABD/SSP and the Uniform Policy Manual/program standards as the implementing source for current assistance standards. The DSS Program Standards Chart is the official current parameter source for the unearned-income disregard amounts encoded here.
+  summary: |-
+    DSS Program Standards Chart as of 1/1/2026: Disregards include Unearned Income $562, Shared Living $629.90, and Boarding Home $469.70.
+rules:
+  - name: ct_ssp_unearned_income_disregard_living_arrangement_index
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    source: DSS Program Standards Chart, Disregards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Disregards Boarding Home $469.70 ... Unearned Income $562 ... Shared Living $629.90"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_is_in_boarding_home: 2 else: if person_is_in_shared_living: 1 else: 0
+  - name: ct_ssp_unearned_income_disregard_by_living_arrangement
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    indexed_by: ct_ssp_unearned_income_disregard_living_arrangement_index
+    source: DSS Program Standards Chart, Disregards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Disregards Boarding Home $469.70 ... Unearned Income $562 ... Shared Living $629.90"
+              table:
+                header: DSS Program Standards Chart Disregards
+                row_key: living_arrangement_index
+                column_key: unearned_income_disregard
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 562
+          1: 629.90
+          2: 469.70
+  - name: ct_ssp_unearned_income_disregard
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS Program Standards Chart, Disregards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/program-standards/2026-01-01/page-1
+              excerpt: "Disregards ... Unearned Income $562 ... Shared Living $629.90 ... Boarding Home $469.70"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard_living_arrangement_index
+              output: ct_ssp_unearned_income_disregard_living_arrangement_index
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/program-standards/2026-01-01/unearned-disregards#ct_ssp_unearned_income_disregard_by_living_arrangement
+              output: ct_ssp_unearned_income_disregard_by_living_arrangement
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ct_ssp_unearned_income_disregard_by_living_arrangement[ct_ssp_unearned_income_disregard_living_arrangement_index]

--- a/us-ct/policies/dss/upm/4005-10.test.yaml
+++ b/us-ct/policies/dss/upm/4005-10.test.yaml
@@ -1,0 +1,85 @@
+- name: ct_ssp_one_person_under_asset_limit
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 1500
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 1
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: true
+  output:
+    us-ct:policies/dss/upm/4005-10#ct_ssp_resource_eligible: holds
+- name: ct_ssp_one_person_over_asset_limit
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 1700
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 1
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: true
+  output:
+    us-ct:policies/dss/upm/4005-10#ct_ssp_resource_eligible: not_holds
+- name: ct_ssp_two_person_at_asset_limit
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 2400
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 2
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: true
+  output:
+    us-ct:policies/dss/upm/4005-10#ct_ssp_resource_eligible: holds
+- name: medicaid_no_asset_test_group_does_not_make_ct_ssp_resource_eligible
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 50000
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 1
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_earnings_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_support_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.primary_work_transition_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.hmo_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_under_poverty_level_threshold_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_under_age_one_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_between_age_one_and_six_coverage_group: false
+    ? us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_age_six_or_over_born_after_statutory_cutoff_coverage_group
+    : false
+    us-ct:policies/dss/upm/4005-10#input.additional_low_income_medicare_beneficiaries_current_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.women_diagnosed_with_breast_or_cervical_cancer_coverage_group: true
+  output:
+    us-ct:policies/dss/upm/4005-10#medicaid_coverage_group_not_required_to_pass_asset_test: holds
+    us-ct:policies/dss/upm/4005-10#ct_ssp_resource_eligible: not_holds
+- name: oracle_parameter_aabd_maabd_general_one_person_asset_limit
+  period: 2001-08
+  input:
+    us-ct:policies/dss/upm/4005-10#input.additional_low_income_medicare_beneficiaries_current_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: false
+    ? us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_age_six_or_over_born_after_statutory_cutoff_coverage_group
+    : false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_between_age_one_and_six_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_under_age_one_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 0
+    us-ct:policies/dss/upm/4005-10#input.hmo_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_earnings_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_support_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 1
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_under_poverty_level_threshold_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.primary_work_transition_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.women_diagnosed_with_breast_or_cervical_cancer_coverage_group: false
+  output:
+    us-ct:policies/dss/upm/4005-10#aabd_maabd_general_one_person_asset_limit: 1600
+- name: oracle_parameter_aabd_maabd_general_two_person_asset_limit
+  period: 2001-08
+  input:
+    us-ct:policies/dss/upm/4005-10#input.additional_low_income_medicare_beneficiaries_current_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.applying_for_aabd_or_maabd_general_coverage_group: false
+    ? us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_age_six_or_over_born_after_statutory_cutoff_coverage_group
+    : false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_between_age_one_and_six_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.children_under_poverty_level_threshold_under_age_one_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.countable_assets: 0
+    us-ct:policies/dss/upm/4005-10#input.hmo_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_earnings_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.increased_support_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.needs_group_size: 1
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.pregnant_women_under_poverty_level_threshold_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.primary_work_transition_extension_coverage_group: false
+    us-ct:policies/dss/upm/4005-10#input.women_diagnosed_with_breast_or_cervical_cancer_coverage_group: false
+  output:
+    us-ct:policies/dss/upm/4005-10#aabd_maabd_general_two_person_asset_limit: 2400

--- a/us-ct/policies/dss/upm/4005-10.yaml
+++ b/us-ct/policies/dss/upm/4005-10.yaml
@@ -1,0 +1,430 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+      - Conn. Gen. Stat. 17b-600
+      - Conn. Gen. Stat. 17b-10
+      - Regulations of Connecticut State Agencies 17b-10-1
+      - Regulations of Connecticut State Agencies 17b-198-2
+      rationale: UPM 4005.10 is the specific DSS implementing source for Connecticut
+        AABD/SSP resource and related DSS program asset limits after checking the
+        upstream statutory and regulatory authority chain.
+  deferred_outputs:
+  - output: us-ct:policies/dss/upm/4005-10#snap_resource_eligible
+    reason: The source states that the SNAP asset limit is established by USDA and
+      adjusted by CPI, but the operative USDA dollar limits are not supplied in this
+      source slice or copied context.
+    source_values:
+    - us-ct:policies/dss/upm/4005-10#snap_asset_limit_cpi_measurement_period_months
+    - us-ct:policies/dss/upm/4005-10#snap_asset_limit_rounding_increment
+    - us-ct:policies/dss/upm/4005-10#snap_elderly_household_age_threshold
+    - us-ct:policies/dss/upm/4005-10#fma_medically_needy_additional_member_asset_limit_increment
+  summary: 4005.10(A) states asset limits including "$1,600 for a needs group of one"
+    and "$2,400 for a needs group of two" for AABD and MAABD categorically and medically
+    needy groups, except listed Medicare, working-disabled, and breast/cervical-cancer
+    groups. It also lists other program limits, SNAP CPI adjustment and rounding rules,
+    and Medicaid coverage groups "not required to pass an asset test."
+rules:
+- name: needs_group_size_one
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(A)(2)-(4), (7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: needs group of one
+  versions:
+  - effective_from: '2001-04-01'
+    formula: '1'
+- name: needs_group_size_two
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(A)(2)-(4), (7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: needs group of two
+  versions:
+  - effective_from: '2001-04-01'
+    formula: '2'
+- name: afdc_fma_categorically_needy_needs_group_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $1,000 per needs group.
+  versions:
+  - effective_from: '2001-07-02'
+    formula: '1000'
+- name: aabd_maabd_general_one_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(2)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $1,600 for a needs group of one.
+  versions:
+  - effective_from: '2001-07-02'
+    formula: '1600'
+- name: aabd_maabd_general_two_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(2)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $2,400 for a needs group of two.
+  versions:
+  - effective_from: '2001-07-02'
+    formula: '2400'
+- name: maabd_qmb_slmb_qdwi_one_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(3)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $4,000 for a needs group of one.
+  versions:
+  - effective_from: '2001-07-02'
+    formula: '4000'
+- name: maabd_qmb_slmb_qdwi_two_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(3)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $6,000 for a needs group of two.
+  versions:
+  - effective_from: '2001-07-02'
+    formula: '6000'
+- name: maabd_alimb_prior_one_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: Prior to April 1, 2001, the asset limit is $4,000 for a needs group
+            of one.
+  versions:
+  - effective_from: '1998-07-01'
+    formula: '4000'
+- name: maabd_alimb_prior_two_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: Prior to April 1, 2001, the asset limit is $6,000 for a needs group
+            of two.
+  versions:
+  - effective_from: '1998-07-01'
+    formula: '6000'
+- name: maabd_working_individuals_disabilities_single_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(5)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $10,000 for a single individual.
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '10000'
+- name: maabd_working_individuals_disabilities_with_spouse_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(5)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $15,000 for an individual living with his or
+            her spouse.
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '15000'
+- name: fma_medically_needy_one_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(7)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $2,000 for a needs group of one.
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '2000'
+- name: fma_medically_needy_two_person_asset_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(7)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The asset limit is $3,000 for a needs group of two.
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '3000'
+- name: fma_medically_needy_additional_member_asset_limit_increment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(7)(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: increased by $100 for each additional member
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '100'
+- name: snap_asset_limit_cpi_measurement_period_months
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(A)(8)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: changes for the 12-month period
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '12'
+- name: snap_asset_limit_rounding_increment
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: UPM 4005.10(A)(8)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: rounded down to the nearest $250 increment
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '250'
+- name: snap_elderly_household_age_threshold
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(A)(8)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: at least one member is age 60 or over
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '60'
+- name: poverty_level_threshold_for_listed_no_asset_test_medicaid_groups
+  kind: parameter
+  dtype: Rate
+  source: UPM 4005.10(B)(5), (7)-(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: Under 185% of the Poverty Level
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '1.85'
+- name: medicaid_child_under_poverty_level_first_age_threshold
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(B)(7)-(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: under age one
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '1'
+- name: medicaid_child_under_poverty_level_second_age_threshold
+  kind: parameter
+  dtype: Count
+  source: UPM 4005.10(B)(8)-(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: between ages one and six
+  versions:
+  - effective_from: '2010-05-10'
+    formula: '6'
+- name: medicaid_coverage_group_not_required_to_pass_asset_test
+  kind: derived
+  entity: AssistanceUnit
+  dtype: Judgment
+  period: Month
+  source: UPM 4005.10(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: The following Medicaid coverage groups are not required to pass
+            an asset test
+  versions:
+  - effective_from: '2001-04-01'
+    formula: 'increased_earnings_extension_coverage_group
+
+      or increased_support_extension_coverage_group
+
+      or primary_work_transition_extension_coverage_group
+
+      or hmo_extension_coverage_group
+
+      or pregnant_women_under_poverty_level_threshold_coverage_group
+
+      or pregnant_women_extension_coverage_group
+
+      or children_under_poverty_level_threshold_under_age_one_coverage_group
+
+      or children_under_poverty_level_threshold_between_age_one_and_six_coverage_group
+
+      or children_under_poverty_level_threshold_age_six_or_over_born_after_statutory_cutoff_coverage_group
+
+      or additional_low_income_medicare_beneficiaries_current_coverage_group
+
+      or women_diagnosed_with_breast_or_cervical_cancer_coverage_group'
+- name: ct_ssp_resource_eligible
+  kind: derived
+  entity: AssistanceUnit
+  dtype: Judgment
+  period: Month
+  source: UPM 4005.10(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/4005.10/block-1
+          excerpt: AABD and MAABD - Categorically and Medically Needy
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/4005-10#needs_group_size_one
+          output: needs_group_size_one
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/4005-10#needs_group_size_two
+          output: needs_group_size_two
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/4005-10#aabd_maabd_general_one_person_asset_limit
+          output: aabd_maabd_general_one_person_asset_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/4005-10#aabd_maabd_general_two_person_asset_limit
+          output: aabd_maabd_general_two_person_asset_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2001-07-02'
+    formula: "applying_for_aabd_or_maabd_general_coverage_group\nand (\n  (needs_group_size\
+      \ == needs_group_size_one and countable_assets <= aabd_maabd_general_one_person_asset_limit)\n\
+      \  or (needs_group_size == needs_group_size_two and countable_assets <= aabd_maabd_general_two_person_asset_limit)\n\
+      )"

--- a/us-ct/policies/dss/upm/4520-10.test.yaml
+++ b/us-ct/policies/dss/upm/4520-10.test.yaml
@@ -1,0 +1,68 @@
+- name: licensed boarding facility monthly shelter rate applies for full-month residence
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_new_horizons_village: false
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: false
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_new_horizons_during_month: 0
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: true
+    us-ct:policies/dss/upm/4520-10#input.facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: true
+    us-ct:policies/dss/upm/4520-10#input.monthly_facility_rate: 900
+    us-ct:policies/dss/upm/4520-10#input.per_diem_facility_rate: 30
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_facility_or_home_during_month: 10
+  output:
+    us-ct:policies/dss/upm/4520-10#ct_ssp_shelter_allowance: 900
+- name: licensed boarding facility shelter rate is prorated by days resided
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_new_horizons_village: false
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: false
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_new_horizons_during_month: 0
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: true
+    us-ct:policies/dss/upm/4520-10#input.facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: false
+    us-ct:policies/dss/upm/4520-10#input.monthly_facility_rate: 900
+    us-ct:policies/dss/upm/4520-10#input.per_diem_facility_rate: 30
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_facility_or_home_during_month: 10
+  output:
+    us-ct:policies/dss/upm/4520-10#ct_ssp_shelter_allowance: 300
+- name: new horizons move-in after first day uses per diem shelter standard
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_new_horizons_village: true
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: true
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_new_horizons_during_month: 10
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/4520-10#input.facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: false
+    us-ct:policies/dss/upm/4520-10#input.monthly_facility_rate: 900
+    us-ct:policies/dss/upm/4520-10#input.per_diem_facility_rate: 30
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_facility_or_home_during_month: 0
+  output:
+    us-ct:policies/dss/upm/4520-10#ct_ssp_shelter_allowance: 1114.1
+- name: new horizons non-prorated month uses monthly shelter standard
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_new_horizons_village: true
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: false
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_new_horizons_during_month: 10
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/4520-10#input.facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: false
+    us-ct:policies/dss/upm/4520-10#input.monthly_facility_rate: 900
+    us-ct:policies/dss/upm/4520-10#input.per_diem_facility_rate: 30
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_facility_or_home_during_month: 0
+  output:
+    us-ct:policies/dss/upm/4520-10#ct_ssp_shelter_allowance: 3388.72
+- name: auto_zero_ct_ssp_shelter_allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: false
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/4520-10#input.assistance_unit_resides_in_new_horizons_village: false
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_facility_or_home_during_month: 0
+    us-ct:policies/dss/upm/4520-10#input.days_assistance_unit_resided_in_new_horizons_during_month: 0
+    us-ct:policies/dss/upm/4520-10#input.facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: false
+    us-ct:policies/dss/upm/4520-10#input.monthly_facility_rate: 0
+    us-ct:policies/dss/upm/4520-10#input.per_diem_facility_rate: 0
+  output:
+    us-ct:policies/dss/upm/4520-10#ct_ssp_shelter_allowance: 0

--- a/us-ct/policies/dss/upm/4520-10.yaml
+++ b/us-ct/policies/dss/upm/4520-10.yaml
@@ -1,0 +1,130 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - Conn. Gen. Stat. 17b-600
+        - Conn. Gen. Stat. 17b-10
+        - Regulations of Connecticut State Agencies 17b-10-1
+        - Regulations of Connecticut State Agencies 17b-198-2
+      rationale: UPM 4520.10 is the specific DSS implementing source for Connecticut AABD/SSP rated-housing personal-needs and shelter standards after checking the upstream statutory and regulatory authority chain.
+  summary: |-
+    UPM 4520.10 defines rated housing facilities to include licensed boarding facilities, New Horizons, and adult family living homes approved by the Department. Personal needs are $28.90 per month for licensed boarding facility and adult family living home residents and $130.40 per month for New Horizons residents. Shelter for licensed boarding facilities and adult family living homes is the monthly facility rate when the unit resides in the facility for the entire calendar month, or the per diem facility rate times days resided when prorated. New Horizons shelter is $3388.72 per month, with a $111.41 per diem standard for move-in months after the first day.
+rules:
+  - name: licensed_boarding_or_adult_family_living_personal_needs_standard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.10(B)(4)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: $28.90 per month for licensed boarding facility and adult family living home residents
+    versions:
+      - effective_from: '1998-05-01'
+        formula: |-
+          28.90
+  - name: new_horizons_personal_needs_standard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.10(B)(4)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: $130.40 per month for New Horizons residents
+    versions:
+      - effective_from: '1998-05-01'
+        formula: |-
+          130.40
+  - name: new_horizons_monthly_shelter_standard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.10(C)(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: New Horizons Village is $3388.72 per month
+    versions:
+      - effective_from: '1988-01-01'
+        formula: |-
+          3388.72
+  - name: new_horizons_per_diem_shelter_standard
+    kind: parameter
+    dtype: Money
+    period: Day
+    unit: USD
+    source: UPM 4520.10(C)(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: the per diem standard is $111.41
+    versions:
+      - effective_from: '1988-01-01'
+        formula: |-
+          111.41
+  - name: ct_ssp_shelter_allowance
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.10(C)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: the monthly facility rate if the assistance unit resides in the facility for entire calendar month
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: the per diem facility rate times the number of days the unit resided in the facility
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.10/block-1
+              excerpt: prorated on a per diem basis for the month the assistance unit moves into New Horizons
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/4520-10#new_horizons_monthly_shelter_standard
+              output: new_horizons_monthly_shelter_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/4520-10#new_horizons_per_diem_shelter_standard
+              output: new_horizons_per_diem_shelter_standard
+              hash: sha256:local
+    versions:
+      - effective_from: '1988-01-01'
+        formula: |-
+          if assistance_unit_resides_in_new_horizons_village: if assistance_unit_moves_into_new_horizons_later_than_first_day_of_month: new_horizons_per_diem_shelter_standard * days_assistance_unit_resided_in_new_horizons_during_month else: new_horizons_monthly_shelter_standard else: if assistance_unit_resides_in_licensed_boarding_facility_or_adult_family_living_home: if facility_or_adult_family_living_home_remains_residence_for_entire_calendar_month: monthly_facility_rate else: per_diem_facility_rate * days_assistance_unit_resided_in_facility_or_home_during_month else: 0

--- a/us-ct/policies/dss/upm/4520-20.test.yaml
+++ b/us-ct/policies/dss/upm/4520-20.test.yaml
@@ -1,0 +1,52 @@
+- name: long term care nursing home personal needs allowance with cola multiplier
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_and_convalescent_nursing_home: true
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_disease_hospital: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_rest_home_with_nursing_supervision: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_intermediate_care_facility_for_the_mentally_retarded: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_state_humane_institution: false
+    us-ct:policies/dss/upm/4520-20#input.cumulative_social_security_cola_multiplier_for_long_term_care_personal_needs_standard: 1.2
+  output:
+    us-ct:policies/dss/upm/4520-20#ct_ssp_personal_needs_allowance: 60
+    us-ct:policies/dss/upm/4520-20#ct_ssp_long_term_care_shelter_allowance: 0
+- name: no listed long term care facility yields no personal needs allowance from
+    this section
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_and_convalescent_nursing_home: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_disease_hospital: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_rest_home_with_nursing_supervision: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_intermediate_care_facility_for_the_mentally_retarded: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_state_humane_institution: false
+    us-ct:policies/dss/upm/4520-20#input.cumulative_social_security_cola_multiplier_for_long_term_care_personal_needs_standard: 1.2
+  output:
+    us-ct:policies/dss/upm/4520-20#ct_ssp_personal_needs_allowance: 0
+    us-ct:policies/dss/upm/4520-20#ct_ssp_long_term_care_shelter_allowance: 0
+- name: auto_output_assistance_unit_resides_in_long_term_care_facility
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_and_convalescent_nursing_home: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_disease_hospital: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_intermediate_care_facility_for_the_mentally_retarded: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_rest_home_with_nursing_supervision: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_state_humane_institution: false
+    us-ct:policies/dss/upm/4520-20#input.cumulative_social_security_cola_multiplier_for_long_term_care_personal_needs_standard: 0
+  output:
+    us-ct:policies/dss/upm/4520-20#assistance_unit_resides_in_long_term_care_facility: not_holds
+- name: auto_positive_assistance_unit_resides_in_long_term_care_facility
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_and_convalescent_nursing_home: true
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_chronic_disease_hospital: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_intermediate_care_facility_for_the_mentally_retarded: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_rest_home_with_nursing_supervision: false
+    us-ct:policies/dss/upm/4520-20#input.assistance_unit_resides_in_state_humane_institution: false
+  output:
+    us-ct:policies/dss/upm/4520-20#assistance_unit_resides_in_long_term_care_facility: holds

--- a/us-ct/policies/dss/upm/4520-20.yaml
+++ b/us-ct/policies/dss/upm/4520-20.yaml
@@ -1,0 +1,106 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/upm/4520.20/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - Conn. Gen. Stat. 17b-600
+        - Conn. Gen. Stat. 17b-10
+        - Regulations of Connecticut State Agencies 17b-10-1
+        - Regulations of Connecticut State Agencies 17b-198-2
+      rationale: UPM 4520.20 is the specific DSS implementing source for Connecticut AABD/SSP long-term-care personal-needs and shelter standards after checking the upstream statutory and regulatory authority chain.
+  summary: |-
+    UPM 4520.20 classifies residents of chronic and convalescent nursing homes, chronic disease hospitals, rest homes with nursing supervision, intermediate care facilities for the mentally retarded, and state humane institutions as residing in long term care facilities. The personal needs standard for assistance units residing in long term care facilities is $50 per month, increased annually effective July 1, 1999 to reflect the Social Security Administration cost-of-living adjustment. There is no shelter standard for assistance units residing in long term care facilities.
+rules:
+  - name: long_term_care_personal_needs_base_standard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.20(B)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.20/block-1
+              excerpt: personal needs standard ... is $50 per month
+    versions:
+      - effective_from: '1998-07-01'
+        formula: |-
+          50
+  - name: assistance_unit_resides_in_long_term_care_facility
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Judgment
+    period: Month
+    source: UPM 4520.20(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.20/block-1
+    versions:
+      - effective_from: '1998-07-01'
+        formula: |-
+          assistance_unit_resides_in_chronic_and_convalescent_nursing_home
+          or assistance_unit_resides_in_chronic_disease_hospital
+          or assistance_unit_resides_in_rest_home_with_nursing_supervision
+          or assistance_unit_resides_in_intermediate_care_facility_for_the_mentally_retarded
+          or assistance_unit_resides_in_state_humane_institution
+  - name: ct_ssp_personal_needs_allowance
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.20(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.20/block-1
+              excerpt: increased to reflect the annual cost of living adjustment used by the Social Security Administration
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/4520-20#long_term_care_personal_needs_base_standard
+              output: long_term_care_personal_needs_base_standard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/4520-20#assistance_unit_resides_in_long_term_care_facility
+              output: assistance_unit_resides_in_long_term_care_facility
+              hash: sha256:local
+    versions:
+      - effective_from: '1998-07-01'
+        formula: |-
+          if assistance_unit_resides_in_long_term_care_facility: long_term_care_personal_needs_base_standard * cumulative_social_security_cola_multiplier_for_long_term_care_personal_needs_standard else: 0
+  - name: ct_ssp_long_term_care_shelter_allowance
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 4520.20(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/4520.20/block-1
+              excerpt: no shelter standard for assistance units residing in long term care facilities
+    versions:
+      - effective_from: '1998-07-01'
+        formula: |-
+          0

--- a/us-ct/policies/dss/upm/5030-10.test.yaml
+++ b/us-ct/policies/dss/upm/5030-10.test.yaml
@@ -1,0 +1,112 @@
+- name: long_term_care_counts_gross_income_in_full
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: true
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 1000
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: true
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+  output:
+    us-ct:policies/dss/upm/5030-10#ct_ssp_earned_income_disregard: 0
+- name: aged_or_disabled_applicant_general_disregard
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 1000
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: true
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+  output:
+    us-ct:policies/dss/upm/5030-10#ct_ssp_earned_income_disregard: 532.5
+- name: disabled_recipient_impairment_related_expenses_branch
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 1000
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 100
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: true
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+  output:
+    us-ct:policies/dss/upm/5030-10#ct_ssp_earned_income_disregard: 482.5
+- name: blind_applicant_or_recipient_disregard
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 1000
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: true
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+  output:
+    us-ct:policies/dss/upm/5030-10#ct_ssp_earned_income_disregard: 542.5
+- name: oracle_parameter_aged_disabled_general_monthly_base_disregard
+  period: 1998-07
+  input:
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 0
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+  output:
+    us-ct:policies/dss/upm/5030-10#aged_disabled_general_monthly_base_disregard: 65
+- name: oracle_parameter_disabled_irwe_monthly_base_disregard
+  period: 1998-07
+  input:
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 0
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+  output:
+    us-ct:policies/dss/upm/5030-10#disabled_irwe_monthly_base_disregard: 65
+- name: oracle_parameter_blind_monthly_base_disregard
+  period: 1998-07
+  input:
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 0
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+  output:
+    us-ct:policies/dss/upm/5030-10#blind_monthly_base_disregard: 85
+- name: oracle_parameter_remaining_earned_income_disregard_rate
+  period: 1998-07
+  input:
+    us-ct:policies/dss/upm/5030-10#input.applicant_for_assistance_to_disabled_or_aged: false
+    us-ct:policies/dss/upm/5030-10#input.applicant_or_recipient_of_assistance_to_blind: false
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_monthly_total_available_gross_earned_income: 0
+    us-ct:policies/dss/upm/5030-10#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-10#input.impairment_related_expenses: 0
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_with_prior_disabled_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance: false
+    us-ct:policies/dss/upm/5030-10#input.recipient_of_assistance_to_disabled: false
+  output:
+    us-ct:policies/dss/upm/5030-10#remaining_earned_income_disregard_rate: 0.5

--- a/us-ct/policies/dss/upm/5030-10.yaml
+++ b/us-ct/policies/dss/upm/5030-10.yaml
@@ -1,0 +1,150 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+      - "Conn. Gen. Stat. \xA7 17b-600"
+      - "Conn. Gen. Stat. \xA7 17b-10"
+      - "Regulations of Connecticut State Agencies \xA7 17b-10-1"
+      - "Regulations of Connecticut State Agencies \xA7 17b-198-2"
+      rationale: UPM 5030.10 is the specific DSS implementing source for the Connecticut
+        AABD/SSP earned-income disregard amounts and formula after checking the upstream
+        statutory and regulatory authority chain.
+  summary: Except for AABD assistance units residing in long term care facilities,
+    earned income disregards are subtracted from the assistance unit's monthly total
+    available gross earned income. Long term care facility assistance units count
+    total available gross earned income in full. The disregard is $65.00 per month
+    plus 1/2 of remaining income for the stated aged/disabled applicant and aged-recipient
+    groups; $65.00 per month plus 1/2 of income remaining after impairment related
+    expenses are deducted for the stated disabled-recipient groups; and $85.00 per
+    month plus 1/2 of remaining income for the stated blind applicant/recipient and
+    aged-prior-blind groups.
+rules:
+- name: aged_disabled_general_monthly_base_disregard
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: UPM 5030.10(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+          excerpt: $65.00 per month plus 1/2 of the remaining income
+  versions:
+  - effective_from: '1998-07-01'
+    formula: '65'
+- name: disabled_irwe_monthly_base_disregard
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: UPM 5030.10(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+          excerpt: $65.00 per month plus 1/2 of the income remaining after impairment
+            related expenses are deducted
+  versions:
+  - effective_from: '1998-07-01'
+    formula: '65'
+- name: blind_monthly_base_disregard
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: UPM 5030.10(B)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+          excerpt: $85.00 per month plus 1/2 of the remaining income
+  versions:
+  - effective_from: '1998-07-01'
+    formula: '85'
+- name: remaining_earned_income_disregard_rate
+  kind: parameter
+  dtype: Rate
+  source: UPM 5030.10(B)(1)-(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+          excerpt: plus 1/2
+  versions:
+  - effective_from: '1998-07-01'
+    formula: 1 / 2
+- name: ct_ssp_earned_income_disregard
+  kind: derived
+  entity: AssistanceUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: UPM 5030.10(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+          excerpt: Total available gross earned income is counted in full
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/policy/dss/upm/5030.10/block-1
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/5030-10#aged_disabled_general_monthly_base_disregard
+          output: aged_disabled_general_monthly_base_disregard
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/5030-10#disabled_irwe_monthly_base_disregard
+          output: disabled_irwe_monthly_base_disregard
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/5030-10#blind_monthly_base_disregard
+          output: blind_monthly_base_disregard
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/upm/5030-10#remaining_earned_income_disregard_rate
+          output: remaining_earned_income_disregard_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '1998-07-01'
+    formula: 'if assistance_unit_resides_in_long_term_care_facility: 0 else: if applicant_or_recipient_of_assistance_to_blind
+      or recipient_of_assistance_to_aged_with_prior_blind_assistance: min(max(0, assistance_unit_monthly_total_available_gross_earned_income),
+      blind_monthly_base_disregard + remaining_earned_income_disregard_rate * max(0,
+      assistance_unit_monthly_total_available_gross_earned_income - blind_monthly_base_disregard))
+      else: if recipient_of_assistance_to_disabled or recipient_of_assistance_to_aged_with_prior_disabled_assistance:
+      min(max(0, assistance_unit_monthly_total_available_gross_earned_income), disabled_irwe_monthly_base_disregard
+      + remaining_earned_income_disregard_rate * max(0, assistance_unit_monthly_total_available_gross_earned_income
+      - impairment_related_expenses - disabled_irwe_monthly_base_disregard)) else:
+      if applicant_for_assistance_to_disabled_or_aged or recipient_of_assistance_to_aged_without_prior_disabled_or_blind_assistance:
+      min(max(0, assistance_unit_monthly_total_available_gross_earned_income), aged_disabled_general_monthly_base_disregard
+      + remaining_earned_income_disregard_rate * max(0, assistance_unit_monthly_total_available_gross_earned_income
+      - aged_disabled_general_monthly_base_disregard)) else: 0'

--- a/us-ct/policies/dss/upm/5030-15.test.yaml
+++ b/us-ct/policies/dss/upm/5030-15.test.yaml
@@ -1,0 +1,108 @@
+- name: standard_disregard_for_own_home
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-15#input.applying_under_working_individuals_with_disabilities_medicaid_coverage_group: false
+    us-ct:policies/dss/upm/5030-15#input.determining_aabd_eligibility_or_benefit: true
+    us-ct:policies/dss/upm/5030-15#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_maabd_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.unit_member_total_gross_monthly_unearned_income: 1000
+    us-ct:policies/dss/upm/5030-15#input.in_kind_income_not_otherwise_excluded: 0
+    us-ct:policies/dss/upm/5030-15#input.individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_battered_women_shelter_or_homeless_shelter: false
+    us-ct:policies/dss/upm/5030-15#input.individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_own_home_in_community: true
+    us-ct:policies/dss/upm/5030-15#input.individual_lives_as_roomer_in_home_of_others: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.annual_social_security_cola_multiplier_for_unearned_income_disregards: 1
+    us-ct:policies/dss/upm/5030-15#input.determining_qmb_medicaid_coverage_group_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.month_is_january_february_or_march: true
+    us-ct:policies/dss/upm/5030-15#input.qmb_additional_social_security_cola_benefits_received: 0
+  output:
+    us-ct:policies/dss/upm/5030-15#ct_ssp_unearned_income_disregard: 227
+- name: special_disregard_for_shared_non_rated_housing
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-15#input.applying_under_working_individuals_with_disabilities_medicaid_coverage_group: false
+    us-ct:policies/dss/upm/5030-15#input.determining_aabd_eligibility_or_benefit: true
+    us-ct:policies/dss/upm/5030-15#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_maabd_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.unit_member_total_gross_monthly_unearned_income: 1000
+    us-ct:policies/dss/upm/5030-15#input.in_kind_income_not_otherwise_excluded: 0
+    us-ct:policies/dss/upm/5030-15#input.individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child: true
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_battered_women_shelter_or_homeless_shelter: false
+    us-ct:policies/dss/upm/5030-15#input.individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_own_home_in_community: false
+    us-ct:policies/dss/upm/5030-15#input.individual_lives_as_roomer_in_home_of_others: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.annual_social_security_cola_multiplier_for_unearned_income_disregards: 1
+    us-ct:policies/dss/upm/5030-15#input.determining_qmb_medicaid_coverage_group_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.month_is_january_february_or_march: true
+    us-ct:policies/dss/upm/5030-15#input.qmb_additional_social_security_cola_benefits_received: 0
+  output:
+    us-ct:policies/dss/upm/5030-15#ct_ssp_unearned_income_disregard: 294.9
+- name: shelter_blocks_special_disregard_and_uses_standard
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-15#input.applying_under_working_individuals_with_disabilities_medicaid_coverage_group: false
+    us-ct:policies/dss/upm/5030-15#input.determining_aabd_eligibility_or_benefit: true
+    us-ct:policies/dss/upm/5030-15#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_maabd_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.unit_member_total_gross_monthly_unearned_income: 1000
+    us-ct:policies/dss/upm/5030-15#input.in_kind_income_not_otherwise_excluded: 0
+    us-ct:policies/dss/upm/5030-15#input.individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child: true
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_battered_women_shelter_or_homeless_shelter: true
+    us-ct:policies/dss/upm/5030-15#input.individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_own_home_in_community: false
+    us-ct:policies/dss/upm/5030-15#input.individual_lives_as_roomer_in_home_of_others: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.annual_social_security_cola_multiplier_for_unearned_income_disregards: 1
+    us-ct:policies/dss/upm/5030-15#input.determining_qmb_medicaid_coverage_group_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.month_is_january_february_or_march: true
+    us-ct:policies/dss/upm/5030-15#input.qmb_additional_social_security_cola_benefits_received: 0
+  output:
+    us-ct:policies/dss/upm/5030-15#ct_ssp_unearned_income_disregard: 227
+- name: qmb_cola_disregard_added_in_january_through_march
+  period: 2024-01
+  input:
+    us-ct:policies/dss/upm/5030-15#input.applying_under_working_individuals_with_disabilities_medicaid_coverage_group: false
+    us-ct:policies/dss/upm/5030-15#input.determining_aabd_eligibility_or_benefit: false
+    us-ct:policies/dss/upm/5030-15#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_maabd_eligibility: true
+    us-ct:policies/dss/upm/5030-15#input.unit_member_total_gross_monthly_unearned_income: 1000
+    us-ct:policies/dss/upm/5030-15#input.in_kind_income_not_otherwise_excluded: 0
+    us-ct:policies/dss/upm/5030-15#input.individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_battered_women_shelter_or_homeless_shelter: false
+    us-ct:policies/dss/upm/5030-15#input.individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_own_home_in_community: true
+    us-ct:policies/dss/upm/5030-15#input.individual_lives_as_roomer_in_home_of_others: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.annual_social_security_cola_multiplier_for_unearned_income_disregards: 1
+    us-ct:policies/dss/upm/5030-15#input.determining_qmb_medicaid_coverage_group_eligibility: true
+    us-ct:policies/dss/upm/5030-15#input.month_is_january_february_or_march: true
+    us-ct:policies/dss/upm/5030-15#input.qmb_additional_social_security_cola_benefits_received: 30
+  output:
+    us-ct:policies/dss/upm/5030-15#ct_ssp_unearned_income_disregard: 257
+- name: auto_zero_ct_ssp_unearned_income_disregard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/upm/5030-15#input.annual_social_security_cola_multiplier_for_unearned_income_disregards: 0
+    us-ct:policies/dss/upm/5030-15#input.applying_under_working_individuals_with_disabilities_medicaid_coverage_group: false
+    us-ct:policies/dss/upm/5030-15#input.assistance_unit_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_aabd_eligibility_or_benefit: false
+    us-ct:policies/dss/upm/5030-15#input.determining_maabd_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.determining_qmb_medicaid_coverage_group_eligibility: false
+    us-ct:policies/dss/upm/5030-15#input.in_kind_income_not_otherwise_excluded: false
+    us-ct:policies/dss/upm/5030-15#input.individual_lives_as_roomer_in_home_of_others: false
+    us-ct:policies/dss/upm/5030-15#input.individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_battered_women_shelter_or_homeless_shelter: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_long_term_care_facility: false
+    us-ct:policies/dss/upm/5030-15#input.individual_resides_in_own_home_in_community: false
+    us-ct:policies/dss/upm/5030-15#input.individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child: false
+    us-ct:policies/dss/upm/5030-15#input.month_is_january_february_or_march: false
+    us-ct:policies/dss/upm/5030-15#input.qmb_additional_social_security_cola_benefits_received: false
+    us-ct:policies/dss/upm/5030-15#input.unit_member_total_gross_monthly_unearned_income: 0
+  output:
+    us-ct:policies/dss/upm/5030-15#ct_ssp_unearned_income_disregard: 0

--- a/us-ct/policies/dss/upm/5030-15.yaml
+++ b/us-ct/policies/dss/upm/5030-15.yaml
@@ -1,0 +1,135 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - Conn. Gen. Stat. 17b-600
+        - Conn. Gen. Stat. 17b-10
+        - Regulations of Connecticut State Agencies 17b-10-1
+        - Regulations of Connecticut State Agencies 17b-198-2
+      rationale: UPM 5030.15 is the specific DSS implementing source for Connecticut AABD/MAABD unearned-income disregards after checking the upstream statutory and regulatory authority chain.
+  summary: |-
+    Except as provided in section 5030.15 D., unearned income disregards are subtracted from the unit member's total gross monthly unearned income. The listed disregards are $227.00 standard, $134.70 boarding home, $294.90 special, the QMB annual Social Security COLA amount for January through March, and in-kind income not otherwise excluded for applied-income calculations. AABD long term care facility assistance units count gross unearned income in full, and Working Individuals with Disabilities have no unearned income disregards.
+rules:
+  - name: standard_unearned_income_base_disregard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 5030.15(B)(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: The disregard is $227.00
+    versions:
+      - effective_from: '2007-01-01'
+        formula: |-
+          227
+  - name: boarding_home_unearned_income_base_disregard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 5030.15(B)(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: The disregard is $134.70
+    versions:
+      - effective_from: '2007-01-01'
+        formula: |-
+          134.70
+  - name: special_unearned_income_base_disregard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 5030.15(B)(1)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: The disregard is $294.90
+    versions:
+      - effective_from: '2007-01-01'
+        formula: |-
+          294.90
+  - name: working_individuals_disabilities_general_monthly_income_disregard
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 5030.15(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: general income disregard of $20.00 per month
+    versions:
+      - effective_from: '2007-01-01'
+        formula: |-
+          20
+  - name: ct_ssp_unearned_income_disregard
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: UPM 5030.15(A)-(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: Total gross monthly unearned income is counted in full
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/policy/dss/upm/5030.15/block-1
+              excerpt: There are no unearned income disregards
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/5030-15#standard_unearned_income_base_disregard
+              output: standard_unearned_income_base_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/5030-15#boarding_home_unearned_income_base_disregard
+              output: boarding_home_unearned_income_base_disregard
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/upm/5030-15#special_unearned_income_base_disregard
+              output: special_unearned_income_base_disregard
+              hash: sha256:local
+    versions:
+      - effective_from: '2007-01-01'
+        formula: |-
+          if applying_under_working_individuals_with_disabilities_medicaid_coverage_group: 0 else: if determining_aabd_eligibility_or_benefit and assistance_unit_resides_in_long_term_care_facility: 0 else: if determining_aabd_eligibility_or_benefit or determining_maabd_eligibility: min(max(0, unit_member_total_gross_monthly_unearned_income), in_kind_income_not_otherwise_excluded + (if individual_shares_non_rated_housing_with_person_not_parent_spouse_or_child and not individual_resides_in_battered_women_shelter_or_homeless_shelter: special_unearned_income_base_disregard * annual_social_security_cola_multiplier_for_unearned_income_disregards else: if individual_pays_room_and_board_in_licensed_boarding_or_adult_family_living_home: boarding_home_unearned_income_base_disregard * annual_social_security_cola_multiplier_for_unearned_income_disregards else: if individual_resides_in_own_home_in_community or individual_lives_as_roomer_in_home_of_others or individual_resides_in_long_term_care_facility or individual_resides_in_battered_women_shelter_or_homeless_shelter: standard_unearned_income_base_disregard * annual_social_security_cola_multiplier_for_unearned_income_disregards else: 0) + (if determining_qmb_medicaid_coverage_group_eligibility and month_is_january_february_or_march: qmb_additional_social_security_cola_benefits_received else: 0)) else: 0


### PR DESCRIPTION
## Summary
- encode Connecticut SSP UPM resource, earned-income, unearned-income, personal-needs, and shelter standards
- encode current 2026 DSS Program Standards chart CT SSP unearned-disregard, personal-needs, shelter, and special-needs cells
- add signed oracle parameter tests for all PolicyEngine-overlapping CT SSP parameter cells

## Source path
- Uses the newly ingested CT DSS UPM and Program Standards corpus artifacts from axiom-corpus PRs #156 and #157.
- Current oracle mappings are in TheAxiomFoundation/axiom-encode#938.

## Validation
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ct-ssp-upm-20260702/us-ct --base-ref origin/main --head-ref HEAD --json -> passed true, no issues
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ct-ssp-upm-20260702 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ct-ssp-upm-20260702/us-ct/policies/dss --json -> success true, 9 test files, 47 cases, 9 compiled programs
- AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-legacy-doc-20260702 uv run axiom-encode validate ... --skip-reviewers --oracle policyengine --require-oracle-classification --json -> rc 0, all_passed true; PolicyEngine coverage total 13 comparable, 13 passed, 0 failed, 0 unmapped
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ct-ssp-upm-20260702 --oracle policyengine --program ssi_state_supplement --json -> 55 comparable, 76 known-not-comparable, 0 untested comparable
