### PR TITLE
Encode 7 CFR 273.11(c): ineligible-member income and resource treatment

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/7-cfr/273/11/c.test.yaml",
+      "sha256": "2c7d0338f14637c2fc5cb0bb2c1367bebbb1ac0f39a417ba7b28f5f7761c0317"
+    },
+    {
+      "path": "us/regulations/7-cfr/273/11/c.yaml",
+      "sha256": "c8be87e1d30bccc329b53867968a7033330e425837ef2a03efbda891765a74b7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "381e62ad800b7efacde65973a6f22d8f1f0f22b4",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "381e62ad800b7efacde65973a6f22d8f1f0f22b4"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "manual",
+  "citation": "us:regulations/7-cfr/273/11/c",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-07T04:55:32.784640+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgg90h8js/sign-applied-files/us/regulations/7-cfr/273/11/c.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgg90h8js",
+  "generated_output_sha256": "c8be87e1d30bccc329b53867968a7033330e425837ef2a03efbda891765a74b7",
+  "generation_prompt_sha256": null,
+  "manual_exception": "#564",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -24861,6 +24861,15 @@
         ]
       }
     ],
+    "us/regulation/7/273/11": [
+      {
+        "module": "us/regulations/7-cfr/273/11/c.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/7/273/2": [
       {
         "module": "us/regulations/7-cfr/273/2/j.yaml",

--- a/us/regulations/7-cfr/273/11/c.test.yaml
+++ b/us/regulations/7-cfr/273/11/c.test.yaml
@@ -1,0 +1,347 @@
+- name: pro_rata_share_of_ssn_disqualified_member_income_counted
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 4
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 0
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 1
+    us:regulations/7-cfr/273/11/c#input.income_after_allowable_exclusions_of_members_subject_to_proration: 1200
+    us:regulations/7-cfr/273/11/c#input.earned_income_after_allowable_exclusions_of_members_subject_to_proration: 1200
+    us:regulations/7-cfr/273/11/c#input.resources_of_members_subject_to_proration: 2000
+    us:regulations/7-cfr/273/11/c#input.deductible_expenses_paid_by_or_billed_to_members_subject_to_proration: 400
+    us:regulations/7-cfr/273/11/c#input.household_contains_member_ineligible_under_section_273_11: true
+  output:
+    us:regulations/7-cfr/273/11/c#snap_nonhousehold_member_treatment_context: holds
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_income: 900
+    us:regulations/7-cfr/273/11/c#snap_earned_income_deduction_on_attributed_prorated_earned_income: 180
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_deductible_expenses: 300
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_resources: 2000
+    us:regulations/7-cfr/273/11/c#snap_household_size_excluding_ineligible_members: 3
+
+- name: two_prorated_members_in_household_of_five
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 5
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 0
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 2
+    us:regulations/7-cfr/273/11/c#input.income_after_allowable_exclusions_of_members_subject_to_proration: 1500
+    us:regulations/7-cfr/273/11/c#input.earned_income_after_allowable_exclusions_of_members_subject_to_proration: 0
+    us:regulations/7-cfr/273/11/c#input.resources_of_members_subject_to_proration: 0
+    us:regulations/7-cfr/273/11/c#input.deductible_expenses_paid_by_or_billed_to_members_subject_to_proration: 0
+  output:
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_income: 900
+    us:regulations/7-cfr/273/11/c#snap_earned_income_deduction_on_attributed_prorated_earned_income: 0
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_deductible_expenses: 0
+    us:regulations/7-cfr/273/11/c#snap_household_size_excluding_ineligible_members: 3
+
+- name: zero_member_household_prorated_amounts_are_zero
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 0
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 0
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 0
+    us:regulations/7-cfr/273/11/c#input.income_after_allowable_exclusions_of_members_subject_to_proration: 500
+    us:regulations/7-cfr/273/11/c#input.earned_income_after_allowable_exclusions_of_members_subject_to_proration: 500
+    us:regulations/7-cfr/273/11/c#input.deductible_expenses_paid_by_or_billed_to_members_subject_to_proration: 100
+  output:
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_income: 0
+    us:regulations/7-cfr/273/11/c#snap_earned_income_deduction_on_attributed_prorated_earned_income: 0
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_deductible_expenses: 0
+
+- name: household_with_ipv_disqualified_member_counts_income_in_entirety
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 3
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 1
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 0
+    us:regulations/7-cfr/273/11/c#input.income_of_members_counted_in_entirety: 1000
+    us:regulations/7-cfr/273/11/c#input.resources_of_members_counted_in_entirety: 3000
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_with_ineligible_members_excluded: 500
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_before_member_exclusion: 550
+  output:
+    us:regulations/7-cfr/273/11/c#snap_full_count_ineligible_members_countable_income: 1000
+    us:regulations/7-cfr/273/11/c#snap_full_count_ineligible_members_countable_resources: 3000
+    us:regulations/7-cfr/273/11/c#snap_household_size_excluding_ineligible_members: 2
+    us:regulations/7-cfr/273/11/c#snap_allotment_not_increased_by_member_exclusion: holds
+
+- name: ipv_disqualification_triggers_full_income_count
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_for_intentional_program_violation: true
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_for_felony_drug_conviction: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_as_fleeing_felon: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance: false
+    us:regulations/7-cfr/273/11/c#input.member_convicted_felon_ineligible_under_section_273_11_s: false
+  output:
+    us:regulations/7-cfr/273/11/c#snap_member_income_counted_in_entirety: holds
+
+- name: ssn_refusal_triggers_proration_when_abawd_time_limit_satisfied
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_for_felony_drug_conviction: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_as_fleeing_felon: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance: false
+    us:regulations/7-cfr/273/11/c#input.member_convicted_felon_ineligible_under_section_273_11_s: false
+    us:regulations/7-cfr/273/11/c#input.member_refused_to_obtain_or_provide_ssn: true
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_k: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_o: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_p: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_q: false
+    us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 20
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_homeless: false
+    us:regulations/7-cfr/273/24#input.member_is_veteran: false
+    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: holds
+    us:regulations/7-cfr/273/11/c#snap_member_income_prorated: holds
+
+- name: abawd_time_limit_ineligibility_triggers_proration
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_for_felony_drug_conviction: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_as_fleeing_felon: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance: false
+    us:regulations/7-cfr/273/11/c#input.member_convicted_felon_ineligible_under_section_273_11_s: false
+    us:regulations/7-cfr/273/11/c#input.member_refused_to_obtain_or_provide_ssn: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_k: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_o: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_p: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_q: false
+    us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: false
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_homeless: false
+    us:regulations/7-cfr/273/24#input.member_is_veteran: false
+    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
+    us:regulations/7-cfr/273/11/c#snap_member_income_prorated: holds
+
+- name: member_with_no_disqualifications_triggers_neither_treatment
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_for_felony_drug_conviction: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_as_fleeing_felon: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance: false
+    us:regulations/7-cfr/273/11/c#input.member_convicted_felon_ineligible_under_section_273_11_s: false
+    us:regulations/7-cfr/273/11/c#input.member_refused_to_obtain_or_provide_ssn: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_k: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_o: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_p: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_q: false
+    us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 20
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_homeless: false
+    us:regulations/7-cfr/273/24#input.member_is_veteran: false
+    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/11/c#snap_member_income_counted_in_entirety: not_holds
+    us:regulations/7-cfr/273/11/c#snap_member_income_prorated: not_holds
+
+- name: ipv_member_who_also_refused_ssn_gets_full_count_not_proration
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_for_intentional_program_violation: true
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_for_felony_drug_conviction: false
+    us:regulations/7-cfr/273/11/c#input.member_ineligible_as_fleeing_felon: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7: false
+    us:regulations/7-cfr/273/11/c#input.member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance: false
+    us:regulations/7-cfr/273/11/c#input.member_convicted_felon_ineligible_under_section_273_11_s: false
+    us:regulations/7-cfr/273/11/c#input.member_refused_to_obtain_or_provide_ssn: true
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_k: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_o: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_p: false
+    us:regulations/7-cfr/273/11/c#input.member_disqualified_under_section_273_11_paragraph_q: false
+    us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 20
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_homeless: false
+    us:regulations/7-cfr/273/24#input.member_is_veteran: false
+    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/11/c#snap_member_income_counted_in_entirety: holds
+    us:regulations/7-cfr/273/11/c#snap_member_income_prorated: not_holds
+
+- name: household_without_section_273_11_ineligible_members_has_no_treatment_context
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_contains_member_ineligible_under_section_273_11: false
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_with_ineligible_members_excluded: 550
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_before_member_exclusion: 550
+  output:
+    us:regulations/7-cfr/273/11/c#snap_nonhousehold_member_treatment_context: not_holds
+    us:regulations/7-cfr/273/11/c#snap_allotment_not_increased_by_member_exclusion: holds
+
+- name: allotment_increase_from_member_exclusion_violates_guard
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_with_ineligible_members_excluded: 560
+    us:regulations/7-cfr/273/11/c#input.snap_monthly_allotment_before_member_exclusion: 550
+  output:
+    us:regulations/7-cfr/273/11/c#snap_allotment_not_increased_by_member_exclusion: not_holds
+
+- name: mixed_household_with_full_count_and_prorated_members
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 5
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 1
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 1
+    us:regulations/7-cfr/273/11/c#input.income_of_members_counted_in_entirety: 800
+    us:regulations/7-cfr/273/11/c#input.resources_of_members_counted_in_entirety: 0
+    us:regulations/7-cfr/273/11/c#input.income_after_allowable_exclusions_of_members_subject_to_proration: 1000
+    us:regulations/7-cfr/273/11/c#input.earned_income_after_allowable_exclusions_of_members_subject_to_proration: 500
+    us:regulations/7-cfr/273/11/c#input.resources_of_members_subject_to_proration: 1500
+    us:regulations/7-cfr/273/11/c#input.deductible_expenses_paid_by_or_billed_to_members_subject_to_proration: 250
+  output:
+    us:regulations/7-cfr/273/11/c#snap_full_count_ineligible_members_countable_income: 800
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_income: 800
+    us:regulations/7-cfr/273/11/c#snap_earned_income_deduction_on_attributed_prorated_earned_income: 80
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_deductible_expenses: 200
+    us:regulations/7-cfr/273/11/c#snap_prorated_ineligible_members_countable_resources: 1500
+    us:regulations/7-cfr/273/11/c#snap_household_size_excluding_ineligible_members: 3
+
+- name: inconsistent_member_counts_clamp_household_size_to_zero
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/11/c#input.household_member_count_including_ineligible_members: 2
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_full_income_count: 2
+    us:regulations/7-cfr/273/11/c#input.member_count_subject_to_income_proration: 1
+  output:
+    us:regulations/7-cfr/273/11/c#snap_household_size_excluding_ineligible_members: 0

--- a/us/regulations/7-cfr/273/11/c.yaml
+++ b/us/regulations/7-cfr/273/11/c.yaml
@@ -1,0 +1,314 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/11
+  deferred_outputs:
+    - output: us:regulations/7-cfr/273/11/c/3#snap_ineligible_alien_income_and_expense_treatment
+      blocked_by:
+        - us:regulations/7-cfr/273/11/c#snap_nonhousehold_member_treatment_context
+      reason: >-
+        Paragraph (c)(3) gives the State agency discretion to count all or all
+        but a pro rata share of an ineligible alien's income and deductible
+        expenses, with carve-outs keyed to INA immigration statuses (lawful
+        permanent residents, asylees, refugees, parolees). Encoding it requires
+        the state-option layer and the immigration-status concepts of
+        7 CFR 273.4; this module encodes the federal member-level treatment in
+        paragraphs (c)(1) and (c)(2).
+  summary: |-
+    7 CFR 273.11(c) sets the treatment of income and resources of certain
+    nonhousehold members while a household member cannot participate.
+    Paragraph (c)(1) requires that the income and resources of members
+    disqualified for an intentional Program violation, a felony drug
+    conviction, fleeing felon status, noncompliance with a work requirement of
+    273.7, a workfare sanction, or 273.11(s) felon status continue to count in
+    their entirety, while the member is excluded from household size for
+    benefit-level, standard deduction, income-standard, and resource-limit
+    purposes, and the allotment may not increase as a result of the exclusion.
+    Paragraph (c)(2) requires that for members ineligible for SSN refusal,
+    the ABAWD time limit, or disqualification under paragraphs (k), (o), (p),
+    or (q), resources count in their entirety but only a pro rata share of
+    income counts: allowable exclusions are subtracted, the income is divided
+    evenly among all household members including the ineligible members, and
+    all but the ineligible members' share counts to the remaining members. The
+    20 percent earned income deduction applies to the attributed prorated
+    earned income, and deductible expenses paid by or billed to the ineligible
+    members are divided evenly with all but their share counted. Paragraph
+    (c)(3) state-option treatment of ineligible aliens is deferred.
+imports:
+  - us:regulations/7-cfr/273/10
+  - us:regulations/7-cfr/273/24
+rules:
+  - name: snap_nonhousehold_member_treatment_context
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.11(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: the eligibility and benefit level of any remaining household members shall be determined in accordance with the procedures outlined in this section
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          household_contains_member_ineligible_under_section_273_11
+
+  - name: snap_member_income_counted_in_entirety
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.11(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: disqualification for an intentional Program violation, a felony drug conviction, their fleeing felon status, noncompliance with a work requirement of § 273.7
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          member_disqualified_for_intentional_program_violation
+          or member_ineligible_for_felony_drug_conviction
+          or member_ineligible_as_fleeing_felon
+          or member_sanctioned_for_noncompliance_with_work_requirement_of_section_273_7
+          or member_sanctioned_while_participating_in_household_disqualified_for_workfare_noncompliance
+          or member_convicted_felon_ineligible_under_section_273_11_s
+
+  - name: snap_member_income_prorated
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.11(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: ineligible for refusal to obtain or provide an SSN, for meeting the time limit for able-bodied adults without dependents or for being disqualified under paragraphs (k), (o), (p), or (q) of this section
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible
+              output: snap_member_abawd_time_limit_eligible
+              hash: sha256:956c2c20b9311eec7bdfba8559662b5b5fe23af90fb34aa8f7d3f61e78b37501
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          not snap_member_income_counted_in_entirety
+          and (
+            member_refused_to_obtain_or_provide_ssn
+            or not snap_member_abawd_time_limit_eligible
+            or member_disqualified_under_section_273_11_paragraph_k
+            or member_disqualified_under_section_273_11_paragraph_o
+            or member_disqualified_under_section_273_11_paragraph_p
+            or member_disqualified_under_section_273_11_paragraph_q
+          )
+
+  - name: snap_full_count_ineligible_members_countable_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(1)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: The income and resources of the ineligible household member(s) shall continue to count in their entirety
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          income_of_members_counted_in_entirety
+
+  - name: snap_full_count_ineligible_members_countable_resources
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(1)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: The income and resources of the ineligible household member(s) shall continue to count in their entirety
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          resources_of_members_counted_in_entirety
+
+  - name: snap_household_size_excluding_ineligible_members
+    kind: derived
+    entity: Household
+    dtype: Count
+    period: Month
+    source: 7 CFR 273.11(c)(1)(ii), (c)(2)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: "The ineligible member shall not be included when determining the household's size for the purposes of:"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: Such ineligible members shall not be included when determining their households' sizes
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          max(
+            0,
+            household_member_count_including_ineligible_members
+            - member_count_subject_to_full_income_count
+            - member_count_subject_to_income_proration
+          )
+
+  - name: snap_allotment_not_increased_by_member_exclusion
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.11(c)(1)(ii)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: The State agency shall ensure that no household's coupon allotment is increased as a result of the exclusion of one or more household members.
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          snap_monthly_allotment_with_ineligible_members_excluded <= snap_monthly_allotment_before_member_exclusion
+
+  - name: snap_prorated_ineligible_members_countable_resources
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(2)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: The resources of such ineligible members shall continue to count in their entirety to the remaining household members.
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          resources_of_members_subject_to_proration
+
+  - name: snap_prorated_ineligible_members_countable_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(2)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: This pro rata share is calculated by first subtracting the allowable exclusions from the ineligible member's income and dividing the income evenly among the household members, including the ineligible members.
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: All but the ineligible members' share is counted as income for the remaining household members.
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if household_member_count_including_ineligible_members > 0:
+            income_after_allowable_exclusions_of_members_subject_to_proration
+            * max(0, household_member_count_including_ineligible_members - member_count_subject_to_income_proration)
+            / household_member_count_including_ineligible_members
+          else: 0
+
+  - name: snap_earned_income_deduction_on_attributed_prorated_earned_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: The 20 percent earned income deduction shall apply to the prorated income earned by such ineligible members which is attributed to their households.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/10#snap_earned_income_deduction_rate_for_net_income
+              output: snap_earned_income_deduction_rate_for_net_income
+              hash: sha256:c0fea2e5d8677777fdf6356f65d31e93f7722eb83335e2dc01214e6b46dc3b27
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if household_member_count_including_ineligible_members > 0:
+            snap_earned_income_deduction_rate_for_net_income
+            * earned_income_after_allowable_exclusions_of_members_subject_to_proration
+            * max(0, household_member_count_including_ineligible_members - member_count_subject_to_income_proration)
+            / household_member_count_including_ineligible_members
+          else: 0
+
+  - name: snap_prorated_ineligible_members_countable_deductible_expenses
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.11(c)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: divided evenly among the households' members including the ineligible members.
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/11
+              excerpt: All but the ineligible members' share is counted as a deductible child support payment, shelter or dependent care expense for the remaining household members.
+    versions:
+      - effective_from: '2008-10-01'
+        formula: |-
+          if household_member_count_including_ineligible_members > 0:
+            deductible_expenses_paid_by_or_billed_to_members_subject_to_proration
+            * max(0, household_member_count_including_ineligible_members - member_count_subject_to_income_proration)
+            / household_member_count_including_ineligible_members
+          else: 0


### PR DESCRIPTION
Supersedes fork PR #564 so repository CI can access AXIOM_ENCODE_APPLY_SIGNING_KEY and verify the signed apply manifest.\n\nIncludes:\n- us/regulations/7-cfr/273/11/c.yaml\n- us/regulations/7-cfr/273/11/c.test.yaml\n- signed apply manifest for the encoding\n- regenerated .axiom/index/provisions_to_rules.json\n\nLocal check:\n- axiom-encode guard-generated --repo <checkout> --base-ref origin/main --head-ref HEAD