### PR TITLE
Encode us-az/statute/43-1041 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1432,6 +1432,15 @@
         ]
       }
     ],
+    "us-az/statute/43-1041": [
+      {
+        "module": "us-az/statutes/43-1041.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/guidance/cdss/acin-2025-i-46-25/page-4": [
       {
         "module": "us-ca/policies/cdss/snap/standard-utility-allowance.yaml",

--- a/us-az/.axiom/encoding-manifests/statutes/43-1041.json
+++ b/us-az/.axiom/encoding-manifests/statutes/43-1041.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/43-1041.yaml",
+      "sha256": "565ae621b55f617f4f1ee856911058f5e04481572778b08c702dd489b0de1ffb"
+    },
+    {
+      "path": "statutes/43-1041.test.yaml",
+      "sha256": "6e4f5aa76e024a49ac74fc1519352c2f1beb7ef6328ec088a1da89e7e7b38cd3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "openai",
+  "citation": "us-az/statute/43-1041",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-az-statute-43-1041/workspace/context-manifest.json",
+  "context_manifest_sha256": "68ee6478555eee6abad42c9aa3ff2a350a4c84d0ca22bd1a14bb9d89fab5a99d",
+  "generated_at": "2026-07-08T11:01:39.491814+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/43-1041.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "565ae621b55f617f4f1ee856911058f5e04481572778b08c702dd489b0de1ffb",
+  "generation_prompt_sha256": "70e8d1b76c55e05e4378cbea7c87590120837c29f3ac2cbe0b3308aeda41bfef",
+  "model": "gpt-5.5",
+  "run_id": "9498dadb",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f2867cecd14a0cf1c45fe8a54abf47c764d83f143b692e87331c2d348f876fe0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-az-statute-43-1041.json",
+  "trace_sha256": "66e8f8c0b068c47185958e45f0fef16eda13a727d6ea6d032f7e6cd327d57f59"
+}

--- a/us-az/statutes/43-1041.test.yaml
+++ b/us-az/statutes/43-1041.test.yaml
@@ -1,0 +1,39 @@
+- name: elected_standard_deduction_gets_initial_twenty_five_percent_charitable_increase
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    us-az:statutes/43-1041#input.taxable_year_subject_to_department_percentage_adjustment: false
+    us-az:statutes/43-1041#input.department_adjusted_charitable_standard_deduction_percentage: 0.4
+    us-az:statutes/43-1041#input.taxpayer_elects_standard_deduction: true
+    us-az:statutes/43-1041#input.charitable_deductions_that_would_have_been_allowed_if_itemized: 1000
+  output:
+    us-az:statutes/43-1041#applicable_charitable_deduction_increase_percentage: 0.25
+    us-az:statutes/43-1041#charitable_standard_deduction_increase: 250
+- name: department_adjusted_percentage_is_capped_at_one_hundred_percent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1041#input.taxable_year_subject_to_department_percentage_adjustment: true
+    us-az:statutes/43-1041#input.department_adjusted_charitable_standard_deduction_percentage: 1.2
+    us-az:statutes/43-1041#input.taxpayer_elects_standard_deduction: true
+    us-az:statutes/43-1041#input.charitable_deductions_that_would_have_been_allowed_if_itemized: 1000
+  output:
+    us-az:statutes/43-1041#applicable_charitable_deduction_increase_percentage: 1
+    us-az:statutes/43-1041#charitable_standard_deduction_increase: 1000
+- name: no_charitable_increase_when_standard_deduction_not_elected
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1041#input.taxable_year_subject_to_department_percentage_adjustment: true
+    us-az:statutes/43-1041#input.department_adjusted_charitable_standard_deduction_percentage: 0.5
+    us-az:statutes/43-1041#input.taxpayer_elects_standard_deduction: false
+    us-az:statutes/43-1041#input.charitable_deductions_that_would_have_been_allowed_if_itemized: 1000
+  output:
+    us-az:statutes/43-1041#applicable_charitable_deduction_increase_percentage: 0.5
+    us-az:statutes/43-1041#charitable_standard_deduction_increase: 0

--- a/us-az/statutes/43-1041.yaml
+++ b/us-az/statutes/43-1041.yaml
@@ -1,0 +1,165 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-az/statute/43-1041
+  summary: |-
+    A taxpayer may elect a standard deduction: $12,200 for single or married filing separately, $18,350 for head of household, and $24,400 for a married couple filing jointly, subject to inflation adjustment for taxable years beginning after December 31, 2019. The standard deduction is in lieu of itemized deductions, is not allowed in certain spouse and short-tax-year cases, and is increased by 25% of charitable deductions that would have been allowed if itemized; for taxable years beginning after December 31, 2021 the department adjusts that percentage, capped at 100%.
+  deferred_outputs:
+    - output: us-az:statutes/43-1041#standard_deduction_under_subsection_a
+      reason: The subsection A standard deduction amount depends on the taxpayer's filing-status legal classification and on subsection H inflation adjustments. No source-backed filing-status output or current inflation-adjusted Arizona amount authority is supplied in this prompt, and local filing-status inputs are prohibited.
+      source_values:
+        - us-az:statutes/43-1041#single_or_married_filing_separately_statutory_standard_deduction
+        - us-az:statutes/43-1041#head_of_household_statutory_standard_deduction
+        - us-az:statutes/43-1041#married_joint_return_statutory_standard_deduction
+rules:
+  - name: single_or_married_filing_separately_statutory_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. § 43-1041(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "single person or a married person filing separately, the standard deduction is $12,200"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12200
+
+  - name: head_of_household_statutory_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. § 43-1041(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "single person who is a head of a household, the standard deduction is $18,350"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          18350
+
+  - name: married_joint_return_statutory_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. § 43-1041(A)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "married couple filing a joint return, the standard deduction is $24,400"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          24400
+
+  - name: initial_charitable_deduction_increase_percentage
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: A.R.S. § 43-1041(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "increased by the amount equal to twenty-five percent of the total amount of a taxpayer's charitable deductions"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          0.25
+
+  - name: charitable_deduction_increase_percentage_cap
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: A.R.S. § 43-1041(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "the adjusted percentage may not exceed one hundred percent"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          1
+
+  - name: applicable_charitable_deduction_increase_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: A.R.S. § 43-1041(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "twenty-five percent ... For taxable years beginning from and after December 31, 2021, the department shall adjust the percentage ... may not exceed one hundred percent"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-az:statutes/43-1041#initial_charitable_deduction_increase_percentage
+              output: initial_charitable_deduction_increase_percentage
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-az:statutes/43-1041#charitable_deduction_increase_percentage_cap
+              output: charitable_deduction_increase_percentage_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          if taxable_year_subject_to_department_percentage_adjustment: min(department_adjusted_charitable_standard_deduction_percentage, charitable_deduction_increase_percentage_cap) else: initial_charitable_deduction_increase_percentage
+
+  - name: charitable_standard_deduction_increase
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. § 43-1041(I)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "standard deduction allowed under subsection A ... shall be increased by the amount equal to ... percent of the total amount of a taxpayer's charitable deductions"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-az:statutes/43-1041#applicable_charitable_deduction_increase_percentage
+              output: applicable_charitable_deduction_increase_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          if taxpayer_elects_standard_deduction: applicable_charitable_deduction_increase_percentage * max(0, charitable_deductions_that_would_have_been_allowed_if_itemized) else: 0


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us-az/statute/43-1041`
- Module: `us-az/statutes/43-1041.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1184)
- Encode wall time: 73s
- Local gate status: **green**

Produced by `axiom-encode encode us-az/statute/43-1041 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-az/statute/43-1041",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "9498dadb",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/43-1041.yaml",
      "sha256": "565ae621b55f617f4f1ee856911058f5e04481572778b08c702dd489b0de1ffb"
    },
    {
      "path": "statutes/43-1041.test.yaml",
      "sha256": "6e4f5aa76e024a49ac74fc1519352c2f1beb7ef6328ec088a1da89e7e7b38cd3"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
