### PR TITLE
Queue A–K state income-tax provisions (bulk batches AK1–AK8)

### DIFF
--- a/bulk/PROGRESS-us-coverage-wave1-lane-a.md
+++ b/bulk/PROGRESS-us-coverage-wave1-lane-a.md
@@ -1,0 +1,44 @@
+# US coverage wave 1 — ingest lane A
+
+Mission: corpus-ingest individual income tax statutes for uncovered state-income-tax
+rows whose **state name starts A–K**, then feed `bulk/worklist.yaml` so the cloud
+dispatcher (gpt-5.5) encodes them. Read authoritative list from
+`axiom-oracles conformance/detail/us-pe.json` (uncovered `*_income_tax`; covered
+already: CA/NY/IL/MA/CO).
+
+## Slice (13 jurisdictions, name A–K)
+
+| Jur | State | Corpus queue status | Income-tax citations verified | Worklist | Bulk PR |
+| --- | --- | --- | --- | --- | --- |
+| us-al | Alabama | done (57667) | pending | – | – |
+| us-az | Arizona | done (28283) | pending | – | – |
+| us-ar | Arkansas | **blocked_primary_source** | pending | – | – |
+| us-ct | Connecticut | done (31301) | pending | – | – |
+| us-de | Delaware | done (25739) | pending | – | – |
+| us-dc | District of Columbia | done (24346) | pending | – | – |
+| us-ga | Georgia | done (32457) | pending | – | – |
+| us-hi | Hawaii | done (20962) | pending | – | – |
+| us-id | Idaho | done (22255) | pending | – | – |
+| us-in | Indiana | done (91620) | pending | – | – |
+| us-ia | Iowa | done (36595) | pending | – | – |
+| us-ks | Kansas | done (49565) | pending | – | – |
+| us-ky | Kentucky | done (40088) | pending | – | – |
+
+Key finding: 12/13 states already have full statute corpora productionized in
+Supabase `corpus.current_provisions` ("uncovered" is an *oracle*/encoding gap, not a
+corpus gap). Lane work = verify the PE-simulated income-tax sections (rate/brackets,
+standard deduction, personal exemption, headline credits) exist as `citation_path`s,
+scope per `<state>_income_tax` PE-US module, skip xref-heavy sections (encode#1058),
+append corpus-VERIFIED worklist entries, dispatch bulk workflow in batches of 6–8.
+
+## Recipe (per state)
+1. Read PE-US `variables|parameters/gov/states/<st>/tax/income` → statutory refs.
+2. Map refs → corpus `citation_path`; verify each in Supabase current_provisions
+   (>0 rows, substantive body). 0 rows = do NOT list.
+3. Append entries to `bulk/worklist.yaml` (small PR, rebase before merge — sibling
+   lanes share the file).
+4. Dispatch `bulk-encode.yml` per batch of ~6–8; poll CI foreground; note
+   fail-closed rejections for pipeline lanes. No admin-merge.
+
+## Log
+- Setup: worktree `us-coverage-wave1-lane-a` from origin/main; Supabase read verified.

--- a/bulk/PROGRESS-us-coverage-wave1-lane-a.md
+++ b/bulk/PROGRESS-us-coverage-wave1-lane-a.md
@@ -1,44 +1,56 @@
 # US coverage wave 1 — ingest lane A
 
-Mission: corpus-ingest individual income tax statutes for uncovered state-income-tax
+Mission: corpus-verify individual income tax statutes for uncovered state-income-tax
 rows whose **state name starts A–K**, then feed `bulk/worklist.yaml` so the cloud
-dispatcher (gpt-5.5) encodes them. Read authoritative list from
-`axiom-oracles conformance/detail/us-pe.json` (uncovered `*_income_tax`; covered
-already: CA/NY/IL/MA/CO).
+dispatcher (gpt-5.5) encodes them. Authoritative list: `axiom-oracles
+conformance/detail/us-pe.json` (uncovered `*_income_tax`; covered already
+CA/NY/IL/MA/CO). Slice = 13 jurisdictions.
 
-## Slice (13 jurisdictions, name A–K)
+Key finding: 11/13 slice states already have full statute corpora productionized in
+Supabase `corpus.current_provisions` — "uncovered" is an *oracle/encoding* gap, not a
+corpus gap. Lane work = map each `<state>_income_tax` PE-US module to its operative
+statutory sections, verify every `citation_path` in Supabase (exact `eq.` query, the
+same view the cloud encoder resolves against), skip AGI/IRC-conformity umbrellas and
+transitory rebates (encode#1058), and queue corpus-VERIFIED entries.
 
-| Jur | State | Corpus queue status | Income-tax citations verified | Worklist | Bulk PR |
-| --- | --- | --- | --- | --- | --- |
-| us-al | Alabama | done (57667) | pending | – | – |
-| us-az | Arizona | done (28283) | pending | – | – |
-| us-ar | Arkansas | **blocked_primary_source** | pending | – | – |
-| us-ct | Connecticut | done (31301) | pending | – | – |
-| us-de | Delaware | done (25739) | pending | – | – |
-| us-dc | District of Columbia | done (24346) | pending | – | – |
-| us-ga | Georgia | done (32457) | pending | – | – |
-| us-hi | Hawaii | done (20962) | pending | – | – |
-| us-id | Idaho | done (22255) | pending | – | – |
-| us-in | Indiana | done (91620) | pending | – | – |
-| us-ia | Iowa | done (36595) | pending | – | – |
-| us-ks | Kansas | done (49565) | pending | – | – |
-| us-ky | Kentucky | done (40088) | pending | – | – |
+## Slice status
 
-Key finding: 12/13 states already have full statute corpora productionized in
-Supabase `corpus.current_provisions` ("uncovered" is an *oracle*/encoding gap, not a
-corpus gap). Lane work = verify the PE-simulated income-tax sections (rate/brackets,
-standard deduction, personal exemption, headline credits) exist as `citation_path`s,
-scope per `<state>_income_tax` PE-US module, skip xref-heavy sections (encode#1058),
-append corpus-VERIFIED worklist entries, dispatch bulk workflow in batches of 6–8.
+| Jur | State | Corpus | Verified income-tax sections | Batches |
+| --- | --- | --- | --- | --- |
+| us-hi | Hawaii | done | 6 (rate, exemption, EITC, renters, CDCC, food/excise) | AK1 |
+| us-az | Arizona | done | 7 (rate, std ded, exemption, family/dependent/excise/property credits) | AK1–AK2 |
+| us-ct | Connecticut | done | 6 (rate, exemption, personal/property/EITC/stillborn credits) | AK2–AK3 |
+| us-ky | Kentucky | done | 5 (rate, std ded, family-size/CDCC/tuition credits) | AK3 |
+| us-de | Delaware | done | 6 (rate, std ded, itemized, personal/CDCC/EITC credits) | AK4 |
+| us-ga | Georgia | done | 5 (rate, exemption, std-ded computation, CDCC, low-income) | AK4–AK5 |
+| us-al | Alabama | done | 3 (rate, deductions std+FIT, exemptions) | AK5 |
+| us-dc | District of Columbia | done | 3 (rate, EITC/CDCC credits, Schedule H property) | AK5–AK6 |
+| us-id | Idaho | done | 8 (rate, food/aged/CTC credits, retirement/care/aged/capgains deductions) | AK6–AK7 |
+| us-in | Indiana | done | 9 (rate, 5 deductions, elderly/529/EITC credits) | AK7–AK8 |
+| us-ia | Iowa | done | 4 (rate, exemption, EITC, CDCC) | AK8 |
+| us-ar | Arkansas | **blocked_primary_source** | 0 corpus statute rows — cannot verify/queue | — |
+| us-ks | Kansas | **income-tax article gap** | article 79-32 absent from corpus (only 79-32,100b) | — |
 
-## Recipe (per state)
-1. Read PE-US `variables|parameters/gov/states/<st>/tax/income` → statutory refs.
-2. Map refs → corpus `citation_path`; verify each in Supabase current_provisions
-   (>0 rows, substantive body). 0 rows = do NOT list.
-3. Append entries to `bulk/worklist.yaml` (small PR, rebase before merge — sibling
-   lanes share the file).
-4. Dispatch `bulk-encode.yml` per batch of ~6–8; poll CI foreground; note
-   fail-closed rejections for pipeline lanes. No admin-merge.
+62 corpus-VERIFIED entries queued across 11 states, batches AK1–AK8 (8×7 + 6).
+Every heading is verbatim from corpus; every citation confirmed FOUND with a
+substantive operative body via live `current_provisions` `eq.` query.
+
+## Remaining in slice (for the pipeline/ingest-adapter lanes)
+- **us-ar (Arkansas)** — 0 statute provisions in corpus (queue: `blocked_primary_source`).
+  Needs a primary official source ingest; secondary summaries (Justia/FindLaw) forbidden.
+  No corpus write creds in-lane (corpus service_role key unavailable), so not ingestible here.
+- **us-ks (Kansas)** — the income-tax article (79-32,101…) is missing from an otherwise
+  complete KS corpus (adapter dropped the comma-format sections; only `79-32,100b` landed).
+  Needs a scoped KS income-tax re-ingest.
+
+## Corpus gaps noted (PE simulates, section absent — for corpus refresh)
+- us-dc: KCCATC (§47-1806.15) and DC CTC (§47-1806.17) — snapshot predates enactment.
+- us-ga: surplus tax rebate (§48-7-20.2) and itemizer credit (§48-7-27.1) — not codified in snapshot.
+- Various one-time rebates (AZ/CT/DE/GA/ID/IN) are session-law/transitory — intentionally not queued.
 
 ## Log
-- Setup: worktree `us-coverage-wave1-lane-a` from origin/main; Supabase read verified.
+- Setup: worktree from origin/main; Supabase read verified; PROGRESS committed at start.
+- Verified all 11 corpus-present states (PE module → statutory refs → Supabase `eq.` confirm).
+- Appended 62 entries (AK1–AK8) to `bulk/worklist.yaml`; compute_matrix parses all batches.
+- Note: shared scratchpad `verify.py` was clobbered by the L–N sibling lane mid-run; used a
+  private re-verification gate — no impact on results.

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -594,3 +594,437 @@ entries:
   heading: Charitable donation deduction
   class: deduction
   note: WA charitable donation deduction; self-contained.
+- citation: us-hi/statute/235-51
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Tax imposed on individuals; rates"
+  class: rate
+  note: "Graduated rate schedule/brackets by filing status; self-contained bracket tables."
+- citation: us-hi/statute/235-54
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Exemptions"
+  class: exemption
+  note: "Personal exemption amount in lieu of IRC personal exemptions; one IRC ref."
+- citation: us-hi/statute/235-55.75
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Refundable earned income tax credit"
+  class: credit
+  note: "State EITC as a percentage of the federal EITC; refundable."
+- citation: us-hi/statute/235-55.7
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Income tax credit for low-income household renters"
+  class: credit
+  note: "Low-income household renters credit; self-contained AGI thresholds and per-exemption amount."
+- citation: us-hi/statute/235-55.6
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Expenses for household and dependent care services necessary for gainful employment"
+  class: credit
+  note: "Household and dependent care credit mirroring federal IRC 21 structure."
+- citation: us-hi/statute/235-55.85
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Refundable food/excise tax credit"
+  class: credit
+  note: "Refundable food/excise tax credit; self-contained per-AGI amount table."
+- citation: us-az/statute/43-1011
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Taxes and tax rates"
+  class: rate
+  note: "Rate schedule culminating in the current flat 2.5%; self-contained (xref=2)."
+- citation: us-az/statute/43-1041
+  repo: rulespec-us
+  batch: AK1
+  status: pending
+  heading: "Optional standard deduction"
+  class: deduction
+  note: "Standard-deduction amounts ($12,200/$18,350/$24,400) with inflation adjustment and increased-deduction rate."
+- citation: us-az/statute/43-1023
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Exemptions for blind persons and persons sixty-five years of age or older"
+  class: exemption
+  note: "Operative age/blind exemption amounts; low xref."
+- citation: us-az/statute/43-1073
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Family income tax credit"
+  class: credit
+  note: "Family income tax credit with per-person amount, cap, and filing-status income limits; self-contained."
+- citation: us-az/statute/43-1073.01
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Dependent tax credit"
+  class: credit
+  note: "Dependent tax credit with $200,000 AGI phase-down; zero cross-references."
+- citation: us-az/statute/43-1072.01
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Credit for increased excise taxes paid"
+  class: credit
+  note: "Increased-excise (property) tax credit; $25/person, $100/household cap with income thresholds."
+- citation: us-az/statute/43-1072
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Earned credit for property taxes; residents sixty-five years of age or older; definitions"
+  class: credit
+  note: "Senior property-tax credit with amount tables and income thresholds; xref=1."
+- citation: us-ct/statute/12-700
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Imposition of tax on income. Rates"
+  class: rate
+  note: "Operative rate schedule/brackets for all filing statuses; internal effective-date refs only."
+- citation: us-ct/statute/12-702
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Exemptions"
+  class: exemption
+  note: "Personal exemption maximum and AGI phase-out."
+- citation: us-ct/statute/12-703
+  repo: rulespec-us
+  batch: AK2
+  status: pending
+  heading: "Credits based on adjusted gross income"
+  class: credit
+  note: "CT personal tax credit — AGI-based fraction-of-tax tables by filing status; number-dense."
+- citation: us-ct/statute/12-704c
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Credits for taxes paid on primary residence or motor vehicle. Credit for conveyance tax"
+  class: credit
+  note: "Property tax credit — cap, age threshold, and AGI reduction schedule."
+- citation: us-ct/statute/12-704e
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Earned income tax credit. Additional amount for certain taxpayers"
+  class: credit
+  note: "CT EITC as a match percentage of the federal EITC plus qualifying-child bonus."
+- citation: us-ct/statute/12-704i
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Credit for delivery of a fetus born dead for which a fetal death certificate has been filed"
+  class: credit
+  note: "Self-contained $2,500 stillborn credit simulated by PE."
+- citation: us-ky/statute/11/141.020
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Levy of income tax on individuals — Rate of normal tax — Reduction — Tax credits — Income of nonresidents subject to tax — Election to pay tax imposed by KRS 141.023."
+  class: rate
+  note: "Flat normal-tax rate levy; subsection (3)(a) carries the aged/blind/military personal tax credits."
+- citation: us-ky/statute/11/141.081
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Optional standard deduction for individuals — Exception."
+  class: deduction
+  note: "Optional inflation-indexed standard deduction."
+- citation: us-ky/statute/11/141.066
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Definitions — Nonrefundable low income, family size, and income gap tax credits."
+  class: credit
+  note: "Nonrefundable family-size tax credit with poverty-level rate schedule."
+- citation: us-ky/statute/11/141.067
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Household and dependent care service credit."
+  class: credit
+  note: "Nonrefundable credit equal to 20% of the federal IRC 21 CDCC."
+- citation: us-ky/statute/11/141.069
+  repo: rulespec-us
+  batch: AK3
+  status: pending
+  heading: "Credit allowed for tuition at eligible educational institution."
+  class: credit
+  note: "Nonrefundable credit equal to 25% of the federal IRC 25A education credit."
+- citation: us-de/statute/30/1102
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Imposition and rate of tax; separate tax on lump-sum distributions"
+  class: rate
+  note: "Progressive bracket schedule (top 6.6%); self-contained rate table."
+- citation: us-de/statute/30/1108
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Standard deduction"
+  class: deduction
+  note: "Standard-deduction amounts by filing status plus age/blindness additional amount; xref=0."
+- citation: us-de/statute/30/1109
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Itemized deductions [For application of this section, see 66 Del. Laws, c. 86, § 8]"
+  class: deduction
+  note: "Elective DE itemized deduction (federal itemized less DE/other-state income taxes); low xref."
+- citation: us-de/statute/30/1110
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Personal exemptions and credits"
+  class: credit
+  note: "Per-exemption personal credit ($110) plus additional credit for age 60+; xref=0."
+- citation: us-de/statute/30/1114
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Child care and dependent care expense credit"
+  class: credit
+  note: "Credit equal to 50% of the federal child and dependent care credit; self-contained."
+- citation: us-de/statute/30/1117
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "Earned income tax credit"
+  class: credit
+  note: "State EITC as a percentage of the federal EITC (refundable option from 2022)."
+- citation: us-ga/statute/48/48-7-20
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "[Effective until January 1, 2024. See note.] Individual tax rates; credit for withholding and other payments; applicability to estates and trusts."
+  class: rate
+  note: "Individual imposition/rate section (GA moved to a near-flat rate); encoder should confirm current flat-rate body."
+- citation: us-ga/statute/48/48-7-26
+  repo: rulespec-us
+  batch: AK4
+  status: pending
+  heading: "[Effective until January 1, 2024. See note.] Personal exemptions."
+  class: exemption
+  note: "Personal and dependent exemption amounts."
+- citation: us-ga/statute/48/48-7-27
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "[Effective until January 1, 2024. See note.] Computation of taxable net income."
+  class: deduction
+  note: "Operative home of the GA standard deduction plus aged/blind and retirement-income exclusions (num_tokens=914); bundled — encoder should extract operative subsections."
+- citation: us-ga/statute/48/48-7-29.10
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Tax credits for qualified child and dependent care expenses."
+  class: credit
+  note: "GA CDCC as a percentage of the federal IRC 21 credit."
+- citation: us-ga/statute/48/48-7A-3
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Persons entitled to claim tax credit; tax credits schedule; tax credit claimed against tax liability; period for filing claims for credit; applicability to food stamp recipients; authority of commissioner."
+  class: credit
+  note: "Low-income credit schedule (O.C.G.A. Chapter 7A); self-contained, xref=0."
+- citation: us-al/statute/40-18-5
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Tax on Individuals"
+  class: rate
+  note: "Individual bracket schedule (2/4/5% by taxable income and filing status); self-contained, xref=1."
+- citation: us-al/statute/40-18-15
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Deductions for Individuals Generally. (Amended by Act 2026-604)"
+  class: deduction
+  note: "Operative home of the AL standard deduction (b) and federal-income-tax deduction (c); encoder should scope to (b)+(c)."
+- citation: us-al/statute/40-18-19
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Exemptions - Generally. (Amended by Act 2026-603)"
+  class: exemption
+  note: "Personal exemption, graduated dependent exemption, and age-65 retirement-income exemption; self-contained amounts."
+- citation: us-dc/statute/47/47-1806.03
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Tax on residents and nonresidents — Imposition and rates."
+  class: rate
+  note: "DC imposition and marginal-rate bracket table; clean operative body, xref=0."
+- citation: us-dc/statute/47/47-1806.04
+  repo: rulespec-us
+  batch: AK5
+  status: pending
+  heading: "Tax on residents and nonresidents — Credits — In general."
+  class: credit
+  note: "Operative home of the DC EITC (f) and child and dependent care credit (c); encoder should scope to the EITC/CDCC subsections."
+- citation: us-dc/statute/47/47-1806.06
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Tax on residents and nonresidents — Credits — Property taxes."
+  class: credit
+  note: "Schedule H real-property-tax circuit-breaker credit; large operative body, xref=0."
+- citation: us-id/statute/63-3024
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Individuals’ tax and tax on estates and trusts"
+  class: rate
+  note: "Imposes the individual income tax at the flat rate on Idaho taxable income; short operative body."
+- citation: us-id/statute/63-3024A
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Food tax credits and refunds"
+  class: credit
+  note: "Idaho grocery/food tax credit (per-person base plus aged add-on)."
+- citation: us-id/statute/63-3025D
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Payment for dependents sixty-five years of age or older or persons with developmental disabilities"
+  class: credit
+  note: "Aged-or-disabled dependent credit taken in lieu of the 63-3022E deduction."
+- citation: us-id/statute/63-3029L
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "child TAX CREDIT"
+  class: credit
+  note: "Nonrefundable per-qualifying-child Idaho child tax credit (2018-2025 window)."
+- citation: us-id/statute/63-3022A
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Deduction of certain retirement benefits"
+  class: deduction
+  note: "Age/disability-gated deduction of specified retirement benefits (incl. military retirement)."
+- citation: us-id/statute/63-3022D
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Deduction of expenses for household and dependent care services"
+  class: deduction
+  note: "Household and dependent care deduction referencing IRC 21 definitions."
+- citation: us-id/statute/63-3022E
+  repo: rulespec-us
+  batch: AK6
+  status: pending
+  heading: "Household deduction for dependents sixty-five years of age or older or persons with developmental disabilities"
+  class: deduction
+  note: "Additional deduction for households maintaining aged/developmentally-disabled members."
+- citation: us-id/statute/63-3022H
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Deduction of capital gains"
+  class: deduction
+  note: "Deduction of 60% (80% in 2001) of qualified Idaho capital gain net income; Idaho-specific percentages (moderate xref)."
+- citation: us-in/statute/6-3-2-1
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Imposition of tax; tax rate; calculation and certification of individual adjusted gross income tax rate"
+  class: rate
+  note: "Flat individual adjusted-gross-income tax rate section (county rates excluded); xref=1."
+- citation: us-in/statute/6-3-2-4
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Military service deduction; retirement income or survivor's benefits deduction"
+  class: deduction
+  note: "Military service / retirement income deduction; clean operative body, xref=0."
+- citation: us-in/statute/6-3-2-6
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Deduction; rent payments"
+  class: deduction
+  note: "Renter's deduction against AGI; clean operative body, xref=0."
+- citation: us-in/statute/6-3-2-10
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Unemployment compensation; deduction"
+  class: deduction
+  note: "Unemployment-compensation deduction with the excess-AGI haircut formula; internal AGI refs."
+- citation: us-in/statute/6-3-2-22
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Deduction; unreimbursed education expenditures"
+  class: deduction
+  note: "Per-dependent-child unreimbursed private/nonpublic-school education deduction; xref=4."
+- citation: us-in/statute/6-3-2-28
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Deduction for qualified health care sharing expenses"
+  class: deduction
+  note: "Health-care-sharing-ministry expense deduction; clean operative body, xref=0."
+- citation: us-in/statute/6-3-3-9
+  repo: rulespec-us
+  batch: AK7
+  status: pending
+  heading: "Unified tax credit for the elderly"
+  class: credit
+  note: "Unified tax credit for the elderly; clean, xref=2."
+- citation: us-in/statute/6-3-3-12
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Credit for contributions to college choice education savings plan; date of contribution; repayment of credit after nonqualified withdrawals; designation of contributions after December 31, 2018"
+  class: credit
+  note: "CollegeChoice 529 contribution credit (rate/cap); internal IC 21-9 account refs."
+- citation: us-in/statute/6-3.1-21-6
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Credit; amount; calculation; eligible persons; determination of taxpayer's earned income; cost of living adjustments under the Internal Revenue Code"
+  class: credit
+  note: "Indiana EITC amount/eligibility; IRC 32 piggyback (xref=7)."
+- citation: us-ia/statute/422.5
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Tax imposed — exclusions — alternate tax rate."
+  class: rate
+  note: "Operative rate section — flat rate plus alternate tax and exclusions; internal-subsection refs."
+- citation: us-ia/statute/422.12
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Deductions from computed tax."
+  class: exemption
+  note: "Personal exemption credit plus tuition-and-textbook credit definitions."
+- citation: us-ia/statute/422.12B
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Earned income tax credit."
+  class: credit
+  note: "Iowa EITC as a percentage of the federal IRC 32 credit; clean, low xref."
+- citation: us-ia/statute/422.12C
+  repo: rulespec-us
+  batch: AK8
+  status: pending
+  heading: "Child and dependent care or early childhood development tax credits."
+  class: credit
+  note: "Iowa CDCC as percentages of the federal child-and-dependent-care credit."


### PR DESCRIPTION
## US coverage wave 1 — ingest lane A (A–K state income taxes)

Queues **62 corpus-verified individual income-tax sections across 11 states** for the
bulk encoder, mirroring the O–W lane (#613). Batches **AK1–AK8**.

Slice = uncovered `*_income_tax` rows in `axiom-oracles conformance/detail/us-pe.json`
whose state name starts A–K (covered already: CA/NY/IL/MA/CO). 11 states already have
full statute corpora in Supabase; "uncovered" is an oracle/encoding gap, not a corpus gap.

| State | Sections | State | Sections |
| --- | --- | --- | --- |
| Hawaii | 6 | Georgia | 5 |
| Arizona | 7 | Alabama | 3 |
| Connecticut | 6 | District of Columbia | 3 |
| Kentucky | 5 | Idaho | 8 |
| Delaware | 6 | Indiana | 9 |
| Iowa | 4 | | |

### Method (corpus-verified, no invented numbers)
- Each `<state>_income_tax` PE-US module read to scope the ingest to what the conformance
  row needs: rate schedules/brackets, standard deduction, personal/dependent exemption,
  and headline credits (EITC, CDCC, CTC, property/renter/food/family-size, low-income).
- Every `citation_path` confirmed present in `corpus.current_provisions` via an exact
  `eq.` query — the same view `axiom-encode` resolves against — with a substantive
  operative body. Headings are verbatim from corpus.
- Scoped per encode#1058: AGI/IRC-conformity umbrella sections (e.g. IN 6-3-1-3.5 xref≈422,
  IA 422.7 xref≈219, HI 235-2.4, CT 12-701, DE 1106) and transitory one-time rebates excluded.

### Remaining in slice (for ingest-adapter lanes)
- **Arkansas** — 0 statute provisions in corpus (`blocked_primary_source`).
- **Kansas** — income-tax article `79-32,1xx` absent from an otherwise complete corpus
  (comma-format sections dropped by the adapter; only `79-32,100b` landed).

Worklist-only change; no RuleSpec YAML touched. `bulk/compute_matrix.py` parses all
AK batches. Dispatching AK1–AK8 opens one auto-merge PR per module.
