### PR TITLE
Encode us-ny/statute/TAX/601-A (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16653,6 +16653,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/601-A": [
+      {
+        "module": "us-ny/statutes/TAX/601-A.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/611": [
       {
         "module": "us-ny/statutes/TAX/611.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/601-A.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/601-A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/601-A.yaml",
+      "sha256": "0afde12da54d63434cc5c699f506162d66cbd739b0e52acefc0da0401f49fecd"
+    },
+    {
+      "path": "statutes/TAX/601-A.test.yaml",
+      "sha256": "b5e75005dda0d1789c7ad446d86e9b4e5949d975ef8a720da3d9a780e0739d7b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ny/statute/TAX/601-A",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ny-statute-TAX-601-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "5363743f173d99478c0a18a37096eaaa7ab854fad4f0a55a0c6f6eda51be2b4d",
+  "generated_at": "2026-07-08T00:54:47.061133+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/TAX/601-A.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "0afde12da54d63434cc5c699f506162d66cbd739b0e52acefc0da0401f49fecd",
+  "generation_prompt_sha256": "9353c98c2538f49042f5bb098a0353d7339bdc3d3dba7155cf3b8cf0fcc2c3ab",
+  "model": "gpt-5.5",
+  "run_id": "aac3b9a4",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3d7253f36e4987ce20201c85440bb02e10123305dd8fee6587a926493971daf9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ny-statute-TAX-601-A.json",
+  "trace_sha256": "6b44372204118e3e16a67521bd55640077d23d469c53affc28e36644d793e0b4"
+}

--- a/us-ny/statutes/TAX/601-A.test.yaml
+++ b/us-ny/statutes/TAX/601-A.test.yaml
@@ -1,0 +1,26 @@
+- name: positive_cost_of_living_adjustment_rounds_increase_down_to_fifty_dollars
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/601-A#input.adjustment_year_average_monthly_consumer_price_index: 220
+    us-ny:statutes/TAX/601-A#input.preceding_adjustment_year_average_monthly_consumer_price_index: 200
+    us-ny:statutes/TAX/601-A#input.amount_specified_in_subsection_b_for_tax_year: 15750
+  output:
+    us-ny:statutes/TAX/601-A#cost_of_living_adjustment: 0.1
+    us-ny:statutes/TAX/601-A#rounded_cost_of_living_increase: 1550
+    us-ny:statutes/TAX/601-A#cost_of_living_adjusted_amount: 17300
+- name: no_cost_of_living_adjustment_when_cpi_does_not_exceed_prior_average
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/601-A#input.adjustment_year_average_monthly_consumer_price_index: 190
+    us-ny:statutes/TAX/601-A#input.preceding_adjustment_year_average_monthly_consumer_price_index: 200
+    us-ny:statutes/TAX/601-A#input.amount_specified_in_subsection_b_for_tax_year: 15750
+  output:
+    us-ny:statutes/TAX/601-A#cost_of_living_adjustment: 0
+    us-ny:statutes/TAX/601-A#rounded_cost_of_living_increase: 0
+    us-ny:statutes/TAX/601-A#cost_of_living_adjusted_amount: 15750

--- a/us-ny/statutes/TAX/601-A.yaml
+++ b/us-ny/statutes/TAX/601-A.yaml
@@ -1,0 +1,131 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/601-A
+  summary: |-
+    "The following amounts shall be indexed by the cost of living adjustment"; the adjustment is the percentage by which the average CPI for the twelve-month period ending June thirtieth of the year immediately preceding the tax year exceeds the prior comparable twelve-month average, and "such increase shall be rounded to the next lowest multiple of fifty dollars."
+rules:
+  - name: cost_of_living_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 601-a(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "rounded to the next lowest multiple of fifty dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          50
+
+  - name: nonindexed_fraction_numerator_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 601-a(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "that is not fifty thousand dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          50000
+
+  - name: cost_of_living_adjustment
+    kind: derived
+    entity: TaxYearAdjustment
+    dtype: Rate
+    period: Year
+    source: N.Y. Tax Law § 601-a(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "the percentage if any, by which the average monthly value of the consumer price index ... exceeds the average monthly value ... for the twelve month period ending on June thirtieth of the year immediately preceding the adjustment year"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "consumer price index means the consumer price index for all urban consumers published by the United States department of labor"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if adjustment_year_average_monthly_consumer_price_index > preceding_adjustment_year_average_monthly_consumer_price_index: (adjustment_year_average_monthly_consumer_price_index - preceding_adjustment_year_average_monthly_consumer_price_index) / preceding_adjustment_year_average_monthly_consumer_price_index else: 0
+
+  - name: rounded_cost_of_living_increase
+    kind: derived
+    entity: TaxYearAdjustment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 601-a(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "If the product of the amounts in subsection (b) and subsection (c) of this section is not a multiple of fifty dollars, such increase shall be rounded to the next lowest multiple of fifty dollars."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/601-A#cost_of_living_adjustment
+              output: cost_of_living_adjustment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/601-A#cost_of_living_rounding_multiple
+              output: cost_of_living_rounding_multiple
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor((amount_specified_in_subsection_b_for_tax_year * cost_of_living_adjustment) / cost_of_living_rounding_multiple) * cost_of_living_rounding_multiple
+
+  - name: cost_of_living_adjusted_amount
+    kind: derived
+    entity: TaxYearAdjustment
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 601-a(a), (d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "shall multiply the amounts specified in subsection (b) ... by one plus the cost of living adjustment"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601-A
+              excerpt: "such increase shall be rounded to the next lowest multiple of fifty dollars"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/601-A#rounded_cost_of_living_increase
+              output: rounded_cost_of_living_increase
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          amount_specified_in_subsection_b_for_tax_year + rounded_cost_of_living_increase


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ny/statute/TAX/601-A`
- Module: `us-ny/statutes/TAX/601-A.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 57s
- Local gate status: **green**

Produced by `axiom-encode encode us-ny/statute/TAX/601-A --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ny/statute/TAX/601-A",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "aac3b9a4",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/TAX/601-A.yaml",
      "sha256": "0afde12da54d63434cc5c699f506162d66cbd739b0e52acefc0da0401f49fecd"
    },
    {
      "path": "statutes/TAX/601-A.test.yaml",
      "sha256": "b5e75005dda0d1789c7ad446d86e9b4e5949d975ef8a720da3d9a780e0739d7b"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
