### PR TITLE
Encode us-oh/statute/5747.025 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16747,6 +16747,15 @@
         ]
       }
     ],
+    "us-oh/statute/5747.025": [
+      {
+        "module": "us-oh/statutes/5747/025.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-oh/statute/5747.71": [
       {
         "module": "us-oh/statutes/5747/71.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 24
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -37,6 +37,42 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#taxable_business_income_after_excess_exemptions
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#adjusted_personal_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2025
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_high_income_band_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_income_band
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_low_income_band_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#personal_exemption_rounding_multiple
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-oh:statutes/5747/025#statutory_personal_exemption_amount_by_income_band
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#earned_income_credit

--- a/us-oh/.axiom/encoding-manifests/statutes/5747/025.json
+++ b/us-oh/.axiom/encoding-manifests/statutes/5747/025.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/5747/025.yaml",
+      "sha256": "9ee0edb818e09639697487892b9c34a95e0ebfc11d7904a0a66eb68cd7d86f14"
+    },
+    {
+      "path": "statutes/5747/025.test.yaml",
+      "sha256": "5ff5edbb9bfa180ce13cf3491632845653379efbfd157332c9a75bdca6fef2b2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-oh/statute/5747.025",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-oh-statute-5747.025/workspace/context-manifest.json",
+  "context_manifest_sha256": "e322aeab8e7d28bafbb2461ed4117a15215c0c51323ef937a59709225ae35d0a",
+  "generated_at": "2026-07-08T10:07:47.577873+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/5747/025.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "9ee0edb818e09639697487892b9c34a95e0ebfc11d7904a0a66eb68cd7d86f14",
+  "generation_prompt_sha256": "aceb8e862813f6c595c6a7468e3d543f0defaa3db6279e111bd24d09525f9c82",
+  "model": "gpt-5.5",
+  "run_id": "8938b936",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a9549ea3208832471809f0dbb410dc1cc05af9dc636286a574b33cb143522227"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-oh-statute-5747.025.json",
+  "trace_sha256": "fc5038b662464de9a9afd63c0f298146e0c9a7296c90fd925414b1d7e661e671"
+}

--- a/us-oh/statutes/5747/025.test.yaml
+++ b/us-oh/statutes/5747/025.test.yaml
@@ -1,0 +1,69 @@
+- name: low_income_2025_receives_low_band_exemption
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-oh:statutes/5747/025#input.modified_adjusted_gross_income: 40000
+    us-oh:statutes/5747/025#input.taxable_year_begins_in_initial_cap_year: true
+    us-oh:statutes/5747/025#input.taxable_year_begins_after_initial_cap_year: false
+    us-oh:statutes/5747/025#input.exemption_under_section_5747_02_allowable_to_another_taxpayer_for_individual: false
+    us-oh:statutes/5747/025#input.personal_exemption_amount_for_preceding_calendar_year: 2350
+    us-oh:statutes/5747/025#input.gross_domestic_product_deflator_percentage_increase: 0.04
+    us-oh:statutes/5747/025#input.new_gdp_deflator_adjustment_would_be_less_than_preceding_calendar_year_adjustment: false
+  output:
+    us-oh:statutes/5747/025#personal_exemption_income_band: 0
+    us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap: holds
+    us-oh:statutes/5747/025#personal_exemption_amount: 2350
+    us-oh:statutes/5747/025#adjusted_personal_exemption_amount: 2450
+- name: middle_income_2025_receives_middle_band_exemption
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-oh:statutes/5747/025#input.modified_adjusted_gross_income: 60000
+    us-oh:statutes/5747/025#input.taxable_year_begins_in_initial_cap_year: true
+    us-oh:statutes/5747/025#input.taxable_year_begins_after_initial_cap_year: false
+    us-oh:statutes/5747/025#input.exemption_under_section_5747_02_allowable_to_another_taxpayer_for_individual: false
+    us-oh:statutes/5747/025#input.personal_exemption_amount_for_preceding_calendar_year: 2350
+    us-oh:statutes/5747/025#input.gross_domestic_product_deflator_percentage_increase: 0.04
+    us-oh:statutes/5747/025#input.new_gdp_deflator_adjustment_would_be_less_than_preceding_calendar_year_adjustment: false
+  output:
+    us-oh:statutes/5747/025#personal_exemption_income_band: 1
+    us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap: holds
+    us-oh:statutes/5747/025#personal_exemption_amount: 2100
+- name: high_income_2026_receives_high_band_exemption_when_below_cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:statutes/5747/025#input.modified_adjusted_gross_income: 90000
+    us-oh:statutes/5747/025#input.taxable_year_begins_in_initial_cap_year: false
+    us-oh:statutes/5747/025#input.taxable_year_begins_after_initial_cap_year: true
+    us-oh:statutes/5747/025#input.exemption_under_section_5747_02_allowable_to_another_taxpayer_for_individual: false
+    us-oh:statutes/5747/025#input.personal_exemption_amount_for_preceding_calendar_year: 2350
+    us-oh:statutes/5747/025#input.gross_domestic_product_deflator_percentage_increase: 0.04
+    us-oh:statutes/5747/025#input.new_gdp_deflator_adjustment_would_be_less_than_preceding_calendar_year_adjustment: true
+  output:
+    us-oh:statutes/5747/025#personal_exemption_income_band: 2
+    us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap: holds
+    us-oh:statutes/5747/025#personal_exemption_amount: 1850
+    us-oh:statutes/5747/025#adjusted_personal_exemption_amount: 2350
+- name: exemption_zero_when_magi_cap_not_met_or_another_taxpayer_can_claim_individual
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:statutes/5747/025#input.modified_adjusted_gross_income: 500000
+    us-oh:statutes/5747/025#input.taxable_year_begins_in_initial_cap_year: false
+    us-oh:statutes/5747/025#input.taxable_year_begins_after_initial_cap_year: true
+    us-oh:statutes/5747/025#input.exemption_under_section_5747_02_allowable_to_another_taxpayer_for_individual: true
+    us-oh:statutes/5747/025#input.personal_exemption_amount_for_preceding_calendar_year: 2350
+    us-oh:statutes/5747/025#input.gross_domestic_product_deflator_percentage_increase: 0.04
+    us-oh:statutes/5747/025#input.new_gdp_deflator_adjustment_would_be_less_than_preceding_calendar_year_adjustment: false
+  output:
+    us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap: not_holds
+    us-oh:statutes/5747/025#personal_exemption_amount: 0

--- a/us-oh/statutes/5747/025.yaml
+++ b/us-oh/statutes/5747/025.yaml
@@ -1,0 +1,247 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-oh/statute/5747.025
+  summary: |-
+    ORC 5747.025(A) provides personal exemption amounts for the taxpayer, spouse, and each dependent when modified adjusted gross income is below $750,000 for taxable years beginning in 2025 or $500,000 for taxable years beginning in 2026 or thereafter: $2,350 if MAGI is <= $40,000; $2,100 if MAGI is > $40,000 and <= $80,000; $1,850 if MAGI is > $80,000. Division (B) sets the exemption amount to zero for an individual for whom an exemption under section 5747.02 is allowable to another taxpayer, and division (C) prescribes annual GDP-deflator adjustment and upward rounding to the nearest $50 multiple, with no decrease adjustment.
+rules:
+  - name: personal_exemption_eligibility_magi_cap_taxable_year_2025
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "less than seven hundred fifty thousand dollars for taxable years beginning in 2025"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          750000
+
+  - name: personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "five hundred thousand dollars for taxable years beginning in 2026 or thereafter"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          500000
+
+  - name: personal_exemption_low_income_band_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "less than or equal to forty thousand dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          40000
+
+  - name: personal_exemption_middle_income_band_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "greater than forty thousand dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          40000
+
+  - name: personal_exemption_middle_income_band_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "less than or equal to eighty thousand dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          80000
+
+  - name: personal_exemption_high_income_band_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(A)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "greater than eighty thousand dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          80000
+
+  - name: statutory_personal_exemption_amount_by_income_band
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: personal_exemption_income_band
+    source: ORC 5747.025(A)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              table:
+                header: "personal exemption amounts by modified adjusted gross income"
+                row_key: "personal_exemption_income_band"
+                column_key: "statutory_personal_exemption_amount"
+    versions:
+      - effective_from: '2025-01-01'
+        values:
+          0: 2350
+          1: 2100
+          2: 1850
+
+  - name: personal_exemption_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: ORC 5747.025(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "rounding the resulting sum upward to the nearest multiple of fifty dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          50
+
+  - name: personal_exemption_income_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: ORC 5747.025(A)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "less than or equal to forty thousand dollars; ... greater than forty thousand dollars but less than or equal to eighty thousand dollars; ... greater than eighty thousand dollars"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if modified_adjusted_gross_income <= personal_exemption_low_income_band_upper_bound: 0 else: if modified_adjusted_gross_income > personal_exemption_middle_income_band_lower_bound and modified_adjusted_gross_income <= personal_exemption_middle_income_band_upper_bound: 1 else: 2
+
+  - name: personal_exemption_magi_below_applicable_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: ORC 5747.025(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "provided the taxpayer's modified adjusted gross income is less than seven hundred fifty thousand dollars for taxable years beginning in 2025 or five hundred thousand dollars for taxable years beginning in 2026 or thereafter"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          (taxable_year_begins_in_initial_cap_year and modified_adjusted_gross_income < personal_exemption_eligibility_magi_cap_taxable_year_2025)
+          or (taxable_year_begins_after_initial_cap_year and modified_adjusted_gross_income < personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after)
+
+  - name: adjusted_personal_exemption_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ORC 5747.025(B)-(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "multiplying that amount by the percentage increase ... adding the resulting product ... and rounding the resulting sum upward to the nearest multiple of fifty dollars"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "shall not make a new adjustment ... in which the amount resulting from the adjustment would be less than the amount resulting from the adjustment in the preceding calendar year"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if new_gdp_deflator_adjustment_would_be_less_than_preceding_calendar_year_adjustment: personal_exemption_amount_for_preceding_calendar_year else: ceil((personal_exemption_amount_for_preceding_calendar_year + (personal_exemption_amount_for_preceding_calendar_year * gross_domestic_product_deflator_percentage_increase)) / personal_exemption_rounding_multiple) * personal_exemption_rounding_multiple
+
+  - name: personal_exemption_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ORC 5747.025(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "The personal exemption for the taxpayer, the taxpayer's spouse, and each dependent shall be one of the following amounts"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-oh/statute/5747.025
+              excerpt: "the exemption amount applicable to such individual for such individual's taxable year shall be zero"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if exemption_under_section_5747_02_allowable_to_another_taxpayer_for_individual: 0 else: if personal_exemption_magi_below_applicable_cap: statutory_personal_exemption_amount_by_income_band[personal_exemption_income_band] else: 0


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-oh/statute/5747.025`
- Module: `us-oh/statutes/5747/025.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 64s
- Local gate status: **green**

Produced by `axiom-encode encode us-oh/statute/5747.025 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-oh/statute/5747.025",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "8938b936",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/5747/025.yaml",
      "sha256": "9ee0edb818e09639697487892b9c34a95e0ebfc11d7904a0a66eb68cd7d86f14"
    },
    {
      "path": "statutes/5747/025.test.yaml",
      "sha256": "5ff5edbb9bfa180ce13cf3491632845653379efbfd157332c9a75bdca6fef2b2"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
