### PR TITLE
Make 42 USC 415(i) COLA application year-general (#552)

### DIFF
--- a/.axiom/encoding-manifests/us/policies/ssa/cola/2026.json
+++ b/.axiom/encoding-manifests/us/policies/ssa/cola/2026.json
@@ -1,30 +1,26 @@
 {
   "applied_files": [
     {
-      "path": "us/policies/ssa/cola/2026.test.yaml",
-      "sha256": "89377cc5ebb8ba5afc1625f33dfa047f1d08bd221a71d843ef0bf2c0ea56c775"
-    },
-    {
       "path": "us/policies/ssa/cola/2026.yaml",
-      "sha256": "5249208f72f03e3909eaa93bb59bf8a6bd6a68b89b5a4ddead2a6859b34af775"
+      "sha256": "698419d0ccb8a5e0a8c301b8bb37647d1f53edb719de43b7f95919847be1661b"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1aee207a735ec409c2730972eece0520de9b33cc",
+    "commit": "b99d8edd0f286d317d33a0fadfcd881027153206",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1153",
-    "version_commit": "1aee207a735ec409c2730972eece0520de9b33cc"
+    "root": "/private/tmp/claude-501/-Users-maxghenis/ca5f4ab7-d8a5-4e03-82eb-71e2a5166288/scratchpad/ae-b99d8ed",
+    "version": "0.2.1155",
+    "version_commit": "b99d8edd0f286d317d33a0fadfcd881027153206"
   },
-  "axiom_encode_version": "0.2.1153",
+  "axiom_encode_version": "0.2.1155",
   "backend": "manual",
   "citation": "us:policies/ssa/cola/2026",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-05T15:46:28.365611+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp92dzb8_6/sign-applied-files/us/policies/ssa/cola/2026.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp92dzb8_6",
-  "generated_output_sha256": "5249208f72f03e3909eaa93bb59bf8a6bd6a68b89b5a4ddead2a6859b34af775",
+  "generated_at": "2026-07-05T18:45:27.350820+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpayxpl476/sign-applied-files/us/policies/ssa/cola/2026.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpayxpl476",
+  "generated_output_sha256": "698419d0ccb8a5e0a8c301b8bb37647d1f53edb719de43b7f95919847be1661b",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,7 +29,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "de59f6ae5823c3524604b5f4dff8761e25fc8b1692a036986704fe0bc481b3e1"
+    "value": "ae7df697edc75e71f7dbcf0a601ebe57dd169e142577fdad4eebfe21a08ba56f"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/statutes/42/415/i.json
+++ b/.axiom/encoding-manifests/us/statutes/42/415/i.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us/statutes/42/415/i.test.yaml",
-      "sha256": "46c292eb5f2a2c33fa2b507bbf07246d18de95cabf7ed4cc4be6fcc9510ef451"
+      "sha256": "302875f6dae8aa4b8d5ae603b6b759ff1651152e0015549e6e5ce0fde9464ab2"
     },
     {
       "path": "us/statutes/42/415/i.yaml",
-      "sha256": "e65278f9114c1577020a5e2b029168b35eeefa4b45d4b1708e71dc1e9e846a72"
+      "sha256": "6414eeaed24d55cb39390bc690113aacff850a573ac6b4967cbc83805356b7bd"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1aee207a735ec409c2730972eece0520de9b33cc",
+    "commit": "b99d8edd0f286d317d33a0fadfcd881027153206",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1153",
-    "version_commit": "1aee207a735ec409c2730972eece0520de9b33cc"
+    "root": "/private/tmp/claude-501/-Users-maxghenis/ca5f4ab7-d8a5-4e03-82eb-71e2a5166288/scratchpad/ae-b99d8ed",
+    "version": "0.2.1155",
+    "version_commit": "b99d8edd0f286d317d33a0fadfcd881027153206"
   },
-  "axiom_encode_version": "0.2.1153",
+  "axiom_encode_version": "0.2.1155",
   "backend": "manual",
   "citation": "us:statutes/42/415/i",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-05T15:46:28.369155+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp92dzb8_6/sign-applied-files/us/statutes/42/415/i.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp92dzb8_6",
-  "generated_output_sha256": "e65278f9114c1577020a5e2b029168b35eeefa4b45d4b1708e71dc1e9e846a72",
+  "generated_at": "2026-07-05T18:45:27.351888+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpayxpl476/sign-applied-files/us/statutes/42/415/i.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpayxpl476",
+  "generated_output_sha256": "6414eeaed24d55cb39390bc690113aacff850a573ac6b4967cbc83805356b7bd",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,7 +33,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "72cb608099883a776c269a4aedeac44fc1383ef7e556b862181948ffc07c38ef"
+    "value": "8253e0ba644f2716fab112a9109c651cdf525ed6d6bbc7e531da299408072ecb"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/us/policies/ssa/cola/2026.yaml
+++ b/us/policies/ssa/cola/2026.yaml
@@ -19,7 +19,7 @@ module:
   deferred_outputs:
     - output: us:policies/ssa/cola/2026#social_security_benefit_after_2026_cost_of_living_increase
       reason: |-
-        This policy module supplies only the 2026 cost-of-living increase percentage as an operational parameter. Applying it to a primary insurance amount is the statutory operation of 42 USC 415(i)(2)(A)(ii), encoded in us/statutes/42/415/i (which imports this percentage to produce primary_insurance_amount_after_cost_of_living_increase). No benefit-bearing numeric output is computed in this policy module itself.
+        This policy module supplies only the 2026 cost-of-living increase percentage as an operational parameter. Applying it to a primary insurance amount is the year-general statutory operation of 42 USC 415(i)(2)(A)(ii), encoded in us/statutes/42/415/i, which takes the applicable increase percentage as a free input (cola_applicable_increase_percentage) rather than importing any determination year's value, and produces primary_insurance_amount_after_cost_of_living_increase. This year's percentage is bound to that free input where the statute is applied. No benefit-bearing numeric output is computed in this policy module itself.
       source_values:
         - us:policies/ssa/cola/2026#social_security_cola_2026_applicable_increase_percentage
 rules:

--- a/us/statutes/42/415/i.test.yaml
+++ b/us/statutes/42/415/i.test.yaml
@@ -1,15 +1,20 @@
-# The 415(i) cost-of-living outputs (unrounded and rounded
-# COLA-adjusted primary insurance amount) consume 42 USC 415(a)'s
-# primary_insurance_amount, which flows from the 415(b) AIME computed
-# with the engine's sum_top_n_over_periods over-periods reduction.
-# That reduction is valid only under lifetime execution, which the
-# per-period companion-test harness does not drive, so those derived
-# outputs cannot be asserted here (listed in
-# known-validation-gaps.yaml#uncovered_derived_rules, tracked by
-# TheAxiomFoundation/axiom-encode#1036). The dime-rounding COLA
-# application is verified by hand in the module (a PIA of 3,263.20
-# increased by the 2.8% 2026 COLA gives 3,354.57, rounded down to the
-# next lower $0.10 = 3,354.50). The rounding-multiple parameter is
+# 42 USC 415(i) is year-general: the applicable increase percentage is
+# the free input cola_applicable_increase_percentage, fixed each year by
+# the Commissioner's determination under 415(i)(2)(A)(i) and supplied by
+# that year's policy module (for 2026, us/policies/ssa/cola/2026 =
+# 2.8%). A new determination year is a new policy file, not an edit here.
+#
+# The COLA-adjusted outputs (unrounded and rounded COLA-adjusted primary
+# insurance amount) consume 42 USC 415(a)'s primary_insurance_amount,
+# which flows from the 415(b) AIME computed with the engine's
+# sum_top_n_over_periods over-periods reduction. That reduction is valid
+# only under lifetime execution, which the per-period companion-test
+# harness does not drive, so those derived outputs cannot be asserted
+# here (listed in known-validation-gaps.yaml#uncovered_derived_rules,
+# tracked by TheAxiomFoundation/axiom-encode#1036). The dime-rounding
+# COLA application is verified by hand in the module: a PIA of 3,263.20
+# multiplied by (1 + 0.028) = 3,354.5696, decreased to the next lower
+# multiple of $0.10 = 3,354.50. The rounding-multiple parameter is
 # asserted below.
 - name: cola_pia_rounding_multiple_is_a_dime
   period:

--- a/us/statutes/42/415/i.yaml
+++ b/us/statutes/42/415/i.yaml
@@ -1,7 +1,6 @@
 format: rulespec/v1
 imports:
   - us:statutes/42/415/a#primary_insurance_amount
-  - us:policies/ssa/cola/2026#social_security_cola_2026_applicable_increase_percentage
 module:
   proof_validation:
     required: true
@@ -11,7 +10,14 @@ module:
       - us/statute/42/415/i
       - us/statute/42/415/i/2
   summary: |-
-    When the Commissioner determines that a base quarter is a cost-of-living computation quarter, the primary insurance amount is increased effective with December by applying the applicable increase percentage. The resulting amount is decreased to the next lower multiple of $0.10 if needed. This module imports the 2026 SSA COLA percentage as an operational parameter.
+    When the Commissioner determines that a base quarter is a cost-of-living computation quarter, the primary insurance amount is increased effective with December by multiplying it by the applicable increase percentage, and the resulting amount is decreased to the next lower multiple of $0.10 if needed. Section 415(i)(2)(A)(i) directs the Commissioner to make this determination each year beginning with 1975, so the applicable increase percentage is a determination fixed per calendar year rather than a value stated in the statute. This module is therefore year-general: it takes the applicable increase percentage as a free input, and each determination year's percentage is supplied by its own policy module (for 2026, us/policies/ssa/cola/2026). A new determination year is a new policy file, not an edit to this statute module.
+
+    Input contract: cola_applicable_increase_percentage is the year's
+    applicable increase percentage fixed by the Commissioner's annual
+    determination under 415(i)(2)(A). Under lifetime execution it must be
+    supplied period-invariant (identical in every period) or wrapped in an
+    over-periods reduction; the engine rejects period-varying bare inputs
+    outside reductions.
 rules:
   - name: cola_pia_rounding_multiple
     kind: parameter
@@ -71,17 +77,11 @@ rules:
               target: us:statutes/42/415/a#primary_insurance_amount
               output: primary_insurance_amount
               hash: sha256:bf244b9460ead81724d135bb1f806a1ffb45ebc2e04bfdc33f1175ea28357221
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:policies/ssa/cola/2026#social_security_cola_2026_applicable_increase_percentage
-              output: social_security_cola_2026_applicable_increase_percentage
-              hash: sha256:5249208f72f03e3909eaa93bb59bf8a6bd6a68b89b5a4ddead2a6859b34af775
     versions:
       - effective_from: '1975-01-01'
         formula: |-
           primary_insurance_amount
-          * (1 + social_security_cola_2026_applicable_increase_percentage)
+          * (1 + cola_applicable_increase_percentage)
   - name: primary_insurance_amount_after_cost_of_living_increase
     kind: derived
     entity: Person


### PR DESCRIPTION
Resolves #552.

The statute-level PIA cost-of-living module `us/statutes/42/415/i` hard-imported the year-specific 2026 COLA policy and year-baked one determination year into a year-general statute module (the PLAUSIBLE flag in the #541 review). Every future determination year would force an edit to the `415/i` statute module rather than a new policy file.

## Change

42 USC 415(i)(2)(A)(i) directs the Commissioner to determine the applicable increase percentage *each year beginning with 1975* (verbatim in the corpus provision `us/statute/42/415/i/2`), so the percentage is a per-year determination, not statutory content. This PR inverts the dependency:

- **`us/statutes/42/415/i.yaml` is now year-general.** It takes the applicable increase percentage as a free input `cola_applicable_increase_percentage` (Input contract documented in the summary, following the `402(q)` free-input convention) and imports **no** determination year's policy. The COLA operation (`pia × (1 + percentage)`, decreased to the next lower `$0.10`) is unchanged and stays grounded solely in `us/statute/42/415/i` and `.../i/2`.
- **Each determination year's percentage is a policy file.** 2026 remains `us/policies/ssa/cola/2026` (2.8%), grounded verbatim in the SSA official 2026 determination `us/guidance/ssa/cola/2026/block-1`. A new year (e.g. 2027) is a new policy file supplying that year's percentage — **not** an edit to the statute module. Its `deferred_outputs` rationale is corrected to describe the free input rather than an import.

Only the 2026 determination exists in the corpus (`corpus#212`), so 2026 is the sole grounded year; the structural win is that the statute no longer carries any year.

## Grounding

Every proof-atom excerpt was verified to appear verbatim in the corpus#212 provision JSONL before commit (`axiom-encode proof-validate` re-checks this: 415/i 11 atoms, cola/2026 2 atoms, both PASS).

## Validation gaps (unchanged, honest)

`415(i)`'s COLA-adjusted derived outputs still consume `415(a)`'s `primary_insurance_amount`, which flows from the `415(b)` AIME `sum_top_n_over_periods` over-periods reduction — valid only under lifetime execution, not the per-period companion-test harness (`axiom-encode#1036`). So `415/i` stays in `known-validation-gaps.yaml` under `uncovered_derived_rules` and `validate_failures` exactly as before; the dime-rounding parameter is asserted and the application is hand-verified in the module.

## Local verification (toolchain pinned to `.axiom/toolchain.toml`: engine `e19f1b7`, encode `0.2.1155`, corpus `7661f3c`)

- `axiom-encode validate` / `proof-validate` on both modules: PASS
- `axiom-encode test` companion tests: 2 files, 2 cases PASS
- money-atom check (whole `us/` scan, ratchet 151): PASS, no new atom-less monetary value
- `axiom-encode guard-generated` (base `origin/main`): all changed files have signed apply manifests
- full `pytest tests`: 17 passed

No new dollar-bearing parameter (the COLA is a `Rate`); the money-atom ratchet is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
