### PR TITLE
Add companion tests for mapped Idaho AABD and Indiana SAPN parameters

### DIFF
--- a/.axiom/encoding-manifests/us-id/regulations/idapa/16/03/05/514.json
+++ b/.axiom/encoding-manifests/us-id/regulations/idapa/16/03/05/514.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-id/regulations/idapa/16/03/05/514.test.yaml",
+      "sha256": "4c916cde72a98e2fba65bbd8af9692a1e6ef50ae730a8d85cc7ae542c5142c91"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-b54684ce",
+    "version": "0.2.1151",
+    "version_commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88"
+  },
+  "axiom_encode_version": "0.2.1151",
+  "backend": "manual",
+  "citation": "us-id:regulations/idapa/16/03/05/514",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-05T15:04:55.410121+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw/sign-applied-files/us-id/regulations/idapa/16/03/05/514.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw",
+  "generated_output_sha256": "6c71bab9dca7b48b59c06705ebcfb4b911f06d8cc49b3539581ca815508d5cd8",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d128e1873a91f2adbcab3585b5c98628f2ea2d3c029dc2409be8802db897a0a6"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.json
+++ b/.axiom/encoding-manifests/us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.test.yaml",
+      "sha256": "c4f13d58671d816d5ac0c469e0bd94a011b2ca31d209c232c1828203c8dba038"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-b54684ce",
+    "version": "0.2.1151",
+    "version_commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88"
+  },
+  "axiom_encode_version": "0.2.1151",
+  "backend": "manual",
+  "citation": "us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-05T15:04:55.411771+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw/sign-applied-files/us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw",
+  "generated_output_sha256": "503b7bd65b3aaa940284247e4be37a059285b5209d1449eaf2b7fc3de39f6969",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1eb1404a1c73f3edc3b71124ec47c87dcceb62c10ba5941f2ff1d832bcfa7617"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-in/statutes/12-15-32-6.json
+++ b/.axiom/encoding-manifests/us-in/statutes/12-15-32-6.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-in/statutes/12-15-32-6.test.yaml",
+      "sha256": "c4f8c3e1076b7df83c988a27f255079784130535e23e464c601d26f34229a474"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-b54684ce",
+    "version": "0.2.1151",
+    "version_commit": "b54684ce3ff49d0f67adb0e92bdb8285343d5e88"
+  },
+  "axiom_encode_version": "0.2.1151",
+  "backend": "manual",
+  "citation": "us-in:statutes/12-15-32-6",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-05T15:04:55.412392+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw/sign-applied-files/us-in/statutes/12-15-32-6.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp00ss60rw",
+  "generated_output_sha256": "63f966911701d9a32494d2008fecd058da1f93d14b2d2a9795565a936da6191c",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "983a02d1c56e98456660705273df5494f9a05e9d615eb64b1834d05bb359fbc3"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-id/regulations/idapa/16/03/05/514.test.yaml
+++ b/us-id/regulations/idapa/16/03/05/514.test.yaml
@@ -75,3 +75,73 @@
     us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
   output:
     us-id:regulations/idapa/16/03/05/514#aabd_living_arrangement_maximum_payment: 0
+- name: oracle_parameter_single_participant_maximum_payment
+  period: 2024-07
+  input:
+    us-id:regulations/idapa/16/03/05/514#input.participant_countable_income: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_financial_need: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_couple_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_in_semi_independent_group_under_subsection_501_03: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_room_and_board_participant_under_section_512: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_single_under_subsection_501_01: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_lives_with_essential_person_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_receives_ssi_payment_for_month: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
+  output:
+    us-id:regulations/idapa/16/03/05/514#single_participant_maximum_payment: 53
+- name: oracle_parameter_couple_maximum_payment
+  period: 2024-07
+  input:
+    us-id:regulations/idapa/16/03/05/514#input.participant_countable_income: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_financial_need: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_couple_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_in_semi_independent_group_under_subsection_501_03: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_room_and_board_participant_under_section_512: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_single_under_subsection_501_01: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_lives_with_essential_person_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_receives_ssi_payment_for_month: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
+  output:
+    us-id:regulations/idapa/16/03/05/514#couple_maximum_payment: 20
+- name: oracle_parameter_essential_person_maximum_payment
+  period: 2024-07
+  input:
+    us-id:regulations/idapa/16/03/05/514#input.participant_countable_income: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_financial_need: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_couple_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_in_semi_independent_group_under_subsection_501_03: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_room_and_board_participant_under_section_512: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_single_under_subsection_501_01: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_lives_with_essential_person_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_receives_ssi_payment_for_month: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
+  output:
+    us-id:regulations/idapa/16/03/05/514#essential_person_maximum_payment: 18
+- name: oracle_parameter_semi_independent_group_maximum_payment
+  period: 2024-07
+  input:
+    us-id:regulations/idapa/16/03/05/514#input.participant_countable_income: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_financial_need: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_couple_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_in_semi_independent_group_under_subsection_501_03: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_room_and_board_participant_under_section_512: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_single_under_subsection_501_01: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_lives_with_essential_person_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_receives_ssi_payment_for_month: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
+  output:
+    us-id:regulations/idapa/16/03/05/514#semi_independent_group_maximum_payment: 169
+- name: oracle_parameter_room_and_board_maximum_payment
+  period: 2024-07
+  input:
+    us-id:regulations/idapa/16/03/05/514#input.participant_countable_income: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_financial_need: 0
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_couple_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_in_semi_independent_group_under_subsection_501_03: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_room_and_board_participant_under_section_512: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_is_single_under_subsection_501_01: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_lives_with_essential_person_under_subsection_501_02: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_receives_ssi_payment_for_month: false
+    us-id:regulations/idapa/16/03/05/514#input.participant_resides_in_ralf_or_cfh: false
+  output:
+    us-id:regulations/idapa/16/03/05/514#room_and_board_maximum_payment: 198

--- a/us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.test.yaml
+++ b/us-in/policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00.test.yaml
@@ -77,3 +77,13 @@
     us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#input.budgeted_unearned_income: 15
   output:
     us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_benefit_amount: 0
+- name: oracle_parameter_sapn_maximum_benefit_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#input.budgeted_earned_income: 0
+    us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#input.budgeted_unearned_income: 0
+  output:
+    us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_maximum_benefit_amount: 22

--- a/us-in/statutes/12-15-32-6.test.yaml
+++ b/us-in/statutes/12-15-32-6.test.yaml
@@ -19,3 +19,13 @@
     us-in:statutes/12-15-32-6#input.receiving_medicaid: false
   output:
     us-in:statutes/12-15-32-6#medicaid_facility_resident_personal_allowance: 0
+- name: oracle_parameter_medicaid_facility_resident_personal_allowance_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/12-15-32-6#input.receiving_medicaid: false
+    us-in:statutes/12-15-32-6#input.resident_of_facility: false
+  output:
+    us-in:statutes/12-15-32-6#medicaid_facility_resident_personal_allowance_amount: 52


### PR DESCRIPTION
## Summary

Adds companion oracle-parameter tests for the 7 pre-existing `comparable`-but-untested parameter outputs that block any full toolchain bump's whole-repo `oracle-coverage --fail-on-untested-comparable` scan (first surfaced by #548's encoder bump):

| Output | Cited value |
|---|---|
| `us-id:regulations/idapa/16/03/05/514#single_participant_maximum_payment` | $53 |
| `us-id:regulations/idapa/16/03/05/514#couple_maximum_payment` | $20 |
| `us-id:regulations/idapa/16/03/05/514#essential_person_maximum_payment` | $18 |
| `us-id:regulations/idapa/16/03/05/514#semi_independent_group_maximum_payment` | $169 |
| `us-id:regulations/idapa/16/03/05/514#room_and_board_maximum_payment` | $198 |
| `us-in:statutes/12-15-32-6#medicaid_facility_resident_personal_allowance_amount` | $52 |
| `us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_maximum_benefit_amount` | $22 |

These files are apply-manifest-guarded, so the tests were generated through the signed deterministic repair path (`axiom-encode repair-oracle-parameter-tests`, encoder `b54684ce`) rather than hand edits; each generated case asserts the module's corpus-cited dollar amount, and signed apply manifests accompany the guarded files.

## Verification (local)

- `guard-generated` PASS under both the pinned encoder (`d38939e0`) and `b54684ce`
- `validate` + `proof-validate` PASS for all three modules under the pinned encoder
- Companion tests: 3 files, 19 cases PASS under the pinned encoder
- Full-repo `oracle-coverage --fail-on-unmapped --fail-on-untested-comparable`: exit 0 (0 unmapped, 0 untested) under both `b54684ce` and encoder main `a314fc62` (post-#1033, needed for the Kansas SSPP outputs merged in #550)
- Repo pytest: 17 passed; reverse index up to date

## Notes

- Main's push CI is currently red (since 5d5ff1b9) on 2 unmapped `us:statutes/42/1397ll/f/1` outputs that only the bumped encoder classifies; that is resolved by #548's toolchain bump, not this PR.
- Unblocks #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
