### PR TITLE
Encode Connecticut TFA statute slices

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1061"
+axiom_encode_version = "0.2.1062"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "21e68a562cf7bffafe07f71039711199e9f19bba"
+axiom_encode_ref = "f4e4b839039c47821d93cfb39962260462358274"
 axiom_corpus_ref = "e17aadc2952ec12ea83703a90e127b099ee931ff"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1059"
+axiom_encode_version = "0.2.1061"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "7272f8647038cc18ac07658000d612564b5326cb"
+axiom_encode_ref = "21e68a562cf7bffafe07f71039711199e9f19bba"
 axiom_corpus_ref = "e17aadc2952ec12ea83703a90e127b099ee931ff"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/programs/us-ct/tanf/fy-2026.yaml
+++ b/programs/us-ct/tanf/fy-2026.yaml
@@ -1,0 +1,121 @@
+# Connecticut Temporary Family Assistance -- FY 2026
+#
+# This program spec composes the Connecticut General Statutes TFA standard-of-need,
+# payment-standard, housing-attribution, resource, income, child-support, and
+# high-earnings slices encoded under us-ct/statutes. Broader demographic,
+# immigration, time-limit, exemption, extension, and application-vs-recipient
+# eligibility gates remain incomplete at this top-level surface.
+
+program: us-ct/tanf
+period: 2026-01
+
+outputs:
+  - ct_tfa_need_standard
+  - ct_tfa_payment_standard
+  - ct_tfa_subsidized_housing_attributed_income
+  - ct_tfa_payment_standard_after_housing_attribution
+  - ct_tfa_resources_eligible
+  - ct_tfa_income_eligible
+  - ct_tfa_eligible
+  - ct_tfa
+
+acknowledged_incomplete:
+  - ct_tfa_income_eligible
+  - ct_tfa_eligible
+  - ct_tfa
+
+scope:
+  state:
+    - statutes/17b-104
+    - statutes/17b-112
+
+transformations:
+  - pattern: derived_formula
+    name: ct_tfa_need_standard
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 standard-of-need bridge
+    formula: temporary_family_assistance_standard_of_need
+
+  - pattern: derived_formula
+    name: ct_tfa_payment_standard
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 payment-standard bridge
+    formula: temporary_family_assistance_payment_standard
+
+  - pattern: derived_formula
+    name: ct_tfa_subsidized_housing_attributed_income
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 subsidized-housing attribution bridge
+    formula: subsidized_housing_attributed_income
+
+  - pattern: derived_formula
+    name: ct_tfa_payment_standard_after_housing_attribution
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 housing-attribution composition
+    formula: max(0, ct_tfa_payment_standard - ct_tfa_subsidized_housing_attributed_income)
+
+  - pattern: derived_formula
+    name: ct_tfa_resources_eligible
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ct/tanf/fy-2026 resource eligibility bridge
+    formula: asset_eligibility
+
+  - pattern: derived_formula
+    name: ct_tfa_income_eligible
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ct/tanf/fy-2026 income eligibility composition
+    formula: |-
+      if family_receiving_temporary_family_assistance: gross_earnings_eligibility else: ct_tfa_countable_income_at_application <= ct_tfa_need_standard
+
+  - pattern: derived_formula
+    name: monthly_award_before_high_earnings_reduction
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 pre-high-earnings award composition
+    formula: max(0, ct_tfa_payment_standard_after_housing_attribution - ct_tfa_countable_unearned_income)
+
+  - pattern: derived_formula
+    name: ct_tfa_eligible
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ct/tanf/fy-2026 financial eligibility composition
+    formula: ct_tfa_resources_eligible and ct_tfa_income_eligible and child_support_cooperation_eligibility
+
+  - pattern: conditional_value
+    name: ct_tfa
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ct/tanf/fy-2026 benefit amount composition
+    condition: ct_tfa_eligible
+    when_true: benefit_after_high_earnings_reduction
+    when_false: 0

--- a/us-ct/.axiom/encoding-manifests/statutes/17b-104.json
+++ b/us-ct/.axiom/encoding-manifests/statutes/17b-104.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/17b-104.yaml",
+      "sha256": "d50a4704d355edd0ccffac4303d07679b6f556f14fda3bedbf1307d6550dff17"
+    },
+    {
+      "path": "statutes/17b-104.test.yaml",
+      "sha256": "cdcba83af7d0b27345f92a5468dbc4a150812e1b70cc14002e1ddbc6e583792b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8d3b5294f8afb68754e2b5215e960150b648c391",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1061",
+    "version_commit": "1e3cdc744065229d9afe616551f3d9865c6cb541"
+  },
+  "axiom_encode_version": "0.2.1061",
+  "backend": "codex",
+  "citation": "us-ct/statute/17b-104",
+  "context_manifest_file": "/tmp/axiom-encode-ct-17b-104/_eval_workspaces/codex-gpt-5.5/us-ct-statute-17b-104/workspace/context-manifest.json",
+  "context_manifest_sha256": "a1d48ae53837fa72cad9b06aea176f6ad4d049719cfb5dd0f9138be525e15caf",
+  "generated_at": "2026-07-02T11:55:59.356281+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ct-17b-104/codex-gpt-5.5/statutes/17b-104.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ct-17b-104",
+  "generated_output_sha256": "d50a4704d355edd0ccffac4303d07679b6f556f14fda3bedbf1307d6550dff17",
+  "generation_prompt_sha256": "4a18adf10269f7ab34d3b9ded9962ecf7c673f138fdc96737f889f9ba2cd5223",
+  "model": "gpt-5.5",
+  "run_id": "7215bf95",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "424a4c950ec36c5e38c1d8d22092cb723ae96cb149cbefe804e7f19eab19a10e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ct-17b-104/traces/codex-gpt-5.5/us-ct-statute-17b-104.json",
+  "trace_sha256": "d9f69c27376d8b6b67fca125204536edfe25451a977b9e7f5c505eeaf4d08c2c"
+}

--- a/us-ct/.axiom/encoding-manifests/statutes/17b-112.json
+++ b/us-ct/.axiom/encoding-manifests/statutes/17b-112.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/17b-112.yaml",
+      "sha256": "539de97f827b9c8ca637ba93a677c217db359231cbdbdb6105072b60d409017e"
+    },
+    {
+      "path": "statutes/17b-112.test.yaml",
+      "sha256": "1f21bdeb09bb8bdcc3b6f9a26c80d55d6cb090901297f8b224a080b4ddfb75c4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "8d3b5294f8afb68754e2b5215e960150b648c391",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1061",
+    "version_commit": "1e3cdc744065229d9afe616551f3d9865c6cb541"
+  },
+  "axiom_encode_version": "0.2.1061",
+  "backend": "codex",
+  "citation": "us-ct/statute/17b-112",
+  "context_manifest_file": "/tmp/axiom-encode-ct-tfa-rerun2/_eval_workspaces/codex-gpt-5.5/us-ct-statute-17b-112/workspace/context-manifest.json",
+  "context_manifest_sha256": "590701271e6e8eb680ca98f448072f78b10d6f97cbdb71f4acf5769fd7e6e9e7",
+  "generated_at": "2026-07-02T11:45:42.207480+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ct-tfa-rerun2/codex-gpt-5.5/statutes/17b-112.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ct-tfa-rerun2",
+  "generated_output_sha256": "539de97f827b9c8ca637ba93a677c217db359231cbdbdb6105072b60d409017e",
+  "generation_prompt_sha256": "ee9122ea337376693055aeaaffdf361ebc77d09dda183f80e3e8d83f0a5ffb5e",
+  "model": "gpt-5.5",
+  "run_id": "62d876bc",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "99d880ba045a6c76d3b8a9c0e26ae0244ad3bec9dfce6a601eb71d9aa4d61c96"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ct-tfa-rerun2/traces/codex-gpt-5.5/us-ct-statute-17b-112.json",
+  "trace_sha256": "a847626382291ccd3286ba76aacf835621e122b42a6496de41a519f1175e9ddf"
+}

--- a/us-ct/statutes/17b-104.test.yaml
+++ b/us-ct/statutes/17b-104.test.yaml
@@ -1,0 +1,21 @@
+- name: tfa_standard_and_payment_standard_from_fpl
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-104#input.federal_poverty_level: 2000
+  output:
+    us-ct:statutes/17b-104#temporary_family_assistance_standard_of_need: 1100
+    us-ct:statutes/17b-104#temporary_family_assistance_payment_standard: 803
+- name: subsidized_housing_attributed_income_applies
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-104#input.family_living_in_subsidized_housing: true
+    us-ct:statutes/17b-104#input.payment_standard_for_family: 1000
+  output:
+    us-ct:statutes/17b-104#subsidized_housing_attributed_income: 80
+- name: subsidized_housing_attributed_income_not_applicable
+  period: 2024-01
+  input:
+    us-ct:statutes/17b-104#input.family_living_in_subsidized_housing: false
+    us-ct:statutes/17b-104#input.payment_standard_for_family: 1000
+  output:
+    us-ct:statutes/17b-104#subsidized_housing_attributed_income: 0

--- a/us-ct/statutes/17b-104.yaml
+++ b/us-ct/statutes/17b-104.yaml
@@ -1,0 +1,143 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-104
+  summary: |-
+    The standard of need for temporary family assistance is fifty-five per cent of the federal poverty level. On and after July 1, 2022, payment standards for families receiving temporary family assistance equal seventy-three per cent of the standards of need. For a family living in subsidized housing, attributed income is eight per cent of the payment standard for such family.
+rules:
+  - name: temporary_family_assistance_standard_of_need_fpl_rate
+    kind: parameter
+    dtype: Rate
+    source: Conn. Gen. Stat. § 17b-104(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "The standard of need for the temporary family assistance program shall be fifty-five per cent of the federal poverty level."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.55
+
+  - name: temporary_family_assistance_payment_standard_rate
+    kind: parameter
+    dtype: Rate
+    source: Conn. Gen. Stat. § 17b-104(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "On and after July 1, 2022, the payment standards ... shall be equal to seventy-three per cent of the standards of need"
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          0.73
+
+  - name: subsidized_housing_attributed_income_rate
+    kind: parameter
+    dtype: Rate
+    source: Conn. Gen. Stat. § 17b-104(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "income shall be attributed ... eight per cent of the payment standard"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.08
+
+  - name: temporary_family_assistance_standard_of_need
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Conn. Gen. Stat. § 17b-104(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "fifty-five per cent of the federal poverty level"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/17b-104#temporary_family_assistance_standard_of_need_fpl_rate
+              output: temporary_family_assistance_standard_of_need_fpl_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          temporary_family_assistance_standard_of_need_fpl_rate * federal_poverty_level
+
+  - name: temporary_family_assistance_payment_standard
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Conn. Gen. Stat. § 17b-104(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "payment standards ... equal to seventy-three per cent of the standards of need"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/17b-104#temporary_family_assistance_payment_standard_rate
+              output: temporary_family_assistance_payment_standard_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/17b-104#temporary_family_assistance_standard_of_need
+              output: temporary_family_assistance_standard_of_need
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          temporary_family_assistance_payment_standard_rate * temporary_family_assistance_standard_of_need
+
+  - name: subsidized_housing_attributed_income
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Conn. Gen. Stat. § 17b-104(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/17b-104
+              excerpt: "For a family living in subsidized housing, income shall be attributed ... eight per cent of the payment standard"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/17b-104#subsidized_housing_attributed_income_rate
+              output: subsidized_housing_attributed_income_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if family_living_in_subsidized_housing: subsidized_housing_attributed_income_rate * payment_standard_for_family else: 0

--- a/us-ct/statutes/17b-112.test.yaml
+++ b/us-ct/statutes/17b-112.test.yaml
@@ -1,0 +1,60 @@
+- name: transitional_earnings_and_reduction_apply
+  period: 2024-02
+  input:
+    us-ct:statutes/17b-112#input.total_gross_earnings: 2200
+    us-ct:statutes/17b-112#input.federal_poverty_level: 1000
+    us-ct:statutes/17b-112#input.transitional_gross_earnings_disregard_applies: true
+    us-ct:statutes/17b-112#input.consecutive_months_since_first_exceeding_fpl: 3
+    us-ct:statutes/17b-112#input.family_assets: 6000
+    us-ct:statutes/17b-112#input.monthly_award_before_high_earnings_reduction: 500
+    us-ct:statutes/17b-112#input.current_child_support_received: 80
+    us-ct:statutes/17b-112#input.family_failed_to_cooperate_with_child_support_enforcement: false
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_thirty_six_month_limit: true
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_sixty_month_limit: false
+  output:
+    us-ct:statutes/17b-112#gross_earnings_eligibility: holds
+    us-ct:statutes/17b-112#asset_eligibility: holds
+    us-ct:statutes/17b-112#benefit_after_high_earnings_reduction: 400
+    us-ct:statutes/17b-112#countable_current_child_support_for_eligibility: 30
+    us-ct:statutes/17b-112#child_support_cooperation_eligibility: holds
+    us-ct:statutes/17b-112#exit_interview_required: holds
+- name: earnings_above_transitional_limit_not_eligible
+  period: 2024-02
+  input:
+    us-ct:statutes/17b-112#input.total_gross_earnings: 2400
+    us-ct:statutes/17b-112#input.federal_poverty_level: 1000
+    us-ct:statutes/17b-112#input.transitional_gross_earnings_disregard_applies: true
+    us-ct:statutes/17b-112#input.consecutive_months_since_first_exceeding_fpl: 3
+    us-ct:statutes/17b-112#input.family_assets: 6001
+    us-ct:statutes/17b-112#input.monthly_award_before_high_earnings_reduction: 500
+    us-ct:statutes/17b-112#input.current_child_support_received: 40
+    us-ct:statutes/17b-112#input.family_failed_to_cooperate_with_child_support_enforcement: false
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_thirty_six_month_limit: false
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_sixty_month_limit: false
+  output:
+    us-ct:statutes/17b-112#gross_earnings_eligibility: not_holds
+    us-ct:statutes/17b-112#asset_eligibility: not_holds
+    us-ct:statutes/17b-112#benefit_after_high_earnings_reduction: 500
+    us-ct:statutes/17b-112#countable_current_child_support_for_eligibility: 0
+    us-ct:statutes/17b-112#child_support_cooperation_eligibility: holds
+    us-ct:statutes/17b-112#exit_interview_required: not_holds
+- name: child_support_noncooperation_blocks_eligibility
+  period: 2024-02
+  input:
+    us-ct:statutes/17b-112#input.total_gross_earnings: 900
+    us-ct:statutes/17b-112#input.federal_poverty_level: 1000
+    us-ct:statutes/17b-112#input.transitional_gross_earnings_disregard_applies: false
+    us-ct:statutes/17b-112#input.consecutive_months_since_first_exceeding_fpl: 0
+    us-ct:statutes/17b-112#input.family_assets: 5000
+    us-ct:statutes/17b-112#input.monthly_award_before_high_earnings_reduction: 500
+    us-ct:statutes/17b-112#input.current_child_support_received: 50
+    us-ct:statutes/17b-112#input.family_failed_to_cooperate_with_child_support_enforcement: true
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_thirty_six_month_limit: false
+    us-ct:statutes/17b-112#input.family_leaving_assistance_at_sixty_month_limit: true
+  output:
+    us-ct:statutes/17b-112#gross_earnings_eligibility: holds
+    us-ct:statutes/17b-112#asset_eligibility: holds
+    us-ct:statutes/17b-112#benefit_after_high_earnings_reduction: 500
+    us-ct:statutes/17b-112#countable_current_child_support_for_eligibility: 0
+    us-ct:statutes/17b-112#child_support_cooperation_eligibility: not_holds
+    us-ct:statutes/17b-112#exit_interview_required: holds

--- a/us-ct/statutes/17b-112.yaml
+++ b/us-ct/statutes/17b-112.yaml
@@ -1,0 +1,345 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-112
+  summary: DSS administers temporary family assistance; benefits are limited to thirty-six
+    months except for exemptions and extensions. Eligibility rules include earnings,
+    self-employment, asset, child-support, pilot-program, and job-training-stipend
+    disregards. Families must cooperate with child support enforcement. Families leaving
+    assistance at the thirty-six-month or sixty-month limit receive an interview and
+    benefit/service determinations.
+  deferred_outputs:
+  - output: us-ct:statutes/17b-112/b#time_limited_benefit_exemption
+    reason: Exemption categories require commissioner-defined incapacity, advanced
+      age, unemployability, household caretaker composition, minor-parent school completion,
+      and postpartum medical determinations not represented by a faithful local executable
+      surface in this parent artifact.
+  - output: us-ct:statutes/17b-112/c#six_month_extension_eligibility
+    reason: Extension eligibility depends on petition process, good-faith compliance,
+      federal poverty level income after earned-income disregard, family/adult barriers,
+      domestic violence, medical impairments, caregiving responsibilities, and federal
+      sixty-month TANF counting mechanics; encode in a dedicated subsection artifact.
+  - output: us-ct:statutes/17b-112/g#annual_cost_of_living_adjustment
+    reason: Cost-of-living adjustment depends on fiscal-year lapsed funds, CPI-U increase,
+      enacted budget contents, and budget-deficiency projections outside the current
+      executable facts.
+  - output: us-ct:statutes/17b-112/h#hearing_right
+    reason: Hearing process is governed by section 17b-60 and is procedural rather
+      than a benefit amount or eligibility formula in this source slice.
+rules:
+- name: tfa_time_limited_benefit_month_limit
+  kind: parameter
+  dtype: Count
+  source: 17b-112(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: benefits shall be provided to a family for not longer than thirty-six
+            months
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '36'
+- name: gross_earnings_fpl_limit_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: total gross earnings exceeding the federal poverty level
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1'
+- name: self_employment_standard_deduction_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: standard deduction equivalent to fifty-one per cent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.51'
+- name: asset_eligibility_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: assets exceed six thousand dollars
+  versions:
+  - effective_from: '2023-10-01'
+    formula: '6000'
+- name: current_child_support_monthly_disregard
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: disregard the first fifty dollars per month of income attributable
+            to current child support
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '50'
+- name: transitional_gross_earnings_disregard_month_limit
+  kind: parameter
+  dtype: Count
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: for a period not to exceed six consecutive months
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '6'
+- name: transitional_gross_earnings_disregard_limit_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: not to exceed two hundred thirty per cent of the federal poverty
+            level
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '2.30'
+- name: benefit_reduction_lower_earnings_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: between one hundred seventy-one per cent and two hundred thirty
+            per cent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '1.71'
+- name: benefit_reduction_upper_earnings_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: between one hundred seventy-one per cent and two hundred thirty
+            per cent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '2.30'
+- name: high_earnings_benefit_reduction_rate
+  kind: parameter
+  dtype: Rate
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: reduce the household's benefit by twenty per cent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: '0.20'
+- name: pilot_program_disregard_month_limit
+  kind: parameter
+  dtype: Count
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: not to exceed thirty-six cumulative months
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '36'
+- name: job_training_stipend_disregard_month_limit
+  kind: parameter
+  dtype: Count
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: not to exceed thirty-six cumulative months
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '36'
+- name: gross_earnings_eligibility
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: no family shall be eligible that has total gross earnings exceeding
+            the federal poverty level
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: for a period not to exceed six consecutive months ... not to exceed
+            two hundred thirty per cent of the federal poverty level
+  versions:
+  - effective_from: '2024-01-01'
+    formula: "total_gross_earnings <= federal_poverty_level * gross_earnings_fpl_limit_rate\n\
+      or (\n  transitional_gross_earnings_disregard_applies\n  and consecutive_months_since_first_exceeding_fpl\
+      \ <= transitional_gross_earnings_disregard_month_limit\n  and total_gross_earnings\
+      \ <= federal_poverty_level * transitional_gross_earnings_disregard_limit_rate\n\
+      )"
+- name: asset_eligibility
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: shall not deny a family assistance ... on the basis of such family's
+            assets unless such assets exceed six thousand dollars
+  versions:
+  - effective_from: '2023-10-01'
+    formula: family_assets <= asset_eligibility_limit
+- name: benefit_after_high_earnings_reduction
+  kind: derived
+  entity: Family
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: If a family's total gross earnings are an amount between one hundred
+            seventy-one per cent and two hundred thirty per cent ... reduce the household's
+            benefit by twenty per cent
+  versions:
+  - effective_from: '2024-01-01'
+    formula: 'if total_gross_earnings >= federal_poverty_level * benefit_reduction_lower_earnings_rate
+      and total_gross_earnings <= federal_poverty_level * benefit_reduction_upper_earnings_rate:
+      max(0, monthly_award_before_high_earnings_reduction - monthly_award_before_high_earnings_reduction
+      * high_earnings_benefit_reduction_rate) else: max(0, monthly_award_before_high_earnings_reduction)'
+- name: countable_current_child_support_for_eligibility
+  kind: derived
+  entity: Family
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 17b-112(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: disregard the first fifty dollars per month of income attributable
+            to current child support ... in determining eligibility
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, current_child_support_received - current_child_support_monthly_disregard)
+- name: child_support_cooperation_eligibility
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: 17b-112(e)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: A family shall be ineligible for benefits for failure to cooperate
+            with child support enforcement.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: not family_failed_to_cooperate_with_child_support_enforcement
+- name: exit_interview_required
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: 17b-112(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-ct/statute/17b-112
+          excerpt: A family leaving assistance at the end of ... said thirty-six-month
+            time limit, or ... the sixty-month limit shall have an interview
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'family_leaving_assistance_at_thirty_six_month_limit
+
+      or family_leaving_assistance_at_sixty_month_limit'


### PR DESCRIPTION
## Summary
- encode Connecticut TFA statutory slices from Conn. Gen. Stat. 17b-104 and 17b-112
- add a FY 2026 CT TANF/TFA program bridge that composes the source-law standard of need, payment standard, housing attribution, resource/income gates, child-support cooperation, and high-earnings reduction while explicitly acknowledging incomplete top-level eligibility pieces
- bump the validation toolchain to TheAxiomFoundation/axiom-encode#948 so oracle coverage sees CT TFA as known-not-comparable rather than falsely pending or comparable

## Validation
- AXIOM_CORPUS_REPO=/tmp/axiom-corpus-ct-tfa uv run axiom-encode validate --skip-reviewers us-ct/statutes/17b-104.yaml us-ct/statutes/17b-112.yaml
- AXIOM_CORPUS_REPO=/tmp/axiom-corpus-ct-tfa uv run axiom-encode proof-validate us-ct/statutes/17b-104.yaml us-ct/statutes/17b-112.yaml
- AXIOM_CORPUS_REPO=/tmp/axiom-corpus-ct-tfa uv run axiom-encode test --root . us-ct/statutes/17b-104.test.yaml us-ct/statutes/17b-112.test.yaml
- AXIOM_CORPUS_REPO=/tmp/axiom-corpus-ct-tfa uv run pytest tests
- uv run axiom-encode guard-generated --repo . --base-ref origin/main --head-ref HEAD
- uv run axiom-encode oracle-coverage --root . --oracle policyengine --include-program-surfaces --limit 20

Depends on TheAxiomFoundation/axiom-encode#948.
