### PR TITLE
Fix bulk-encode applied-file detection for new nested module dirs

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -245,7 +245,13 @@ jobs:
           # sibling checkouts under _axiom/ and any build artifacts are never
           # picked up.
           slug='${{ matrix.item.slug }}'
-          mapfile -t applied < <(git -C "$GITHUB_WORKSPACE" status --porcelain \
+          # -uall (untracked-files=all): a brand-new module path creates a new
+          # nested untracked dir; without -uall, `git status --porcelain`
+          # COLLAPSES it to the bare dir entry (e.g. `?? us-ca/statutes/rtc/17053/`),
+          # which the *.yaml regex misses -> the applied module is not detected
+          # even though --apply wrote it (fail-closed false negative). Mirrors the
+          # rulespec-be/rulespec-gh fix.
+          mapfile -t applied < <(git -C "$GITHUB_WORKSPACE" status --porcelain -uall \
             | sed 's/^...//' \
             | grep -E '^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$' \
             | grep -v '\.test\.yaml$' || true)


### PR DESCRIPTION
## Problem

The overnight bulk-encode dispatches produced red legs that were **not** clean
fail-closed gate rejections. Diagnosing the failed legs of run 28909375122
(rulespec-us) / 28909376168 (rulespec-uk) showed the encoder actually
**succeeded** — `outcome=apply_applied final_success=True`, `compile=yes ci=yes`,
exit 0, files named under the worktree — yet the leg exited red with no PR.

Root cause: the applied-file detection runs

```bash
git -C "$GITHUB_WORKSPACE" status --porcelain | sed 's/^...//' | grep -E '.../.*\.yaml$'
```

Without `-uall`, `git status --porcelain` **collapses a brand-new untracked
nested directory** to a single bare dir entry (e.g. `?? us-ca/statutes/rtc/17053/`)
instead of listing the file inside it. When a module lands in a freshly-created
section directory, the `*.yaml` regex matches nothing, `applied[@]` is empty, and
the guard fails the leg — a false negative.

This is why `us-ny/statutes/TAX/601-A.yaml` (parent dir already existed) passed
but `us-ca/statutes/rtc/17053/6.yaml` (new `17053/` dir) failed, and why all four
UK `ukpga/2003/1/681*` legs sharing a fresh parent dir failed.

## Fix

Add `-uall` (untracked-files=all) so files inside new directories are listed
individually. One-line change, mirrors the fix already on **rulespec-be** and
**rulespec-gh**.

## Verification

Deterministic: reproduced by mapping each failed leg's `apply=` path to its
parent directory — every false-negative leg created a new nested dir; every
success leg reused an existing one. `apply_blocked_validation` legs (genuine
fail-closed) are unaffected and remain hard failures by design.
