### PR TITLE
Encode us-ut/statute/59-10-1018 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-ut/statute/59-10-1018": [
+      {
+        "module": "us-ut/statutes/59-10-1018.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 35
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,74 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#applicable_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#credit_reduction_rate_per_excess_dollar
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#deduction_credit_component
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#head_of_household_filing_status
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#income_based_credit_reduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_head_of_household_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_joint_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_single_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_utah_personal_exemption_base_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#joint_filing_status
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#personal_exemption_credit_component
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#single_filing_status
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#state_or_local_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#statutory_head_of_household_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#statutory_joint_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#statutory_single_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#statutory_utah_personal_exemption_base_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#tax_credit_before_income_reduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#utah_itemized_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1018#utah_personal_exemption
     source: bulk
     since: 2026-07-08

--- a/us-ut/.axiom/encoding-manifests/statutes/59-10-1018.json
+++ b/us-ut/.axiom/encoding-manifests/statutes/59-10-1018.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/59-10-1018.yaml",
+      "sha256": "d56c0f8f5fc18058ec889854a65762078a2e5c7ab6b9e6071c78a6038507b87d"
+    },
+    {
+      "path": "statutes/59-10-1018.test.yaml",
+      "sha256": "bc475c0fe65594ca5973973837c5e5bf0a729aede3af50340b36e98ee31aa97c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ut/statute/59-10-1018",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ut-statute-59-10-1018/workspace/context-manifest.json",
+  "context_manifest_sha256": "0fe9825b177870605ee33baf9378cb90b01705e98704f90931ebcf45434d1d64",
+  "generated_at": "2026-07-08T10:36:44.639213+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/59-10-1018.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "d56c0f8f5fc18058ec889854a65762078a2e5c7ab6b9e6071c78a6038507b87d",
+  "generation_prompt_sha256": "87b9741605a66e948c186ea6b6cd1cef338fa667574b359483f7cad6f40319d4",
+  "model": "gpt-5.5",
+  "run_id": "e0857ad8",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e0bdd41fddc0d8594ca9c9c2a826810dcd2b9061167b4ccb3b03c2ea3eb10d92"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ut-statute-59-10-1018.json",
+  "trace_sha256": "462440a944935c68fe81cd84283f2bfe0c75ecd4de3c24aee2f19b06cf2b25af"
+}

--- a/us-ut/statutes/59-10-1018.test.yaml
+++ b/us-ut/statutes/59-10-1018.test.yaml
@@ -1,0 +1,188 @@
+- name: standard deduction single filer credit below threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1018#input.single_individual_files_single_federal_return_for_taxable_year: true
+    us-ut:statutes/59-10-1018#input.married_individual_files_single_federal_return_for_taxable_year: false
+    ? us-ut:statutes/59-10-1018#input.married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year
+    : false
+    us-ut:statutes/59-10-1018#input.head_of_household_under_section_2_b_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.files_single_federal_individual_income_tax_return_for_taxable_year: true
+    us-ut:statutes/59-10-1018#input.spouses_file_single_return_jointly_under_this_chapter_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.surviving_spouse_under_section_2_a_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_paid_and_reported_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.itemized_deductions_allowed_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_preceding_calendar_year: 100
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_calendar_year_2020: 100
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_count: 1
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_birth_year_additional_count: 0
+    us-ut:statutes/59-10-1018#input.deducts_standard_deduction_on_federal_return: true
+    us-ut:statutes/59-10-1018#input.federal_standard_deduction_amount_deducted: 10000
+    us-ut:statutes/59-10-1018#input.itemizes_deductions_on_federal_return: false
+    us-ut:statutes/59-10-1018#input.state_taxable_income: 15095
+  output:
+    us-ut:statutes/59-10-1018#single_filing_status: holds
+    us-ut:statutes/59-10-1018#head_of_household_filing_status: not_holds
+    us-ut:statutes/59-10-1018#joint_filing_status: not_holds
+    us-ut:statutes/59-10-1018#state_or_local_income_tax: 0
+    us-ut:statutes/59-10-1018#utah_itemized_deduction: 0
+    us-ut:statutes/59-10-1018#inflation_adjusted_single_income_threshold: 15095
+    us-ut:statutes/59-10-1018#inflation_adjusted_head_of_household_income_threshold: 22643
+    us-ut:statutes/59-10-1018#inflation_adjusted_joint_income_threshold: 30190
+    us-ut:statutes/59-10-1018#applicable_income_threshold: 15095
+    us-ut:statutes/59-10-1018#inflation_adjusted_utah_personal_exemption_base_amount: 1750
+    us-ut:statutes/59-10-1018#utah_personal_exemption: 1750
+    us-ut:statutes/59-10-1018#deduction_credit_component: 600
+    us-ut:statutes/59-10-1018#personal_exemption_credit_component: 105
+    us-ut:statutes/59-10-1018#tax_credit_before_income_reduction: 705
+    us-ut:statutes/59-10-1018#income_based_credit_reduction: 0
+    us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed: 705
+    us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed: not_holds
+- name: itemized head of household with income reduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1018#input.single_individual_files_single_federal_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.married_individual_files_single_federal_return_for_taxable_year: false
+    ? us-ut:statutes/59-10-1018#input.married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year
+    : false
+    us-ut:statutes/59-10-1018#input.head_of_household_under_section_2_b_internal_revenue_code: true
+    us-ut:statutes/59-10-1018#input.files_single_federal_individual_income_tax_return_for_taxable_year: true
+    us-ut:statutes/59-10-1018#input.spouses_file_single_return_jointly_under_this_chapter_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.surviving_spouse_under_section_2_a_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_paid_and_reported_on_federal_return: 2000
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return: 1500
+    us-ut:statutes/59-10-1018#input.itemized_deductions_allowed_on_federal_return: 10000
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_preceding_calendar_year: 100
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_calendar_year_2020: 100
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_count: 2
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_birth_year_additional_count: 1
+    us-ut:statutes/59-10-1018#input.deducts_standard_deduction_on_federal_return: false
+    us-ut:statutes/59-10-1018#input.federal_standard_deduction_amount_deducted: 0
+    us-ut:statutes/59-10-1018#input.itemizes_deductions_on_federal_return: true
+    us-ut:statutes/59-10-1018#input.state_taxable_income: 23643
+  output:
+    us-ut:statutes/59-10-1018#single_filing_status: not_holds
+    us-ut:statutes/59-10-1018#head_of_household_filing_status: holds
+    us-ut:statutes/59-10-1018#joint_filing_status: not_holds
+    us-ut:statutes/59-10-1018#state_or_local_income_tax: 1500
+    us-ut:statutes/59-10-1018#utah_itemized_deduction: 8500
+    us-ut:statutes/59-10-1018#applicable_income_threshold: 22643
+    us-ut:statutes/59-10-1018#utah_personal_exemption: 5250
+    us-ut:statutes/59-10-1018#deduction_credit_component: 510
+    us-ut:statutes/59-10-1018#personal_exemption_credit_component: 315
+    us-ut:statutes/59-10-1018#tax_credit_before_income_reduction: 825
+    us-ut:statutes/59-10-1018#income_based_credit_reduction: 13
+    us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed: 812
+    us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed: not_holds
+- name: joint filer inflation adjustment and full phaseout floor
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1018#input.single_individual_files_single_federal_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.married_individual_files_single_federal_return_for_taxable_year: false
+    ? us-ut:statutes/59-10-1018#input.married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year
+    : false
+    us-ut:statutes/59-10-1018#input.head_of_household_under_section_2_b_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.files_single_federal_individual_income_tax_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.spouses_file_single_return_jointly_under_this_chapter_for_taxable_year: true
+    us-ut:statutes/59-10-1018#input.surviving_spouse_under_section_2_a_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_paid_and_reported_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.itemized_deductions_allowed_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_preceding_calendar_year: 110
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_calendar_year_2020: 100
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_count: 0
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_birth_year_additional_count: 0
+    us-ut:statutes/59-10-1018#input.deducts_standard_deduction_on_federal_return: true
+    us-ut:statutes/59-10-1018#input.federal_standard_deduction_amount_deducted: 1000
+    us-ut:statutes/59-10-1018#input.itemizes_deductions_on_federal_return: false
+    us-ut:statutes/59-10-1018#input.state_taxable_income: 40000
+  output:
+    us-ut:statutes/59-10-1018#single_filing_status: not_holds
+    us-ut:statutes/59-10-1018#head_of_household_filing_status: not_holds
+    us-ut:statutes/59-10-1018#joint_filing_status: holds
+    us-ut:statutes/59-10-1018#inflation_adjusted_single_income_threshold: 16605
+    us-ut:statutes/59-10-1018#inflation_adjusted_head_of_household_income_threshold: 24907
+    us-ut:statutes/59-10-1018#inflation_adjusted_joint_income_threshold: 33210
+    us-ut:statutes/59-10-1018#applicable_income_threshold: 33210
+    us-ut:statutes/59-10-1018#inflation_adjusted_utah_personal_exemption_base_amount: 1925
+    us-ut:statutes/59-10-1018#utah_personal_exemption: 0
+    us-ut:statutes/59-10-1018#deduction_credit_component: 60
+    us-ut:statutes/59-10-1018#personal_exemption_credit_component: 0
+    us-ut:statutes/59-10-1018#tax_credit_before_income_reduction: 60
+    us-ut:statutes/59-10-1018#income_based_credit_reduction: 88.27
+    us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed: 0
+    us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed: not_holds
+- name: surviving spouse treated as joint filing status
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1018#input.single_individual_files_single_federal_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.married_individual_files_single_federal_return_for_taxable_year: false
+    ? us-ut:statutes/59-10-1018#input.married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year
+    : false
+    us-ut:statutes/59-10-1018#input.head_of_household_under_section_2_b_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.files_single_federal_individual_income_tax_return_for_taxable_year: true
+    us-ut:statutes/59-10-1018#input.spouses_file_single_return_jointly_under_this_chapter_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.surviving_spouse_under_section_2_a_internal_revenue_code: true
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_paid_and_reported_on_federal_return: 300
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return: 500
+    us-ut:statutes/59-10-1018#input.itemized_deductions_allowed_on_federal_return: 300
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_preceding_calendar_year: 100
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_calendar_year_2020: 100
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_count: 0
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_birth_year_additional_count: 0
+    us-ut:statutes/59-10-1018#input.deducts_standard_deduction_on_federal_return: false
+    us-ut:statutes/59-10-1018#input.federal_standard_deduction_amount_deducted: 0
+    us-ut:statutes/59-10-1018#input.itemizes_deductions_on_federal_return: true
+    us-ut:statutes/59-10-1018#input.state_taxable_income: 30190
+  output:
+    us-ut:statutes/59-10-1018#single_filing_status: not_holds
+    us-ut:statutes/59-10-1018#head_of_household_filing_status: not_holds
+    us-ut:statutes/59-10-1018#joint_filing_status: holds
+    us-ut:statutes/59-10-1018#state_or_local_income_tax: 300
+    us-ut:statutes/59-10-1018#utah_itemized_deduction: 0
+    us-ut:statutes/59-10-1018#applicable_income_threshold: 30190
+    us-ut:statutes/59-10-1018#deduction_credit_component: 0
+    us-ut:statutes/59-10-1018#personal_exemption_credit_component: 0
+    us-ut:statutes/59-10-1018#tax_credit_before_income_reduction: 0
+    us-ut:statutes/59-10-1018#income_based_credit_reduction: 0
+    us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed: 0
+    us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed: not_holds
+- name: auto_zero_applicable_income_threshold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_calendar_year_2020: 0
+    us-ut:statutes/59-10-1018#input.consumer_price_index_for_preceding_calendar_year: 0
+    us-ut:statutes/59-10-1018#input.deducts_standard_deduction_on_federal_return: false
+    us-ut:statutes/59-10-1018#input.federal_standard_deduction_amount_deducted: 0
+    us-ut:statutes/59-10-1018#input.files_single_federal_individual_income_tax_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.head_of_household_under_section_2_b_internal_revenue_code: false
+    us-ut:statutes/59-10-1018#input.itemized_deductions_allowed_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.itemizes_deductions_on_federal_return: false
+    ? us-ut:statutes/59-10-1018#input.married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year
+    : false
+    us-ut:statutes/59-10-1018#input.married_individual_files_single_federal_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_birth_year_additional_count: 0
+    us-ut:statutes/59-10-1018#input.qualifying_dependent_count: 0
+    us-ut:statutes/59-10-1018#input.single_individual_files_single_federal_return_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.spouses_file_single_return_jointly_under_this_chapter_for_taxable_year: false
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.state_or_local_income_tax_paid_and_reported_on_federal_return: 0
+    us-ut:statutes/59-10-1018#input.state_taxable_income: 0
+    us-ut:statutes/59-10-1018#input.surviving_spouse_under_section_2_a_internal_revenue_code: false
+  output:
+    us-ut:statutes/59-10-1018#applicable_income_threshold: 0

--- a/us-ut/statutes/59-10-1018.yaml
+++ b/us-ut/statutes/59-10-1018.yaml
@@ -1,0 +1,447 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/statute/59-10-1018
+  summary: |-
+    Utah § 59-10-1018 defines filing-status terms, "state or local income tax," "Utah itemized deduction," and "Utah personal exemption"; allows a nonrefundable credit equal to 6% of the federal standard deduction or Utah itemized deduction plus 6% of Utah personal exemption; disallows carryforward/carryback; reduces the credit by $.013 per dollar of state taxable income above filing-status thresholds of $15,095, $22,643, and $30,190, with specified CPI adjustments beginning in 2022.
+rules:
+  - name: credit_rate
+    kind: parameter
+    dtype: Rate
+    source: § 59-10-1018(2)(a), (2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "6% of the amount ...; and ... 6% of the claimant's Utah personal exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.06
+
+  - name: credit_reduction_rate_per_excess_dollar
+    kind: parameter
+    dtype: Rate
+    source: § 59-10-1018(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "reduced by $.013 for each dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.013
+
+  - name: statutory_single_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: § 59-10-1018(4)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "single filing status, $15,095"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          15095
+
+  - name: statutory_head_of_household_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: § 59-10-1018(4)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "head of household filing status, $22,643"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          22643
+
+  - name: statutory_joint_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: § 59-10-1018(4)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "joint filing status, $30,190"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30190
+
+  - name: statutory_utah_personal_exemption_base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: § 59-10-1018(1)(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: '"Utah personal exemption" means, subject to Subsection (6), $1,750 multiplied by'
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1750
+
+  - name: single_filing_status
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: § 59-10-1018(1)(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (single_individual_files_single_federal_return_for_taxable_year)
+          or (married_individual_files_single_federal_return_for_taxable_year
+          and married_individual_does_not_file_single_federal_return_jointly_with_spouse_for_taxable_year)
+
+  - name: head_of_household_filing_status
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: § 59-10-1018(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          head_of_household_under_section_2_b_internal_revenue_code
+          and files_single_federal_individual_income_tax_return_for_taxable_year
+
+  - name: joint_filing_status
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: § 59-10-1018(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          spouses_file_single_return_jointly_under_this_chapter_for_taxable_year
+          or (surviving_spouse_under_section_2_a_internal_revenue_code
+          and files_single_federal_individual_income_tax_return_for_taxable_year)
+
+  - name: state_or_local_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(1)(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(state_or_local_income_tax_paid_and_reported_on_federal_return, state_or_local_income_tax_included_and_allowed_as_itemized_deduction_on_federal_return)
+
+  - name: utah_itemized_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(1)(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, itemized_deductions_allowed_on_federal_return - state_or_local_income_tax)
+
+  - name: inflation_adjusted_single_income_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(5)(a), (5)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "increase or decrease annually ... by a percentage equal to the percentage difference ... and ... round ... to the nearest whole dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor((statutory_single_income_threshold * (consumer_price_index_for_preceding_calendar_year / consumer_price_index_for_calendar_year_2020)) + 0.5)
+
+  - name: inflation_adjusted_head_of_household_income_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(5)(a), (5)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "increase or decrease annually ... Subsection (4)(b) ... round ... to the nearest whole dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor((statutory_head_of_household_income_threshold * (consumer_price_index_for_preceding_calendar_year / consumer_price_index_for_calendar_year_2020)) + 0.5)
+
+  - name: inflation_adjusted_joint_income_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(5)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "equal to the product of ... Subsection (4)(a); and ... two"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          inflation_adjusted_single_income_threshold * 2
+
+  - name: applicable_income_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(4), (5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if single_filing_status: inflation_adjusted_single_income_threshold else: if head_of_household_filing_status: inflation_adjusted_head_of_household_income_threshold else: if joint_filing_status: inflation_adjusted_joint_income_threshold else: 0
+
+  - name: inflation_adjusted_utah_personal_exemption_base_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "increase annually the Utah personal exemption amount ... by a percentage ... exceeds ... calendar year 2020 ... round ... nearest whole dollar"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          floor((statutory_utah_personal_exemption_base_amount * (consumer_price_index_for_preceding_calendar_year / consumer_price_index_for_calendar_year_2020)) + 0.5)
+
+  - name: utah_personal_exemption
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(1)(g), (6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "$1,750 multiplied by the number of the claimant's qualifying dependents plus an additional qualifying dependent in the year of a qualifying dependent's birth"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          inflation_adjusted_utah_personal_exemption_base_amount * (qualifying_dependent_count + qualifying_dependent_birth_year_additional_count)
+
+  - name: deduction_credit_component
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "for a claimant that deducts the standard deduction ... 6% ... or ... itemizes deductions ... 6%"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if deducts_standard_deduction_on_federal_return: credit_rate * federal_standard_deduction_amount_deducted else: if itemizes_deductions_on_federal_return: credit_rate * utah_itemized_deduction else: 0
+
+  - name: personal_exemption_credit_component
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "6% of the claimant's Utah personal exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          credit_rate * utah_personal_exemption
+
+  - name: tax_credit_before_income_reduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          deduction_credit_component + personal_exemption_credit_component
+
+  - name: income_based_credit_reduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "reduced by $.013 for each dollar by which a claimant's state taxable income exceeds"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          credit_reduction_rate_per_excess_dollar * max(0, state_taxable_income - applicable_income_threshold)
+
+  - name: nonrefundable_tax_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: § 59-10-1018(2), (4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, tax_credit_before_income_reduction - income_based_credit_reduction)
+
+  - name: tax_credit_carryforward_or_carryback_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: § 59-10-1018(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/statute/59-10-1018
+              excerpt: "may not carry forward or carry back"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          false


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ut/statute/59-10-1018`
- Module: `us-ut/statutes/59-10-1018.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 105s
- Local gate status: **green**

Produced by `axiom-encode encode us-ut/statute/59-10-1018 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ut/statute/59-10-1018",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "e0857ad8",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/59-10-1018.yaml",
      "sha256": "d56c0f8f5fc18058ec889854a65762078a2e5c7ab6b9e6071c78a6038507b87d"
    },
    {
      "path": "statutes/59-10-1018.test.yaml",
      "sha256": "bc475c0fe65594ca5973973837c5e5bf0a729aede3af50340b36e98ee31aa97c"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
