### PR TITLE
Fix NYC income tax validation metadata

### DIFF
--- a/.axiom/encoding-manifests/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.json
+++ b/.axiom/encoding-manifests/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml",
+      "sha256": "b4ce08c868f15a04e3fedde5985a336383438c013f67837aabd97ee876a6dbbb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d6eba6aca2df6ba752ae099bd51d2650dc0b6816",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.1176",
+    "version_commit": "d6eba6aca2df6ba752ae099bd51d2650dc0b6816"
+  },
+  "axiom_encode_version": "0.2.1176",
+  "backend": "manual",
+  "citation": "us-ny:policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-06T20:11:16.583683+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbajpt1as/sign-applied-files/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbajpt1as",
+  "generated_output_sha256": "b4ce08c868f15a04e3fedde5985a336383438c013f67837aabd97ee876a6dbbb",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9ac4a8d60c6ab67522ba7ae7823ff15a174b29cdff99c37e5df1c1015a34fcef"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.json
+++ b/.axiom/encoding-manifests/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml",
+      "sha256": "b519fb659046c5a112a1740f57d093b2c4db939e701e88fcdabb68b22f9a231e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "d6eba6aca2df6ba752ae099bd51d2650dc0b6816",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.1176",
+    "version_commit": "d6eba6aca2df6ba752ae099bd51d2650dc0b6816"
+  },
+  "axiom_encode_version": "0.2.1176",
+  "backend": "manual",
+  "citation": "us-ny:policies/tax/it-216-instructions/nyc-child-dependent-care-credit",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-06T20:11:16.584596+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbajpt1as/sign-applied-files/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbajpt1as",
+  "generated_output_sha256": "b519fb659046c5a112a1740f57d093b2c4db939e701e88fcdabb68b22f9a231e",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ed507ec4c8e25427ce9f749b847db65d7989899eeadd69ef0efa9013abf45abe"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml
+++ b/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml
@@ -4,6 +4,18 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-ny/form/tax/it-201-instructions/page-21
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-ny/statute/NYC/11-1701
+        - us-ny/statute/NYC/11-1706
+        - us-ny/form/tax/it-201-instructions/page-21
+      rationale: |-
+        The NYC Administrative Code supplies the resident personal income-tax
+        framework and credit authority, while the New York State IT-201
+        instructions are the official tax-administration source for the
+        current-year NYC school tax credit rate-reduction worksheet tables,
+        thresholds, base amounts, and rates encoded here.
   summary: |-
     "Calculation of NYC school tax credit (rate reduction amount)" tables: for married filing jointly and qualifying surviving spouse, $0-$21,600 uses 0.171% of taxable income and $21,600-$500,000 uses $37 plus 0.228% of excess over $21,600; for single and married filing separately, $0-$12,000 uses 0.171% and $12,000-$500,000 uses $21 plus 0.228% of excess over $12,000; for head of household, $0-$14,400 uses 0.171% and $14,400-$500,000 uses $25 plus 0.228% of excess over $14,400.
 rules:

--- a/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml
+++ b/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml
@@ -4,6 +4,18 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-ny/form/tax/it-216-instructions/page-6
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-ny/statute/NYC/11-1701
+        - us-ny/statute/NYC/11-1706
+        - us-ny/form/tax/it-216-instructions/page-6
+      rationale: |-
+        The NYC Administrative Code supplies the resident personal income-tax
+        framework and credit authority, while the New York State IT-216
+        instructions are the official tax-administration source for the
+        current-year NYC child and dependent care credit worksheet lines,
+        thresholds, limitation table, and line 24 placement encoded here.
   summary: |-
     Caution: If your FAGI is over $30,000 or you have no children under 4 years old, stop; you do not qualify for the New York City child and dependent care credit. Worksheet 2 computes line 7 by multiplying line 1 by the line 2/line 3 ratio, capped at 100% (1.0000), and then by the NYC limitation table decimal. Full-year New York City residents enter line 7 on Form IT-216, line 24. Part-year residents complete lines 8-13: the credit first reduces New York City tax liability to zero, and remaining excess is refunded based on the ratio of resident period income to combined income.
 rules:


### PR DESCRIPTION
## Summary
- add upstream source verification metadata for NYC school tax credit rate-reduction and NYC child/dependent care credit policy files
- add signed monorepo manifests for the two updated NY policy files using axiom-encode 0.2.1176
- leaves the archived rulespec-us-ny repo untouched; canonical changes are under rulespec-us/us-ny

## Verification
- `uv run axiom-encode validate --skip-reviewers /Users/pavelmakarchuk/rulespec-us/us-ny/statutes/NYC/11-1701.yaml /Users/pavelmakarchuk/rulespec-us/us-ny/statutes/NYC/11-1704/1.yaml /Users/pavelmakarchuk/rulespec-us/us-ny/statutes/NYC/11-1706.yaml /Users/pavelmakarchuk/rulespec-us/us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml /Users/pavelmakarchuk/rulespec-us/us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml` -> all 5 passed
- `uv run axiom-encode test --root /Users/pavelmakarchuk/rulespec-us/us-ny /Users/pavelmakarchuk/rulespec-us/us-ny/statutes/NYC /Users/pavelmakarchuk/rulespec-us/us-ny/policies/tax` -> 5 file(s), 17 case(s)
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run axiom-encode sign-applied-files --repo /Users/pavelmakarchuk/rulespec-us --base-ref origin/main --head-ref HEAD --dry-run` -> 2 manifest(s) for 2 file(s)
