### PR TITLE
Add DC OSSP living arrangement selector

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1070"
+axiom_encode_version = "0.2.1071"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "fac1d7881916c19fc0e51e475d4b3dc21ce459be"
+axiom_encode_ref = "0dc663f08b6ca1c40955667fe94620c6d16362fe"
 axiom_corpus_ref = "4eeb171c6d84e668dba997bceaab2af6eb425d1d"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.json
+++ b/us-dc/.axiom/encoding-manifests/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.yaml",
+      "sha256": "63609cfb3ba376ac7a4818ffa57d371db0f70936920a6cb947407f3a09bfd4da"
+    },
+    {
+      "path": "policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.test.yaml",
+      "sha256": "ba3b57dc76ca3f2021d4e32bdf30e8dab77d33febfed53b5111556543c449741"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fac1d7881916c19fc0e51e475d4b3dc21ce459be",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1070",
+    "version_commit": "fac1d7881916c19fc0e51e475d4b3dc21ce459be"
+  },
+  "axiom_encode_version": "0.2.1070",
+  "backend": "codex",
+  "citation": "policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations",
+  "context_manifest_file": "/tmp/axiom-encode-dc-ossp-living-arrangements-20260703-usdcroot/_eval_workspaces/codex-gpt-5.5/policies-ssa-poms-si-01415-058-2026-dc-ossp-living-arrangement-variations/workspace/context-manifest.json",
+  "context_manifest_sha256": "631ade980ee3d95f895718e0c9e0989a162fe3304b7fb0041862bb78358354dc",
+  "generated_at": "2026-07-03T01:14:25.408135+00:00",
+  "generated_output_file": "/tmp/axiom-encode-dc-ossp-living-arrangements-20260703-usdcroot/codex-gpt-5.5/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.yaml",
+  "generated_output_root": "/tmp/axiom-encode-dc-ossp-living-arrangements-20260703-usdcroot",
+  "generated_output_sha256": "63609cfb3ba376ac7a4818ffa57d371db0f70936920a6cb947407f3a09bfd4da",
+  "generation_prompt_sha256": "0c78353722903249d91f8de0e9351fc0f394cafb393bd857168c694cb5aba917",
+  "model": "gpt-5.5",
+  "run_id": "1e9d306f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "341f294ffdf752e75ddccd004aa5398c8b8aca657485d48cab1c063e0fbee256"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-dc-ossp-living-arrangements-20260703-usdcroot/traces/codex-gpt-5.5/policies-ssa-poms-si-01415-058-2026-dc-ossp-living-arrangement-variations.json",
+  "trace_sha256": "8b27d1bc7f198e56ce97473ef54e6bd8aba60a14e74d75b0d2959164b04950fc"
+}

--- a/us-dc/.axiom/encoding-manifests/statutes/4/4-205/49.json
+++ b/us-dc/.axiom/encoding-manifests/statutes/4/4-205/49.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/4/4-205/49.yaml",
+      "sha256": "01734ecefaec7ab70fd060a6391bb0beec508727c5171d011a4c45d66c130a78"
+    },
+    {
+      "path": "statutes/4/4-205/49.test.yaml",
+      "sha256": "03f476c35315bb6a4c3d732a18d014dd004cd6334a03c67977ca7f11f7580424"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "fac1d7881916c19fc0e51e475d4b3dc21ce459be",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1070",
+    "version_commit": "fac1d7881916c19fc0e51e475d4b3dc21ce459be"
+  },
+  "axiom_encode_version": "0.2.1070",
+  "backend": "codex",
+  "citation": "us-dc/statutes/4/4-205.49",
+  "context_manifest_file": "/tmp/axiom-encode-dc-code-4-205-49-20260703/_eval_workspaces/codex-gpt-5.5/us-dc-statutes-4-4-205.49/workspace/context-manifest.json",
+  "context_manifest_sha256": "5df60be3c24fa382e701863d8664ca24b9b10b530ad50abf0ff2776b32a7e3d2",
+  "generated_at": "2026-07-03T01:06:31.327581+00:00",
+  "generated_output_file": "/tmp/axiom-encode-dc-code-4-205-49-20260703/codex-gpt-5.5/statutes/4/4-205/49.yaml",
+  "generated_output_root": "/tmp/axiom-encode-dc-code-4-205-49-20260703",
+  "generated_output_sha256": "01734ecefaec7ab70fd060a6391bb0beec508727c5171d011a4c45d66c130a78",
+  "generation_prompt_sha256": "a5476a010c5ad4d2e595dae7409c5fbf064300c165aea0dc365b8d08ad7e5220",
+  "model": "gpt-5.5",
+  "run_id": "c111348a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "607e46ea76fc8a3ccd1521df44234cf24380495be4089b4f181a10b2167776d0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-dc-code-4-205-49-20260703/traces/codex-gpt-5.5/us-dc-statutes-4-4-205.49.json",
+  "trace_sha256": "e00bb675bcd255e802f9b7b60fc805a9ed8ecdd7f143cbda733ed67eb15fd817"
+}

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.test.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.test.yaml
@@ -1,0 +1,96 @@
+- name: adult_foster_care_small_os_code
+  period: 2026-01
+  input:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.department_of_health_certification_received
+    : true
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_adult_foster_care_home_resident
+    : true
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.adult_foster_care_home_resident_count
+    : 50
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_title_xix_facility_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_eligible_for_optional_supplement
+    : false
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_waived_optional_supplement: false
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_small_os_code_applies: holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_large_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#title_xix_facility_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#optional_supplement_waived_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#no_supplement_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#dc_ossp_living_arrangement_os_code: A
+- name: adult_foster_care_large_os_code
+  period: 2026-01
+  input:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.department_of_health_certification_received
+    : true
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_adult_foster_care_home_resident
+    : true
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.adult_foster_care_home_resident_count
+    : 51
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_title_xix_facility_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_eligible_for_optional_supplement
+    : false
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_waived_optional_supplement: false
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_small_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_large_os_code_applies: holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#dc_ossp_living_arrangement_os_code: B
+- name: title_xix_facility_os_code
+  period: 2026-01
+  input:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.department_of_health_certification_received
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_adult_foster_care_home_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.adult_foster_care_home_resident_count
+    : 0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_title_xix_facility_resident
+    : true
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_eligible_for_optional_supplement
+    : false
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_waived_optional_supplement: false
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#title_xix_facility_os_code_applies: holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#no_supplement_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#dc_ossp_living_arrangement_os_code: G
+- name: optional_supplement_waived_os_code
+  period: 2026-01
+  input:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.department_of_health_certification_received
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_adult_foster_care_home_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.adult_foster_care_home_resident_count
+    : 0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_title_xix_facility_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_eligible_for_optional_supplement
+    : true
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_waived_optional_supplement: true
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#optional_supplement_waived_os_code_applies: holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#no_supplement_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#dc_ossp_living_arrangement_os_code: Y
+- name: no_supplement_os_code
+  period: 2026-01
+  input:
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.department_of_health_certification_received
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_adult_foster_care_home_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.adult_foster_care_home_resident_count
+    : 0
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_is_title_xix_facility_resident
+    : false
+    ? us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_eligible_for_optional_supplement
+    : false
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#input.recipient_waived_optional_supplement: false
+  output:
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_small_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_large_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#title_xix_facility_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#optional_supplement_waived_os_code_applies: not_holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#no_supplement_os_code_applies: holds
+    us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#dc_ossp_living_arrangement_os_code: Z

--- a/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.yaml
+++ b/us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.yaml
@@ -1,0 +1,141 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-dc:statutes/4/4-205/49
+      rationale: |-
+        D.C. Code § 4-205.49 provides related District supplemental payment authority and residence-size concepts, but this POMS block is the operative current source for the federally administered District of Columbia OS code definitions used in payment-level tables.
+  summary: |-
+    Use OS code “A” for a certified resident of an adult foster care home with 50 or fewer residents; “B” for more than 50 residents; “G” for Title XIX facility residents; “Y” when optional supplementation is waived; and “Z” for recipients not included in A, B, G, or Y.
+rules:
+  - name: adult_foster_care_home_os_code_resident_threshold
+    kind: parameter
+    dtype: Count
+    source: POMS SI 01415.058, block 11, OS codes A and B definitions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+              excerpt: adult foster care home with 50 or fewer residents
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          50
+  - name: adult_foster_care_small_os_code_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code A definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          department_of_health_certification_received
+          and recipient_is_adult_foster_care_home_resident
+          and adult_foster_care_home_resident_count <= adult_foster_care_home_os_code_resident_threshold
+  - name: adult_foster_care_large_os_code_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code B definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          department_of_health_certification_received
+          and recipient_is_adult_foster_care_home_resident
+          and adult_foster_care_home_resident_count > adult_foster_care_home_os_code_resident_threshold
+  - name: title_xix_facility_os_code_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code G definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          recipient_is_title_xix_facility_resident
+  - name: optional_supplement_waived_os_code_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code Y definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          recipient_eligible_for_optional_supplement
+          and recipient_waived_optional_supplement
+  - name: no_supplement_os_code_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code Z definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          not adult_foster_care_small_os_code_applies
+          and not adult_foster_care_large_os_code_applies
+          and not title_xix_facility_os_code_applies
+          and not optional_supplement_waived_os_code_applies
+  - name: dc_ossp_living_arrangement_os_code
+    kind: derived
+    entity: Person
+    dtype: String
+    period: Month
+    source: POMS SI 01415.058, block 11, OS code definitions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/ssa/poms/si-01415-058/2026/block-11
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if adult_foster_care_small_os_code_applies: "A" else: if adult_foster_care_large_os_code_applies: "B" else: if title_xix_facility_os_code_applies: "G" else: if optional_supplement_waived_os_code_applies: "Y" else: "Z"

--- a/us-dc/statutes/4/4-205/49.test.yaml
+++ b/us-dc/statutes/4/4-205/49.test.yaml
@@ -1,0 +1,350 @@
+- name: nursing_home_public_assistance_recipient_gets_clothing_payment
+  period: 2026-01
+  input:
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: true
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: true
+  output:
+    us-dc:statutes/4/4-205/49#nursing_home_clothing_and_personal_needs_payment_due: 40
+- name: halfway_house_public_assistance_recipient_gets_allocated_payment
+  period: 2026-01
+  input:
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: true
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: true
+  output:
+    us-dc:statutes/4/4-205/49#halfway_house_total_payment_due: 170
+    us-dc:statutes/4/4-205/49#halfway_house_room_board_care_payment_due: 150
+    us-dc:statutes/4/4-205/49#halfway_house_clothing_and_personal_needs_payment_due: 20
+- name: small_community_residence_facility_ssi_recipient_with_increases_and_proration
+  period: 2026-01
+  input:
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: true
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: true
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 50
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 10
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 5
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: true
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: true
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: true
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: 1000
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 100
+  output:
+    us-dc:statutes/4/4-205/49#small_residence_total_payment_due: 646.2
+    us-dc:statutes/4/4-205/49#small_residence_room_board_care_payment_due: 571.2
+    us-dc:statutes/4/4-205/49#small_residence_clothing_and_personal_needs_payment_due: 75.0
+    us-dc:statutes/4/4-205/49#additional_supplemental_room_board_care_payment_due: 10
+- name: large_assisted_living_residence_ssi_recipient_within_district_cap
+  period: 2026-01
+  input:
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: true
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: true
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 17
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 250
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+  output:
+    us-dc:statutes/4/4-205/49#large_residence_total_payment_due: 741.2
+    us-dc:statutes/4/4-205/49#large_residence_room_board_care_payment_due: 671.2
+    us-dc:statutes/4/4-205/49#large_residence_clothing_and_personal_needs_payment_due: 70.0
+- name: auto_zero_nursing_home_clothing_and_personal_needs_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#nursing_home_clothing_and_personal_needs_payment_due: 0
+- name: auto_zero_halfway_house_total_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#halfway_house_total_payment_due: 0
+- name: auto_zero_halfway_house_room_board_care_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#halfway_house_room_board_care_payment_due: 0
+- name: auto_zero_halfway_house_clothing_and_personal_needs_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#halfway_house_clothing_and_personal_needs_payment_due: 0
+- name: auto_zero_small_residence_total_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 17
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 51
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#small_residence_total_payment_due: 0
+- name: auto_zero_small_residence_room_board_care_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 17
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 51
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#small_residence_room_board_care_payment_due: 0
+- name: auto_zero_small_residence_clothing_and_personal_needs_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 17
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 51
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#small_residence_clothing_and_personal_needs_payment_due: 0
+- name: auto_zero_large_residence_total_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 251
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#large_residence_total_payment_due: 0
+- name: auto_zero_large_residence_room_board_care_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 251
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#large_residence_room_board_care_payment_due: 0
+- name: auto_zero_large_residence_clothing_and_personal_needs_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 251
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#large_residence_clothing_and_personal_needs_payment_due: 0
+- name: auto_zero_additional_supplemental_room_board_care_payment_due
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-dc:statutes/4/4-205/49#input.assisted_living_residence_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_capacity: 0
+    us-dc:statutes/4/4-205/49#input.community_residence_facility_resident_count: 0
+    us-dc:statutes/4/4-205/49#input.district_of_columbia_resident: false
+    us-dc:statutes/4/4-205/49#input.mayor_rulemaking_clothing_and_personal_needs_increase: 0
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: false
+    us-dc:statutes/4/4-205/49#input.recipient_is_in_nursing_home: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_assisted_living_residence: false
+    us-dc:statutes/4/4-205/49#input.recipient_lives_in_community_residence_facility: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_general_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_public_assistance: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income: false
+    us-dc:statutes/4/4-205/49#input.recipient_receives_supplemental_security_income_payment_pursuant_to_this_section: false
+    us-dc:statutes/4/4-205/49#input.ssi_payment_increase_after_baseline: 0
+    us-dc:statutes/4/4-205/49#input.subsection_e_1_applicability_date_has_arrived: false
+    us-dc:statutes/4/4-205/49#input.supplemental_funds_forwarded_by_district: false
+    us-dc:statutes/4/4-205/49#input.total_persons_receiving_large_residence_payments_including_recipient: 0
+    ? us-dc:statutes/4/4-205/49#input.total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence
+    : 0
+  output:
+    us-dc:statutes/4/4-205/49#additional_supplemental_room_board_care_payment_due: 0

--- a/us-dc/statutes/4/4-205/49.yaml
+++ b/us-dc/statutes/4/4-205/49.yaml
@@ -1,0 +1,460 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-dc/statute/4/4-205.49
+  summary: |-
+    Recipients of public assistance in nursing homes receive $40 per month for clothing and personal needs. Recipients in half-way houses for alcoholics or drug addicts receive $170 per month, with $150 for room, board, and care and $20 for clothing and personal needs. Effective with payments beginning on January 1, 1997, specified SSI or General Public Assistance recipients in community residence facilities or Assisted Living Residences receive monthly payments of $631.20 or $741.20 depending on facility size, with stated room-board-care and clothing allocations. SSI increases are added to those payment levels for room, board, and care, and additional supplemental payments are prorated by District funds divided by the covered SSI recipient population.
+rules:
+  - name: nursing_home_clothing_and_personal_needs_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: payment of $40 per month for clothing and personal needs
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          40
+  - name: halfway_house_total_monthly_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: payment of $170 per month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          170
+  - name: halfway_house_room_board_care_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $150 of which shall be for room, board, and care
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          150
+  - name: halfway_house_clothing_and_personal_needs_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: remaining $20 for clothing and personal needs
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          20
+  - name: small_community_residence_facility_maximum_residents
+    kind: parameter
+    dtype: Count
+    source: D.C. Code § 4-205.49(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: community residence facility that has 50 or fewer residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          50
+  - name: small_assisted_living_residence_maximum_residents
+    kind: parameter
+    dtype: Count
+    source: D.C. Code § 4-205.49(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: Assisted Living Residence that has 16 or fewer residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          16
+  - name: small_residence_base_total_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: receive a payment of $631.20 per month
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          631.20
+  - name: small_residence_base_room_board_care_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $561.20 shall be used for room, board, and care
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          561.20
+  - name: residence_base_clothing_and_personal_needs_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(c), (d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $70.00 shall be retained by the recipient for clothing and personal needs
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          70.00
+  - name: large_community_residence_facility_capacity_threshold
+    kind: parameter
+    dtype: Count
+    source: D.C. Code § 4-205.49(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: capacity for more than 50 residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          50
+  - name: large_assisted_living_residence_minimum_residents
+    kind: parameter
+    dtype: Count
+    source: D.C. Code § 4-205.49(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: Assisted Living Residence that has 17 or more residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          17
+  - name: large_residence_base_total_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: receive a payment of $741.20 per month
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          741.20
+  - name: large_residence_base_room_board_care_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: D.C. Code § 4-205.49(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $671.20 shall be used for room, board, and care
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          671.20
+  - name: large_residence_district_payment_person_cap
+    kind: parameter
+    dtype: Count
+    source: D.C. Code § 4-205.49(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: exceed 250 persons
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          250
+  - name: nursing_home_clothing_and_personal_needs_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: Recipients of public assistance who are in nursing homes shall receive a payment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if recipient_receives_public_assistance and recipient_is_in_nursing_home: nursing_home_clothing_and_personal_needs_amount else: 0
+  - name: halfway_house_total_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: Recipients of public assistance who are in half-way houses for alcoholics or drug addicts
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if recipient_receives_public_assistance and recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: halfway_house_total_monthly_payment_amount else: 0
+  - name: halfway_house_room_board_care_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $150 of which shall be for room, board, and care
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if recipient_receives_public_assistance and recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: halfway_house_room_board_care_amount else: 0
+  - name: halfway_house_clothing_and_personal_needs_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: remaining $20 for clothing and personal needs
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if recipient_receives_public_assistance and recipient_is_in_halfway_house_for_alcoholics_or_drug_addicts: halfway_house_clothing_and_personal_needs_amount else: 0
+  - name: small_residence_total_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(c), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: SSI or General Public Assistance ... community residence facility that has 50 or fewer residents or an Assisted Living Residence that has 16 or fewer residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if (recipient_receives_supplemental_security_income or recipient_receives_general_public_assistance) and ((recipient_lives_in_community_residence_facility and community_residence_facility_resident_count <= small_community_residence_facility_maximum_residents) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count <= small_assisted_living_residence_maximum_residents)): max(0, small_residence_base_total_payment_amount + ssi_payment_increase_after_baseline + mayor_rulemaking_clothing_and_personal_needs_increase) else: 0
+  - name: small_residence_room_board_care_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(c), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: SSI payment is increased ... any increase shall be added ... and shall be used for room, board, and care
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if (recipient_receives_supplemental_security_income or recipient_receives_general_public_assistance) and ((recipient_lives_in_community_residence_facility and community_residence_facility_resident_count <= small_community_residence_facility_maximum_residents) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count <= small_assisted_living_residence_maximum_residents)): max(0, small_residence_base_room_board_care_amount + ssi_payment_increase_after_baseline) else: 0
+  - name: small_residence_clothing_and_personal_needs_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(c), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $70.00 shall be retained by the recipient for clothing and personal needs
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if (recipient_receives_supplemental_security_income or recipient_receives_general_public_assistance) and ((recipient_lives_in_community_residence_facility and community_residence_facility_resident_count <= small_community_residence_facility_maximum_residents) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count <= small_assisted_living_residence_maximum_residents)): max(0, residence_base_clothing_and_personal_needs_amount + mayor_rulemaking_clothing_and_personal_needs_increase) else: 0
+  - name: large_residence_total_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(d), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: Supplemental Security Income ... capacity for more than 50 residents or ... 17 or more residents
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if recipient_receives_supplemental_security_income and ((recipient_lives_in_community_residence_facility and community_residence_facility_capacity > large_community_residence_facility_capacity_threshold) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count >= large_assisted_living_residence_minimum_residents)) and total_persons_receiving_large_residence_payments_including_recipient <= large_residence_district_payment_person_cap: max(0, large_residence_base_total_payment_amount + ssi_payment_increase_after_baseline + mayor_rulemaking_clothing_and_personal_needs_increase) else: 0
+  - name: large_residence_room_board_care_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(d), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $671.20 shall be used for room, board, and care
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if recipient_receives_supplemental_security_income and ((recipient_lives_in_community_residence_facility and community_residence_facility_capacity > large_community_residence_facility_capacity_threshold) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count >= large_assisted_living_residence_minimum_residents)) and total_persons_receiving_large_residence_payments_including_recipient <= large_residence_district_payment_person_cap: max(0, large_residence_base_room_board_care_amount + ssi_payment_increase_after_baseline) else: 0
+  - name: large_residence_clothing_and_personal_needs_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(d), (e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: $70.00 shall be retained by the recipient for clothing and personal needs
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if recipient_receives_supplemental_security_income and ((recipient_lives_in_community_residence_facility and community_residence_facility_capacity > large_community_residence_facility_capacity_threshold) or (recipient_lives_in_assisted_living_residence and assisted_living_residence_resident_count >= large_assisted_living_residence_minimum_residents)) and total_persons_receiving_large_residence_payments_including_recipient <= large_residence_district_payment_person_cap: max(0, residence_base_clothing_and_personal_needs_amount + mayor_rulemaking_clothing_and_personal_needs_increase) else: 0
+  - name: additional_supplemental_room_board_care_payment_due
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: D.C. Code § 4-205.49(e-1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/4/4-205.49
+              excerpt: prorated based upon the amount of supplemental funds forwarded by the District ... divided by the total population
+    versions:
+      - effective_from: '1997-01-01'
+        formula: |-
+          if district_of_columbia_resident and recipient_receives_supplemental_security_income_payment_pursuant_to_this_section and (recipient_lives_in_community_residence_facility or recipient_lives_in_assisted_living_residence) and subsection_e_1_applicability_date_has_arrived and total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence > 0: max(0, supplemental_funds_forwarded_by_district) / total_population_of_district_ssi_recipients_in_community_residence_facility_or_assisted_living_residence else: 0


### PR DESCRIPTION
## Summary
- encode D.C. Code § 4-205.49 payment authority for DC supplemental assistance living arrangements
- encode POMS SI 01415.058 block 11 OS-code selector for DC OSSP living-arrangement variations
- include encoder manifests for both applied runs

## Validation
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus-be-workbonus uv run axiom-encode validate --skip-reviewers ...`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-ossp-selector-20260703/us-dc ...`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-ossp-selector-20260703 --roots us-dc --json`
- `git diff --check`

Notes: reviewer-backed validation was skipped locally because reviewer auth is unavailable in this environment; compile/CI validation and companion tests passed.