### PR TITLE
[proof] scoped PR still runs repo-wide gates

### DIFF
--- a/us-vt/proof-artifact.rac
+++ b/us-vt/proof-artifact.rac
@@ -1,0 +1,1 @@
+obsolete generated artifact (throwaway negative test)


### PR DESCRIPTION
Throwaway negative test (do not merge). Diff is scoped to us-vt but adds an obsolete generated file; the repo-wide obsolete-file gate runs on the scoped shard and must fail, proving a scoped PR cannot skip repo-wide gates.