### PR TITLE
Add Montana TANF assistance standards

### DIFF
--- a/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.json
+++ b/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.yaml",
+      "sha256": "4d28598187cc6fd5d5e2505812bdeb6e304bd90a685c16aeae38c5d7f92d9560"
+    },
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.test.yaml",
+      "sha256": "ce6d94d9ae61b48f417f107a75a3b5f55b4b3a4b5d578e28d158ab892bba0d9d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ar:policies/dhs/tea/manual/2024/earned-income-deductions",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:34:52.309426+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbbhqwvjf/deterministic-repair/us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbbhqwvjf",
+  "generated_output_sha256": "4d28598187cc6fd5d5e2505812bdeb6e304bd90a685c16aeae38c5d7f92d9560",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ca0e242780ceb30253a0e9501fc7f342f78b39fa06fcb98bf772e263468eb495"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.json
+++ b/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.yaml",
+      "sha256": "2592ff6ca83ead9b03e7eb398df196fa00ec94cfda5b10ef6570650c30093d70"
+    },
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.test.yaml",
+      "sha256": "0fa2796a80f246ea1942da8b0788cf0e111a8f00a95e6ba10dbc58b8af5c74e1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:34:55.930791+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpn_ikita6/deterministic-repair/us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpn_ikita6",
+  "generated_output_sha256": "2592ff6ca83ead9b03e7eb398df196fa00ec94cfda5b10ef6570650c30093d70",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "da73746daa2ae242bf3d23d60fb98868104d5c2a05a7097a0b6a808465da2c4d"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/payment-levels.json
+++ b/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/payment-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/payment-levels.yaml",
+      "sha256": "c73337a43af976d35f0bda6e1b8f06757330a8c0966edebd45ab9da57c8390c4"
+    },
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/payment-levels.test.yaml",
+      "sha256": "0cb1b703021c96bfa8c93ecefb1ce37d33494a4ef268248faf7322d17b5e42ce"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ar:policies/dhs/tea/manual/2024/payment-levels",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:34:59.629316+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp23nmdvm2/deterministic-repair/us-ar/policies/dhs/tea/manual/2024/payment-levels.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp23nmdvm2",
+  "generated_output_sha256": "c73337a43af976d35f0bda6e1b8f06757330a8c0966edebd45ab9da57c8390c4",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5d62b819920b037fed92904c7b746b95a1920c51675851971b88d32b64078df9"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.json
+++ b/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.yaml",
+      "sha256": "fcf8a8a900869abcbf95885d26d02e8c50995896b481db1ffd8e557c84585c60"
+    },
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.test.yaml",
+      "sha256": "3057ce3f7ce7a955d24a5393a4b2a47ee6a0c9705e0a5d3d76d0ca24b041e10d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:35:03.395517+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpjx_tissn/deterministic-repair/us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpjx_tissn",
+  "generated_output_sha256": "fcf8a8a900869abcbf95885d26d02e8c50995896b481db1ffd8e557c84585c60",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3519f8071fad94e870447f84da40e0204433ed1216dca5bab624def7ce86fdf4"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/resource-eligibility.json
+++ b/.axiom/encoding-manifests/us-ar/policies/dhs/tea/manual/2024/resource-eligibility.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/resource-eligibility.yaml",
+      "sha256": "2864ac521a0549bbc129ec91ab92b048de22f12ee254960b25639031e915fa0c"
+    },
+    {
+      "path": "us-ar/policies/dhs/tea/manual/2024/resource-eligibility.test.yaml",
+      "sha256": "7e84ef594c9bfd4ab31c4ca936fb8990e565eebfbeef3df1cd9e39ddb958fb6f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ar:policies/dhs/tea/manual/2024/resource-eligibility",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:35:07.589533+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9gjxz_bk/deterministic-repair/us-ar/policies/dhs/tea/manual/2024/resource-eligibility.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9gjxz_bk",
+  "generated_output_sha256": "2864ac521a0549bbc129ec91ab92b048de22f12ee254960b25639031e915fa0c",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "44056490fb05a3abe7a7099b85c3bd3408c7454c5e0ac2634ea51a35e81e1a0e"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ct/policies/dss/upm/5520-10.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/upm/5520-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/upm/5520-10.yaml",
+      "sha256": "f1e85b85726f6df03f842ca0fc4c280687726eafe15fb9b70465a60e61e46016"
+    },
+    {
+      "path": "us-ct/policies/dss/upm/5520-10.test.yaml",
+      "sha256": "a1b242a985a8b36f533c599bcb334e7c11f4414c7fab1c70d455b16c4648146e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "372b74669c9afd04eee15b94fe2b7a5c2fa086d5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1058",
+    "version_commit": "4e50d68c07b91a005283f2281748e307db4bb0e9"
+  },
+  "axiom_encode_version": "0.2.1058",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/upm/5520-10",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T09:35:11.670680+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmptv4r1p04/deterministic-repair/us-ct/policies/dss/upm/5520-10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmptv4r1p04",
+  "generated_output_sha256": "f1e85b85726f6df03f842ca0fc4c280687726eafe15fb9b70465a60e61e46016",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "97c79c5c87c0d2fb90ab3e242b496857eb1132960273751bf46faaf2b7bf4805"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -22,6 +22,7 @@ allowed_root_directories:
   - us-md
   - us-mi
   - us-mn
+  - us-mt
   - us-ks
   - us-la
   - us-nc

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1058"
+axiom_encode_version = "0.2.1059"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "4e50d68c07b91a005283f2281748e307db4bb0e9"
+axiom_encode_ref = "7272f8647038cc18ac07658000d612564b5326cb"
 axiom_corpus_ref = "e17aadc2952ec12ea83703a90e127b099ee931ff"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1051"
+axiom_encode_version = "0.2.1058"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "a0304b74d67c5447cbb97b17ef6bc23105633224"
+axiom_encode_ref = "4e50d68c07b91a005283f2281748e307db4bb0e9"
 axiom_corpus_ref = "e17aadc2952ec12ea83703a90e127b099ee931ff"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.test.yaml
+++ b/us-ar/policies/dhs/tea/manual/2024/earned-income-deductions.test.yaml
@@ -1,1 +1,10 @@
-[]
+- name: oracle_parameter_ar_tea_work_related_earned_income_deduction_rate
+  period: 1999-02
+  input: {}
+  output:
+    us-ar:policies/dhs/tea/manual/2024/earned-income-deductions#ar_tea_work_related_earned_income_deduction_rate: 0.2
+- name: oracle_parameter_ar_tea_work_incentive_earned_income_deduction_rate
+  period: 1999-02
+  input: {}
+  output:
+    us-ar:policies/dhs/tea/manual/2024/earned-income-deductions#ar_tea_work_incentive_earned_income_deduction_rate: 0.6

--- a/us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.test.yaml
+++ b/us-ar/policies/dhs/tea/manual/2024/income-eligibility-standard.test.yaml
@@ -16,3 +16,10 @@
     us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#ar_tea_income_limit: 513
     us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#ar_tea_total_countable_income_for_income_eligibility: 514
     us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#ar_tea_income_eligible: not_holds
+- name: oracle_parameter_ar_tea_income_eligibility_standard
+  period: 2023-01
+  input:
+    us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#input.countable_unearned_income: 0
+    us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#input.net_earned_income: 0
+  output:
+    us-ar:policies/dhs/tea/manual/2024/income-eligibility-standard#ar_tea_income_eligibility_standard: 513

--- a/us-ar/policies/dhs/tea/manual/2024/payment-levels.test.yaml
+++ b/us-ar/policies/dhs/tea/manual/2024/payment-levels.test.yaml
@@ -26,3 +26,16 @@
   output:
     us-ar:policies/dhs/tea/manual/2024/payment-levels#ar_tea_payment_level_family_size: 9
     us-ar:policies/dhs/tea/manual/2024/payment-levels#ar_tea_maximum_benefit: 457
+- name: oracle_parameter_ar_tea_maximum_payment_level_open_ended_family_size
+  period: 2012-01
+  input:
+    us-ar:policies/dhs/tea/manual/2024/payment-levels#input.assistance_unit_size: 1
+  output:
+    us-ar:policies/dhs/tea/manual/2024/payment-levels#ar_tea_maximum_payment_level_open_ended_family_size: 9
+- name: oracle_parameter_ar_tea_maximum_payment_amount_by_family_size_1
+  period: 2012-01
+  input:
+    us-ar:policies/dhs/tea/manual/2024/payment-levels#input.assistance_unit_size: 1
+    us-ar:policies/dhs/tea/manual/2024/payment-levels#input.ar_tea_payment_level_family_size: 1
+  output:
+    us-ar:policies/dhs/tea/manual/2024/payment-levels#ar_tea_maximum_payment_amount_by_family_size: 81

--- a/us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.test.yaml
+++ b/us-ar/policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger.test.yaml
@@ -42,3 +42,17 @@
     us-ar:policies/dhs/tea/manual/2024/income-eligibility-budget#input.countable_unearned_income: 600
   output:
     us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger#ar_tea: 0
+- name: oracle_parameter_ar_tea_reduced_payment_gross_income_trigger
+  period: 2023-01
+  input:
+    ? us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger#input.countable_monthly_gross_income_excluding_assigned_child_support_payments
+    : 0
+  output:
+    us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger#ar_tea_reduced_payment_gross_income_trigger: 1026
+- name: oracle_parameter_ar_tea_reduced_payment_rate
+  period: 2023-01
+  input:
+    ? us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger#input.countable_monthly_gross_income_excluding_assigned_child_support_payments
+    : 0
+  output:
+    us-ar:policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger#ar_tea_reduced_payment_rate: 0.5

--- a/us-ar/policies/dhs/tea/manual/2024/resource-eligibility.test.yaml
+++ b/us-ar/policies/dhs/tea/manual/2024/resource-eligibility.test.yaml
@@ -10,3 +10,9 @@
     us-ar:policies/dhs/tea/manual/2024/resource-eligibility#input.countable_resources_on_first_day_of_month: 3001
   output:
     us-ar:policies/dhs/tea/manual/2024/resource-eligibility#ar_tea_resources_eligible: not_holds
+- name: oracle_parameter_ar_tea_resource_limit
+  period: 1997-07
+  input:
+    us-ar:policies/dhs/tea/manual/2024/resource-eligibility#input.countable_resources_on_first_day_of_month: 0
+  output:
+    us-ar:policies/dhs/tea/manual/2024/resource-eligibility#ar_tea_resource_limit: 3000

--- a/us-ct/policies/dss/upm/5520-10.test.yaml
+++ b/us-ct/policies/dss/upm/5520-10.test.yaml
@@ -136,3 +136,18 @@
     us-ct:policies/dss/upm/5045-10#input.total_amount_deemed: 100
   output:
     us-ct:policies/dss/upm/5520-10#ct_ssp_income_eligible: holds
+- name: oracle_parameter_aabd_individual_gross_income_limit_multiplier
+  period: 1988-07
+  input:
+    us-ct:policies/dss/upm/5520-10#input.applicant_and_eligible_spouse_total_basic_and_special_needs: 0
+    us-ct:policies/dss/upm/5520-10#input.applicant_basic_and_special_needs_plus_ineligible_spouse_basic_needs: 0
+    us-ct:policies/dss/upm/5520-10#input.assistance_unit_total_gross_monthly_income: 0
+    us-ct:policies/dss/upm/5520-10#input.maximum_ssi_benefit_for_individual_with_no_income_living_in_own_home: 0
+    us-ct:policies/dss/upm/5520-10#input.needs_group_comprises_both_spouses: false
+    us-ct:policies/dss/upm/5520-10#input.needs_group_comprises_only_individual_applicant_or_recipient: false
+    us-ct:policies/dss/upm/5520-10#input.spouse_is_eligible: false
+    us-ct:policies/dss/upm/5520-10#input.spouse_is_ineligible: false
+    us-ct:policies/dss/upm/5520-10#input.total_gross_monthly_income_of_applicant_or_recipient_and_spouse: 0
+    us-ct:policies/dss/upm/5520-10#input.total_needs_of_individual: 0
+  output:
+    us-ct:policies/dss/upm/5520-10#aabd_individual_gross_income_limit_multiplier: 3.0

--- a/us-mt/.axiom/encoding-manifests/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.json
+++ b/us-mt/.axiom/encoding-manifests/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",
+      "sha256": "16714bff5ddcd9cbb8ce4740f98d76d0570201b1450edd1f03ac623adb64ffd1"
+    },
+    {
+      "path": "regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.test.yaml",
+      "sha256": "2ade108865a82ca636878b420e82e263bba929ca9888ee1438729a5c77d82c04"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e22745b43719be1b55973ed7a192224f9c079218",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-table-numeric-grounding-20260702",
+    "version": "0.2.1057",
+    "version_commit": "e22745b43719be1b55973ed7a192224f9c079218"
+  },
+  "axiom_encode_version": "0.2.1057",
+  "backend": "codex",
+  "citation": "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420",
+  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-mt-regulation-title-37-chapter-37-78-subchapter-37-78-4-rule-37-78-420/workspace/context-manifest.json",
+  "context_manifest_sha256": "9308ba9fbf99c4aa17f89efbb5590d38044e0fd97fa540db0050813ff396fd5e",
+  "generated_at": "2026-07-02T09:03:22.952372+00:00",
+  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",
+  "generated_output_root": "/tmp/axiom-encode-encodings",
+  "generated_output_sha256": "16714bff5ddcd9cbb8ce4740f98d76d0570201b1450edd1f03ac623adb64ffd1",
+  "generation_prompt_sha256": "128922855da8499d5285052f0ac6a0fe2b782f03d1dd3928aaf835ed08807ece",
+  "model": "gpt-5.5",
+  "run_id": "8b62a17d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3ffa447c9941f6ce989a8a2305c99fb2d34251064969e2465e0469ca28f7db59"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-mt-regulation-title-37-chapter-37-78-subchapter-37-78-4-rule-37-78-420.json",
+  "trace_sha256": "f88e92755cbf594aa07c0f0993c96bfd3fbbf92a512990c065519d12a2edfb14"
+}

--- a/us-mt/.axiom/encoding-manifests/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.json
+++ b/us-mt/.axiom/encoding-manifests/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",
-      "sha256": "16714bff5ddcd9cbb8ce4740f98d76d0570201b1450edd1f03ac623adb64ffd1"
+      "sha256": "146c90d048529cabb2c26c8c0d7a6465cf177844a101d49bfc6c5e343c21b1ec"
     },
     {
       "path": "regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.test.yaml",
@@ -10,32 +10,32 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "e22745b43719be1b55973ed7a192224f9c079218",
+    "commit": "f904885e09d592fc2cb5a234586c839446912453",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-table-numeric-grounding-20260702",
-    "version": "0.2.1057",
-    "version_commit": "e22745b43719be1b55973ed7a192224f9c079218"
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1059",
+    "version_commit": "f904885e09d592fc2cb5a234586c839446912453"
   },
-  "axiom_encode_version": "0.2.1057",
-  "backend": "codex",
-  "citation": "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-mt-regulation-title-37-chapter-37-78-subchapter-37-78-4-rule-37-78-420/workspace/context-manifest.json",
-  "context_manifest_sha256": "9308ba9fbf99c4aa17f89efbb5590d38044e0fd97fa540db0050813ff396fd5e",
-  "generated_at": "2026-07-02T09:03:22.952372+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "16714bff5ddcd9cbb8ce4740f98d76d0570201b1450edd1f03ac623adb64ffd1",
-  "generation_prompt_sha256": "128922855da8499d5285052f0ac6a0fe2b782f03d1dd3928aaf835ed08807ece",
-  "model": "gpt-5.5",
-  "run_id": "8b62a17d",
-  "runner": "codex-gpt-5.5",
+  "axiom_encode_version": "0.2.1059",
+  "backend": "deterministic",
+  "citation": "us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T10:13:21.081780+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpyyktojan/deterministic-repair/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpyyktojan",
+  "generated_output_sha256": "146c90d048529cabb2c26c8c0d7a6465cf177844a101d49bfc6c5e343c21b1ec",
+  "generation_prompt_sha256": null,
+  "model": "source-child-corpus-path-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3ffa447c9941f6ce989a8a2305c99fb2d34251064969e2465e0469ca28f7db59"
+    "value": "8b6d950e651eff26c1f650074a6df53b71c3ed5d85748bdec24efcb0bd7bf0bc"
   },
-  "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-mt-regulation-title-37-chapter-37-78-subchapter-37-78-4-rule-37-78-420.json",
-  "trace_sha256": "f88e92755cbf594aa07c0f0993c96bfd3fbbf92a512990c065519d12a2edfb14"
+  "tool": "axiom-encode repair-source-child-corpus-paths",
+  "trace_file": null,
+  "trace_sha256": null
 }

--- a/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.test.yaml
+++ b/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.test.yaml
@@ -1,0 +1,30 @@
+- name: cash assistance payment standard for three-person unit
+  period: 2024-01
+  input:
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program
+    : false
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program_month
+    : 1
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_assistance_unit_size: 3
+  output:
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_payment_standard: 504
+- name: post-employment payment standard first month ignores unit size
+  period: 2024-01
+  input:
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program
+    : true
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program_month
+    : 1
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_assistance_unit_size: 6
+  output:
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_payment_standard: 375
+- name: post-employment payment standard third month
+  period: 2024-01
+  input:
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program
+    : true
+    ? us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_cash_assistance_post_employment_program_month
+    : 3
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#input.tanf_assistance_unit_size: 20
+  output:
+    us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_payment_standard: 175

--- a/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml
+++ b/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml
@@ -1,0 +1,232 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+  summary: '"The payment standard is used to determine the amount of the monthly cash
+    payment in the TANF cash assistance program and is based on the size of the ...
+    assistance unit, unless the household is receiving benefits through the TANF Cash
+    Assistance Post-Employment Program. Payment standards in the Post-Employment Program
+    are a set amount as defined in (4)(e)."'
+rules:
+- name: mt_tanf_gross_monthly_income_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: tanf_assistance_unit_size
+  source: ARM 37.78.420(4)(a), Gross Monthly Income Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          table:
+            header: GROSS MONTHLY INCOME STANDARDS (GMI)
+            row_key: Number of Persons in Household
+            column_key: Gross Monthly Income (GMI)
+  versions:
+  - effective_from: '2011-01-28'
+    values:
+      1: 557
+      2: 777
+      3: 979
+      4: 1178
+      5: 1378
+      6: 1580
+      7: 1780
+      8: 1980
+      9: 2179
+      10: 2381
+      11: 2581
+      12: 2781
+      13: 2980
+      14: 3182
+      15: 3382
+      16: 3582
+      17: 3783
+      18: 3983
+      19: 4183
+      20: 4383
+- name: mt_tanf_net_monthly_income_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: tanf_assistance_unit_size
+  source: ARM 37.78.420(4)(b), Net Monthly Income Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          table:
+            header: NET MONTHLY INCOME STANDARDS (NMI)
+            row_key: household size
+            column_key: net monthly income standard
+  versions:
+  - effective_from: '2011-01-28'
+    values:
+      1: 312
+      2: 420
+      3: 529
+      4: 637
+      5: 745
+      6: 854
+      7: 962
+      8: 1070
+      9: 1178
+      10: 1287
+      11: 1395
+      12: 1503
+      13: 1611
+      14: 1720
+      15: 1828
+      16: 1936
+      17: 2045
+      18: 2153
+      19: 2261
+      20: 2369
+- name: mt_tanf_benefit_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: tanf_assistance_unit_size
+  source: ARM 37.78.420(4)(c), Benefits Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          table:
+            header: BENEFITS STANDARDS
+            row_key: household size
+            column_key: benefit standard
+  versions:
+  - effective_from: '2011-01-28'
+    values:
+      1: 245
+      2: 330
+      3: 415
+      4: 500
+      5: 585
+      6: 670
+      7: 755
+      8: 840
+      9: 925
+      10: 1010
+      11: 1095
+      12: 1180
+      13: 1265
+      14: 1350
+      15: 1435
+      16: 1520
+      17: 1605
+      18: 1690
+      19: 1775
+      20: 1860
+- name: mt_tanf_cash_assistance_payment_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: tanf_assistance_unit_size
+  source: ARM 37.78.420(4)(d), Payment Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          table:
+            header: PAYMENT STANDARDS (33% of the FY 2007 Federal Poverty Level)
+            row_key: household size
+            column_key: payment standard
+  versions:
+  - effective_from: '2011-01-28'
+    values:
+      1: 298
+      2: 401
+      3: 504
+      4: 606
+      5: 709
+      6: 812
+      7: 915
+      8: 1018
+      9: 1121
+      10: 1223
+      11: 1326
+      12: 1429
+      13: 1532
+      14: 1635
+      15: 1738
+      16: 1841
+      17: 1943
+      18: 2046
+      19: 2149
+      20: 2252
+- name: mt_tanf_post_employment_payment_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  indexed_by: tanf_cash_assistance_post_employment_program_month
+  source: ARM 37.78.420(4)(e), Post-Employment Payment Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          table:
+            header: POST-EMPLOYMENT PAYMENT STANDARDS
+            row_key: program month
+            column_key: payment standard
+  versions:
+  - effective_from: '2011-01-28'
+    values:
+      1: 375
+      2: 275
+      3: 175
+- name: mt_tanf_payment_standard
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  unit: USD
+  period: Month
+  source: ARM 37.78.420(1)(d), (4)(d), and (4)(e)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+          excerpt: Payment standards in the Post-Employment Program are a set amount
+            as defined in (4)(e). This amount is not based on household size.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_cash_assistance_payment_standard
+          output: mt_tanf_cash_assistance_payment_standard
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_post_employment_payment_standard
+          output: mt_tanf_post_employment_payment_standard
+          hash: sha256:local
+  versions:
+  - effective_from: '2011-01-28'
+    formula: 'if tanf_cash_assistance_post_employment_program: mt_tanf_post_employment_payment_standard[tanf_cash_assistance_post_employment_program_month]
+      else: mt_tanf_cash_assistance_payment_standard[tanf_assistance_unit_size]'

--- a/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml
+++ b/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml
@@ -16,7 +16,7 @@ rules:
   unit: USD
   period: Month
   indexed_by: tanf_assistance_unit_size
-  source: ARM 37.78.420(4)(a), Gross Monthly Income Standards
+  source: ARM 37.78.420(4)(a), Gross Monthly Income Standards; us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(a)
   metadata:
     proof:
       atoms:
@@ -98,7 +98,7 @@ rules:
   unit: USD
   period: Month
   indexed_by: tanf_assistance_unit_size
-  source: ARM 37.78.420(4)(c), Benefits Standards
+  source: ARM 37.78.420(4)(c), Benefits Standards; us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(c)
   metadata:
     proof:
       atoms:
@@ -139,7 +139,7 @@ rules:
   unit: USD
   period: Month
   indexed_by: tanf_assistance_unit_size
-  source: ARM 37.78.420(4)(d), Payment Standards
+  source: ARM 37.78.420(4)(d), Payment Standards; us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(d)
   metadata:
     proof:
       atoms:
@@ -180,7 +180,7 @@ rules:
   unit: USD
   period: Month
   indexed_by: tanf_cash_assistance_post_employment_program_month
-  source: ARM 37.78.420(4)(e), Post-Employment Payment Standards
+  source: ARM 37.78.420(4)(e), Post-Employment Payment Standards; us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(e)
   metadata:
     proof:
       atoms:


### PR DESCRIPTION
## Summary
- add ARM 37.78.420 Montana TANF income-standard/payment-standard RuleSpec generated by axiom-encode `--apply`
- admit `us-mt` in the country-level RuleSpec repository structure
- bump the RuleSpec toolchain to axiom-encode 0.2.1058 so CI has standalone table grounding and Montana oracle classifications

## Source boundary
- Source: official Montana Administrative Rules corpus provision `us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420`
- Encoder run: `8b62a17d`
- The generated outputs are classified as PolicyEngine known-not-comparable because PolicyEngine's current Montana TANF standards use State Plan/manual FPG-year/rate parameters, while this upstream ARM slice contains fixed tables plus a post-employment branch.

## Tests
- `AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702:/Users/maxghenis/TheAxiomFoundation/rulespec-us AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-mt-tanf-20260702 AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-mt-tanf-20260702/data/corpus uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml --skip-reviewers`
- `AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702:/Users/maxghenis/TheAxiomFoundation/rulespec-us uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-vat-runtime-20260701 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702/us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.test.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=*** uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-mt-tanf-20260702 --base-ref origin/main --head-ref HEAD --roots us-mt --json`
- `uv run --with pytest --with pyyaml python -m pytest -q tests`
- temp CI-shaped `axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-mt-tanf-ci-root --json` check: 6 changed Montana outputs, all `known_not_comparable`, 0 failures
