### PR TITLE
Add Utah FEP payment standard RuleSpec

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -33,6 +33,7 @@ allowed_root_directories:
   - us-sc
   - us-tn
   - us-tx
+  - us-ut
   - us-wa
   - us-wy
 allowed_root_files:

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1062"
+axiom_encode_version = "0.2.1064"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "f4e4b839039c47821d93cfb39962260462358274"
-axiom_corpus_ref = "e17aadc2952ec12ea83703a90e127b099ee931ff"
+axiom_encode_ref = "0c4cb16e3811a7fb54fa85ccbcbb33729030c7d6"
+axiom_corpus_ref = "45e32314143e9ac714ea9911adfbe6e7d828fa0f"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/us-ut/.axiom/encoding-manifests/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.json
+++ b/us-ut/.axiom/encoding-manifests/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml",
+      "sha256": "8431222069db54be192fea6631dce8be7b1e335b3a27d99c77fb4a955e861b02"
+    },
+    {
+      "path": "policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.test.yaml",
+      "sha256": "ce31ae4c9bd04eaf9a90e5b01ec2c5fbdeebaa6fad91b2741ea2ce83a7694484"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db2c053ca0d8668f7f9f0e1e54c997afed1c64f3",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1063",
+    "version_commit": "db2c053ca0d8668f7f9f0e1e54c997afed1c64f3"
+  },
+  "axiom_encode_version": "0.2.1063",
+  "backend": "codex",
+  "citation": "us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits",
+  "context_manifest_file": "/tmp/axiom-encode-ut-fep-20260702-with-reg/_eval_workspaces/codex-gpt-5.5/us-ut-policies-dws-eligibility-manual-table-1-financial-monthly-income-limits/workspace/context-manifest.json",
+  "context_manifest_sha256": "784c45dcca7a9097d29bfa5503ba0477ff7314f49c3abcbc6145c15ce7452f13",
+  "generated_at": "2026-07-02T13:43:17.924924+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ut-fep-20260702-with-reg/codex-gpt-5.5/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ut-fep-20260702-with-reg",
+  "generated_output_sha256": "8431222069db54be192fea6631dce8be7b1e335b3a27d99c77fb4a955e861b02",
+  "generation_prompt_sha256": "c4fab9bde9dd9dfd1de0cecf5235361faa38733acc0a8edc9363277f6fb1ce01",
+  "model": "gpt-5.5",
+  "run_id": "146bd5b6",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b6c3aa5b8ca67fb96157da8f3913a7e3cfab8c41f9a0f4efaf272f17ff4a41a0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ut-fep-20260702-with-reg/traces/codex-gpt-5.5/us-ut-policies-dws-eligibility-manual-table-1-financial-monthly-income-limits.json",
+  "trace_sha256": "533098b46cc38434e69023706a8272f20eda0048ffb162c762332ba7896ba8ac"
+}

--- a/us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.test.yaml
+++ b/us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.test.yaml
@@ -1,0 +1,18 @@
+- name: household_size_1_fep_payment_standard
+  period: 2024-01
+  input:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#input.household_size: 1
+  output:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#ut_fep_payment_standard: 383
+- name: household_size_2_fep_payment_standard_not_wte_ga
+  period: 2024-01
+  input:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#input.household_size: 2
+  output:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#ut_fep_payment_standard: 531
+- name: household_size_16_fep_payment_standard
+  period: 2024-01
+  input:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#input.household_size: 16
+  output:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#ut_fep_payment_standard: 1450

--- a/us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml
+++ b/us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-ut/regulation/admin-rules/r986/200/block-1
+      rationale: |-
+        Utah Admin. Code R986-200-239 provides the FEP financial-assistance framework and states that the Standard Needs Budget and payment standard percentage are determined by the Department. The DWS eligibility manual Table 1 is therefore used as the Department-published monthly table for the FEP/FEP-TP payment-standard dollar values.
+  summary: |-
+    Table 1 lists monthly amounts by Household Size for Gross Test (185% of Adjusted SNB), Net Test/SNB, and Max. Assistance. The FEP/FEP-TP Max. Assistance column is headed "87.5% of SNB" and includes household-size amounts from 1 through 16.
+rules:
+  - name: gross_income_test_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: household_size
+    source: DWS Eligibility Manual Table 1, Gross Test column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2
+              table:
+                header: Household Size Gross Test (Test 1) 185% of Adjusted Standard Needs Budget (SNB)
+                row_key: household_size
+                column_key: gross_test_185_percent_adjusted_snb
+              excerpt: "1 608 ... 16 2301"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 608
+          2: 843
+          3: 1050
+          4: 1230
+          5: 1400
+          6: 1542
+          7: 1615
+          8: 1690
+          9: 1770
+          10: 1844
+          11: 1920
+          12: 1996
+          13: 2072
+          14: 2147
+          15: 2225
+          16: 2301
+  - name: net_income_test_snb
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: household_size
+    source: DWS Eligibility Manual Table 1, Net Test/SNB column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2
+              table:
+                header: Household Size Net Test (Test 2) SNB
+                row_key: household_size
+                column_key: net_test_snb
+              excerpt: "1 329 ... 16 1244"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 329
+          2: 456
+          3: 568
+          4: 665
+          5: 757
+          6: 834
+          7: 873
+          8: 914
+          9: 957
+          10: 997
+          11: 1038
+          12: 1079
+          13: 1120
+          14: 1161
+          15: 1203
+          16: 1244
+  - name: fep_fep_tp_max_assistance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: household_size
+    source: DWS Eligibility Manual Table 1, FEP/FEP-TP Max. Assistance column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2
+              table:
+                header: Household Size Max. Assistance (Test 3) FEP/FEP-TP 87.5% of SNB
+                row_key: household_size
+                column_key: fep_fep_tp_max_assistance
+              excerpt: "1 608 329 383 ... 16 2301 1244 1450"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 383
+          2: 531
+          3: 662
+          4: 775
+          5: 882
+          6: 972
+          7: 1017
+          8: 1065
+          9: 1116
+          10: 1162
+          11: 1210
+          12: 1258
+          13: 1306
+          14: 1354
+          15: 1403
+          16: 1450
+  - name: ut_fep_payment_standard
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: DWS Eligibility Manual Table 1, FEP/FEP-TP Max. Assistance column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2
+              excerpt: "Max. Assistance (Test 3) FEP/FEP-TP 87.5% of SNB"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#fep_fep_tp_max_assistance
+              output: fep_fep_tp_max_assistance
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          fep_fep_tp_max_assistance[household_size]


### PR DESCRIPTION
## Summary
- add the generated Utah FEP/FEP-TP Table 1 payment-standard RuleSpec
- include companion tests for household sizes 1, 2, and 16, including the guard against the WTE/GA column mix-up
- record the higher-authority source check against Utah Admin. Code R986-200, with the Department manual table used for delegated payment-standard dollar values

Depends on TheAxiomFoundation/axiom-corpus#163 for the official Utah R986-200 corpus source.

## Verification
- uv run axiom-encode compile us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-clean-20260702 --json
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ut-fep-20260702 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-clean-20260702 us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.test.yaml --json
- uv run axiom-encode validate us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml --skip-reviewers --json
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ut-fep-20260702 --base-ref origin/main --head-ref HEAD --json
- uv run pytest /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ut-fep-20260702/tests -q
