### PR TITLE
Add DC OSSP state supplement payment levels

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -13,6 +13,7 @@ allowed_root_directories:
   - us-co
   - us-ct
   - us-de
+  - us-dc
   - us-fl
   - us-ga
   - us-id

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1067"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
 axiom_encode_ref = "a3269d03ef94bd46972a6e4396ed7b732bc74c62"
-axiom_corpus_ref = "45e32314143e9ac714ea9911adfbe6e7d828fa0f"
+axiom_corpus_ref = "4eeb171c6d84e668dba997bceaab2af6eb425d1d"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1067"
+axiom_encode_version = "0.2.1070"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "a3269d03ef94bd46972a6e4396ed7b732bc74c62"
+axiom_encode_ref = "fac1d7881916c19fc0e51e475d4b3dc21ce459be"
 axiom_corpus_ref = "4eeb171c6d84e668dba997bceaab2af6eb425d1d"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.json
+++ b/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.yaml",
+      "sha256": "21ad9844d54b88c3ce499353124fa38bd49e372ca5f92ef5be95976ab56ae8d1"
+    },
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.test.yaml",
+      "sha256": "aafd48bcc3cbcec96e4ee4d48dba3206e196cc736c0d102fe4f1cb800e012e51"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2cef2f0058d8810476a9c17e435ebd2860464f6b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-string-test-input-repair-20260703",
+    "version": "0.2.1069",
+    "version_commit": "2cef2f0058d8810476a9c17e435ebd2860464f6b"
+  },
+  "axiom_encode_version": "0.2.1069",
+  "backend": "codex",
+  "citation": "us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels",
+  "context_manifest_file": "/tmp/axiom-encode-dc-ossp-couple-20260703/_eval_workspaces/codex-gpt-5.5/us-dc-policies-ssa-poms-si-01415-058-2026-dc-ossp-couple-state-supplement-levels/workspace/context-manifest.json",
+  "context_manifest_sha256": "59ae43ae77969d0ae290b4563d34057f912be4cca9a912dae823a7245da0d48e",
+  "generated_at": "2026-07-02T23:56:01.567426+00:00",
+  "generated_output_file": "/tmp/axiom-encode-dc-ossp-couple-20260703/codex-gpt-5.5/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.yaml",
+  "generated_output_root": "/tmp/axiom-encode-dc-ossp-couple-20260703",
+  "generated_output_sha256": "21ad9844d54b88c3ce499353124fa38bd49e372ca5f92ef5be95976ab56ae8d1",
+  "generation_prompt_sha256": "e1f81ebe039053412fdcf0957f6853678226d9f3cfc1195264a690b91b205153",
+  "model": "gpt-5.5",
+  "run_id": "3960435b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3d030e28b722a4b85ee59f4c6737b474dc4d7c9389ab33543019464be08d968b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-dc-ossp-couple-20260703/traces/codex-gpt-5.5/us-dc-policies-ssa-poms-si-01415-058-2026-dc-ossp-couple-state-supplement-levels.json",
+  "trace_sha256": "5a7f739e7457444ebcbadbc7d233e4adb96359074f38add5774ab906eaa0a0cb"
+}

--- a/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.json
+++ b/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.yaml",
+      "sha256": "cf1bc3aef4deb96aa9b7359b037e8eaabbdb8266160e8127ca21fa23f47e8e85"
+    },
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.test.yaml",
+      "sha256": "d57164129a3ddb224af0d91a905cfbf2c591d9ffe34d11fbeb776a78cb2e845f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "2cef2f0058d8810476a9c17e435ebd2860464f6b",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-string-test-input-repair-20260703",
+    "version": "0.2.1069",
+    "version_commit": "2cef2f0058d8810476a9c17e435ebd2860464f6b"
+  },
+  "axiom_encode_version": "0.2.1069",
+  "backend": "codex",
+  "citation": "us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels",
+  "context_manifest_file": "/tmp/axiom-encode-dc-ossp-individual-20260703-apply/_eval_workspaces/codex-gpt-5.5/us-dc-policies-ssa-poms-si-01415-058-2026-dc-ossp-individual-state-supplement-levels/workspace/context-manifest.json",
+  "context_manifest_sha256": "5ba82bd2a9b1a46f6023985f2ddfdb531db9c67c42c4f9f8e662f8ccc2dabd84",
+  "generated_at": "2026-07-02T23:59:02.527656+00:00",
+  "generated_output_file": "/tmp/axiom-encode-dc-ossp-individual-20260703-apply/codex-gpt-5.5/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.yaml",
+  "generated_output_root": "/tmp/axiom-encode-dc-ossp-individual-20260703-apply",
+  "generated_output_sha256": "cf1bc3aef4deb96aa9b7359b037e8eaabbdb8266160e8127ca21fa23f47e8e85",
+  "generation_prompt_sha256": "a4a9e1fdd4f791aa9534522d68a29e4e8fc47ef42a24b64afbf740967b45b48d",
+  "model": "gpt-5.5",
+  "run_id": "bd73abb4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c6372b60efca07cbf9862d876fdd6bf05ebf29e476f6306ea054e8906d00fccb"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-dc-ossp-individual-20260703-apply/traces/codex-gpt-5.5/us-dc-policies-ssa-poms-si-01415-058-2026-dc-ossp-individual-state-supplement-levels.json",
+  "trace_sha256": "ebfb1c9f96fb91330afb399bf6830f607ea9031ae38ce0ddf289f88d5f3120c1"
+}

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.test.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.test.yaml
@@ -1,0 +1,56 @@
+- name: adult_foster_care_small_couple_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: A
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: A
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_federal_payment_level: 1491.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_state_supplement_level: 1717.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level: 3208.0
+- name: adult_foster_care_large_couple_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: A
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: B
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_federal_payment_level: 1491.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_state_supplement_level: 1937.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level: 3428.0
+- name: living_in_household_of_another_no_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: B
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: Z
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_federal_payment_level: 994.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_state_supplement_level: 0.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level: 994.0
+- name: title_xix_facility_couple_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: D
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: G
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_federal_payment_level: 60.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_state_supplement_level: 158.0
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level: 218.0
+- name: auto_zero_dc_ossp_couple_federal_payment_level
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: ''
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: ''
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_federal_payment_level: 0
+- name: auto_zero_dc_ossp_couple_total_payment_level
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.federal_payment_code: ''
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#input.state_os_code: ''
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level: 0

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.yaml
@@ -1,0 +1,276 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-dc/statute/4/4-205.49
+      rationale: |-
+        D.C. Code § 4-205.49 authorizes District supplemental payment levels and federal administration agreements, but the POMS chart is the official current federally administered January 2026 parameter source for District of Columbia couple payment levels.
+  summary: |-
+    Couple payment levels for the District of Columbia: Federal Code A with State OS Code A has FBR 1491.00, State Supplement Level 1717.00, Total Payment Level 3208.00; State OS Code B has 1937.00 and 3428.00; State OS Code Z has 0.00 and 1491.00. Federal Code B / State OS Code Z has 994.00, 0.00, 994.00. Federal Code D / State OS Code G has 60.00, 158.00, 218.00.
+rules:
+  - name: federal_code_a_couple_fbr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Federal Code A ... FBR ... 1491.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1491.00
+  - name: federal_code_b_couple_fbr_less_vtr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code B / State OS Code Z row and footnote 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: B Z All 994.00 ... 1 Not the FBR; the amount represents the FBR less the VTR.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: federal_code_d_couple_title_xix_payment_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code D / State OS Code G row and footnote 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: D G All 60.00 ... 2 Not the FBR; the amount represents a payment cap to recipients in a Title XIX institution.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          60.00
+  - name: adult_foster_care_small_couple_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A / State OS Code A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: A A All 1491.00 1717.00 3208.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1717.00
+  - name: adult_foster_care_large_couple_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A / State OS Code B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: B All 1491.00 1937.00 3428.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1937.00
+  - name: no_supplement_couple_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, State OS Code Z rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Z All ... 0.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.00
+  - name: title_xix_couple_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code D / State OS Code G row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: D G All 60.00 2 158.00 218.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          158.00
+  - name: adult_foster_care_small_couple_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A / State OS Code A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: A A All 1491.00 1717.00 3208.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          3208.00
+  - name: adult_foster_care_large_couple_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A / State OS Code B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: B All 1491.00 1937.00 3428.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          3428.00
+  - name: federal_code_a_no_supplement_couple_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code A / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Z All 1491.00 0.00 1491.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1491.00
+  - name: federal_code_b_no_supplement_couple_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code B / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: B Z All 994.00 1 0.00 994.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: title_xix_couple_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 14, Federal Code D / State OS Code G row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: D G All 60.00 2 158.00 218.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          218.00
+  - name: dc_ossp_couple_federal_payment_level
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 14, FBR column for couple payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": federal_code_a_couple_fbr else: if federal_payment_code == "A" and state_os_code == "B": federal_code_a_couple_fbr else: if federal_payment_code == "A" and state_os_code == "Z": federal_code_a_couple_fbr else: if federal_payment_code == "B" and state_os_code == "Z": federal_code_b_couple_fbr_less_vtr else: if federal_payment_code == "D" and state_os_code == "G": federal_code_d_couple_title_xix_payment_cap else: 0
+  - name: dc_ossp_couple_state_supplement_level
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 14, State Supplement Level column for couple payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": adult_foster_care_small_couple_state_supplement_level else: if federal_payment_code == "A" and state_os_code == "B": adult_foster_care_large_couple_state_supplement_level else: if federal_payment_code == "A" and state_os_code == "Z": no_supplement_couple_state_supplement_level else: if federal_payment_code == "B" and state_os_code == "Z": no_supplement_couple_state_supplement_level else: if federal_payment_code == "D" and state_os_code == "G": title_xix_couple_state_supplement_level else: 0
+  - name: dc_ossp_couple_total_payment_level
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 14, Total Payment Levels column for couple payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-14
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": adult_foster_care_small_couple_total_payment_level else: if federal_payment_code == "A" and state_os_code == "B": adult_foster_care_large_couple_total_payment_level else: if federal_payment_code == "A" and state_os_code == "Z": federal_code_a_no_supplement_couple_total_payment_level else: if federal_payment_code == "B" and state_os_code == "Z": federal_code_b_no_supplement_couple_total_payment_level else: if federal_payment_code == "D" and state_os_code == "G": title_xix_couple_total_payment_level else: 0

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.test.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.test.yaml
@@ -1,0 +1,70 @@
+- name: adult_foster_care_small_individual_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: A
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: A
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_federal_payment_level
+    : 994.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_state_supplement_level
+    : 681.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_total_payment_level
+    : 1675.0
+- name: adult_foster_care_large_individual_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: A
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: B
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_federal_payment_level
+    : 994.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_state_supplement_level
+    : 791.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_total_payment_level
+    : 1785.0
+- name: living_in_household_of_another_no_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: B
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: Z
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_federal_payment_level
+    : 662.67
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_state_supplement_level
+    : 0.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_total_payment_level
+    : 662.67
+- name: title_xix_facility_individual_state_supplement
+  period: 2026-01
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: D
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: G
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_federal_payment_level
+    : 30.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_state_supplement_level
+    : 79.0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_total_payment_level
+    : 109.0
+- name: auto_zero_dc_ossp_individual_federal_payment_level
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: ''
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: ''
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_federal_payment_level
+    : 0
+- name: auto_zero_dc_ossp_individual_total_payment_level
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.federal_payment_code: ''
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#input.state_os_code: ''
+  output:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#dc_ossp_individual_total_payment_level
+    : 0

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.yaml
@@ -1,0 +1,310 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-dc/statute/4/4-205.49
+      rationale: |-
+        D.C. Code § 4-205.49 authorizes District supplemental payment levels and federal administration agreements, but the POMS chart is the official current federally administered January 2026 parameter source for District of Columbia individual payment levels.
+  summary: |-
+    Individual payment levels for the District of Columbia: Federal Code A with State OS Code A has FBR 994.00, State Supplement Level 681.00, Total Payment Level 1675.00; State OS Code B has 791.00 and 1785.00; State OS Code Z has 0.00 and 994.00. Federal Code B / State OS Code Z has 662.67, 0.00, 662.67. Federal Code C / State OS Code Z has 994.00, 0.00, 994.00. Federal Code D / State OS Code G has 30.00, 79.00, 109.00.
+rules:
+  - name: federal_code_a_individual_fbr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: A A All 994.00 681.00 1675.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: federal_code_b_individual_fbr_less_vtr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code B / State OS Code Z row and footnote 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: B Z All 662.67 1 0.00 662.67
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          662.67
+  - name: federal_code_c_individual_fbr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code C / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: C Z All 994.00 0.00 994.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: federal_code_d_individual_title_xix_payment_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code D / State OS Code G row and footnote 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: D G All 30.00 2 79.00 109.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          30.00
+  - name: adult_foster_care_small_individual_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A / State OS Code A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: A A All 994.00 681.00 1675.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          681.00
+  - name: adult_foster_care_large_individual_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A / State OS Code B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: B All 994.00 791.00 1785.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          791.00
+  - name: no_supplement_individual_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, State OS Code Z rows
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: Z All 994.00 0.00 994.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.00
+  - name: title_xix_individual_state_supplement_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code D / State OS Code G row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: D G All 30.00 2 79.00 109.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          79.00
+  - name: adult_foster_care_small_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A / State OS Code A row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: A A All 994.00 681.00 1675.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1675.00
+  - name: adult_foster_care_large_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A / State OS Code B row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: B All 994.00 791.00 1785.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1785.00
+  - name: federal_code_a_no_supplement_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code A / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: Z All 994.00 0.00 994.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: federal_code_b_no_supplement_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code B / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: B Z All 662.67 1 0.00 662.67
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          662.67
+  - name: federal_code_c_no_supplement_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code C / State OS Code Z row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: C Z All 994.00 0.00 994.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          994.00
+  - name: title_xix_individual_total_payment_level
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: POMS SI 01415.058, block 13, Federal Code D / State OS Code G row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: D G All 30.00 2 79.00 109.00
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          109.00
+  - name: dc_ossp_individual_federal_payment_level
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 13, FBR column for individual payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": federal_code_a_individual_fbr else: if federal_payment_code == "A" and state_os_code == "B": federal_code_a_individual_fbr else: if federal_payment_code == "A" and state_os_code == "Z": federal_code_a_individual_fbr else: if federal_payment_code == "B" and state_os_code == "Z": federal_code_b_individual_fbr_less_vtr else: if federal_payment_code == "C" and state_os_code == "Z": federal_code_c_individual_fbr else: if federal_payment_code == "D" and state_os_code == "G": federal_code_d_individual_title_xix_payment_cap else: 0
+  - name: dc_ossp_individual_state_supplement_level
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 13, State Supplement Level column for individual payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": adult_foster_care_small_individual_state_supplement_level else: if federal_payment_code == "A" and state_os_code == "B": adult_foster_care_large_individual_state_supplement_level else: if federal_payment_code == "A" and state_os_code == "Z": no_supplement_individual_state_supplement_level else: if federal_payment_code == "B" and state_os_code == "Z": no_supplement_individual_state_supplement_level else: if federal_payment_code == "C" and state_os_code == "Z": no_supplement_individual_state_supplement_level else: if federal_payment_code == "D" and state_os_code == "G": title_xix_individual_state_supplement_level else: 0
+  - name: dc_ossp_individual_total_payment_level
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: POMS SI 01415.058, block 13, Total Payment Levels column for individual payment levels
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-13
+              excerpt: Federal Code State OS Code Category FBR State Supplement Level Total Payment Levels
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_payment_code == "A" and state_os_code == "A": adult_foster_care_small_individual_total_payment_level else: if federal_payment_code == "A" and state_os_code == "B": adult_foster_care_large_individual_total_payment_level else: if federal_payment_code == "A" and state_os_code == "Z": federal_code_a_no_supplement_individual_total_payment_level else: if federal_payment_code == "B" and state_os_code == "Z": federal_code_b_no_supplement_individual_total_payment_level else: if federal_payment_code == "C" and state_os_code == "Z": federal_code_c_no_supplement_individual_total_payment_level else: if federal_payment_code == "D" and state_os_code == "G": title_xix_individual_total_payment_level else: 0


### PR DESCRIPTION
## Summary
- add District of Columbia OSSP individual and couple 2026 payment-level RuleSpec encodings from SSA POMS SI 01415.058
- include encoder apply manifests and companion tests for federal payment level, state supplement level, and total payment level branches
- ground source verification in D.C. Code § 4-205.49 plus the now-merged axiom-corpus DC POMS/statute source records (axiom-corpus#165)

## Validation
- AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-corpus-dc-ossp-20260703 uv run axiom-encode validate --skip-reviewers <new yaml files>
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-ossp-20260703/us-dc <new test files>
- uv run --with pytest --with pyyaml pytest tests -q
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-ossp-20260703 --all --roots us-dc --json