### PR TITLE
Encode us-va/statute/58.1/58.1-321 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-va/statute/58.1/58.1-321": [
+      {
+        "module": "us-va/statutes/58.1/58/1-321.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 20
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,29 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#armed_forces_service_compensation_not_liable_to_va_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#individual_and_spouse_no_tax_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#married_separate_threshold_fraction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#no_tax_or_return_required
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#single_individual_no_tax_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification
     source: bulk
     since: 2026-07-08

--- a/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-321.json
+++ b/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-321.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/58.1/58/1-321.yaml",
+      "sha256": "c31e9cdc0975ae934e8071c4997a321930aeae93c0cd487567d49c58d7b4aa3e"
+    },
+    {
+      "path": "statutes/58.1/58/1-321.test.yaml",
+      "sha256": "a501fe23e7e689d1e77890e51d2f64fc88e80971b9e8889a7af86b860690b59c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-va/statute/58.1/58.1-321",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-va-statute-58.1-58.1-321/workspace/context-manifest.json",
+  "context_manifest_sha256": "733c58cf0a65375877f174269a4756be0045a560a7225ad1045521ecb0d92eba",
+  "generated_at": "2026-07-08T10:38:47.190001+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/58.1/58/1-321.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "c31e9cdc0975ae934e8071c4997a321930aeae93c0cd487567d49c58d7b4aa3e",
+  "generation_prompt_sha256": "811235d762bea66d29fae4021f19e9e42624bc940c298006c27ecf29e601e641",
+  "model": "gpt-5.5",
+  "run_id": "b6cfbe17",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7db6f28d02459911a6aa5efe6571522f4e0c7e0617c4d443ec13b22160705582"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-va-statute-58.1-58.1-321.json",
+  "trace_sha256": "cc13c177250ca57e41928e264d3cd872625e986d9a176dd0507318ef7250e269"
+}

--- a/us-va/statutes/58.1/58/1-321.test.yaml
+++ b/us-va/statutes/58.1/58/1-321.test.yaml
@@ -1,0 +1,84 @@
+- name: single_individual_below_threshold_has_no_tax_or_return_required
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-321#input.federal_adjusted_gross_income: 11000
+    us-va:statutes/58.1/58/1-321#input.modifications_specified_in_sections_58_1_322_01_and_58_1_322_02: 500
+    us-va:statutes/58.1/58/1-321#input.modification_specified_in_subdivision_5_of_section_58_1_322_03: 400
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_single_individual: true
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_individual_and_spouse: false
+    us-va:statutes/58.1/58/1-321#input.married_individual_filing_separate_return: false
+  output:
+    us-va:statutes/58.1/58/1-321#va_adjusted_gross_income: 11500
+    us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification: 11900
+    us-va:statutes/58.1/58/1-321#no_tax_or_return_required: holds
+- name: married_separate_at_or_above_half_threshold_does_not_qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-321#input.federal_adjusted_gross_income: 12000
+    us-va:statutes/58.1/58/1-321#input.modifications_specified_in_sections_58_1_322_01_and_58_1_322_02: 0
+    us-va:statutes/58.1/58/1-321#input.modification_specified_in_subdivision_5_of_section_58_1_322_03: 0
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_single_individual: false
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_individual_and_spouse: false
+    us-va:statutes/58.1/58/1-321#input.married_individual_filing_separate_return: true
+  output:
+    us-va:statutes/58.1/58/1-321#va_adjusted_gross_income: 12000
+    us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification: 12000
+    us-va:statutes/58.1/58/1-321#no_tax_or_return_required: not_holds
+- name: armed_forces_nonresident_service_compensation_not_liable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-321#input.person_in_armed_forces_of_the_united_states: true
+    us-va:statutes/58.1/58/1-321#input.stationed_on_military_or_naval_reservation_within_virginia: true
+    us-va:statutes/58.1/58/1-321#input.domiciled_in_virginia: false
+    us-va:statutes/58.1/58/1-321#input.compensation_received_from_military_or_naval_service: true
+  output:
+    us-va:statutes/58.1/58/1-321#armed_forces_service_compensation_not_liable_to_va_income_tax: holds
+- name: eligible_veteran_loan_discharge_amount_excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-321#input.taxable_year_is_in_temporary_effective_window: true
+    us-va:statutes/58.1/58/1-321#input.veteran_rated_with_100_percent_service_connected_permanent_and_total_disability: true
+    us-va:statutes/58.1/58/1-321#input.loan_described_in_section_108_f_5_B: true
+    us-va:statutes/58.1/58/1-321#input.discharge_described_in_clauses_i_ii_and_iii_of_section_108_f_5_A: true
+    us-va:statutes/58.1/58/1-321#input.discharge_occurs_after_applicable_cutoff_date: true
+    ? us-va:statutes/58.1/58/1-321#input.amount_includible_in_federal_adjusted_gross_income_by_reason_of_whole_or_partial_loan_discharge
+    : 7000
+  output:
+    us-va:statutes/58.1/58/1-321#eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income: 7000
+- name: auto_zero_eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-va:statutes/58.1/58/1-321#input.amount_includible_in_federal_adjusted_gross_income_by_reason_of_whole_or_partial_loan_discharge
+    : 0
+    us-va:statutes/58.1/58/1-321#input.compensation_received_from_military_or_naval_service: false
+    us-va:statutes/58.1/58/1-321#input.discharge_described_in_clauses_i_ii_and_iii_of_section_108_f_5_A: false
+    us-va:statutes/58.1/58/1-321#input.discharge_occurs_after_applicable_cutoff_date: false
+    us-va:statutes/58.1/58/1-321#input.domiciled_in_virginia: false
+    us-va:statutes/58.1/58/1-321#input.federal_adjusted_gross_income: 0
+    us-va:statutes/58.1/58/1-321#input.loan_described_in_section_108_f_5_B: false
+    us-va:statutes/58.1/58/1-321#input.married_individual_filing_separate_return: false
+    us-va:statutes/58.1/58/1-321#input.modification_specified_in_subdivision_5_of_section_58_1_322_03: 0
+    us-va:statutes/58.1/58/1-321#input.modifications_specified_in_sections_58_1_322_01_and_58_1_322_02: 0
+    us-va:statutes/58.1/58/1-321#input.person_in_armed_forces_of_the_united_states: false
+    us-va:statutes/58.1/58/1-321#input.stationed_on_military_or_naval_reservation_within_virginia: false
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_individual_and_spouse: false
+    us-va:statutes/58.1/58/1-321#input.tax_unit_is_single_individual: false
+    us-va:statutes/58.1/58/1-321#input.taxable_year_is_in_temporary_effective_window: false
+    us-va:statutes/58.1/58/1-321#input.veteran_rated_with_100_percent_service_connected_permanent_and_total_disability: false
+  output:
+    us-va:statutes/58.1/58/1-321#eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income: 0

--- a/us-va/statutes/58.1/58/1-321.yaml
+++ b/us-va/statutes/58.1/58/1-321.yaml
@@ -1,0 +1,238 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-va/statute/58.1/58.1-321
+  summary: "A. No tax levied pursuant to \xA7 58.1-320 is imposed, nor any return\
+    \ required to be filed, by: (1) a single individual where Virginia adjusted gross\
+    \ income plus the subdivision 5 modification is less than $11,650 for taxable\
+    \ years beginning on and after January 1, 2010, but before January 1, 2012, and\
+    \ less than $11,950 for taxable years beginning on and after January 1, 2012;\
+    \ (2) an individual and spouse if combined Virginia adjusted gross income plus\
+    \ that modification is less than $23,300 for taxable years beginning on and after\
+    \ January 1, 2010, but before January 1, 2012, and less than $23,900 for taxable\
+    \ years beginning on and after January 1, 2012, or one-half for a married individual\
+    \ filing separately. B. Certain non-domiciled Armed Forces persons stationed on\
+    \ Virginia military or naval reservations are not liable to income taxation for\
+    \ compensation from military or naval service. C. For taxable years beginning\
+    \ on and after January 1, 2020, but before January 1, 2026, eligible veterans\
+    \ exclude specified federal student-loan discharge income from Virginia adjusted\
+    \ gross income."
+rules:
+- name: single_individual_no_tax_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "Va. Code \xA7 58.1-321(A)(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: less than $11,650 for taxable years beginning on and after January
+            1, 2010, but before January 1, 2012
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: less than $11,950 for taxable years beginning on and after January
+            1, 2012
+  versions:
+  - effective_from: '2010-01-01'
+    formula: '11650'
+  - effective_from: '2012-01-01'
+    formula: '11950'
+- name: individual_and_spouse_no_tax_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "Va. Code \xA7 58.1-321(A)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: less than $23,300 for taxable years beginning on and after January
+            1, 2010 ... but before January 1, 2012
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: less than $23,900 for taxable years beginning on and after January
+            1, 2012
+  versions:
+  - effective_from: '2010-01-01'
+    formula: '23300'
+  - effective_from: '2012-01-01'
+    formula: '23900'
+- name: married_separate_threshold_fraction
+  kind: parameter
+  dtype: Rate
+  source: "Va. Code \xA7 58.1-321(A)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: one-half of such amount in the case of a married individual filing
+            a separate return
+  versions:
+  - effective_from: '2010-01-01'
+    formula: '0.5'
+- name: va_adjusted_gross_income
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-321(A)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: "Virginia adjusted gross income means federal adjusted gross income\
+            \ ... with the modifications specified in \xA7\xA7 58.1-322.01 and 58.1-322.02"
+  versions:
+  - effective_from: '2010-01-01'
+    formula: federal_adjusted_gross_income + modifications_specified_in_sections_58_1_322_01_and_58_1_322_02
+- name: va_adjusted_gross_income_plus_subdivision_5_modification
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-321(A)(1)-(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: "Virginia adjusted gross income plus the modification specified\
+            \ in subdivision 5 of \xA7 58.1-322.03"
+  versions:
+  - effective_from: '2010-01-01'
+    formula: va_adjusted_gross_income + modification_specified_in_subdivision_5_of_section_58_1_322_03
+- name: no_tax_or_return_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-321(A)(1)-(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: 'No tax ... is imposed, nor any return required to be filed, by:
+            A single individual ... less than $11,950 ... An individual and spouse
+            ... less than $23,900 ... or one-half ... married individual filing a
+            separate return'
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-va:statutes/58.1/58/1-321#single_individual_no_tax_threshold
+          output: single_individual_no_tax_threshold
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-va:statutes/58.1/58/1-321#individual_and_spouse_no_tax_threshold
+          output: individual_and_spouse_no_tax_threshold
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-va:statutes/58.1/58/1-321#married_separate_threshold_fraction
+          output: married_separate_threshold_fraction
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification
+          output: va_adjusted_gross_income_plus_subdivision_5_modification
+          hash: sha256:local
+  versions:
+  - effective_from: '2010-01-01'
+    formula: '(tax_unit_is_single_individual and va_adjusted_gross_income_plus_subdivision_5_modification
+      < single_individual_no_tax_threshold)
+
+      or (tax_unit_is_individual_and_spouse and va_adjusted_gross_income_plus_subdivision_5_modification
+      < individual_and_spouse_no_tax_threshold)
+
+      or (married_individual_filing_separate_return and va_adjusted_gross_income_plus_subdivision_5_modification
+      < individual_and_spouse_no_tax_threshold * married_separate_threshold_fraction)'
+- name: armed_forces_service_compensation_not_liable_to_va_income_tax
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-321(B)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: Persons in the Armed Forces of the United States stationed on military
+            or naval reservations within Virginia who are not domiciled in Virginia
+            shall not be held liable to income taxation for compensation received
+            from military or naval service.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_in_armed_forces_of_the_united_states
+
+      and stationed_on_military_or_naval_reservation_within_virginia
+
+      and not domiciled_in_virginia
+
+      and compensation_received_from_military_or_naval_service'
+- name: eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-321(C)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: For taxable years beginning on and after January 1, 2020, but before
+            January 1, 2026
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: "any amount that is includible in the federal adjusted gross income\
+            \ of an eligible veteran by reason of the whole or partial discharge of\
+            \ any loan described in \xA7 108(f)(5)(B) ... shall be excluded"
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-321
+          excerpt: eligible veteran means a veteran ... rated ... to have a 100 percent
+            service-connected, permanent, and total disability
+  versions:
+  - effective_from: '2020-01-01'
+    formula: 'if taxable_year_is_in_temporary_effective_window and veteran_rated_with_100_percent_service_connected_permanent_and_total_disability
+      and loan_described_in_section_108_f_5_B and discharge_described_in_clauses_i_ii_and_iii_of_section_108_f_5_A
+      and discharge_occurs_after_applicable_cutoff_date: amount_includible_in_federal_adjusted_gross_income_by_reason_of_whole_or_partial_loan_discharge
+      else: 0'


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-va/statute/58.1/58.1-321`
- Module: `us-va/statutes/58.1/58/1-321.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 78s
- Local gate status: **green**

Produced by `axiom-encode encode us-va/statute/58.1/58.1-321 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-va/statute/58.1/58.1-321",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "b6cfbe17",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/58.1/58/1-321.yaml",
      "sha256": "c31e9cdc0975ae934e8071c4997a321930aeae93c0cd487567d49c58d7b4aa3e"
    },
    {
      "path": "statutes/58.1/58/1-321.test.yaml",
      "sha256": "a501fe23e7e689d1e77890e51d2f64fc88e80971b9e8889a7af86b860690b59c"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
