### PR TITLE
Fix bulk-encode: pass --apply to the encode command

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -231,6 +231,7 @@ jobs:
             --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
             --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
             --output "$RUNNER_TEMP/encode-out" \
+            --apply \
             --no-sync 2>&1 | tee "$RUNNER_TEMP/encode.log"
           apply_status=${PIPESTATUS[0]}
           set -e


### PR DESCRIPTION
## Fix: pass `--apply` to the bulk-encode command

The bulk-encode dispatcher's encode step omitted `--apply`, so `axiom-encode encode` ran in generate-only mode (writing to `RUNNER_TEMP`), installed nothing into the checked-out repo, and the job's applied-files detection then reported every module as failed (`exit 0`, no git changes, no PR opened).

The pilot batch-A dispatch (run 28832119239) surfaced this on the first two completed legs. Fix adds `--apply`, matching the step's documented behavior and the local end-to-end verification (7/8 batch-A modules confirmed to encode + apply + pass the full gate battery locally).

Workflow-only change; lints clean with actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
