### PR TITLE
[proof] multi-tree falls back to full matrix

### DIFF
--- a/us-vt/policies/cms/vermont-chip-eligibility.yaml
+++ b/us-vt/policies/cms/vermont-chip-eligibility.yaml
@@ -103,3 +103,5 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           false
+
+# proof: multi-tree diff must fall back to the full matrix (throwaway)

--- a/us-wy/policies/cms/wyoming-chip-eligibility.yaml
+++ b/us-wy/policies/cms/wyoming-chip-eligibility.yaml
@@ -103,3 +103,5 @@ rules:
       - effective_from: '2023-12-01'
         formula: |-
           false
+
+# proof: multi-tree diff must fall back to the full matrix (throwaway)


### PR DESCRIPTION
Throwaway proof (do not merge). Diff touches us-vt and us-wy, so the matrix must fall back to the full jurisdiction set.