### PR TITLE
Encode us-ri/statute/44-30-103 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16756,6 +16756,15 @@
         ]
       }
     ],
+    "us-ri/statute/44-30-103": [
+      {
+        "module": "us-ri/statutes/44-30-103.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-10": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-10.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 22
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,35 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#child_for_rebate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#child_maximum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_claim_penalty
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_penalty_per_dependent
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#joint_agi_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#maximum_rebate_children
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#rebate_amount_per_child
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#rebate_child_count
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#rebate_payment_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
     source: bulk
     since: 2026-07-08

--- a/us-ri/.axiom/encoding-manifests/statutes/44-30-103.json
+++ b/us-ri/.axiom/encoding-manifests/statutes/44-30-103.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/44-30-103.yaml",
+      "sha256": "b9ed6a5a5fdbf2e594cf3be8887d6a6f426344839dabee96b62ecd5766123e1a"
+    },
+    {
+      "path": "statutes/44-30-103.test.yaml",
+      "sha256": "67580b758f1961c3b24fe0746dc7dee618f49d5f20ae6eabcee93c77d1d1f38d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ri/statute/44-30-103",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ri-statute-44-30-103/workspace/context-manifest.json",
+  "context_manifest_sha256": "629ad10b3ab30d54ec1aba10119b17279908f872ca98a73eacfc35fa28024a6c",
+  "generated_at": "2026-07-08T10:28:43.552103+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/44-30-103.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "b9ed6a5a5fdbf2e594cf3be8887d6a6f426344839dabee96b62ecd5766123e1a",
+  "generation_prompt_sha256": "f36bbcf6ffc949d9aea39cd3fd81a7927d9e87794fc7164219ef4c09ef74bf13",
+  "model": "gpt-5.5",
+  "run_id": "18efbede",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a6ab558ee1c704855f8bc7949e71ea6de33fa6b34b3d6508e3532ab68e0b52a9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ri-statute-44-30-103.json",
+  "trace_sha256": "045b0853c2a131450d6e5d8793d559f0daec1d42b8e3f439faec26a8c2e2afec"
+}

--- a/us-ri/statutes/44-30-103.test.yaml
+++ b/us-ri/statutes/44-30-103.test.yaml
@@ -1,0 +1,56 @@
+- name: person_age_18_is_child_for_rebate
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-ri:statutes/44-30-103#input.age_as_of_rebate_child_reference_date: 18
+  output:
+    us-ri:statutes/44-30-103#child_for_rebate: holds
+- name: person_age_19_is_not_child_for_rebate
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-ri:statutes/44-30-103#input.age_as_of_rebate_child_reference_date: 19
+  output:
+    us-ri:statutes/44-30-103#child_for_rebate: not_holds
+- name: eligible_taxpayer_with_two_children_gets_rebate
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-ri:statutes/44-30-103#input.taxpayer_is_eligible_taxpayer_under_subsection_a: true
+    us-ri:statutes/44-30-103#input.validly_claimed_child_dependent_count: 2
+    us-ri:statutes/44-30-103#input.fraudulently_claimed_dependent_count: 0
+  output:
+    us-ri:statutes/44-30-103#rebate_child_count: 2
+    us-ri:statutes/44-30-103#rebate_payment_amount: 500
+    us-ri:statutes/44-30-103#fraudulent_dependent_claim_penalty: 0
+- name: rebate_child_count_is_capped_at_three_and_penalty_multiplies
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-ri:statutes/44-30-103#input.taxpayer_is_eligible_taxpayer_under_subsection_a: true
+    us-ri:statutes/44-30-103#input.validly_claimed_child_dependent_count: 5
+    us-ri:statutes/44-30-103#input.fraudulently_claimed_dependent_count: 2
+  output:
+    us-ri:statutes/44-30-103#rebate_child_count: 3
+    us-ri:statutes/44-30-103#rebate_payment_amount: 750
+    us-ri:statutes/44-30-103#fraudulent_dependent_claim_penalty: 20000
+- name: auto_zero_rebate_payment_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ri:statutes/44-30-103#input.age_as_of_rebate_child_reference_date: 0
+    us-ri:statutes/44-30-103#input.fraudulently_claimed_dependent_count: 0
+    us-ri:statutes/44-30-103#input.taxpayer_is_eligible_taxpayer_under_subsection_a: false
+    us-ri:statutes/44-30-103#input.validly_claimed_child_dependent_count: 0
+  output:
+    us-ri:statutes/44-30-103#rebate_payment_amount: 0

--- a/us-ri/statutes/44-30-103.yaml
+++ b/us-ri/statutes/44-30-103.yaml
@@ -1,0 +1,227 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ri/statute/44-30-103
+  summary: |-
+    Defines “child” as an individual eighteen years of age or under as of December 31, 2021, and “eligible taxpayer” by Rhode Island domicile, timely 2021 personal income tax filing, filing category, and federal adjusted gross income thresholds of $100,000 or $200,000. Provides a $250 rebate for each validly claimed child dependent, up to three children; amended filings after August 31, 2022 do not determine the rebate; fraudulent dependent claims incur a $10,000 penalty per dependent plus repayment.
+  deferred_outputs:
+    - output: us-ri:statutes/44-30-103/a#eligible_taxpayer
+      reason: Eligibility depends on Rhode Island personal income tax filing-status classifications and timely return filing mechanics not supplied as executable upstream RuleSpec context; filing status cannot be modeled as a local input under the RuleSpec filing-status protocol.
+    - output: us-ri:statutes/44-30-103/b#rebate_payment_issuance_and_payee
+      reason: The administrative issuance/payee and no-offset/no-income/no-interest treatment clauses are not a scalar taxpayer computation in the supported schema; the executable rebate amount is encoded separately.
+rules:
+  - name: child_maximum_age
+    kind: parameter
+    dtype: Integer
+    source: 44-30-103(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "“child” means an individual who is eighteen years of age or under as of December 31, 2021"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          18
+
+  - name: single_separate_head_widow_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 44-30-103(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "federal adjusted gross income of $100,000.00 or less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          100000
+
+  - name: joint_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 44-30-103(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "Married filing jointly with a federal adjusted gross income of $200,000.00 or less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200000
+
+  - name: rebate_amount_per_child
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 44-30-103(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "a rebate payment in the amount of two hundred fifty dollars for each child"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          250
+
+  - name: maximum_rebate_children
+    kind: parameter
+    dtype: Count
+    source: 44-30-103(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "up to a maximum of three children"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: fraudulent_dependent_penalty_per_dependent
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 44-30-103(b)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "a ten thousand dollar ($10,000) penalty for each dependent fraudulently claimed"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10000
+
+  - name: child_for_rebate
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 44-30-103(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "“child” means an individual who is eighteen years of age or under as of December 31, 2021"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ri:statutes/44-30-103#child_maximum_age
+              output: child_maximum_age
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          age_as_of_rebate_child_reference_date <= child_maximum_age
+
+  - name: rebate_child_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    source: 44-30-103(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "for each child, up to a maximum of three children, whom the eligible taxpayer validly claims as a dependent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ri:statutes/44-30-103#maximum_rebate_children
+              output: maximum_rebate_children
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(validly_claimed_child_dependent_count, maximum_rebate_children)
+
+  - name: rebate_payment_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 44-30-103(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "An eligible taxpayer will be issued a rebate payment in the amount of two hundred fifty dollars for each child, up to a maximum of three children"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ri:statutes/44-30-103#rebate_amount_per_child
+              output: rebate_amount_per_child
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ri:statutes/44-30-103#rebate_child_count
+              output: rebate_child_count
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_is_eligible_taxpayer_under_subsection_a: rebate_amount_per_child * rebate_child_count else: 0
+
+  - name: fraudulent_dependent_claim_penalty
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 44-30-103(b)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ri/statute/44-30-103
+              excerpt: "shall pay a ten thousand dollar ($10,000) penalty for each dependent fraudulently claimed"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ri:statutes/44-30-103#fraudulent_dependent_penalty_per_dependent
+              output: fraudulent_dependent_penalty_per_dependent
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          fraudulent_dependent_penalty_per_dependent * fraudulently_claimed_dependent_count


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ri/statute/44-30-103`
- Module: `us-ri/statutes/44-30-103.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 69s
- Local gate status: **green**

Produced by `axiom-encode encode us-ri/statute/44-30-103 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ri/statute/44-30-103",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "18efbede",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/44-30-103.yaml",
      "sha256": "b9ed6a5a5fdbf2e594cf3be8887d6a6f426344839dabee96b62ecd5766123e1a"
    },
    {
      "path": "statutes/44-30-103.test.yaml",
      "sha256": "67580b758f1961c3b24fe0746dc7dee618f49d5f20ae6eabcee93c77d1d1f38d"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
