### PR TITLE
Encode us-il/statute/35/5/206 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9729,6 +9729,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/206": [
+      {
+        "module": "us-il/statutes/35/5/206.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/statute/35/5/212": [
       {
         "module": "us-il/statutes/35/5/212.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/206.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/206.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/206.yaml",
+      "sha256": "292d72bcd85fced9ee6880ae9e7af024d59378d12cb733a06863d462a3f1cf74"
+    },
+    {
+      "path": "statutes/35/5/206.test.yaml",
+      "sha256": "1e9d726b55e0e401284d0a0a2928f6d884c081f95fbe72269eb50bf041cdcc34"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-il/statute/35/5/206",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-il-statute-35-5-206/workspace/context-manifest.json",
+  "context_manifest_sha256": "c99c654f593419b7ec03a6624ae1605e2d25c668da32fe679992571b4ec42d16",
+  "generated_at": "2026-07-07T10:28:28.769557+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/35/5/206.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "292d72bcd85fced9ee6880ae9e7af024d59378d12cb733a06863d462a3f1cf74",
+  "generation_prompt_sha256": "4140ffe36b69c429f683af3514d176ec294ee6f3d29a7be26fe7a00393846eb2",
+  "model": "gpt-5.5",
+  "run_id": "aaa7f62d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d87ef4738fd2eed490ff1580383fd23475ec37da122eebbe48a556794bdcf7b8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-il-statute-35-5-206.json",
+  "trace_sha256": "c545ea7e47c4f115330170ab1747c0e65069c37437466f0bc20ad29e7353de3e"
+}

--- a/us-il/statutes/35/5/206.test.yaml
+++ b/us-il/statutes/35/5/206.test.yaml
@@ -1,0 +1,68 @@
+- name: corporation_before_sunset_gets_both_generated_coal_credits
+  period:
+    period_kind: tax_year
+    start: '2004-01-01'
+    end: '2004-12-31'
+  input:
+    us-il:statutes/35/5/206#input.corporation_subject_to_act: true
+    us-il:statutes/35/5/206#input.amount_donated_to_illinois_center_for_research_on_sulfur_in_coal: 1000
+    us-il:statutes/35/5/206#input.equipment_is_qualifying_direct_coal_combustion_or_necessary_pollution_control_equipment: true
+    ? us-il:statutes/35/5/206#input.equipment_purchased_for_maintaining_or_increasing_illinois_coal_use_at_corporation_illinois_facility
+    : true
+    us-il:statutes/35/5/206#input.equipment_placed_in_service_for_credit_year: true
+    us-il:statutes/35/5/206#input.qualifying_equipment_federal_depreciation_basis: 2000
+  output:
+    us-il:statutes/35/5/206#coal_research_donation_credit: 200
+    us-il:statutes/35/5/206#coal_utilization_equipment_credit: 100
+    us-il:statutes/35/5/206#total_generated_coal_credit: 300
+- name: non_subject_corporation_gets_no_generated_coal_credit
+  period:
+    period_kind: tax_year
+    start: '2004-01-01'
+    end: '2004-12-31'
+  input:
+    us-il:statutes/35/5/206#input.corporation_subject_to_act: false
+    us-il:statutes/35/5/206#input.amount_donated_to_illinois_center_for_research_on_sulfur_in_coal: 1000
+    us-il:statutes/35/5/206#input.equipment_is_qualifying_direct_coal_combustion_or_necessary_pollution_control_equipment: true
+    ? us-il:statutes/35/5/206#input.equipment_purchased_for_maintaining_or_increasing_illinois_coal_use_at_corporation_illinois_facility
+    : true
+    us-il:statutes/35/5/206#input.equipment_placed_in_service_for_credit_year: true
+    us-il:statutes/35/5/206#input.qualifying_equipment_federal_depreciation_basis: 2000
+  output:
+    us-il:statutes/35/5/206#coal_research_donation_credit: 0
+    us-il:statutes/35/5/206#coal_utilization_equipment_credit: 0
+    us-il:statutes/35/5/206#total_generated_coal_credit: 0
+- name: equipment_credit_requires_qualifying_equipment_and_service
+  period:
+    period_kind: tax_year
+    start: '2004-01-01'
+    end: '2004-12-31'
+  input:
+    us-il:statutes/35/5/206#input.corporation_subject_to_act: true
+    us-il:statutes/35/5/206#input.amount_donated_to_illinois_center_for_research_on_sulfur_in_coal: 0
+    us-il:statutes/35/5/206#input.equipment_is_qualifying_direct_coal_combustion_or_necessary_pollution_control_equipment: false
+    ? us-il:statutes/35/5/206#input.equipment_purchased_for_maintaining_or_increasing_illinois_coal_use_at_corporation_illinois_facility
+    : true
+    us-il:statutes/35/5/206#input.equipment_placed_in_service_for_credit_year: true
+    us-il:statutes/35/5/206#input.qualifying_equipment_federal_depreciation_basis: 2000
+  output:
+    us-il:statutes/35/5/206#coal_research_donation_credit: 0
+    us-il:statutes/35/5/206#coal_utilization_equipment_credit: 0
+    us-il:statutes/35/5/206#total_generated_coal_credit: 0
+- name: credits_are_zero_after_sunset
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/206#input.corporation_subject_to_act: true
+    us-il:statutes/35/5/206#input.amount_donated_to_illinois_center_for_research_on_sulfur_in_coal: 1000
+    us-il:statutes/35/5/206#input.equipment_is_qualifying_direct_coal_combustion_or_necessary_pollution_control_equipment: true
+    ? us-il:statutes/35/5/206#input.equipment_purchased_for_maintaining_or_increasing_illinois_coal_use_at_corporation_illinois_facility
+    : true
+    us-il:statutes/35/5/206#input.equipment_placed_in_service_for_credit_year: true
+    us-il:statutes/35/5/206#input.qualifying_equipment_federal_depreciation_basis: 2000
+  output:
+    us-il:statutes/35/5/206#coal_research_donation_credit: 0
+    us-il:statutes/35/5/206#coal_utilization_equipment_credit: 0
+    us-il:statutes/35/5/206#total_generated_coal_credit: 0

--- a/us-il/statutes/35/5/206.yaml
+++ b/us-il/statutes/35/5/206.yaml
@@ -1,0 +1,171 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/206
+  summary: |-
+    Until January 1, 2005, each corporation subject to the Act was entitled to credits against Section 201(a) and (b) tax equal to 20% of amounts donated to the Illinois Center for Research on Sulfur in Coal and 5% of amounts spent on qualifying Illinois-coal utilization equipment. The equipment amount is the federal depreciation basis. Excess credit may be carried forward to the 5 taxable years following the excess credit year, applied to the earliest liability year and with earlier credits applied first.
+  deferred_outputs:
+    - output: us-il:statutes/35/5/206#coal_credit_applied_against_tax_liability
+      reason: The final application of credits against Section 201 tax liability depends on original or amended tax liability for the credit year, excess-credit carryforward tracking across the 5 following taxable years, earliest-liability-year ordering, and ordering among credits from multiple tax years. Those multi-year liability and ordering mechanics are not representable as a faithful single-period formula here.
+      source_values:
+        - us-il:statutes/35/5/206#coal_credit_carryforward_year_limit
+        - us-il:statutes/35/5/206#coal_research_donation_credit_rate
+        - us-il:statutes/35/5/206#coal_utilization_equipment_credit_rate
+rules:
+  - name: coal_research_donation_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 206(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "a credit ... in an amount equal to 20% of the amount donated"
+          - path: versions[1].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "Until January 1, 2005"
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          0.20
+      - effective_from: '2005-01-01'
+        formula: |-
+          0
+
+  - name: coal_utilization_equipment_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 206(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "a credit ... in an amount equal to 5% of the amount spent"
+          - path: versions[1].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "Until January 1, 2005"
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          0.05
+      - effective_from: '2005-01-01'
+        formula: |-
+          0
+
+  - name: coal_credit_carryforward_year_limit
+    kind: parameter
+    dtype: Count
+    source: 206
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "carried forward and applied to the tax liability of the 5 taxable years"
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          5
+
+  - name: coal_research_donation_credit
+    kind: derived
+    entity: Corporation
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "each corporation subject to this Act shall be entitled to a credit ... equal to 20% of the amount donated"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:statutes/35/5/206#coal_research_donation_credit_rate
+              output: coal_research_donation_credit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          if corporation_subject_to_act: max(0, amount_donated_to_illinois_center_for_research_on_sulfur_in_coal * coal_research_donation_credit_rate) else: 0
+
+  - name: coal_utilization_equipment_credit
+    kind: derived
+    entity: Corporation
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "amount spent on qualifying equipment shall be defined as the basis of the equipment used to compute the depreciation deduction for federal income tax purposes"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "equipment purchased for the purpose of maintaining or increasing the use of Illinois coal"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:statutes/35/5/206#coal_utilization_equipment_credit_rate
+              output: coal_utilization_equipment_credit_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          if corporation_subject_to_act and equipment_is_qualifying_direct_coal_combustion_or_necessary_pollution_control_equipment and equipment_purchased_for_maintaining_or_increasing_illinois_coal_use_at_corporation_illinois_facility and equipment_placed_in_service_for_credit_year: max(0, qualifying_equipment_federal_depreciation_basis * coal_utilization_equipment_credit_rate) else: 0
+
+  - name: total_generated_coal_credit
+    kind: derived
+    entity: Corporation
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206(a), 206(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/206
+              excerpt: "credit ... equal to 20% of the amount donated ... credit ... equal to 5% of the amount spent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:statutes/35/5/206#coal_research_donation_credit
+              output: coal_research_donation_credit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-il:statutes/35/5/206#coal_utilization_equipment_credit
+              output: coal_utilization_equipment_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '1987-12-31'
+        formula: |-
+          max(0, coal_research_donation_credit + coal_utilization_equipment_credit)


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-il/statute/35/5/206`
- Module: `us-il/statutes/35/5/206.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 57s
- Local gate status: **green**

Produced by `axiom-encode encode us-il/statute/35/5/206 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-il/statute/35/5/206",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "aaa7f62d",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/35/5/206.yaml",
      "sha256": "292d72bcd85fced9ee6880ae9e7af024d59378d12cb733a06863d462a3f1cf74"
    },
    {
      "path": "statutes/35/5/206.test.yaml",
      "sha256": "1e9d726b55e0e401284d0a0a2928f6d884c081f95fbe72269eb50bf041cdcc34"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
