### PR TITLE
Encode us-or/statute/316.085 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16756,6 +16756,15 @@
         ]
       }
     ],
+    "us-or/statute/316.085": [
+      {
+        "module": "us-or/statutes/316/085.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-10": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-10.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 17
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,20 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/316/085#joint_surviving_spouse_head_of_household_federal_agi_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/316/085#other_filer_federal_agi_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/316/085#personal_exemption_credit_indexing_factor
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
     source: bulk
     since: 2026-07-08

--- a/us-or/.axiom/encoding-manifests/statutes/316/085.json
+++ b/us-or/.axiom/encoding-manifests/statutes/316/085.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/316/085.yaml",
+      "sha256": "98ccc6252ed5a6c7e478f819738bdad1dddffd971bb6797815fa381294cba96c"
+    },
+    {
+      "path": "statutes/316/085.test.yaml",
+      "sha256": "52e41fd077b24e200d13a3459de53f539715caf7cbecb1b55fef6f7adff13bd5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-or/statute/316.085",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-or-statute-316.085/workspace/context-manifest.json",
+  "context_manifest_sha256": "fa8a8caca66c3dadac12f757f2e07b5315a612229c2c97983a8fc67c2a7c47ea",
+  "generated_at": "2026-07-08T10:12:23.142908+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/316/085.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "98ccc6252ed5a6c7e478f819738bdad1dddffd971bb6797815fa381294cba96c",
+  "generation_prompt_sha256": "af158d653ca8092b480c3d0d2ace43f858ae2d95508196e00355143ee036fb4b",
+  "model": "gpt-5.5",
+  "run_id": "ff17cdcc",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4c0c8441d7ba82bf396a93445fb6572acd543f73c922d9af10f1e308b1f343fc"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-or-statute-316.085.json",
+  "trace_sha256": "02973fc15974bf3f9cffded9127b31ae563a71de5c66587fc89aaee67de5ed16"
+}

--- a/us-or/statutes/316/085.test.yaml
+++ b/us-or/statutes/316/085.test.yaml
@@ -1,0 +1,22 @@
+- name: cpi_indexed_credit_doubles_when_index_factor_is_two
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/316/085#input.cpi_average_for_12_consecutive_months_ending_august_31_of_prior_calendar_year: 200
+    us-or:statutes/316/085#input.cpi_average_for_statutory_base_period: 100
+  output:
+    us-or:statutes/316/085#personal_exemption_credit_indexing_factor: 2
+    us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount: 180
+- name: cpi_indexed_credit_rounds_to_nearest_dollar
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/316/085#input.cpi_average_for_12_consecutive_months_ending_august_31_of_prior_calendar_year: 301
+    us-or:statutes/316/085#input.cpi_average_for_statutory_base_period: 200
+  output:
+    us-or:statutes/316/085#personal_exemption_credit_indexing_factor: 1.505
+    us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount: 135

--- a/us-or/statutes/316/085.yaml
+++ b/us-or/statutes/316/085.yaml
@@ -1,0 +1,121 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/statute/316.085
+  summary: |-
+    ORS 316.085 allows a personal exemption credit equal to $90 times personal exemptions allowed under IRC section 151, with zero credit for an individual whose credit is allowable to another taxpayer. Nonresident and short/status-change-year credits are prorated under cited Oregon provisions. The Department recomputes the dollar amount by multiplying $90 by the CPI indexing factor and rounding to the nearest $1. A taxpayer may not claim the credit if federal adjusted gross income exceeds $200,000 for joint return filers, surviving spouse, or head of household, or $100,000 for other specified filers.
+  deferred_outputs:
+    - output: us-or:statutes/316/085#oregon_personal_exemption_credit
+      reason: The final credit depends on the number of personal exemptions allowed under IRC section 151, which is not provided in copied context, and on proration rules in ORS 316.117 and ORS 314.085 plus filing-status classifications for the AGI limitation. Those upstream legal computations are not available here.
+      source_values:
+        - us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
+        - us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount
+        - us-or:statutes/316/085#joint_surviving_spouse_head_of_household_federal_agi_limit
+        - us-or:statutes/316/085#other_filer_federal_agi_limit
+rules:
+  - name: statutory_personal_exemption_credit_base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 316.085(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/316.085
+              excerpt: "The credit shall equal $90 multiplied by the number of personal exemptions allowed under section 151 of the Internal Revenue Code."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          90
+
+  - name: joint_surviving_spouse_head_of_household_federal_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 316.085(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/316.085
+              excerpt: "exceeds $200,000 for joint return filers, a surviving spouse or a head of household"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200000
+
+  - name: other_filer_federal_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 316.085(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/316.085
+              excerpt: "$100,000 for an individual who is not a married individual and is not a surviving spouse, or is a married individual who files a separate return."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          100000
+
+  - name: personal_exemption_credit_indexing_factor
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 316.085(3)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/statute/316.085
+              excerpt: "Divide the monthly averaged U.S. City Average Consumer Price Index for the 12 consecutive months ending August 31 of the prior calendar year by the monthly averaged index for the first six months of 1986."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cpi_average_for_12_consecutive_months_ending_august_31_of_prior_calendar_year / cpi_average_for_statutory_base_period
+
+  - name: indexed_personal_exemption_credit_dollar_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 316.085(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/statute/316.085
+              excerpt: "Recompute the dollar amount of the personal exemption credit by multiplying $90 by the appropriate indexing factor determined as provided in paragraph (a) of this subsection. Round off the amount obtained under this paragraph to the nearest $1."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
+              output: statutory_personal_exemption_credit_base_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/316/085#personal_exemption_credit_indexing_factor
+              output: personal_exemption_credit_indexing_factor
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor((statutory_personal_exemption_credit_base_amount * personal_exemption_credit_indexing_factor) + 0.5)


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-or/statute/316.085`
- Module: `us-or/statutes/316/085.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 58s
- Local gate status: **green**

Produced by `axiom-encode encode us-or/statute/316.085 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-or/statute/316.085",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "ff17cdcc",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/316/085.yaml",
      "sha256": "98ccc6252ed5a6c7e478f819738bdad1dddffd971bb6797815fa381294cba96c"
    },
    {
      "path": "statutes/316/085.test.yaml",
      "sha256": "52e41fd077b24e200d13a3459de53f539715caf7cbecb1b55fef6f7adff13bd5"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
