### PR TITLE
Add Texas TANF proration bridge

### DIFF
--- a/programs/us-tx/tanf/fy-2026.yaml
+++ b/programs/us-tx/tanf/fy-2026.yaml
@@ -1,0 +1,48 @@
+# Texas TANF -- FY 2026
+#
+# This program spec exposes Texas Works Handbook TANF rules already encoded
+# under us-tx/policies/hhs/texas-works-handbook. The current bridge covers the
+# C-111 payment-standard table, A-1340 grant amount rule, and C-112 first-month
+# proration. Broader nonfinancial eligibility, resource, sanction, time-limit,
+# and full income-budget gates remain incomplete at this top-level surface.
+
+program: us-tx/tanf
+period: 2026-01
+
+outputs:
+  - tx_tanf_payment_standard
+  - recommended_tanf_grant_amount
+  - tanf_first_month_grant_amount
+  - tx_tanf
+
+acknowledged_incomplete:
+  - recommended_tanf_grant_amount
+  - tanf_first_month_grant_amount
+  - tx_tanf
+
+scope:
+  state:
+    - policies/hhs/texas-works-handbook/c-110-tanf/block-2
+    - policies/hhs/texas-works-handbook/a-1340-income-limits/block-16
+    - policies/hhs/texas-works-handbook/c-110-tanf
+
+transformations:
+  - pattern: derived_formula
+    name: maximum_grant_amount_allowed_for_household_size_and_composition
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-tx/tanf/fy-2026 payment-standard bridge
+    formula: tx_tanf_payment_standard
+
+  - pattern: derived_formula
+    name: recommended_tanf_grant_amount_for_month
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-tx/tanf/fy-2026 proration input bridge
+    formula: recommended_tanf_grant_amount

--- a/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/c-110-tanf.json
+++ b/us-tx/.axiom/encoding-manifests/policies/hhs/texas-works-handbook/c-110-tanf.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/hhs/texas-works-handbook/c-110-tanf.yaml",
+      "sha256": "6d0cfb285e2d2b91b9c723719089a56f3f6ff77955294f34bf483cca3bd665e0"
+    },
+    {
+      "path": "policies/hhs/texas-works-handbook/c-110-tanf.test.yaml",
+      "sha256": "8e1cdf29a53c304a7610e2e150757362be4a4b27791321f17c6a98df191c4350"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f4e4b839039c47821d93cfb39962260462358274",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1062",
+    "version_commit": "f4e4b839039c47821d93cfb39962260462358274"
+  },
+  "axiom_encode_version": "0.2.1062",
+  "backend": "codex",
+  "citation": "us-tx/manual/hhs/texas-works-handbook/c-110-tanf",
+  "context_manifest_file": "/tmp/axiom-encode-tx-c-110-tanf/_eval_workspaces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-c-110-tanf/workspace/context-manifest.json",
+  "context_manifest_sha256": "56a93be7672b195850f731f70637e9202f5c920248ed4c17fdb521d47a4d2133",
+  "generated_at": "2026-07-02T12:42:49.986385+00:00",
+  "generated_output_file": "/tmp/axiom-encode-tx-c-110-tanf/codex-gpt-5.5/policies/hhs/texas-works-handbook/c-110-tanf.yaml",
+  "generated_output_root": "/tmp/axiom-encode-tx-c-110-tanf",
+  "generated_output_sha256": "6d0cfb285e2d2b91b9c723719089a56f3f6ff77955294f34bf483cca3bd665e0",
+  "generation_prompt_sha256": "d03dfb9ffeedd61604199874af6d8dd50f7cfa7e2a80dd67040e5856cba4fcbe",
+  "model": "gpt-5.5",
+  "run_id": "6a64f88a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3e4d16af5944e31757c6270c87c9a703691cd95cfbb6cd4e7680f1a7b07df6ec"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-tx-c-110-tanf/traces/codex-gpt-5.5/us-tx-manual-hhs-texas-works-handbook-c-110-tanf.json",
+  "trace_sha256": "3deffebcdbdfdec83f354e8cb7a359a828c10787069289bf2b5a3accf10fdf11"
+}

--- a/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.test.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.test.yaml
@@ -1,0 +1,36 @@
+- name: regular_tanf_first_day_not_reduced
+  period: 2025-10
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.recommended_tanf_grant_amount_for_month: 331
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.date_financial_eligibility_begins_day: 1
+    ? us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.tanf_payment_is_one_time_tanf_or_one_time_tanf_for_relatives_payment
+    : false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#tanf_first_month_grant_amount: 331
+- name: regular_tanf_mid_month_prorated_and_floored
+  period: 2025-10
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.recommended_tanf_grant_amount_for_month: 331
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.date_financial_eligibility_begins_day: 15
+    ? us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.tanf_payment_is_one_time_tanf_or_one_time_tanf_for_relatives_payment
+    : false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#tanf_first_month_grant_amount: 175
+- name: regular_tanf_below_ten_dollars_no_first_month_grant
+  period: 2025-10
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.recommended_tanf_grant_amount_for_month: 130
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.date_financial_eligibility_begins_day: 29
+    ? us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.tanf_payment_is_one_time_tanf_or_one_time_tanf_for_relatives_payment
+    : false
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#tanf_first_month_grant_amount: 0
+- name: one_time_tanf_not_prorated
+  period: 2025-10
+  input:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.recommended_tanf_grant_amount_for_month: 130
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.date_financial_eligibility_begins_day: 29
+    ? us-tx:policies/hhs/texas-works-handbook/c-110-tanf#input.tanf_payment_is_one_time_tanf_or_one_time_tanf_for_relatives_payment
+    : true
+  output:
+    us-tx:policies/hhs/texas-works-handbook/c-110-tanf#tanf_first_month_grant_amount: 130

--- a/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml
+++ b/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml
@@ -1,0 +1,139 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us-tx/statute/hr/31.003
+        - us-tx/statute/hr/31.043
+      rationale: Texas Human Resources Code delegates TANF financial assistance amount rules and budgeting methods to HHSC; the Texas Works Handbook is the operative HHSC parameter and proration source for these TANF grant calculations.
+  summary: |-
+    C-111 lists TANF Budgetary Allowances effective Oct. 1, 2025. C-112 provides that after eligibility is determined, the TANF grant amount is prorated for the first month by multiplying the recommended grant by the C-112.1 multiplier, rounding down to the next dollar, and denying a first-month grant if the result is less than $10. One-Time TANF and One-Time TANF for Relatives payments are not prorated.
+imports:
+rules:
+  - name: proration_file_date_day_limit
+    kind: parameter
+    dtype: Count
+    source: Texas Works Handbook C-112, Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+              excerpt: "Determine the earlier of the certification date or the 30th day after the file date."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          30
+
+  - name: first_month_minimum_prorated_grant
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-112, Step 4
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+              excerpt: "If the resulting prorated grant is less than $10, the household is not eligible for a grant in the first month."
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          10
+
+  - name: tanf_proration_multiplier_by_financial_eligibility_begin_day
+    kind: parameter
+    dtype: Rate
+    indexed_by: date_financial_eligibility_begins_day
+    source: Texas Works Handbook C-112.1, Proration Multiplier Chart
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+              table:
+                header: "Date Financial Eligibility Begins Proration Multiplier"
+                row_key: "Date Financial Eligibility Begins"
+                column_key: "Proration Multiplier"
+    versions:
+      - effective_from: '2001-10-01'
+        values:
+          1: 1
+          2: 0.97
+          3: 0.93
+          4: 0.90
+          5: 0.87
+          6: 0.83
+          7: 0.80
+          8: 0.77
+          9: 0.73
+          10: 0.70
+          11: 0.67
+          12: 0.63
+          13: 0.60
+          14: 0.57
+          15: 0.53
+          16: 0.50
+          17: 0.47
+          18: 0.43
+          19: 0.40
+          20: 0.37
+          21: 0.33
+          22: 0.30
+          23: 0.27
+          24: 0.23
+          25: 0.20
+          26: 0.17
+          27: 0.13
+          28: 0.10
+          29: 0.07
+          30: 0.03
+          31: 0.03
+
+  - name: tanf_first_month_grant_amount
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Texas Works Handbook C-112, How to Prorate TANF Grants
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+              excerpt: "Multiply the recommended grant amount from Step 1 by the multiplier from Step 2. Round the amount from Step 3 down to the next dollar."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-tx/manual/hhs/texas-works-handbook/c-110-tanf
+              excerpt: "One-Time TANF and One-Time TANF for Relatives payments are not prorated."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf#tanf_proration_multiplier_by_financial_eligibility_begin_day
+              output: tanf_proration_multiplier_by_financial_eligibility_begin_day
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-tx:policies/hhs/texas-works-handbook/c-110-tanf#first_month_minimum_prorated_grant
+              output: first_month_minimum_prorated_grant
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          if tanf_payment_is_one_time_tanf_or_one_time_tanf_for_relatives_payment: recommended_tanf_grant_amount_for_month else: if floor(recommended_tanf_grant_amount_for_month * tanf_proration_multiplier_by_financial_eligibility_begin_day[date_financial_eligibility_begins_day]) < first_month_minimum_prorated_grant: 0 else: floor(recommended_tanf_grant_amount_for_month * tanf_proration_multiplier_by_financial_eligibility_begin_day[date_financial_eligibility_begins_day])


### PR DESCRIPTION
## Summary
- add a Texas TANF FY 2026 program bridge over existing Texas Works Handbook C-111 and A-1340 RuleSpec slices
- add the signed `axiom-encode --apply` output for C-110/C-112 first-month TANF proration
- expose payment standard, recommended grant, first-month grant, and final `tx_tanf` as acknowledged-incomplete program outputs

## Verification
- `uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml`
- `uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702/us-tx/policies/hhs/texas-works-handbook/c-110-tanf.test.yaml`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702 --base-ref origin/main --head-ref HEAD --roots us-tx --json`

## Notes
- The program bridge remains intentionally incomplete for nonfinancial eligibility, resource, sanction, time-limit, and full income-budget gates.
- Paired axiom-encode PR wires the PolicyEngine program-surface manifest/mapping so `tx_tanf` leaves the pending queue.
