### PR TITLE
Queue O–W state income-tax provisions (bulk batches C1–C5)

### DIFF
--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -377,3 +377,220 @@ entries:
   class: mechanics
   note: Self-contained interpretive rule for acts affecting the imposition of the
     tax. In-section text only.
+- citation: us-oh/statute/5747.02
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Tax rates
+  class: rate
+  note: OH modified-AGI marginal rate schedule; brackets uprated by gov.irs.uprating. Self-contained schedule.
+- citation: us-oh/statute/5747.025
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Personal exemptions
+  class: exemption
+  note: OH personal and dependent exemption amounts; self-contained (one internal ref).
+- citation: us-oh/statute/5747.71
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Earned income tax credit
+  class: credit
+  note: OH EITC as a percentage of the federal EITC; short self-contained credit.
+- citation: us-ok/statute/68-2355
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Tax imposed; classes of taxpayers
+  class: rate
+  note: OK individual income-tax rate schedule (Title 68). Larger class-scoped section; may fail-closed under encode#1058, queued for CI adjudication.
+- citation: us-or/statute/316.037
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Imposition and rate of tax
+  class: rate
+  note: OR marginal rate schedule; zero external Section refs (clean).
+- citation: us-or/statute/316.085
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Personal exemption credit
+  class: credit
+  note: OR per-exemption credit; self-contained (one ref).
+- citation: us-or/statute/315.264
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Working family household and dependent care credit
+  class: credit
+  note: OR WFHDC credit; references federal IRC 21 descriptively.
+- citation: us-or/statute/315.266
+  repo: rulespec-us
+  batch: C1
+  status: pending
+  heading: Earned income credit
+  class: credit
+  note: OR EIC as a percentage of the federal EITC.
+- citation: us-ri/statute/44-30-2.6
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Rhode Island taxable income; rate of tax
+  class: rate-base
+  note: RI taxable income, standard deduction, exemption, bracket schedule and EITC defined here; large but part-internal structure.
+- citation: us-ri/statute/44-30-103
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Child tax rebates
+  class: credit
+  note: RI child tax rebate; self-contained (zero external refs).
+- citation: us-sc/statute/12-6-510
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Tax rates for individuals, estates, and trusts
+  class: rate
+  note: SC marginal rate schedule.
+- citation: us-sc/statute/12-6-520
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Annual bracket inflation adjustment
+  class: indexing
+  note: SC cumulative-CPI bracket indexing; self-contained.
+- citation: us-sc/statute/12-6-1170
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Retirement income deduction
+  class: deduction
+  note: SC retirement and age deduction from taxable income; self-contained.
+- citation: us-sc/statute/12-6-3632
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Earned income tax credit
+  class: credit
+  note: SC EITC as a percentage of the federal EITC; short self-contained.
+- citation: us-sc/statute/12-6-3330
+  repo: rulespec-us
+  batch: C2
+  status: pending
+  heading: Two wage earner credit
+  class: credit
+  note: SC two-earner credit for married filing jointly; self-contained.
+- citation: us-ut/statute/59-10-104
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Tax basis; tax rate; exemption
+  class: rate
+  note: UT single-rate income tax; very short self-contained section.
+- citation: us-ut/statute/59-10-1018
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Nonrefundable taxpayer tax credit
+  class: credit
+  note: UT taxpayer tax credit with income phase-out; self-contained definitions and credit.
+- citation: us-ut/statute/59-10-1019
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Nonrefundable retirement tax credit
+  class: credit
+  note: UT retirement tax credit; self-contained.
+- citation: us-va/statute/58.1/58.1-320
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Imposition of tax
+  class: rate
+  note: VA marginal rate schedule; zero external Section refs.
+- citation: us-va/statute/58.1/58.1-321
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Exemptions and exclusions
+  class: exemption
+  note: VA personal exemptions and filing thresholds; self-contained.
+- citation: us-va/statute/58.1/58.1-322.03
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Virginia taxable income; subtractions and deductions
+  class: deduction
+  note: VA standard deduction, age deduction and subtractions; large list, self-contained.
+- citation: us-va/statute/58.1/58.1-339.8
+  repo: rulespec-us
+  batch: C3
+  status: pending
+  heading: Income tax credit for low-income taxpayers
+  class: credit
+  note: VA low-income / EITC-option credit; self-contained.
+- citation: us-wv/statute/11-21-3
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: Imposition of tax; persons subject to tax
+  class: rate-base
+  note: WV imposition anchor; self-contained. Operative rate schedule 11-21-4e/4g/4j not yet in corpus (see remainder).
+- citation: us-wv/statute/11-21-16
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: West Virginia personal exemptions of resident individual
+  class: exemption
+  note: WV personal exemption amounts; self-contained.
+- citation: us-wv/statute/11-21-21
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: Senior citizens' property-tax credit
+  class: credit
+  note: WV senior citizens' tax credit; zero external refs.
+- citation: us-wv/statute/11-21-23
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: Refundable credit for real property taxes
+  class: credit
+  note: WV homestead excess property-tax credit; zero external refs.
+- citation: us-wv/statute/11-21-10
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: Low income exclusion
+  class: deduction
+  note: WV low-income exclusion; self-contained.
+- citation: us-wi/statute/71.06
+  repo: rulespec-us
+  batch: C4
+  status: pending
+  heading: Rates of taxation
+  class: rate
+  note: WI marginal rate schedule; large but single external ref.
+- citation: us-wa/statute/82/82.87/82.87.040
+  repo: rulespec-us
+  batch: C5
+  status: pending
+  heading: Tax imposed; long-term capital assets
+  class: rate
+  note: WA 7% long-term capital gains tax; self-contained rate.
+- citation: us-wa/statute/82/82.87/82.87.060
+  repo: rulespec-us
+  batch: C5
+  status: pending
+  heading: Deductions (standard deduction)
+  class: deduction
+  note: WA capital-gains standard deduction (annually indexed); self-contained.
+- citation: us-wa/statute/82/82.87/82.87.080
+  repo: rulespec-us
+  batch: C5
+  status: pending
+  heading: Charitable donation deduction
+  class: deduction
+  note: WA charitable donation deduction; self-contained.


### PR DESCRIPTION
Appends 31 corpus-verified operative individual income-tax sections for the uncovered O–W states to `bulk/worklist.yaml`, in dispatch batches C1–C5.

**States (10):** OH, OK, OR, RI, SC, UT, VA, WI, WV, WA.

Each `citation` is confirmed present in `corpus.current_provisions` and scoped to what PE-US's `<state>_income_tax` tree simulates — rate schedule/brackets, standard deduction/exemptions, and headline credits. Cross-reference-heavy sections (encode#1058) are skipped. Values are authored by the encoder from the corpus body; this PR only queues citations.

**Batches**
- C1 (8): OH 5747.02/5747.025/5747.71, OK 68-2355, OR 316.037/316.085/315.264/315.266
- C2 (7): RI 44-30-2.6/44-30-103, SC 12-6-510/12-6-520/12-6-1170/12-6-3632/12-6-3330
- C3 (7): UT 59-10-104/59-10-1018/59-10-1019, VA 58.1-320/58.1-321/58.1-322.03/58.1-339.8
- C4 (6): WV 11-21-3/11-21-16/11-21-21/11-21-23/11-21-10, WI 71.06
- C5 (3): WA 82.87.040/82.87.060/82.87.080

**Not queued (ingest gaps, statute absent from shared corpus):** PA Tax Reform Code (72 P.S. §7301-7304); VT 32 V.S.A. §5822/§5828b/§5828c; OK EITC 68-2357.43; WV rate 11-21-4e/4g/4j.

Append-only worklist change; no RuleSpec modules touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
