### PR TITLE
Encode us-wv/statute/11-21-10 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21601,6 +21601,15 @@
         ]
       }
     ],
+    "us-wv/statute/11-21-10": [
+      {
+        "module": "us-wv/statutes/11-21-10.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1": [
       {
         "module": "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 21
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,32 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#earned_income_for_section
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#separate_return_earned_income_exclusion_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wv:statutes/11-21-10#temporary_initial_year_exclusion_fraction
     source: bulk
     since: 2026-07-08

--- a/us-wv/.axiom/encoding-manifests/statutes/11-21-10.json
+++ b/us-wv/.axiom/encoding-manifests/statutes/11-21-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/11-21-10.yaml",
+      "sha256": "8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0"
+    },
+    {
+      "path": "statutes/11-21-10.test.yaml",
+      "sha256": "4ff832d1678779204ad5e7d03f680ea6ea6c9e3cad1b493edc5443836518ae30"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-wv/statute/11-21-10",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-wv-statute-11-21-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "69c447f4df86381fa034f70f24b0abfc49b2ac4fa73975f55925e33692213c9f",
+  "generated_at": "2026-07-08T10:50:02.208490+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/11-21-10.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0",
+  "generation_prompt_sha256": "38c6a2e3940596df7fc0e1503e0340f6cf817838fca2d86496cb49dd0de69f0c",
+  "model": "gpt-5.5",
+  "run_id": "969e0d8b",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "195cdc83e42d97a69076b90a7421b83ec23aa5ff063214a0683c027cfcf4c08f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-wv-statute-11-21-10.json",
+  "trace_sha256": "5ad8e5b42ab4c5e9408c46b4c7c6453eb4298485ce63586ad8d5843c9c2957bc"
+}

--- a/us-wv/statutes/11-21-10.test.yaml
+++ b/us-wv/statutes/11-21-10.test.yaml
@@ -1,0 +1,83 @@
+- name: person_earned_income_excludes_pensions_and_inmate_services
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-10#input.wages_salaries_tips_and_other_employee_compensation: 9000
+    us-wv:statutes/11-21-10#input.net_earnings_from_self_employment_determined_with_section_164_deduction: 4000
+    us-wv:statutes/11-21-10#input.pension_or_annuity_amount_otherwise_included_in_earned_income: 1000
+    us-wv:statutes/11-21-10#input.penal_institution_services_amount_otherwise_included_in_earned_income: 500
+  output:
+    us-wv:statutes/11-21-10#earned_income_for_section: 11500
+- name: unmarried_eligible_taxpayer_gets_earned_income_deduction_up_to_annual_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-10#input.taxpayer_is_unmarried_individual: true
+    us-wv:statutes/11-21-10#input.husband_and_wife_file_joint_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.husband_or_wife_files_separate_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.federal_adjusted_gross_income: 9500
+    us-wv:statutes/11-21-10#input.taxable_year_is_initial_partial_exclusion_year: false
+    us-wv:statutes/11-21-10#input.taxable_year_covers_full_twelve_months: true
+    us-wv:statutes/11-21-10#input.taxable_year_closed_by_reason_of_death_of_taxpayer: false
+    us-wv:statutes/11-21-10#input.earned_income_included_in_federal_adjusted_gross_income: 12000
+  output:
+    us-wv:statutes/11-21-10#eligible_taxpayer: holds
+    us-wv:statutes/11-21-10#earned_income_exclusion_cap: 10000
+    us-wv:statutes/11-21-10#earned_income_exclusion_deduction: 10000
+- name: joint_return_taxpayer_over_fagi_threshold_is_not_eligible
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-10#input.taxpayer_is_unmarried_individual: false
+    us-wv:statutes/11-21-10#input.husband_and_wife_file_joint_return_under_this_article: true
+    us-wv:statutes/11-21-10#input.husband_or_wife_files_separate_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.federal_adjusted_gross_income: 12000
+    us-wv:statutes/11-21-10#input.taxable_year_is_initial_partial_exclusion_year: false
+    us-wv:statutes/11-21-10#input.taxable_year_covers_full_twelve_months: true
+    us-wv:statutes/11-21-10#input.taxable_year_closed_by_reason_of_death_of_taxpayer: false
+    us-wv:statutes/11-21-10#input.earned_income_included_in_federal_adjusted_gross_income: 8000
+  output:
+    us-wv:statutes/11-21-10#eligible_taxpayer: not_holds
+    us-wv:statutes/11-21-10#earned_income_exclusion_deduction: 0
+- name: separate_return_eligible_taxpayer_uses_separate_return_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wv:statutes/11-21-10#input.taxpayer_is_unmarried_individual: false
+    us-wv:statutes/11-21-10#input.husband_and_wife_file_joint_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.husband_or_wife_files_separate_return_under_this_article: true
+    us-wv:statutes/11-21-10#input.federal_adjusted_gross_income: 5000
+    us-wv:statutes/11-21-10#input.taxable_year_is_initial_partial_exclusion_year: false
+    us-wv:statutes/11-21-10#input.taxable_year_covers_full_twelve_months: true
+    us-wv:statutes/11-21-10#input.taxable_year_closed_by_reason_of_death_of_taxpayer: false
+    us-wv:statutes/11-21-10#input.earned_income_included_in_federal_adjusted_gross_income: 7000
+  output:
+    us-wv:statutes/11-21-10#eligible_taxpayer: holds
+    us-wv:statutes/11-21-10#earned_income_exclusion_cap: 5000
+    us-wv:statutes/11-21-10#earned_income_exclusion_deduction: 5000
+- name: initial_partial_exclusion_year_limits_cap_to_fifty_percent
+  period:
+    period_kind: tax_year
+    start: '1996-01-01'
+    end: '1996-12-31'
+  input:
+    us-wv:statutes/11-21-10#input.taxpayer_is_unmarried_individual: true
+    us-wv:statutes/11-21-10#input.husband_and_wife_file_joint_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.husband_or_wife_files_separate_return_under_this_article: false
+    us-wv:statutes/11-21-10#input.federal_adjusted_gross_income: 9000
+    us-wv:statutes/11-21-10#input.taxable_year_is_initial_partial_exclusion_year: true
+    us-wv:statutes/11-21-10#input.taxable_year_covers_full_twelve_months: true
+    us-wv:statutes/11-21-10#input.taxable_year_closed_by_reason_of_death_of_taxpayer: false
+    us-wv:statutes/11-21-10#input.earned_income_included_in_federal_adjusted_gross_income: 8000
+  output:
+    us-wv:statutes/11-21-10#eligible_taxpayer: holds
+    us-wv:statutes/11-21-10#earned_income_exclusion_cap: 5000
+    us-wv:statutes/11-21-10#earned_income_exclusion_deduction: 5000

--- a/us-wv/statutes/11-21-10.yaml
+++ b/us-wv/statutes/11-21-10.yaml
@@ -1,0 +1,201 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wv/statute/11-21-10
+  summary: Allows an eligible taxpayer a deduction from federal adjusted gross income
+    for earned income included therein, capped at $10,000, or $5,000 per separate
+    return for spouses filing separately. Eligible taxpayers are unmarried individuals
+    or joint-return spouses with federal adjusted gross income of $10,000 or less,
+    and separate-return spouses with federal adjusted gross income of $5,000 or less.
+    Earned income includes wages, salaries, tips, other employee compensation, and
+    net earnings from self-employment, excluding pensions, annuities, and inmate-services
+    amounts.
+rules:
+- name: annual_earned_income_exclusion_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-10(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: not to exceed $10,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '10000'
+- name: separate_return_earned_income_exclusion_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-10(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: when a husband and wife file separate returns ... shall not exceed
+            $5,000 per separate return
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '5000'
+- name: temporary_initial_year_exclusion_fraction
+  kind: parameter
+  dtype: Rate
+  source: 11-21-10(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: for the taxable year beginning January 1, 1996 ... shall not exceed
+            fifty percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.50'
+- name: eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-10(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: unmarried individual and any husband and wife filing a joint return
+            ... federal adjusted gross income of $10,000 or less
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '10000'
+- name: eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 11-21-10(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: husband or wife filing a separate return ... federal adjusted gross
+            income of $5,000 or less
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '5000'
+- name: earned_income_for_section
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-10(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, wages_salaries_tips_and_other_employee_compensation + net_earnings_from_self_employment_determined_with_section_164_deduction
+      - pension_or_annuity_amount_otherwise_included_in_earned_income - penal_institution_services_amount_otherwise_included_in_earned_income)
+- name: eligible_taxpayer
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 11-21-10(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: unmarried individual and any husband and wife filing a joint return
+            ... $10,000 or less
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: husband or wife filing a separate return ... $5,000 or less
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '((taxpayer_is_unmarried_individual or husband_and_wife_file_joint_return_under_this_article)
+      and federal_adjusted_gross_income <= eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold)
+
+      or (husband_or_wife_files_separate_return_under_this_article and federal_adjusted_gross_income
+      <= eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold)'
+- name: earned_income_exclusion_cap
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-10(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: not to exceed $10,000, except that when a husband and wife file
+            separate returns ... not exceed $5,000
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: for the taxable year beginning January 1, 1996 ... not exceed fifty
+            percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if taxable_year_is_initial_partial_exclusion_year:\n  temporary_initial_year_exclusion_fraction\
+      \ * (if husband_or_wife_files_separate_return_under_this_article: separate_return_earned_income_exclusion_cap\
+      \ else: annual_earned_income_exclusion_cap)\nelse:\n  if husband_or_wife_files_separate_return_under_this_article:\
+      \ separate_return_earned_income_exclusion_cap else: annual_earned_income_exclusion_cap"
+- name: earned_income_exclusion_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 11-21-10(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: there shall be allowed as a deduction from federal adjusted gross
+            income the amount of his or her earned income included therein
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-wv/statute/11-21-10
+          excerpt: no credit shall be allowed ... taxable year covering a period of
+            less than twelve months
+  versions:
+  - effective_from: '0001-01-01'
+    formula: |-
+      if eligible_taxpayer and (taxable_year_covers_full_twelve_months or taxable_year_closed_by_reason_of_death_of_taxpayer): min(max(0, earned_income_included_in_federal_adjusted_gross_income), max(0, earned_income_exclusion_cap)) else: 0


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-wv/statute/11-21-10`
- Module: `us-wv/statutes/11-21-10.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 80s
- Local gate status: **green**

Produced by `axiom-encode encode us-wv/statute/11-21-10 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-wv/statute/11-21-10",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "969e0d8b",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/11-21-10.yaml",
      "sha256": "8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0"
    },
    {
      "path": "statutes/11-21-10.test.yaml",
      "sha256": "4ff832d1678779204ad5e7d03f680ea6ea6c9e3cad1b493edc5443836518ae30"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
