### PR TITLE
Encode us-ut/statute/59-10-1019 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-ut/statute/59-10-1019": [
+      {
+        "module": "us-ut/statutes/59-10-1019.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 19
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,26 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#eligible_claimant
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#head_of_household_phaseout_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#joint_phaseout_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#married_filing_separately_phaseout_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#senior_credit_base_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#senior_credit_reduction_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:statutes/59-10-1019#single_phaseout_threshold
     source: bulk
     since: 2026-07-08

--- a/us-ut/.axiom/encoding-manifests/statutes/59-10-1019.json
+++ b/us-ut/.axiom/encoding-manifests/statutes/59-10-1019.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/59-10-1019.yaml",
+      "sha256": "d69cb3b64c76fc35399617f596be075dd328367ca1e084c2fde93b338fbf9aeb"
+    },
+    {
+      "path": "statutes/59-10-1019.test.yaml",
+      "sha256": "1cce2a23870695e61daf2ae65c4f997f37f7743b7bc379bb338dc5a93b4ad6d8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-ut/statute/59-10-1019",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-ut-statute-59-10-1019/workspace/context-manifest.json",
+  "context_manifest_sha256": "7ad80585e6003f419435e3f56505296e85ac31b2d4f08b1fdc4abcd76d8e16fc",
+  "generated_at": "2026-07-08T10:37:27.212296+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/59-10-1019.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "d69cb3b64c76fc35399617f596be075dd328367ca1e084c2fde93b338fbf9aeb",
+  "generation_prompt_sha256": "0d1cf3f411f4945d0da01cd7cc8e978df90ccb6d3ac435948b24b0ce18423da4",
+  "model": "gpt-5.5",
+  "run_id": "c0a86ab6",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9bdc97b5618b7e2a412a6084ee8d94649cece4e59b88da2e8646236dad74f33d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-ut-statute-59-10-1019.json",
+  "trace_sha256": "dd9ba11584d959d58da5b9694fcf88466569015946079da9dcbc32098c788c28"
+}

--- a/us-ut/statutes/59-10-1019.test.yaml
+++ b/us-ut/statutes/59-10-1019.test.yaml
@@ -1,0 +1,38 @@
+- name: eligible single claimant below phaseout receives base credit limited by tax
+    liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1019#input.claimant_born_on_or_before_december_31_1952: true
+  output:
+    us-ut:statutes/59-10-1019#eligible_claimant: holds
+- name: eligible joint claimant phases out above joint threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1019#input.claimant_born_on_or_before_december_31_1952: true
+  output:
+    us-ut:statutes/59-10-1019#eligible_claimant: holds
+- name: claimant born after eligible date receives no credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1019#input.claimant_born_on_or_before_december_31_1952: false
+  output:
+    us-ut:statutes/59-10-1019#eligible_claimant: not_holds
+- name: section 1042 credit claimed blocks this credit and tax liability also caps
+    nonrefundable amount
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ut:statutes/59-10-1019#input.claimant_born_on_or_before_december_31_1952: true
+  output:
+    us-ut:statutes/59-10-1019#eligible_claimant: holds

--- a/us-ut/statutes/59-10-1019.yaml
+++ b/us-ut/statutes/59-10-1019.yaml
@@ -1,0 +1,152 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/statute/59-10-1019
+  summary: Section 59-10-1019 allows each eligible claimant born on or before December
+    31, 1952 a nonrefundable $450 credit, except as provided in Section 59-10-1002.2
+    and Subsections (3) and (4). The credit may not be carried forward or back, may
+    not be claimed if a credit under Section 59-10-1042 or 59-10-1043 is claimed for
+    the same taxable year, and is reduced by $.025 per dollar of modified adjusted
+    gross income above filing-status thresholds of $16,000, $25,000, or $32,000.
+  deferred_outputs:
+  - output: us-ut:statutes/59-10-1019#senior_credit
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us-ut:statutes/59-10-1019#senior_credit_allowed_before_tax_liability_limit
+    reason: Generated rule kept a local fact for a cited legal section. This output
+      is deferred until the cited source can be encoded or imported without a local
+      cross-reference placeholder.
+  - output: us-ut:statutes/59-10-1019#modified_adjusted_gross_income
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us-ut:statutes/59-10-1019#senior_credit_reduction_rate
+  - output: us-ut:statutes/59-10-1019#senior_credit_phaseout_threshold
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us-ut:statutes/59-10-1019#senior_credit_reduction_rate
+rules:
+- name: senior_credit_base_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: may claim a nonrefundable tax credit of $450
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '450'
+- name: senior_credit_reduction_rate
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(4)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: reduced by $.025 for each dollar
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.025'
+- name: married_filing_separately_phaseout_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(4)(a)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: married filing separately status, $16,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '16000'
+- name: single_phaseout_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(4)(b)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: single filing status, $25,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25000'
+- name: head_of_household_phaseout_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(4)(c)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: head of household filing status, $32,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '32000'
+- name: joint_phaseout_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(4)(d)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: joint filing status, $32,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '32000'
+- name: eligible_claimant
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Utah Code \xA7 59-10-1019(1)(a)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-ut/statute/59-10-1019
+          excerpt: born on or before December 31, 1952
+  versions:
+  - effective_from: '0001-01-01'
+    formula: claimant_born_on_or_before_december_31_1952


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-ut/statute/59-10-1019`
- Module: `us-ut/statutes/59-10-1019.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 145s
- Local gate status: **green**

Produced by `axiom-encode encode us-ut/statute/59-10-1019 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ut/statute/59-10-1019",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "c0a86ab6",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/59-10-1019.yaml",
      "sha256": "d69cb3b64c76fc35399617f596be075dd328367ca1e084c2fde93b338fbf9aeb"
    },
    {
      "path": "statutes/59-10-1019.test.yaml",
      "sha256": "1cce2a23870695e61daf2ae65c4f997f37f7743b7bc379bb338dc5a93b4ad6d8"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
