### PR TITLE
Encode us-il/statute/35/5/306 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9738,6 +9738,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/306": [
+      {
+        "module": "us-il/statutes/35/5/306.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/statute/35/5/404": [
       {
         "module": "us-il/statutes/35/5/404.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/306.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/306.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/306.yaml",
+      "sha256": "df345e90aa0cb0e24223d90f68e98e3241c99ff712a635316f10df597917bf00"
+    },
+    {
+      "path": "statutes/35/5/306.test.yaml",
+      "sha256": "63776a08db12e332f6e1a9e102f2739acfb786ebb1b6c31567ac83e8d80823f9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-il/statute/35/5/306",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-il-statute-35-5-306/workspace/context-manifest.json",
+  "context_manifest_sha256": "c5154099e32b0c08c9339072f40b7cb6b4b2b79be0e7d40994831e88d2c957bb",
+  "generated_at": "2026-07-07T10:34:18.859775+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/35/5/306.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "df345e90aa0cb0e24223d90f68e98e3241c99ff712a635316f10df597917bf00",
+  "generation_prompt_sha256": "06d26e1a275128947decc5c9e1d9e7b6e88c9b6e1516c4921da0f3601b74afe1",
+  "model": "gpt-5.5",
+  "run_id": "2373e45e",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cced597e40c6ce0c34613152134c793db16f850cfb199f1828270e8b142f9bbd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-il-statute-35-5-306.json",
+  "trace_sha256": "6bb0d9a5e532035ba77d36baf51dd971b30d7c3c69fde78aa99955c032126cdb"
+}

--- a/us-il/statutes/35/5/306.test.yaml
+++ b/us-il/statutes/35/5/306.test.yaml
@@ -1,0 +1,22 @@
+- name: beneficiary_receives_pro_rata_illinois_allocated_item_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/306#input.item_taken_into_account_by_estate_or_trust_in_computing_base_income: true
+    us-il:statutes/35/5/306#input.illinois_allocated_or_apportioned_item_amount_under_sections_301_through_304: 1000
+    us-il:statutes/35/5/306#input.beneficiary_pro_rata_share_of_items_properly_paid_credited_or_required_to_be_distributed: 0.25
+  output:
+    us-il:statutes/35/5/306#beneficiary_pro_rata_illinois_allocated_item_amount: 250
+- name: item_not_taken_into_account_by_estate_or_trust_yields_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/306#input.item_taken_into_account_by_estate_or_trust_in_computing_base_income: false
+    us-il:statutes/35/5/306#input.illinois_allocated_or_apportioned_item_amount_under_sections_301_through_304: 1000
+    us-il:statutes/35/5/306#input.beneficiary_pro_rata_share_of_items_properly_paid_credited_or_required_to_be_distributed: 0.25
+  output:
+    us-il:statutes/35/5/306#beneficiary_pro_rata_illinois_allocated_item_amount: 0

--- a/us-il/statutes/35/5/306.yaml
+++ b/us-il/statutes/35/5/306.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/306
+  summary: |-
+    Items of income and deduction taken into account by an estate or trust in computing base income are allocated or apportioned to Illinois under Sections 301 through 304 and, to the extent properly paid, credited, or required to be distributed to beneficiaries, are deemed paid, credited, or distributed pro rata.
+rules:
+  - name: beneficiary_pro_rata_illinois_allocated_item_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 35 ILCS 5/306
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/306
+              excerpt: "allocated or apportioned to this State to the extent provided by Sections 301 through 304"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/306
+              excerpt: "to the extent properly paid, credited or required to be distributed to beneficiaries ... shall be deemed to have been so paid, credited or distributed pro rata"
+    versions:
+      - effective_from: '2017-07-01'
+        formula: |-
+          if item_taken_into_account_by_estate_or_trust_in_computing_base_income: max(0, illinois_allocated_or_apportioned_item_amount_under_sections_301_through_304 * beneficiary_pro_rata_share_of_items_properly_paid_credited_or_required_to_be_distributed) else: 0


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-il/statute/35/5/306`
- Module: `us-il/statutes/35/5/306.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 39s
- Local gate status: **green**

Produced by `axiom-encode encode us-il/statute/35/5/306 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-il/statute/35/5/306",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "2373e45e",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/35/5/306.yaml",
      "sha256": "df345e90aa0cb0e24223d90f68e98e3241c99ff712a635316f10df597917bf00"
    },
    {
      "path": "statutes/35/5/306.test.yaml",
      "sha256": "63776a08db12e332f6e1a9e102f2739acfb786ebb1b6c31567ac83e8d80823f9"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
