### PR TITLE
Add Colorado CMS effective MAGI limits

### DIFF
--- a/.axiom/encoding-manifests/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.json
+++ b/.axiom/encoding-manifests/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml",
+      "sha256": "47da5da01ee31b19356a20ab494a99cdb5e1f2518e819e66f0c5660d2023885e"
+    },
+    {
+      "path": "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml",
+      "sha256": "afbd97a826b32c7f199d333a168dba0fb432a7df307804af40bf548207b93ddf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "44e88dc54664fbe21b6fd18488a28565358955a5",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-tool-main-20260705",
+    "version": "0.2.1130",
+    "version_commit": "61f3cd8e44898642d0580842cf6dfa1c328e6842"
+  },
+  "axiom_encode_version": "0.2.1130",
+  "backend": "deterministic",
+  "citation": "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-05T02:53:42.852096+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0eichhbw/deterministic-repair/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp0eichhbw",
+  "generated_output_sha256": "47da5da01ee31b19356a20ab494a99cdb5e1f2518e819e66f0c5660d2023885e",
+  "generation_prompt_sha256": null,
+  "model": "cms-effective-magi-limits-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "55d7e97757217b7757f92ed02a96d26092f2fe8995056936a313c12868bdb41d"
+  },
+  "tool": "axiom-encode repair-cms-effective-magi-limits",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1127"
+axiom_encode_version = "0.2.1130"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "91a324f3f81d1f0ec35b1a53593bc867ff704973"
+axiom_encode_ref = "44e88dc54664fbe21b6fd18488a28565358955a5"
 axiom_corpus_ref = "b53a9d415793c6b572f7051527bbe06aca133716"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.

--- a/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml
+++ b/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml
@@ -15,3 +15,9 @@
     us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_chip_fpl_limit: 2.6
     us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_parent_caretaker_adults_medicaid_fpl_limit: 0.68
     us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_adult_medicaid_expansion_fpl_limit: 1.33
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_1_to_5_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_6_to_18_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_separate_chip_effective_fpl_limit: 2.65
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_chip_effective_fpl_limit: 2.65
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_medicaid_effective_fpl_limit: 2.00

--- a/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml
+++ b/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml
@@ -183,3 +183,100 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           1.33
+
+  - name: colorado_children_medicaid_ages_0_to_1_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_children_medicaid_ages_0_to_1_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_medicaid_ages_1_to_5_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_children_medicaid_ages_1_to_5_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_medicaid_ages_6_to_18_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_children_medicaid_ages_6_to_18_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_separate_chip_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_children_separate_chip_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_pregnant_women_chip_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_pregnant_women_chip_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_pregnant_women_medicaid_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Colorado row, including the MAGI 5% FPL disregard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          colorado_pregnant_women_medicaid_fpl_limit + magi_fpl_disregard_rate


### PR DESCRIPTION
## Summary
- add generated Colorado effective MAGI FPL limits for children Medicaid, separate CHIP, and pregnant women thresholds
- compute each effective threshold from the existing CMS raw FPL limit plus the 5% MAGI disregard
- add the signed Axiom encoding manifest and bump the pinned encoder toolchain to merged axiom-encode PR #1017 (`0.2.1130`, `44e88dc5`)

## Source / scope
The source is the CMS Medicaid, CHIP and BHP Eligibility Levels table for Colorado, with its 5% FPL disregard note. This is a cleanup to make the already-encoded CMS thresholds comparable to PolicyEngine effective MAGI parameters; it is not a claim that Colorado CHIP/Medicaid is fully encoded from maximally upstream state sources.

## Validation
- `uv run axiom-encode compile /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml --as-of 2023-12-01`
- `uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705/us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml`
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705 --base-ref origin/main --head-ref HEAD --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705 --oracle policyengine --program chip --fail-on-untested-comparable --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-next-20260705 --oracle policyengine --program health --fail-on-untested-comparable --json`