### PR TITLE
Add Utah FEP resource and section 204 eligibility rules

### DIFF
--- a/.axiom/encoding-manifests/us-ut/regulations/admin-rules/r986/200/230.json
+++ b/.axiom/encoding-manifests/us-ut/regulations/admin-rules/r986/200/230.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ut/regulations/admin-rules/r986/200/230.yaml",
+      "sha256": "1290997aa575221ef9b6b28ee8b68f78b9c94eb9839ca37d2f818702610fed90"
+    },
+    {
+      "path": "us-ut/regulations/admin-rules/r986/200/230.test.yaml",
+      "sha256": "2cbbd6b2ce26ec623a4b9f10901b9ef0e26ff8c975f45a4694e5ee0e2f6cd7a2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "a3269d03ef94bd46972a6e4396ed7b732bc74c62",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1067",
+    "version_commit": "a3269d03ef94bd46972a6e4396ed7b732bc74c62"
+  },
+  "axiom_encode_version": "0.2.1067",
+  "backend": "deterministic",
+  "citation": "us-ut:regulations/admin-rules/r986/200/230",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T22:14:12.550562+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp21e7yl_0/deterministic-repair/us-ut/regulations/admin-rules/r986/200/230.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp21e7yl_0",
+  "generated_output_sha256": "1290997aa575221ef9b6b28ee8b68f78b9c94eb9839ca37d2f818702610fed90",
+  "generation_prompt_sha256": null,
+  "model": "oracle-parameter-test-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "728ae484b30d8e3260e4c372a9165e87ad1153355822e30d30d3e38d67a518a2"
+  },
+  "tool": "axiom-encode repair-oracle-parameter-tests",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1064"
+axiom_encode_version = "0.2.1067"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "0c4cb16e3811a7fb54fa85ccbcbb33729030c7d6"
+axiom_encode_ref = "a3269d03ef94bd46972a6e4396ed7b732bc74c62"
 axiom_corpus_ref = "45e32314143e9ac714ea9911adfbe6e7d828fa0f"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-ut/.axiom/encoding-manifests/regulations/admin-rules/r986/200/204.json
+++ b/us-ut/.axiom/encoding-manifests/regulations/admin-rules/r986/200/204.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/admin-rules/r986/200/204.yaml",
+      "sha256": "cdcc2537ac9c7fcbc0ffd5478b5e86f473a7af6b1db460832d6836c64a694696"
+    },
+    {
+      "path": "regulations/admin-rules/r986/200/204.test.yaml",
+      "sha256": "6c5fb966ac24b898a0c7e374128e2499f466517c50cf684df9885f6a26048703"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6fc553b0799204c53a50c6dc74e0906f1430c9d2",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1066",
+    "version_commit": "6fc553b0799204c53a50c6dc74e0906f1430c9d2"
+  },
+  "axiom_encode_version": "0.2.1066",
+  "backend": "codex",
+  "citation": "us-ut:regulations/admin-rules/r986/200/204",
+  "context_manifest_file": "/tmp/axiom-encode-ut-fep-204-strict-20260702/_eval_workspaces/codex-gpt-5.5/us-ut-regulations-admin-rules-r986-200-204/workspace/context-manifest.json",
+  "context_manifest_sha256": "24bf8c177fc0a6d851f9d3281a50c33e0f7ffe23de08392451b637f21615e814",
+  "generated_at": "2026-07-02T21:27:09.290828+00:00",
+  "generated_output_file": "/tmp/axiom-encode-ut-fep-204-strict-20260702/codex-gpt-5.5/regulations/admin-rules/r986/200/204.yaml",
+  "generated_output_root": "/tmp/axiom-encode-ut-fep-204-strict-20260702",
+  "generated_output_sha256": "cdcc2537ac9c7fcbc0ffd5478b5e86f473a7af6b1db460832d6836c64a694696",
+  "generation_prompt_sha256": "e261ac34b457a0c107fbcbe3d35369366b627dcd18188d04541d886958f7358a",
+  "model": "gpt-5.5",
+  "run_id": "ca295a97",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5c0c8c447c19c1434648dc77e6f9b2726bab16b60e6101600d647caea0cdc6ca"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-ut-fep-204-strict-20260702/traces/codex-gpt-5.5/us-ut-regulations-admin-rules-r986-200-204.json",
+  "trace_sha256": "3382b6fc312c31debbd9eefdb16c623841264bc417d9a71e1a718026a2a111b5"
+}

--- a/us-ut/.axiom/encoding-manifests/regulations/admin-rules/r986/200/230.json
+++ b/us-ut/.axiom/encoding-manifests/regulations/admin-rules/r986/200/230.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/admin-rules/r986/200/230.yaml",
+      "sha256": "1290997aa575221ef9b6b28ee8b68f78b9c94eb9839ca37d2f818702610fed90"
+    },
+    {
+      "path": "regulations/admin-rules/r986/200/230.test.yaml",
+      "sha256": "59820ce76b43e0212b3a9c86ab76fcb19d5f46887c5a53f7932f49a862dd32c8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "6fc553b0799204c53a50c6dc74e0906f1430c9d2",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1066",
+    "version_commit": "6fc553b0799204c53a50c6dc74e0906f1430c9d2"
+  },
+  "axiom_encode_version": "0.2.1066",
+  "backend": "deterministic",
+  "citation": "us-ut:regulations/admin-rules/r986/200/230",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-02T21:46:36.647040+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8_efckrf/deterministic-repair/regulations/admin-rules/r986/200/230.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8_efckrf",
+  "generated_output_sha256": "1290997aa575221ef9b6b28ee8b68f78b9c94eb9839ca37d2f818702610fed90",
+  "generation_prompt_sha256": null,
+  "model": "source-proof-atom-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "729f7679bc3e8d6968f648b0926147e8145de4a6af39d1aa9f6f7b660254746e"
+  },
+  "tool": "axiom-encode repair-missing-source-proofs",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ut/regulations/admin-rules/r986/200/204.test.yaml
+++ b/us-ut/regulations/admin-rules/r986/200/204.test.yaml
@@ -1,0 +1,102 @@
+- name: qualifying minor dependent child meets section 204 component
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: false
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 3
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : false
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 1
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: false
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: false
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: false
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: holds
+- name: qualifying pregnancy meets demographic requirement
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: true
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 3
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : true
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 0
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: false
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: false
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: false
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: holds
+- name: no qualifying pregnancy or minor dependent child fails section 204 component
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: false
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 4
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : false
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 0
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: false
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: false
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: false
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: not_holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: not_holds
+- name: fleeing felony prosecution blocks section 204 component
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: false
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 3
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : false
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 1
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: false
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: false
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: not_holds
+- name: parole or probation violation blocks section 204 component
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: false
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 3
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : false
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 1
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: false
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: true
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: false
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: not_holds
+- name: same-month parent tanf from another state or tribe blocks section 204 component
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/204#input.household_has_medically_verified_pregnant_woman: false
+    us-ut:regulations/admin-rules/r986/200/204#input.pregnant_woman_calendar_months_prior_to_expected_delivery: 3
+    ? us-ut:regulations/admin-rules/r986/200/204#input.unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+    : false
+    us-ut:regulations/admin-rules/r986/200/204#input.qualifying_minor_dependent_child_count: 1
+    us-ut:regulations/admin-rules/r986/200/204#input.school_age_minor_children_attend_school_or_are_exempt: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_satisfies_other_fep_and_r986_100_eligibility_requirements: true
+    us-ut:regulations/admin-rules/r986/200/204#input.application_completion_requirement_met: true
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_fleeing_felony_prosecution: false
+    us-ut:regulations/admin-rules/r986/200/204#input.household_contains_person_violating_parole_or_probation: false
+    us-ut:regulations/admin-rules/r986/200/204#input.parent_received_same_month_tanf_from_other_state_or_tribe: true
+  output:
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_demographic_requirement_met: holds
+    us-ut:regulations/admin-rules/r986/200/204#ut_fep_or_feptp_204_eligibility_component_met: not_holds

--- a/us-ut/regulations/admin-rules/r986/200/204.yaml
+++ b/us-ut/regulations/admin-rules/r986/200/204.yaml
@@ -1,0 +1,237 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+  summary: |-
+    R986-200-204. Eligibility Requirements. To be eligible for financial assistance under FEP or FEPTP a household assistance unit must include a qualifying pregnancy or at least one minor dependent child who is a citizen or meets alienage criteria. Households must meet other eligibility requirements of income, assets, and participation; persons fleeing felony prosecution or violating parole or probation are ineligible; required clients must complete orientation, agreement, and employment-plan steps within 30 days; and same-month TANF-funded assistance to a parent from another state or tribe makes the entire household ineligible in Utah for that month.
+rules:
+  - name: qualifying_pregnancy_months_before_expected_delivery
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: third calendar month prior to the expected month of delivery
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          3
+
+  - name: required_minor_dependent_child_count
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: at least one minor dependent child
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          1
+
+  - name: school_attendance_minimum_age
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: minor children age 6 to 16 must attend school
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          6
+
+  - name: school_attendance_maximum_age
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: minor children age 6 to 16 must attend school
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          16
+
+  - name: minor_child_age_limit
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: under the age of 18 years and not emancipated
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          18
+
+  - name: older_student_child_minimum_age
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: at least 18 years old but under 19 years old
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          18
+
+  - name: older_student_child_age_limit
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(1)(b)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: at least 18 years old but under 19 years old
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          19
+
+  - name: application_completion_deadline_days
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: R986-200-204(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: within 30 days of submitting his or her application
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          30
+
+  - name: ut_fep_or_feptp_demographic_requirement_met
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: R986-200-204(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: a pregnant woman when it has been medically verified
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: at least one minor dependent child who is a citizen or meets the alienage criteria
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: minor children age 6 to 16 must attend school, or be exempt
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          (
+            household_has_medically_verified_pregnant_woman
+            and pregnant_woman_calendar_months_prior_to_expected_delivery <= qualifying_pregnancy_months_before_expected_delivery
+            and unborn_child_if_born_and_living_with_woman_in_month_of_payment_would_be_eligible
+          )
+          or (
+            qualifying_minor_dependent_child_count >= required_minor_dependent_child_count
+            and school_age_minor_children_attend_school_or_are_exempt
+          )
+
+  - name: ut_fep_or_feptp_204_eligibility_component_met
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: R986-200-204(1)-(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: Households must meet other eligibility requirements of income, assets, and participation
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: fleeing to avoid prosecution of a felony
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: violating parole or probation for a felony or a misdemeanor
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: application for assistance will not be complete until the client has attended the meeting
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: parent ... received TANF funded financial assistance benefits from another state or from a tribe
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          ut_fep_or_feptp_demographic_requirement_met
+          and household_satisfies_other_fep_and_r986_100_eligibility_requirements
+          and application_completion_requirement_met
+          and not household_contains_person_fleeing_felony_prosecution
+          and not household_contains_person_violating_parole_or_probation
+          and not parent_received_same_month_tanf_from_other_state_or_tribe

--- a/us-ut/regulations/admin-rules/r986/200/230.test.yaml
+++ b/us-ut/regulations/admin-rules/r986/200/230.test.yaml
@@ -1,0 +1,12 @@
+- name: countable available assets at resource limit are eligible
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/230#input.countable_available_asset_equity_value_on_first_day_of_month: 2000
+  output:
+    us-ut:regulations/admin-rules/r986/200/230#ut_fep_resources_eligible: holds
+- name: countable available assets above resource limit are not eligible
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/230#input.countable_available_asset_equity_value_on_first_day_of_month: 2001
+  output:
+    us-ut:regulations/admin-rules/r986/200/230#ut_fep_resources_eligible: not_holds

--- a/us-ut/regulations/admin-rules/r986/200/230.test.yaml
+++ b/us-ut/regulations/admin-rules/r986/200/230.test.yaml
@@ -10,3 +10,9 @@
     us-ut:regulations/admin-rules/r986/200/230#input.countable_available_asset_equity_value_on_first_day_of_month: 2001
   output:
     us-ut:regulations/admin-rules/r986/200/230#ut_fep_resources_eligible: not_holds
+- name: oracle_parameter_ut_fep_resource_limit
+  period: 2022-11
+  input:
+    us-ut:regulations/admin-rules/r986/200/230#input.countable_available_asset_equity_value_on_first_day_of_month: 0
+  output:
+    us-ut:regulations/admin-rules/r986/200/230#ut_fep_resource_limit: 2000

--- a/us-ut/regulations/admin-rules/r986/200/230.yaml
+++ b/us-ut/regulations/admin-rules/r986/200/230.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+  summary: |-
+    R986-200-230. Assets Counted in Determining Eligibility. All available assets, unless exempt, are counted in determining eligibility. An asset is available when the applicant or client owns it and has the ability and legal right to sell it or dispose of it. The value of an asset is determined by its equity value. The value of countable real and personal property cannot exceed $2,000. If the household assets are below the limits on the first day of the month the household is eligible for the remainder of the month.
+rules:
+  - name: ut_fep_resource_limit
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: R986-200-230(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: The value of countable real and personal property cannot exceed $2,000.
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          2000
+
+  - name: ut_fep_resources_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: R986-200-230(1), R986-200-230(2), R986-200-230(5), R986-200-230(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: All available assets, unless exempt, are counted in determining eligibility.
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: The value of an asset is determined by its equity value.
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: cannot exceed $2,000
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/regulation/admin-rules/r986/200/block-1
+              excerpt: If the household assets are below the limits on the first day of the month the household is eligible for the remainder of the month.
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          countable_available_asset_equity_value_on_first_day_of_month <= ut_fep_resource_limit


### PR DESCRIPTION
## Summary
- add Utah Administrative Code R986-200-230 resource-limit eligibility rules from the official Utah Office of Administrative Rules corpus block
- add R986-200-204 FEP/FEPTP section-level eligibility component rules, including pregnancy/minor-child routes, school-age thresholds, felony/parole disqualifications, application-completion condition, and same-month out-of-state/tribal TANF disqualification
- include signed axiom-encode apply manifests for both generated modules

## Validation
- `axiom-encode compile` for R986-200-230 and R986-200-204
- `axiom-encode test` for both companion test files: 2 cases for 230, 6 cases for 204
- `axiom-encode validate --skip-reviewers` for both modules
- `axiom-encode proof-validate` for both modules
- `axiom-encode guard-generated --base-ref origin/main --head-ref HEAD --json`

## Notes
- R986-200-202 and R986-200-239 were attempted but not included: generated outputs omitted required section-202 conditions or did not preserve the desired section-239/Table 1 composition. Those should be re-encoded after tightening encoder compliance rather than merged as partial parity.
- Supabase run sync was skipped locally because the Supabase environment variables were not present; signed local manifests are included.