### PR TITLE
[proof] scoped single-jurisdiction validation

### DIFF
--- a/us-vt/policies/cms/vermont-chip-eligibility.yaml
+++ b/us-vt/policies/cms/vermont-chip-eligibility.yaml
@@ -103,3 +103,5 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           false
+
+# proof: exercise the scoped single-jurisdiction validation path (throwaway)


### PR DESCRIPTION
Throwaway proof for shard-on-demand (do not merge). Diff touches only us-vt, so the validate matrix should scope to the single us-vt shard.