### PR TITLE
Encode us-ny/statute/TAX/672 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16684,6 +16684,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/672": [
+      {
+        "module": "us-ny/statutes/TAX/672.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/673": [
       {
         "module": "us-ny/statutes/TAX/673.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/672.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/672.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/672.yaml",
+      "sha256": "2125b6742cf831ff3c1a025a09ac4ef88c988611245ea9399f4ad112278a31c9"
+    },
+    {
+      "path": "statutes/TAX/672.test.yaml",
+      "sha256": "09835efb97a0e5afcd38a3e1f08aa53321e1d49cf78eadfad44429cf51c05838"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ny/statute/TAX/672",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ny-statute-TAX-672/workspace/context-manifest.json",
+  "context_manifest_sha256": "c28484cea31c88245cdd2327980e50ec66e44a842ce060b7f2be21add3c16517",
+  "generated_at": "2026-07-08T00:59:52.504967+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/TAX/672.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "2125b6742cf831ff3c1a025a09ac4ef88c988611245ea9399f4ad112278a31c9",
+  "generation_prompt_sha256": "0f8c2de82586a138def22f8dce4d2646300fdac7834ec3205fba280158868acb",
+  "model": "gpt-5.5",
+  "run_id": "5b05a934",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e9aadc465800bec86c8db328b2683062ffd67c841e6b5899843ccf3cf13f0822"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ny-statute-TAX-672.json",
+  "trace_sha256": "b26635078c86d4d11708a4738bbb14f2adc866546c9a90507e9726f790f84712"
+}

--- a/us-ny/statutes/TAX/672.test.yaml
+++ b/us-ny/statutes/TAX/672.test.yaml
@@ -1,0 +1,88 @@
+- name: regular_calendar_year_employee_statement_is_timely_and_complete
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/672#input.employer_paid_wages_to_employee_during_calendar_year: true
+    us-ny:statutes/TAX/672#input.employer_required_to_deduct_and_withhold_tax_from_employee_wages_under_this_article: true
+    ? us-ny:statutes/TAX/672#input.employer_would_have_been_required_to_deduct_and_withhold_tax_if_employee_claimed_no_more_than_one_withholding_exemption
+    : false
+    us-ny:statutes/TAX/672#input.employment_terminated_before_close_of_calendar_year: false
+    us-ny:statutes/TAX/672#input.statement_furnished_within_thirty_days_from_last_wage_payment: false
+    us-ny:statutes/TAX/672#input.statement_furnished_on_or_before_february_fifteenth_of_succeeding_year: true
+    us-ny:statutes/TAX/672#input.written_information_statement_furnished_to_employee: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_of_wages_paid: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_deducted_and_withheld_as_tax: true
+    us-ny:statutes/TAX/672#input.statement_shows_other_information_prescribed_by_tax_commission: true
+  output:
+    us-ny:statutes/TAX/672#employer_subject_to_employee_information_statement_requirement: holds
+    us-ny:statutes/TAX/672#employee_information_statement_timing_satisfies_deadline: holds
+    us-ny:statutes/TAX/672#employer_complies_with_employee_information_statement_requirement: holds
+- name: terminated_employee_statement_is_timely_within_thirty_days
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/672#input.employer_paid_wages_to_employee_during_calendar_year: true
+    us-ny:statutes/TAX/672#input.employer_required_to_deduct_and_withhold_tax_from_employee_wages_under_this_article: false
+    ? us-ny:statutes/TAX/672#input.employer_would_have_been_required_to_deduct_and_withhold_tax_if_employee_claimed_no_more_than_one_withholding_exemption
+    : true
+    us-ny:statutes/TAX/672#input.employment_terminated_before_close_of_calendar_year: true
+    us-ny:statutes/TAX/672#input.statement_furnished_within_thirty_days_from_last_wage_payment: true
+    us-ny:statutes/TAX/672#input.statement_furnished_on_or_before_february_fifteenth_of_succeeding_year: false
+    us-ny:statutes/TAX/672#input.written_information_statement_furnished_to_employee: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_of_wages_paid: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_deducted_and_withheld_as_tax: true
+    us-ny:statutes/TAX/672#input.statement_shows_other_information_prescribed_by_tax_commission: true
+  output:
+    us-ny:statutes/TAX/672#employer_subject_to_employee_information_statement_requirement: holds
+    us-ny:statutes/TAX/672#employee_information_statement_timing_satisfies_deadline: holds
+    us-ny:statutes/TAX/672#employer_complies_with_employee_information_statement_requirement: holds
+- name: employer_not_in_statement_class_has_no_required_furnishing_failure
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/672#input.employer_paid_wages_to_employee_during_calendar_year: true
+    us-ny:statutes/TAX/672#input.employer_required_to_deduct_and_withhold_tax_from_employee_wages_under_this_article: false
+    ? us-ny:statutes/TAX/672#input.employer_would_have_been_required_to_deduct_and_withhold_tax_if_employee_claimed_no_more_than_one_withholding_exemption
+    : false
+    us-ny:statutes/TAX/672#input.employment_terminated_before_close_of_calendar_year: false
+    us-ny:statutes/TAX/672#input.statement_furnished_within_thirty_days_from_last_wage_payment: false
+    us-ny:statutes/TAX/672#input.statement_furnished_on_or_before_february_fifteenth_of_succeeding_year: false
+    us-ny:statutes/TAX/672#input.written_information_statement_furnished_to_employee: false
+    us-ny:statutes/TAX/672#input.statement_shows_amount_of_wages_paid: false
+    us-ny:statutes/TAX/672#input.statement_shows_amount_deducted_and_withheld_as_tax: false
+    us-ny:statutes/TAX/672#input.statement_shows_other_information_prescribed_by_tax_commission: false
+  output:
+    us-ny:statutes/TAX/672#employer_subject_to_employee_information_statement_requirement: not_holds
+    us-ny:statutes/TAX/672#employee_information_statement_timing_satisfies_deadline: not_holds
+    us-ny:statutes/TAX/672#employer_complies_with_employee_information_statement_requirement: holds
+- name: required_employer_fails_when_statement_is_not_timely
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/672#input.employer_paid_wages_to_employee_during_calendar_year: true
+    us-ny:statutes/TAX/672#input.employer_required_to_deduct_and_withhold_tax_from_employee_wages_under_this_article: true
+    ? us-ny:statutes/TAX/672#input.employer_would_have_been_required_to_deduct_and_withhold_tax_if_employee_claimed_no_more_than_one_withholding_exemption
+    : false
+    us-ny:statutes/TAX/672#input.employment_terminated_before_close_of_calendar_year: false
+    us-ny:statutes/TAX/672#input.statement_furnished_within_thirty_days_from_last_wage_payment: false
+    us-ny:statutes/TAX/672#input.statement_furnished_on_or_before_february_fifteenth_of_succeeding_year: false
+    us-ny:statutes/TAX/672#input.written_information_statement_furnished_to_employee: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_of_wages_paid: true
+    us-ny:statutes/TAX/672#input.statement_shows_amount_deducted_and_withheld_as_tax: true
+    us-ny:statutes/TAX/672#input.statement_shows_other_information_prescribed_by_tax_commission: true
+  output:
+    us-ny:statutes/TAX/672#employer_subject_to_employee_information_statement_requirement: holds
+    us-ny:statutes/TAX/672#employee_information_statement_timing_satisfies_deadline: not_holds
+    us-ny:statutes/TAX/672#employer_complies_with_employee_information_statement_requirement: not_holds

--- a/us-ny/statutes/TAX/672.yaml
+++ b/us-ny/statutes/TAX/672.yaml
@@ -1,0 +1,123 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/672
+  summary: |-
+    Every employer required to deduct and withhold tax, or who would have been required to do so if the employee had claimed no more than one withholding exemption, shall furnish each such employee a written statement showing wages paid, tax withheld, and other prescribed information by the stated deadline.
+rules:
+  - name: employer_subject_to_employee_information_statement_requirement
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: N.Y. Tax Law § 672
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "Every employer required to deduct and withhold tax under this article from the wages of an employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "or who would have been required so to deduct and withhold tax if the employee had claimed no more than one withholding exemption"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "in respect of the wages paid by such employer to such employee during the calendar year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_paid_wages_to_employee_during_calendar_year
+          and (
+            employer_required_to_deduct_and_withhold_tax_from_employee_wages_under_this_article
+            or employer_would_have_been_required_to_deduct_and_withhold_tax_if_employee_claimed_no_more_than_one_withholding_exemption
+          )
+  - name: employee_information_statement_timing_satisfies_deadline
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: N.Y. Tax Law § 672
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "on or before February fifteenth of the succeeding year"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "if his employment is terminated before the close of such calendar year, within thirty days from the date on which the last payment of the wages is made"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            employment_terminated_before_close_of_calendar_year
+            and statement_furnished_within_thirty_days_from_last_wage_payment
+          )
+          or (
+            not employment_terminated_before_close_of_calendar_year
+            and statement_furnished_on_or_before_february_fifteenth_of_succeeding_year
+          )
+  - name: employer_complies_with_employee_information_statement_requirement
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: N.Y. Tax Law § 672
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "shall furnish to each such employee ... a written statement as prescribed by the tax commission"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "showing the amount of wages paid by the employer to the employee"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "the amount deducted and withheld as tax"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/672
+              excerpt: "and such other information as the tax commission shall prescribe"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/672#employer_subject_to_employee_information_statement_requirement
+              output: employer_subject_to_employee_information_statement_requirement
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/672#employee_information_statement_timing_satisfies_deadline
+              output: employee_information_statement_timing_satisfies_deadline
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not employer_subject_to_employee_information_statement_requirement
+          or (
+            written_information_statement_furnished_to_employee
+            and employee_information_statement_timing_satisfies_deadline
+            and statement_shows_amount_of_wages_paid
+            and statement_shows_amount_deducted_and_withheld_as_tax
+            and statement_shows_other_information_prescribed_by_tax_commission
+          )


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ny/statute/TAX/672`
- Module: `us-ny/statutes/TAX/672.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 57s
- Local gate status: **green**

Produced by `axiom-encode encode us-ny/statute/TAX/672 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ny/statute/TAX/672",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "5b05a934",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/TAX/672.yaml",
      "sha256": "2125b6742cf831ff3c1a025a09ac4ef88c988611245ea9399f4ad112278a31c9"
    },
    {
      "path": "statutes/TAX/672.test.yaml",
      "sha256": "09835efb97a0e5afcd38a3e1f08aa53321e1d49cf78eadfad44429cf51c05838"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
