### PR TITLE
Queue L–N state income-tax provisions (bulk batches B1–B6)

### DIFF
--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1028,3 +1028,290 @@ entries:
   heading: "Child and dependent care or early childhood development tax credits."
   class: credit
   note: "Iowa CDCC as percentages of the federal child-and-dependent-care credit."
+- citation: us-la/statute/47:295
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Tax imposed on individuals; administration"
+  class: rate
+  note: "LA individual income tax imposition and flat rate; self-contained (zero external Section refs)."
+- citation: us-la/statute/47:294
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Standard deduction"
+  class: deduction
+  note: "LA combined personal exemption-standard deduction amount; self-contained (part-internal refs)."
+- citation: us-la/statute/47:297.8
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Earned income tax credit"
+  class: credit
+  note: "LA EITC as a percentage of the federal EITC; short self-contained credit."
+- citation: us-la/statute/47:297.4
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Reduction to tax due; child care expenses"
+  class: credit
+  note: "LA child care expense credit keyed to the federal CDCC; self-contained."
+- citation: us-me/statute/36/5111
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Imposition and rate of tax"
+  class: rate
+  note: "ME marginal rate schedule with inflation adjustment; large text but only ~4 external refs (clean)."
+- citation: us-me/statute/36/5124-C
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Standard deduction; resident on or after January 1, 2018"
+  class: deduction
+  note: "ME standard deduction for post-2018 residents with uprating and phaseout; self-contained."
+- citation: us-me/statute/36/5126-A
+  repo: rulespec-us
+  batch: B1
+  status: pending
+  heading: "Personal exemptions on or after January 1, 2018"
+  class: exemption
+  note: "ME personal exemption on/after 2018 with phaseout; part-internal refs."
+- citation: us-me/statute/36/5213-A
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Sales tax fairness credit"
+  class: credit
+  note: "ME sales tax fairness credit; income-based table, self-contained."
+- citation: us-me/statute/36/5219-S
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Earned income credit"
+  class: credit
+  note: "ME EIC as a percentage of the federal EITC; references federal IRC 32 - moderate xref."
+- citation: us-me/statute/36/5219-SS
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Dependent exemption tax credit"
+  class: credit
+  note: "ME dependent exemption tax credit; moderate xref to federal dependent definitions; may fail-closed under encode#1058."
+- citation: us-md/statute/gtg/10-105
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "State income tax rates"
+  class: rate
+  note: "MD individual income tax marginal rate schedule; part-internal bracket refs - moderate xref."
+- citation: us-md/statute/gtg/10-217
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Standard deduction"
+  class: deduction
+  note: "MD standard deduction (percentage-of-AGI with floor and cap); self-contained."
+- citation: us-md/statute/gtg/10-211
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Exemptions"
+  class: exemption
+  note: "MD personal and dependent exemptions with income phaseout; part-internal refs."
+- citation: us-md/statute/gtg/10-751
+  repo: rulespec-us
+  batch: B2
+  status: pending
+  heading: "Earned income credit"
+  class: credit
+  note: "MD earned income credit as a share of the federal EITC; short self-contained."
+- citation: us-md/statute/gtg/10-716
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Credit for child and dependent care expenses"
+  class: credit
+  note: "MD child and dependent care credit keyed to federal IRC 21 - moderate xref."
+- citation: us-mi/statute/206.51
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Tax rate on taxable income"
+  class: rate
+  note: "MI flat income tax rate; large section (rate history + earmarks), ~39 refs - may fail-closed under encode#1058."
+- citation: us-mi/statute/206.30
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Taxable income defined; personal exemption; deductions"
+  class: exemption
+  note: "MI omnibus of taxable-income definition, personal exemption, and deductions; very large (~40 KB, 120+ refs); expected fail-closed under encode#1058 / needs subsection split - queued for CI adjudication."
+- citation: us-mi/statute/206.272
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Earned income tax credit"
+  class: credit
+  note: "MI EITC as a percentage of the federal credit; self-contained (federal ref only)."
+- citation: us-mn/statute/290.06
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Rates of tax; credits"
+  class: rate
+  note: "MN marginal rate schedule and credits omnibus; very large (~38 KB, 90+ refs); may fail-closed under encode#1058 / needs split - queued for CI adjudication."
+- citation: us-mn/statute/290.0123
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Standard deduction"
+  class: deduction
+  note: "MN standard deduction with inflation adjustment and phaseout; self-contained."
+- citation: us-mn/statute/290.0121
+  repo: rulespec-us
+  batch: B3
+  status: pending
+  heading: "Dependent exemption"
+  class: exemption
+  note: "MN dependent exemption; self-contained (near-zero external refs)."
+- citation: us-mn/statute/290.0661
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Minnesota child tax credit"
+  class: credit
+  note: "MN child tax credit; references federal dependent definitions - moderate xref."
+- citation: us-mn/statute/290.0671
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Minnesota working family credit"
+  class: credit
+  note: "MN working family credit (state EITC); moderate xref to federal IRC 32."
+- citation: us-mn/statute/290.067
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Dependent care credit"
+  class: credit
+  note: "MN dependent care credit keyed to federal IRC 21 - moderate xref."
+- citation: us-mt/statute/15-30-2103
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Rate of tax; net long-term capital gains"
+  class: rate
+  note: "MT rate of tax on the federal-taxable-income base plus net long-term capital gains rate (post-SB399, 2024); self-contained."
+- citation: us-mt/statute/15-30-2318
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Earned income tax credit"
+  class: credit
+  note: "MT EITC as a percentage of the federal credit; references federal IRC 32 - moderate xref."
+- citation: us-ne/statute/77/77-2715.03
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Individual income tax brackets and rates"
+  class: rate
+  note: "NE individual income tax brackets and rates with inflation indexing; part-internal refs."
+- citation: us-ne/statute/77/77-2716.01
+  repo: rulespec-us
+  batch: B4
+  status: pending
+  heading: "Personal exemptions; standard deduction; computation"
+  class: exemption
+  note: "NE personal exemption credit and standard deduction computation; part-internal refs."
+- citation: us-ne/statute/77/77-2715.07
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Income tax credits"
+  class: credit
+  note: "NE income tax credits omnibus (EITC, CDCC, elderly/disabled); large (~11 KB, 41 refs) - may fail-closed under encode#1058; queued for CI adjudication."
+- citation: us-nm/statute/7-2-7
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Individual income tax rates"
+  class: rate
+  note: "NM individual income tax rate schedule; self-contained (near-zero external refs)."
+- citation: us-nm/statute/7-2-5.8
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Exemption for low- and middle-income taxpayers"
+  class: exemption
+  note: "NM exemption for low- and middle-income taxpayers; self-contained."
+- citation: us-nm/statute/7-2-18.15
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Working families tax credit"
+  class: credit
+  note: "NM working families tax credit (state EITC as a share of federal); self-contained."
+- citation: us-nm/statute/7-2-18.34
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Child income tax credit"
+  class: credit
+  note: "NM child income tax credit; per-child amount by income tier - moderate xref."
+- citation: us-nm/statute/7-2-18.1
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Credit for dependent child day care"
+  class: credit
+  note: "NM dependent day care credit keyed to federal IRC 21 descriptively; self-contained."
+- citation: us-nc/statute/105/105-153.7
+  repo: rulespec-us
+  batch: B5
+  status: pending
+  heading: "Individual income tax imposed"
+  class: rate
+  note: "NC flat individual income tax rate; self-contained."
+- citation: us-nc/statute/105/105-153.5
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "Modifications to adjusted gross income"
+  class: deduction
+  note: "NC modifications to AGI: standard deduction, child deduction, and additions/subtractions; very large (~49 KB, 120+ refs); expected fail-closed under encode#1058 / needs subsection split - queued for CI adjudication."
+- citation: us-nc/statute/105/105-153.9
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "Tax credits for income taxes paid to other states"
+  class: credit
+  note: "NC credit for income taxes paid to other states; part-internal refs - moderate xref."
+- citation: us-nd/statute/57/57-38-30.3
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "Individual, estate, and trust income tax"
+  class: rate
+  note: "ND individual/estate/trust rate schedule on the federal-taxable-income base; very large (~24 KB, 100+ refs, historical schedules); may fail-closed under encode#1058 / needs split - queued for CI adjudication."
+- citation: us-nd/statute/57/57-38-01.28
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "Marriage penalty credit"
+  class: credit
+  note: "ND marriage penalty credit; moderate xref."
+- citation: us-nj/statute/54a:4-7
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "New Jersey Earned Income Tax Credit program"
+  class: credit
+  note: "NJ earned income tax credit (share of the federal EITC); moderate xref to federal IRC 32."
+- citation: us-nj/statute/54a:4-17.1
+  repo: rulespec-us
+  batch: B6
+  status: pending
+  heading: "Child tax credit, income limit"
+  class: credit
+  note: "NJ child tax credit with income limit; self-contained."


### PR DESCRIPTION
Wave-1 ingest **lane B** (state names L–N). Appends 41 individual income-tax provisions to `bulk/worklist.yaml` for the 11 L–N states already present in `corpus.current_provisions`: **LA ME MD MI MN MT NE NM NC ND NJ**.

Each entry is a rate schedule, standard deduction, exemption, or headline credit **scoped to what PolicyEngine-US's `<state>_income_tax` tree simulates**. Every `citation` was `eq.`-verified against `current_provisions` with a non-empty body before queueing. Batches **B1–B6** (~7 each), all `status: pending`.

Plumbing only — no RuleSpec files touched; the bulk-encode dispatcher and PR CI own correctness.

**Not queued / remainder**
- **MO, MS, NH** — not in the corpus yet (no loaded statute scope); left for the ingest lanes. (NH I&D tax repealed 2025.)
- **NJ 54A core** (54a:2-1/3-1/4-1) — empty bodies upstream (ingest defect); omitted.
- **Omnibus sections** (MI 206.30, MN 290.06, NC 105-153.5, ND 57-38-30.3) — queued with an `encode#1058` caveat; expected to fail-closed / need a subsection split, flagged for the pipeline lanes.

Parallel with lane A and lane C (#613, merged), which append to the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)