### PR TITLE
Encode us-wv/statute/11-21-16 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21601,6 +21601,15 @@
         ]
       }
     ],
+    "us-wv/statute/11-21-16": [
+      {
+        "module": "us-wv/statutes/11-21-16.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1": [
       {
         "module": "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 20
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,29 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#resident_individual_exemption
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#separately_determined_spouse_exemption
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#surviving_spouse
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
     source: bulk
     since: 2026-07-08

--- a/us-wv/.axiom/encoding-manifests/statutes/11-21-16.json
+++ b/us-wv/.axiom/encoding-manifests/statutes/11-21-16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/11-21-16.yaml",
+      "sha256": "990a10139d1bb1ed8e065cd9ecf683130449d68786402095af8a6fe3a059b336"
+    },
+    {
+      "path": "statutes/11-21-16.test.yaml",
+      "sha256": "8f0c7ed2e4aed02d084094d065269663bc50062f47b211223477104926de35de"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-wv/statute/11-21-16",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-wv-statute-11-21-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "2a523534161f6540e27a6ba8fe80b907e006fbdb20b4bf7630c0ec682e1aca8f",
+  "generated_at": "2026-07-08T10:44:21.896034+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/11-21-16.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "990a10139d1bb1ed8e065cd9ecf683130449d68786402095af8a6fe3a059b336",
+  "generation_prompt_sha256": "3c60620adfa3b3dbd5079e91bb95cb457ad603f7172f5f3db347a64f97fd43a3",
+  "model": "gpt-5.5",
+  "run_id": "13cf7218",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d7a7834c19bed49da8f5c4442ff6ca97703d913ef990195e3db2745894c75f7e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-wv-statute-11-21-16.json",
+  "trace_sha256": "2d703426da50f4ebf3910d5968db55d8f21361512195d12ce22783fb8245a32c"
+}

--- a/us-wv/statutes/11-21-16.test.yaml
+++ b/us-wv/statutes/11-21-16.test.yaml
@@ -1,0 +1,92 @@
+- name: resident individual receives exemption for federal exemption count
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.resident_individual: true
+    us-wv:statutes/11-21-16#input.federal_exemption_count: 2
+  output:
+    us-wv:statutes/11-21-16#resident_individual_exemption: 4000
+- name: separately determined spouse uses separate-return federal exemption count
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.west_virginia_income_taxes_separately_determined_and_federal_income_tax_joint_return: true
+    us-wv:statutes/11-21-16#input.separate_return_federal_exemption_count: 1
+  output:
+    us-wv:statutes/11-21-16#separately_determined_spouse_exemption: 2000
+- name: surviving spouse receives additional exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.spouse_died_during_taxable_year_prior_to_return_year: true
+    us-wv:statutes/11-21-16#input.remarried_before_end_of_taxable_year: false
+    us-wv:statutes/11-21-16#input.taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death: true
+  output:
+    us-wv:statutes/11-21-16#surviving_spouse: holds
+    us-wv:statutes/11-21-16#surviving_spouse_additional_exemption: 2000
+- name: remarriage prevents surviving spouse status and additional exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.spouse_died_during_taxable_year_prior_to_return_year: true
+    us-wv:statutes/11-21-16#input.remarried_before_end_of_taxable_year: true
+    us-wv:statutes/11-21-16#input.taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death: true
+  output:
+    us-wv:statutes/11-21-16#surviving_spouse: not_holds
+    us-wv:statutes/11-21-16#surviving_spouse_additional_exemption: 0
+- name: auto_output_certain_dependent_single_exemption
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.federal_exemption_amount_is_zero_by_virtue_of_section_151_d_2: false
+    us-wv:statutes/11-21-16#input.federal_exemption_count: 1
+    us-wv:statutes/11-21-16#input.remarried_before_end_of_taxable_year: false
+    us-wv:statutes/11-21-16#input.resident_individual: false
+    us-wv:statutes/11-21-16#input.separate_return_federal_exemption_count: 1
+    us-wv:statutes/11-21-16#input.spouse_died_during_taxable_year_prior_to_return_year: false
+    us-wv:statutes/11-21-16#input.taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death: false
+    us-wv:statutes/11-21-16#input.west_virginia_income_taxes_separately_determined_and_federal_income_tax_joint_return: false
+  output:
+    us-wv:statutes/11-21-16#certain_dependent_single_exemption: 0
+- name: auto_zero_resident_individual_exemption
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.federal_exemption_amount_is_zero_by_virtue_of_section_151_d_2: false
+    us-wv:statutes/11-21-16#input.federal_exemption_count: 0
+    us-wv:statutes/11-21-16#input.remarried_before_end_of_taxable_year: false
+    us-wv:statutes/11-21-16#input.resident_individual: false
+    us-wv:statutes/11-21-16#input.separate_return_federal_exemption_count: 0
+    us-wv:statutes/11-21-16#input.spouse_died_during_taxable_year_prior_to_return_year: false
+    us-wv:statutes/11-21-16#input.taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death: false
+    us-wv:statutes/11-21-16#input.west_virginia_income_taxes_separately_determined_and_federal_income_tax_joint_return: false
+  output:
+    us-wv:statutes/11-21-16#resident_individual_exemption: 0
+- name: auto_zero_separately_determined_spouse_exemption
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-wv:statutes/11-21-16#input.federal_exemption_amount_is_zero_by_virtue_of_section_151_d_2: false
+    us-wv:statutes/11-21-16#input.federal_exemption_count: 0
+    us-wv:statutes/11-21-16#input.remarried_before_end_of_taxable_year: false
+    us-wv:statutes/11-21-16#input.resident_individual: false
+    us-wv:statutes/11-21-16#input.separate_return_federal_exemption_count: 0
+    us-wv:statutes/11-21-16#input.spouse_died_during_taxable_year_prior_to_return_year: false
+    us-wv:statutes/11-21-16#input.taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death: false
+    us-wv:statutes/11-21-16#input.west_virginia_income_taxes_separately_determined_and_federal_income_tax_joint_return: false
+  output:
+    us-wv:statutes/11-21-16#separately_determined_spouse_exemption: 0

--- a/us-wv/statutes/11-21-16.yaml
+++ b/us-wv/statutes/11-21-16.yaml
@@ -1,0 +1,233 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wv/statute/11-21-16
+  summary: 'Resident individuals are allowed a West Virginia exemption for each federal
+    exemption: $600 before 1983, $700 for taxable years beginning in 1983, $800 for
+    taxable years beginning on or after 1984, and $2,000 for taxable years beginning
+    on or after 1987. For taxable years beginning after December 31, 1986, a surviving
+    spouse is allowed one additional $2,000 exemption for the two taxable years beginning
+    after the year of the deceased spouse''s death; "surviving spouse" means a taxpayer
+    whose spouse died during the prior taxable year and who has not remarried before
+    the end of the taxable year. Certain dependents with zero federal exemption amount
+    by virtue of IRC section 151(d)(2) receive a single $500 West Virginia exemption.'
+rules:
+- name: west_virginia_exemption_per_federal_exemption
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-16(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: taxable year prior to January 1, 1983 ... exemption of $600
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: taxable year beginning on or after January 1, 1983, and prior to
+            January 1, 1984 ... $700
+      - path: versions[2].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: taxable year beginning on or after January 1, 1984 ... $800
+      - path: versions[3].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: taxable year beginning on or after January 1, 1987 ... $2,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '600'
+  - effective_from: '1983-01-01'
+    formula: '700'
+  - effective_from: '1984-01-01'
+    formula: '800'
+  - effective_from: '1987-01-01'
+    formula: '2000'
+- name: surviving_spouse_additional_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-16(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: a surviving spouse shall be allowed one additional exemption of
+            $2,000
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: For taxable years beginning after December 31, 1986
+  versions:
+  - effective_from: '1987-01-01'
+    formula: '2000'
+- name: certain_dependent_single_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-16(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: shall be allowed a single West Virginia exemption in the amount
+            of $500
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: for taxable years beginning after December 31, 1986
+  versions:
+  - effective_from: '1987-01-01'
+    formula: '500'
+- name: resident_individual_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-16(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: a resident individual shall be allowed a West Virginia exemption
+            ... for each exemption for which he is entitled to a deduction ... for
+            federal income tax purposes
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
+          output: west_virginia_exemption_per_federal_exemption
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if resident_individual: west_virginia_exemption_per_federal_exemption
+      * federal_exemption_count else: 0'
+- name: separately_determined_spouse_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-16(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: If the West Virginia income taxes of a husband and wife are separately
+            determined but their federal income tax is determined on a joint return,
+            each of them shall be separately entitled ... for each federal exemption
+            to which he would be separately entitled
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
+          output: west_virginia_exemption_per_federal_exemption
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if west_virginia_income_taxes_separately_determined_and_federal_income_tax_joint_return:
+      west_virginia_exemption_per_federal_exemption * separate_return_federal_exemption_count
+      else: 0'
+- name: surviving_spouse
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 11-21-16(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: a surviving spouse means a taxpayer whose spouse died during the
+            taxable year prior to the taxable year ... and who has not remarried
+  versions:
+  - effective_from: '1987-01-01'
+    formula: 'spouse_died_during_taxable_year_prior_to_return_year
+
+      and not remarried_before_end_of_taxable_year'
+- name: surviving_spouse_additional_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-16(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: a surviving spouse shall be allowed one additional exemption of
+            $2,000 for the two taxable years beginning after the year of death
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption_amount
+          output: surviving_spouse_additional_exemption_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wv:statutes/11-21-16#surviving_spouse
+          output: surviving_spouse
+          hash: sha256:local
+  versions:
+  - effective_from: '1987-01-01'
+    formula: 'if surviving_spouse and taxable_year_is_one_of_two_taxable_years_beginning_after_year_of_death:
+      surviving_spouse_additional_exemption_amount else: 0'
+- name: certain_dependent_single_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-16(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-16
+          excerpt: a resident individual whose exemption amount for federal tax purposes
+            is zero by virtue of section 151(d)(2) ... shall be allowed a single West
+            Virginia exemption ... $500
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount
+          output: certain_dependent_single_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '1987-01-01'
+    formula: 'if resident_individual and federal_exemption_amount_is_zero_by_virtue_of_section_151_d_2:
+      certain_dependent_single_exemption_amount else: 0'


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-wv/statute/11-21-16`
- Module: `us-wv/statutes/11-21-16.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 67s
- Local gate status: **green**

Produced by `axiom-encode encode us-wv/statute/11-21-16 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-wv/statute/11-21-16",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "13cf7218",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/11-21-16.yaml",
      "sha256": "990a10139d1bb1ed8e065cd9ecf683130449d68786402095af8a6fe3a059b336"
    },
    {
      "path": "statutes/11-21-16.test.yaml",
      "sha256": "8f0c7ed2e4aed02d084094d065269663bc50062f47b211223477104926de35de"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
