### PR TITLE
Seed money-atom ratchet for the org proof gate

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -47,6 +47,7 @@ allowed_root_files:
   - CLAUDE.md
   - README.md
   - known-dangling.yaml
+  - known-missing-money-atoms.yaml
   - known-validation-gaps.yaml
 path_rules:
   - patterns:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ pre-consolidation layout; only file locations changed.
 - `known-validation-gaps.yaml`: pre-existing content debt surfaced when
   repository-wide discipline first ran across all jurisdictions
   (rulespec-us#394).
+- `known-missing-money-atoms.yaml`: policy-bearing monetary values
+  (currency parameters, currency parameter-table cells, and currency
+  literals in derived formulas) that still lack a proof atom citing a
+  provision. Seeded from the current backlog measured by
+  `axiom-encode proof-validate --emit-ratchet`; the org
+  `validate-rulespec` workflow's money-atom step reads it so CI blocks any
+  new atom-less monetary value while the existing 151 are burned down.
 
-Both lists fail CI on new entries AND on listed entries that get fixed
+These lists fail CI on new entries AND on listed entries that get fixed
 without being removed, so they only shrink.
 
 Do not add singular rule roots, separate parameter/test fixture files, or

--- a/known-missing-money-atoms.yaml
+++ b/known-missing-money-atoms.yaml
@@ -1,0 +1,22 @@
+# Money-atom proof-obligation ratchet.
+#
+# Each count is the number of monetary values (currency parameters,
+# currency parameter-table cells, and currency literals in derived
+# formulas) that still lack a proof atom citing a provision.
+# `axiom-encode proof-validate --require-money-atoms` fails when the
+# untracked missing count exceeds `total_allowed`. Burn this down; do
+# not raise it. Regenerate with `--emit-ratchet`.
+total_allowed: 151
+# Current per-file backlog (informational):
+#   us-fl/policies/dcf/ess-program-policy-manual/appendix-a-12-state-funded-programs-eligibility-standards/page-1.yaml: 18
+#   us-il/policies/dhs/csmm/25-06-01.yaml: 46
+#   us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.yaml: 40
+#   us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml: 3
+#   us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml: 3
+#   us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml: 1
+#   us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml: 12
+#   us/policies/irs/rev-proc-2025-32/capital-gains.yaml: 8
+#   us/policies/irs/rev-proc-2025-32/child-tax-credit.yaml: 2
+#   us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml: 7
+#   us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml: 4
+#   us/statutes/26/25A.yaml: 7

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -49,6 +49,7 @@ def allowed_yaml_roots() -> set[str]:
         ".github",
         "programs",
         "known-dangling.yaml",
+        "known-missing-money-atoms.yaml",
         "known-validation-gaps.yaml",
         *(d.name for d in jurisdiction_dirs()),
     }


### PR DESCRIPTION
## Seed the money-atom proof ratchet

Adds `known-missing-money-atoms.yaml` at the repo root (`total_allowed: 151`),
the ratchet the org `validate-rulespec` workflow's new money-atom step reads.
Every policy-bearing monetary value — currency parameters, currency
parameter-table cells, and currency literals in derived formulas — must carry a
proof atom citing a provision; the check fails when the untracked missing count
exceeds the allowance.

**151 is a burn-down target, not a budget.** It is the current real backlog
measured by `axiom-encode proof-validate --emit-ratchet` over the same
jurisdiction-directory YAML set the workflow scans (35 roots, 3,042 files;
151 missing of 1,290 monetary obligations). Do not raise it — burn it down and
regenerate with `--emit-ratchet`. CI blocks any new atom-less monetary value
while the existing 151 are worked off.

### Guard registration
The ratchet lives at the repo root (like `known-dangling.yaml`) so the
`guard-generated` layout guard does not protect its path. Registered in both:
- `.axiom/repository-structure.yaml` `allowed_root_files` (org structure guard),
- `tests/test_repository_layout.py` `allowed_yaml_roots()` (repo layout test),

mirroring what rulespec-be#36 needed for its root ratchet files.

### Rollout note
This repo's `.axiom/toolchain.toml` pins an `axiom_encode_ref` that predates the
`--money-atoms-only` flag, so the workflow's money-atom step capability-skips
(loud `::warning::`, exit 0) until the ref is bumped. The seed is correct now
and activates for real on that bump — no CI behavior change from this PR beyond
the layout guards accepting the new root file.

Part of the org money-atom gate rollout:
- encoder gate: TheAxiomFoundation/axiom-encode#1019
- org reusable-workflow step: TheAxiomFoundation/.github#19
- sibling seed (Belgium): TheAxiomFoundation/rulespec-be#38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
