### PR TITLE
Arm the money-atom proof gate (bump axiom-encode ref past #1019)

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,9 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1130"
+axiom_encode_version = "0.2.1132"
 axiom_rules_engine_ref = "a1906e9fd870d435550511e8249cc44a6674c322"
-axiom_encode_ref = "44e88dc54664fbe21b6fd18488a28565358955a5"
+axiom_encode_ref = "1c676685b06cd69baa81d37660060caf8e49007b"
 axiom_corpus_ref = "b53a9d415793c6b572f7051527bbe06aca133716"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.


### PR DESCRIPTION
## Arm the money-atom proof gate

Bumps `.axiom/toolchain.toml` `axiom_encode_ref` to the current `axiom-encode` main SHA (`1c676685b06cd69baa81d37660060caf8e49007b`, the merge commit of TheAxiomFoundation/axiom-encode#1019) and the coupled `axiom_encode_version` to `0.2.1132` to match that commit's `pyproject.toml`.

### Why

The org reusable workflow's `Require money proof atoms` step (added in TheAxiomFoundation/.github#19) currently **capability-skips** in this repo: the pinned `axiom-encode` ref (`44e88dc5`, `0.2.1130`) predates the `--money-atoms-only` flag (added in axiom-encode#1019), so the step emits the `::warning:: Pinned axiom-encode does not support --money-atoms-only; skipping money-atom check` line and exits 0 without evaluating anything.

Bumping the toolchain ref past #1019 makes `axiom-encode proof-validate --help` expose `--money-atoms-only`, so the step runs for real and evaluates the repo-wide missing-money-atom count against the seed ratchet.

### Ratchet

The seed ratchet `known-missing-money-atoms.yaml` (`total_allowed: 151`) landed in #538. With the gate armed, the step enforces that the untracked missing-money-atom count stays at or below 151.

### Scope

Only `axiom_encode_ref` + its required `axiom_encode_version` change. `axiom_rules_engine_ref`, `axiom_corpus_ref`, and `rulespec_us_ref` are left untouched. Because `.axiom/toolchain.toml` changed, the workflow runs a full-repository revalidation (mode `full-toolchain-bump`).

Cross-links: TheAxiomFoundation/.github#19 (gate), #538 (seed ratchet), TheAxiomFoundation/axiom-encode#1019 (`--money-atoms-only`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
