### PR TITLE
bulk-encode: gate PR-open on the gate battery, not always() (#605)

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -326,7 +326,16 @@ jobs:
 
       - name: Assemble PR body
         id: prbody
-        if: ${{ always() && steps.encode.outputs.module != '' }}
+        # Only assemble/open a PR when the local gate battery actually passed.
+        # `status` is written `green`/`needs-fixtures` only after guard-generated
+        # + validate + proof-validate run; an apply failure writes `failed` and a
+        # guard/validate/proof failure exits the encode step BEFORE `status` is
+        # written, so in every non-passing case this condition is false and no PR
+        # body is assembled. (`needs-fixtures` is a soft companion-test fail and
+        # still opens the PR by design.) Replaces an `always() && module != ''`
+        # guard that assembled and pushed gate-failing generations
+        # (rulespec-uk#104 D2 / rulespec-us#605).
+        if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
         shell: bash
         env:
           CITATION: ${{ matrix.item.citation }}
@@ -379,7 +388,13 @@ jobs:
           echo "path=$body" >> "$GITHUB_OUTPUT"
 
       - name: Open PR and enable auto-merge
-        if: ${{ always() && steps.encode.outputs.module != '' }}
+        # Same gate-battery guard as "Assemble PR body": never force-push the
+        # bulk branch, open a PR, or arm auto-merge for an encode whose gate
+        # battery did not pass. Under the old `always() && module != ''` guard a
+        # guard/validate/proof failure (which sets `module` but leaves `status`
+        # unwritten) still force-pushed the broken commit and armed auto-merge
+        # (rulespec-uk#104 D2 / rulespec-us#605).
+        if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.BULK_ENCODE_TOKEN }}


### PR DESCRIPTION
## Problem (rulespec-us#605)

`.github/workflows/bulk-encode.yml` gated the **Assemble PR body** and **Open PR and enable auto-merge** steps on

```yaml
if: ${{ always() && steps.encode.outputs.module != '' }}
```

The encode step emits `module` right after `--apply` succeeds, but writes `status` (`green`/`needs-fixtures`) only *after* the gate battery (guard-generated + validate + proof-validate). A hard gate failure exits the step (`set -euo pipefail`) before `status` is written, yet `module` is already set — so under `always()` the PR steps still ran, force-pushing the broken commit onto `bulk/<slug>` and arming auto-merge. A requeue reproduced the same broken PR. This is the D2 defect diagnosed in the rulespec-uk drain.

## Fix (mirror rulespec-uk#104 D2)

Gate both steps on a real success signal:

```yaml
if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
```

- hard gate failure → `status` unwritten → condition false → **no PR, no force-push**
- apply failure → `status=failed` → condition false → no PR
- `needs-fixtures` (soft companion-test fail) → still opens the PR by design

## Coordination with #592 (D3)

#592 rewrites the **Open PR** step *body* (reopen-before-force-push, fresh-PR fallback, 5xx retry). This PR changes only the two `if:` **guards**. The regions do not overlap; a local test-merge of the two branches is clean (no conflict), so they can land in either order.

## Verification (negative + positive proof)

Proved with instrumented `workflow_dispatch` runs of this same `bulk-encode.yml` on a throwaway `ci/proof-d2-gate` branch (encode step short-circuited to the two terminal states; heavy setup gated off; no live encode, no side effects). Evidence linked in a comment below:

- **negative** (module set, gate fails → `status` unwritten): the real **Open PR** step is **skipped**; a companion `[D2 proof]` step carrying the *old* `always() && module != ''` guard **runs**, showing the old guard would have force-pushed here.
- **positive** (`status=green`): the **Open PR** step **runs**.

Closes #605.
