### PR TITLE
Bump RuleSpec corpus toolchain

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1071"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
 axiom_encode_ref = "0dc663f08b6ca1c40955667fe94620c6d16362fe"
-axiom_corpus_ref = "4eeb171c6d84e668dba997bceaab2af6eb425d1d"
+axiom_corpus_ref = "51e7c108eb9ef0227a7340d911151606d03ac9d2"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary\n- bump the pinned RuleSpec validation corpus from 4eeb171 to 51e7c10\n- picks up the merged DC Code Title 4 refresh that preserves TANF table text\n\n## Local validation\n- git diff --check\n- AXIOM_CORPUS_REPO=/tmp/axiom-corpus-51e7c10 uv run axiom-encode validate --json --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-tanf-20260703/us-dc/statutes/4/4-205/52.yaml\n\nThis unblocks rulespec-us#521, whose generated DC TANF table values are grounded only when CI uses the refreshed corpus.