### PR TITLE
Encode 26 USC 85 unemployment compensation

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,10 +2,10 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1073"
+axiom_encode_version = "0.2.1078"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "e26ebc49bbc9693a1411e61dca1fc6377e184953"
-axiom_corpus_ref = "51e7c108eb9ef0227a7340d911151606d03ac9d2"
+axiom_encode_ref = "019fb9c9dc283ef0e7c2a9d2b27000a44fe10323"
+axiom_corpus_ref = "9ee50de6ab77d190bd0a23ab84b43a6bd99c4855"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1078"
+axiom_encode_version = "0.2.1079"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "019fb9c9dc283ef0e7c2a9d2b27000a44fe10323"
+axiom_encode_ref = "f7d1e19a1712d2dfd7266675a41ddb2b3fecda34"
 axiom_corpus_ref = "9ee50de6ab77d190bd0a23ab84b43a6bd99c4855"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us/.axiom/encoding-manifests/statutes/26/85.json
+++ b/us/.axiom/encoding-manifests/statutes/26/85.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/85.yaml",
+      "sha256": "c5fa101230f23c26e444ea00c05dd518ba485a2786aa9b0ee9da735f0d12d805"
+    },
+    {
+      "path": "statutes/26/85.test.yaml",
+      "sha256": "c4916de824cbac91d87cc0aeb86169369442e6b39386e3811140dd53ce5452bf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "019fb9c9dc283ef0e7c2a9d2b27000a44fe10323",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1078",
+    "version_commit": "1b853e21b637735adfe8d9d2000336dd782aa086"
+  },
+  "axiom_encode_version": "0.2.1078",
+  "backend": "deterministic",
+  "citation": "us:statutes/26/85",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-03T05:41:51.742641+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp_afjr818/deterministic-repair/statutes/26/85.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp_afjr818",
+  "generated_output_sha256": "c5fa101230f23c26e444ea00c05dd518ba485a2786aa9b0ee9da735f0d12d805",
+  "generation_prompt_sha256": null,
+  "model": "section-85-unemployment-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "600fabeaab383cd62bec81ade97ad543472af6d39242aa8633609d8ca15aae94"
+  },
+  "tool": "axiom-encode repair-section-85-unemployment",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us/statutes/26/85.test.yaml
+++ b/us/statutes/26/85.test.yaml
@@ -1,0 +1,77 @@
+- name: unemployment_compensation_definition_amount_received
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 15000
+  output:
+    us:statutes/26/85#unemployment_compensation: 15000
+    us:statutes/26/85#section_85_unemployment_compensation_recipient_has_unemployment_compensation: holds
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion_for_recipient: 10200
+- name: temporary_2020_exclusion_caps_single_recipient
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    us:statutes/26/85#input.taxable_year_begins_in_temporary_unemployment_exclusion_year: true
+    us:statutes/26/85#input.adjusted_gross_income_for_temporary_unemployment_exclusion: 50000
+    us:statutes/26/85#relation.section_85_unemployment_compensation_recipient_of_tax_unit:
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 15000
+  output:
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 10200
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 4800
+- name: temporary_2020_exclusion_applies_per_spouse_on_joint_return
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    us:statutes/26/85#input.taxable_year_begins_in_temporary_unemployment_exclusion_year: true
+    us:statutes/26/85#input.adjusted_gross_income_for_temporary_unemployment_exclusion: 120000
+    us:statutes/26/85#relation.section_85_unemployment_compensation_recipient_of_tax_unit:
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 12000
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 13000
+  output:
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 20400
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 4600
+- name: temporary_2020_exclusion_denied_at_threshold
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    us:statutes/26/85#input.taxable_year_begins_in_temporary_unemployment_exclusion_year: true
+    us:statutes/26/85#input.adjusted_gross_income_for_temporary_unemployment_exclusion: 150000
+    us:statutes/26/85#relation.section_85_unemployment_compensation_recipient_of_tax_unit:
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 9000
+  output:
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 0
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 9000
+- name: pre_temporary_year_includes_unemployment_compensation
+  period:
+    period_kind: tax_year
+    start: '2019-01-01'
+    end: '2019-12-31'
+  input:
+    us:statutes/26/85#input.taxable_year_begins_in_temporary_unemployment_exclusion_year: false
+    us:statutes/26/85#input.adjusted_gross_income_for_temporary_unemployment_exclusion: 50000
+    us:statutes/26/85#relation.section_85_unemployment_compensation_recipient_of_tax_unit:
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 8000
+  output:
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 0
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 8000
+- name: non_temporary_year_includes_unemployment_compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/85#input.taxable_year_begins_in_temporary_unemployment_exclusion_year: false
+    us:statutes/26/85#input.adjusted_gross_income_for_temporary_unemployment_exclusion: 50000
+    us:statutes/26/85#relation.section_85_unemployment_compensation_recipient_of_tax_unit:
+    - us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 7000
+  output:
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 0
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 7000

--- a/us/statutes/26/85.yaml
+++ b/us/statutes/26/85.yaml
@@ -1,0 +1,181 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/85
+  summary: |-
+    Section 85 includes unemployment compensation in gross income for an
+    individual. Unemployment compensation is any amount received under a law of
+    the United States or of a State that is in the nature of unemployment
+    compensation. For taxable years beginning in 2020, if the taxpayer's
+    adjusted gross income determined under section 85(c)(1) is less than
+    $150,000, gross income excludes up to $10,200 of unemployment compensation
+    received by the taxpayer and, on a joint return, up to $10,200 received by
+    each spouse.
+rules:
+  - name: section_85_unemployment_compensation_recipient_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: section_85_unemployment_compensation_recipient_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+
+  - name: temporary_unemployment_exclusion_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: adjusted gross income of the taxpayer for such taxable year is less than $150,000
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          150000
+
+  - name: temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: as does not exceed $10,200
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          10200
+
+  - name: unemployment_compensation
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 85(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: any amount received under a law of the United States or of a State which is in the nature of unemployment compensation
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation
+
+  - name: section_85_unemployment_compensation_recipient_has_unemployment_compensation
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: unemployment compensation received by the taxpayer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          unemployment_compensation > 0
+
+  - name: temporary_unemployment_compensation_exclusion_for_recipient
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: unemployment compensation received by the taxpayer as does not exceed $10,200
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          min(
+              max(0, unemployment_compensation),
+              temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse
+          )
+
+  - name: temporary_unemployment_compensation_exclusion
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: gross income includes unemployment compensation
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: in the case of a joint return, the unemployment compensation received by each spouse
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if taxable_year_begins_in_temporary_unemployment_exclusion_year and adjusted_gross_income_for_temporary_unemployment_exclusion < temporary_unemployment_exclusion_adjusted_gross_income_threshold:
+              sum_where(
+                  section_85_unemployment_compensation_recipient_of_tax_unit,
+                  temporary_unemployment_compensation_exclusion_for_recipient,
+                  section_85_unemployment_compensation_recipient_has_unemployment_compensation
+              )
+          else:
+              0
+
+  - name: unemployment_compensation_included_in_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 85(a), 26 USC 85(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/85
+              excerpt: gross income includes unemployment compensation
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              sum_where(
+                  section_85_unemployment_compensation_recipient_of_tax_unit,
+                  unemployment_compensation,
+                  section_85_unemployment_compensation_recipient_has_unemployment_compensation
+              ) - temporary_unemployment_compensation_exclusion
+          )


### PR DESCRIPTION
## Summary
- encode 26 USC 85 unemployment compensation inclusion and the temporary 2020 unemployment compensation exclusion
- add signed applied-encoding manifest generated by axiom-encode 0.2.1078
- update toolchain pins for the merged axiom-corpus §85 ingestion and section 85 encoder repair

## Validation
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703/us/statutes/26/85.yaml --skip-reviewers
- uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703/us/statutes/26/85.yaml
- uv run axiom-encode test /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703/us/statutes/26/85.test.yaml --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703
- uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703 --base-ref origin/main --head-ref HEAD --json