### PR TITLE
Encode us-or/statute/315.266 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16756,6 +16756,15 @@
         ]
       }
     ],
+    "us-or/statute/315.266": [
+      {
+        "module": "us-or/statutes/315/266.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-10": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-10.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 18
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,23 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#base_earned_income_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#earned_income_credit_applicable_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#refundable_credit_excess
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#young_dependent_age_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/266#young_dependent_earned_income_credit_rate
     source: bulk
     since: 2026-07-08

--- a/us-or/.axiom/encoding-manifests/statutes/315/266.json
+++ b/us-or/.axiom/encoding-manifests/statutes/315/266.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/315/266.yaml",
+      "sha256": "1071c5e08fc53984ed0b71a16160c789e742a637b87683b023c90324a68665e6"
+    },
+    {
+      "path": "statutes/315/266.test.yaml",
+      "sha256": "c89fb3878e9be0df687acc81725e433e5316801122ee3ff2cdcbddd54c389ae3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-or/statute/315.266",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-or-statute-315.266/workspace/context-manifest.json",
+  "context_manifest_sha256": "7932a019eb66fe53794f73dc6173387e56b7aa820dc8d313c8dcd21f6f68b8ec",
+  "generated_at": "2026-07-08T10:15:12.954992+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/315/266.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "1071c5e08fc53984ed0b71a16160c789e742a637b87683b023c90324a68665e6",
+  "generation_prompt_sha256": "6d8f7ff21b2fc1bab531463d46a4b90be2e997ffd8e3f04dc7ecbcd804e9a6b1",
+  "model": "gpt-5.5",
+  "run_id": "4271bba6",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bf735b1ad28e542ac2ec6909a10dba7f6e083b4e21ec6fe0c06fb13970ed5629"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-or-statute-315.266.json",
+  "trace_sha256": "aadf1dd4d3467ffb3158329dd75b6198f0393cf6cdfce2bec943728134ea0f3d"
+}

--- a/us-or/statutes/315/266.test.yaml
+++ b/us-or/statutes/315/266.test.yaml
@@ -1,0 +1,51 @@
+- name: base rate applies when taxpayer has no dependent under age three
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/315/266#input.taxpayer_has_dependent_at_close_of_tax_year: false
+    us-or:statutes/315/266#input.youngest_dependent_age_at_close_of_tax_year: 5
+    us-or:statutes/315/266#input.credit_allowable_under_this_section: 100
+    us-or:statutes/315/266#input.tax_payments_under_ors_316_187_or_316_583: 20
+    us-or:statutes/315/266#input.other_tax_prepayment_amounts: 10
+    us-or:statutes/315/266#input.other_refundable_credit_amounts: 5
+    us-or:statutes/315/266#input.taxes_imposed_after_nonrefundable_credits: 200
+  output:
+    us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit: not_holds
+    us-or:statutes/315/266#earned_income_credit_applicable_rate: 0.09
+    us-or:statutes/315/266#refundable_credit_excess: 0
+- name: twelve percent rate applies with dependent under age three
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/315/266#input.taxpayer_has_dependent_at_close_of_tax_year: true
+    us-or:statutes/315/266#input.youngest_dependent_age_at_close_of_tax_year: 2
+    us-or:statutes/315/266#input.credit_allowable_under_this_section: 100
+    us-or:statutes/315/266#input.tax_payments_under_ors_316_187_or_316_583: 20
+    us-or:statutes/315/266#input.other_tax_prepayment_amounts: 10
+    us-or:statutes/315/266#input.other_refundable_credit_amounts: 5
+    us-or:statutes/315/266#input.taxes_imposed_after_nonrefundable_credits: 120
+  output:
+    us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit: holds
+    us-or:statutes/315/266#earned_income_credit_applicable_rate: 0.12
+    us-or:statutes/315/266#refundable_credit_excess: 15
+- name: dependent age three is not under age three
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/315/266#input.taxpayer_has_dependent_at_close_of_tax_year: true
+    us-or:statutes/315/266#input.youngest_dependent_age_at_close_of_tax_year: 3
+    us-or:statutes/315/266#input.credit_allowable_under_this_section: 100
+    us-or:statutes/315/266#input.tax_payments_under_ors_316_187_or_316_583: 20
+    us-or:statutes/315/266#input.other_tax_prepayment_amounts: 10
+    us-or:statutes/315/266#input.other_refundable_credit_amounts: 5
+    us-or:statutes/315/266#input.taxes_imposed_after_nonrefundable_credits: 120
+  output:
+    us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit: not_holds
+    us-or:statutes/315/266#earned_income_credit_applicable_rate: 0.09
+    us-or:statutes/315/266#refundable_credit_excess: 15

--- a/us-or/statutes/315/266.yaml
+++ b/us-or/statutes/315/266.yaml
@@ -1,0 +1,153 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/statute/315.266
+  summary: |-
+    ORS 315.266 allows an Oregon earned income credit equal to nine percent of the federal earned income credit allowable under IRC section 32, but for a taxpayer with a dependent under age three at the close of the tax year the credit is 12 percent. Nonresident and taxable-year/status-change cases are prorated under cited Oregon provisions; excess credit is refundable, and refunds attributable to the credit do not bear interest.
+  deferred_outputs:
+    - output: us-or:statutes/315/266#earned_income_credit
+      reason: Final credit amount depends on the earned income credit allowable, or the amount that would be allowed but for IRC section 32(m), under IRC section 32; that cited federal computation is not available in supplied RuleSpec context.
+      source_values:
+        - us-or:statutes/315/266#base_earned_income_credit_rate
+        - us-or:statutes/315/266#young_dependent_earned_income_credit_rate
+    - output: us-or:statutes/315/266#nonresident_earned_income_credit
+      reason: Nonresident credit computation depends on the Oregon earned income credit under subsection (1) or (2), IRC section 32 computations, and proration under ORS 316.117, none of which are available as executable upstream RuleSpec outputs in supplied context.
+    - output: us-or:statutes/315/266#prorated_credit_for_taxable_year_change
+      reason: Credit for taxable-year changes or department termination must be prorated or computed consistently with ORS 314.085, which is cited but not available as executable upstream RuleSpec context.
+    - output: us-or:statutes/315/266#credit_for_residency_status_change
+      reason: Credit for resident/nonresident status changes must be determined consistently with ORS 316.117, which is cited but not available as executable upstream RuleSpec context.
+rules:
+  - name: base_earned_income_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 315.266(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/315.266
+              excerpt: "an amount equal to nine percent of the earned income credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.09
+
+  - name: young_dependent_earned_income_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 315.266(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/315.266
+              excerpt: "with a dependent under the age of three ... 12 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.12
+
+  - name: young_dependent_age_limit
+    kind: parameter
+    dtype: Count
+    source: 315.266(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/statute/315.266
+              excerpt: "dependent under the age of three at the close of the tax year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: taxpayer_has_dependent_under_age_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 315.266(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-or/statute/315.266
+              excerpt: "for a taxpayer with a dependent under the age of three at the close of the tax year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/315/266#young_dependent_age_limit
+              output: young_dependent_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          taxpayer_has_dependent_at_close_of_tax_year
+          and youngest_dependent_age_at_close_of_tax_year < young_dependent_age_limit
+
+  - name: earned_income_credit_applicable_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 315.266(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/statute/315.266
+              excerpt: "Notwithstanding paragraph (a) ... dependent under the age of three ... 12 percent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/315/266#base_earned_income_credit_rate
+              output: base_earned_income_credit_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/315/266#young_dependent_earned_income_credit_rate
+              output: young_dependent_earned_income_credit_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit
+              output: taxpayer_has_dependent_under_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_has_dependent_under_age_limit: young_dependent_earned_income_credit_rate else: base_earned_income_credit_rate
+
+  - name: refundable_credit_excess
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 315.266(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/statute/315.266
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, credit_allowable_under_this_section + tax_payments_under_ors_316_187_or_316_583 + other_tax_prepayment_amounts + other_refundable_credit_amounts - taxes_imposed_after_nonrefundable_credits)


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-or/statute/315.266`
- Module: `us-or/statutes/315/266.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 56s
- Local gate status: **green**

Produced by `axiom-encode encode us-or/statute/315.266 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-or/statute/315.266",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "4271bba6",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/315/266.yaml",
      "sha256": "1071c5e08fc53984ed0b71a16160c789e742a637b87683b023c90324a68665e6"
    },
    {
      "path": "statutes/315/266.test.yaml",
      "sha256": "c89fb3878e9be0df687acc81725e433e5316801122ee3ff2cdcbddd54c389ae3"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
