### PR TITLE
Encode us-ut/statute/59-10-104 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-ut/statute/59-10-104": [
+      {
+        "module": "us-ut/statutes/59-10-104.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 15
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,14 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_applies
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
     source: bulk
     since: 2026-07-08

--- a/us-ut/.axiom/encoding-manifests/statutes/59-10-104.json
+++ b/us-ut/.axiom/encoding-manifests/statutes/59-10-104.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/59-10-104.yaml",
+      "sha256": "a6a9d878c99572670d08eb55745c3357b16d2fde709cd1b4be9a17bbab08b703"
+    },
+    {
+      "path": "statutes/59-10-104.test.yaml",
+      "sha256": "ee986d161289a6fc588066d126a9bd329b570e92414f1b63b7cb5538bbe61412"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ut/statute/59-10-104",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ut-statute-59-10-104/workspace/context-manifest.json",
+  "context_manifest_sha256": "8dffe98fc857bfa68987372c49f9e6127857491f5b7ed238f02be03b3d30bd4a",
+  "generated_at": "2026-07-08T10:35:19.687263+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/59-10-104.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "a6a9d878c99572670d08eb55745c3357b16d2fde709cd1b4be9a17bbab08b703",
+  "generation_prompt_sha256": "07e5334c79e5e15354cbbde137f4a4e5db0a5fc780a10cc59e695ee5dcfbfc21",
+  "model": "gpt-5.5",
+  "run_id": "6f27a980",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a83325388233cf9e61a751ff38964359c7da1fcd23ec8538ba5ee16b23d8fcaf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ut-statute-59-10-104.json",
+  "trace_sha256": "5407cbe38b56845d6b6292b49be250887572d2b79c3f77d2b1bca2136e5854c1"
+}

--- a/us-ut/statutes/59-10-104.test.yaml
+++ b/us-ut/statutes/59-10-104.test.yaml
@@ -1,0 +1,36 @@
+- name: resident individual pays 4.45 percent tax on state taxable income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-104#input.resident_individual: true
+    us-ut:statutes/59-10-104#input.exempt_from_taxation_under_section_59_10_104_1: false
+    us-ut:statutes/59-10-104#input.state_taxable_income: 100000
+  output:
+    us-ut:statutes/59-10-104#resident_individual_income_tax_applies: holds
+    us-ut:statutes/59-10-104#resident_individual_income_tax: 4450
+- name: exemption under Section 59-10-104.1 blocks the tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-104#input.resident_individual: true
+    us-ut:statutes/59-10-104#input.exempt_from_taxation_under_section_59_10_104_1: true
+    us-ut:statutes/59-10-104#input.state_taxable_income: 100000
+  output:
+    us-ut:statutes/59-10-104#resident_individual_income_tax_applies: not_holds
+    us-ut:statutes/59-10-104#resident_individual_income_tax: 0
+- name: nonresident individual is outside the resident-individual tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-104#input.resident_individual: false
+    us-ut:statutes/59-10-104#input.exempt_from_taxation_under_section_59_10_104_1: false
+    us-ut:statutes/59-10-104#input.state_taxable_income: 100000
+  output:
+    us-ut:statutes/59-10-104#resident_individual_income_tax_applies: not_holds
+    us-ut:statutes/59-10-104#resident_individual_income_tax: 0

--- a/us-ut/statutes/59-10-104.yaml
+++ b/us-ut/statutes/59-10-104.yaml
@@ -1,0 +1,76 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/statute/59-10-104
+  summary: |-
+    A tax is imposed on the state taxable income of a resident individual; for a taxable year, the tax equals the resident individual's state taxable income multiplied by 4.45%. This section does not apply to a resident individual exempt from taxation under Section 59-10-104.1.
+rules:
+  - name: resident_individual_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: Utah Code § 59-10-104(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "4.45%"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.0445
+
+  - name: resident_individual_income_tax_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Utah Code § 59-10-104(1), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          resident_individual
+          and not exempt_from_taxation_under_section_59_10_104_1
+
+  - name: resident_individual_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Utah Code § 59-10-104(1), (2), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "4.45%"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if resident_individual_income_tax_applies: max(0, state_taxable_income * resident_individual_income_tax_rate) else: 0


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ut/statute/59-10-104`
- Module: `us-ut/statutes/59-10-104.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 35s
- Local gate status: **green**

Produced by `axiom-encode encode us-ut/statute/59-10-104 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ut/statute/59-10-104",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "6f27a980",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/59-10-104.yaml",
      "sha256": "a6a9d878c99572670d08eb55745c3357b16d2fde709cd1b4be9a17bbab08b703"
    },
    {
      "path": "statutes/59-10-104.test.yaml",
      "sha256": "ee986d161289a6fc588066d126a9bd329b570e92414f1b63b7cb5538bbe61412"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
