### PR TITLE
Complete oracle-coverage pending-lane integration + local Codex drain runner

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -205,6 +205,33 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" "$GITHUB_WORKSPACE/../axiom-rules-engine"
           ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-corpus" "$GITHUB_WORKSPACE/../axiom-corpus"
 
+      # The oracle-coverage-pending lane (the fix for new-state bulk PRs failing
+      # the changed-file PolicyEngine oracle-coverage gate) is a *newer* encoder
+      # feature than the pinned validate toolchain: the pinned axiom-encode has
+      # no `oracle-coverage-pending` subcommand, and the CI coverage classifier
+      # deliberately runs axiom-encode@main so new mappings unblock generated PRs
+      # (validate-rulespec.yml `oracle-coverage-axiom-encode-ref`, default main).
+      # Install that same classifier in an isolated venv so the sync step below
+      # declares a new module's unmapped outputs exactly as the CI gate reads
+      # them. Without this, every new-state module opens a PR that fails the
+      # required validate check on `... : unmapped` and auto-merge hangs forever
+      # (rulespec-us #614-616, #619-636 etc.).
+      - name: Checkout oracle-coverage classifier (axiom-encode main)
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: main
+          path: _axiom/axiom-encode-oracle-coverage
+
+      - name: Install oracle-coverage classifier (isolated venv)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/cov-venv"
+          "$RUNNER_TEMP/cov-venv/bin/pip" install --quiet --upgrade pip
+          "$RUNNER_TEMP/cov-venv/bin/pip" install --quiet -e _axiom/axiom-encode-oracle-coverage
+          echo "COV_AE=$RUNNER_TEMP/cov-venv/bin/axiom-encode" >> "$GITHUB_ENV"
+
       - name: Encode --apply and run the gate battery
         id: encode
         shell: bash
@@ -289,12 +316,42 @@ jobs:
             (cd "$GITHUB_WORKSPACE" && python tests/generate_reverse_index.py)
           fi
 
+          # Declare the module's unmapped executable outputs in the
+          # oracle-coverage pending lane, using the axiom-encode@main classifier
+          # installed above. The changed-file oracle-coverage gate reclassifies
+          # declared outputs from `unmapped` to `pending_classification`, so this
+          # is what lets a new-state module's PR pass the required validate check
+          # instead of hanging on `... : unmapped`. `sync` rewrites
+          # oracle-coverage-pending.yaml to exactly the repo's current unmapped
+          # set; it is a no-op when the module's outputs are already mapped.
+          pending_file="oracle-coverage-pending.yaml"
+          "$COV_AE" oracle-coverage-pending sync \
+            --root "$GITHUB_WORKSPACE/.." \
+            --repo rulespec-us \
+            --source bulk || {
+              echo "::error::oracle-coverage-pending sync failed for $CITATION." >&2
+              exit 1
+            }
+
           # --- Gate battery (fail-closed pre-check; mirrors PR CI order) ---
           # 1. guard-generated: applied files must carry a valid signed manifest.
           # Stage ONLY the applied module, its companion test, its signed
-          # manifest, and the regenerated reverse index -- never `git add -A`,
-          # which would commit the _axiom/ sibling checkouts and build artifacts.
+          # manifest, the regenerated reverse index, and the pending-lane
+          # declaration -- never `git add -A`, which would commit the _axiom/
+          # sibling checkouts and build artifacts.
           git -C "$GITHUB_WORKSPACE" add -- "$module" "$test_file" "$manifest_rel" "$index_file"
+          # Keep the pending declaration only when it has entries (a new unmapped
+          # output) or is already tracked. A fully-mapped module syncs an empty
+          # declaration; committing that empty repo-root file would needlessly
+          # flip the PR to full-matrix validation, so drop it and stay scoped.
+          if [ -f "$GITHUB_WORKSPACE/$pending_file" ]; then
+            if grep -q -- '- legal_id:' "$GITHUB_WORKSPACE/$pending_file" \
+               || git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch "$pending_file" >/dev/null 2>&1; then
+              git -C "$GITHUB_WORKSPACE" add -- "$pending_file"
+            else
+              rm -f "$GITHUB_WORKSPACE/$pending_file"
+            fi
+          fi
           git -C "$GITHUB_WORKSPACE" -c user.email=bulk-encode@axiom \
             -c user.name="bulk-encode" commit -q -m "wip: $CITATION"
           axiom-encode guard-generated \

--- a/bulk/PROGRESS-local-drain.md
+++ b/bulk/PROGRESS-local-drain.md
@@ -1,0 +1,70 @@
+# Local bulk-encode drain — progress
+
+Draining `bulk/worklist.yaml` on the operator's machine with the local Codex CLI
+(ChatGPT subscription, `gpt-5.5`) instead of the cloud `bulk-encode.yml`
+dispatcher. One PR per module, auto-merge on green — identical to the cloud path.
+Runner: [`bulk/local_drain.py`](./local_drain.py).
+
+## Why this PR exists (repo-side integration of the oracle-coverage pending lane)
+
+Every new-state bulk PR (rulespec-us #614-616, #619-636, …) was failing the
+required `validate / validate` check on the changed-file PolicyEngine
+oracle-coverage gate: the module's executable outputs are `unmapped` and nothing
+declared them. `axiom-encode oracle-coverage-pending sync` writes
+`oracle-coverage-pending.yaml`, which the coverage classifier (axiom-encode
+`main`, the `oracle-coverage-axiom-encode-ref` default) reclassifies from
+`unmapped` to `pending_classification`, clearing the gate. But the tool side
+shipped without the repo side:
+
+1. **`tests/test_repository_layout.py`** rejected `oracle-coverage-pending.yaml`
+   as a stray root YAML → every shard's whole-repo layout gate failed. Fixed
+   here by allowlisting the file.
+2. **`.github/workflows/bulk-encode.yml`** never ran the sync, so the dispatcher
+   kept opening PRs that fail the gate. Fixed here by installing the
+   axiom-encode `main` classifier in an isolated venv and syncing the pending
+   lane after `--apply`, staging the declaration into the module commit.
+
+With both landed on `main`, new-state modules self-declare and merge cleanly.
+
+## Toolchain (non-obvious, load-bearing)
+
+- **Generation** uses the **toolchain-pinned** encoder (`.axiom/toolchain.toml`,
+  `axiom_encode_version` = 0.2.1184). The required `validate` check validates
+  with that same pin; generating with anything newer risks schema/manifest skew.
+- **Coverage declaration** uses **axiom-encode `main` (≥0.2.1190)** — the pinned
+  1184 encoder has no `oracle-coverage-pending` subcommand, and `main` is what
+  CI's coverage classifier runs.
+
+Operator workspace (`_bulk_drain/`, built once, not committed): pinned
+axiom-encode venv (`.venv`), main classifier venv (`.venv-cov`), pinned engine
+(`cargo build`), pinned corpus, per-entry worktrees whose leaf dir is exactly
+`rulespec-us` (the `--apply` resolver requirement). `python bulk/local_drain.py
+doctor` verifies all of it.
+
+## Status
+
+- Authoritative queue (origin/main): **173 pending**, ~27 open bulk PRs, 3 merged.
+- **Unstick mechanism proven** on #614 (us-oh/5747.02): sync flips its 10 outputs
+  `unmapped → pending_classification`; the `validate / validate (us-oh)` shard
+  goes green. It surfaced the two repo-side gaps fixed in this PR.
+- **Part B generation proven** end-to-end on us-il/statute/35/5/705: local Codex
+  `gpt-5.5` generated a valid module in ~45s (`compile=yes ci=yes`), `--apply`
+  installed module+test+signed manifest, and the full gate battery passed
+  (guard-generated, validate, proof-validate, companion test = 4 cases). Its
+  outputs are already oracle-mapped, so sync is a no-op and no pending file is
+  added (mapped modules stay shard-scoped).
+- Runner `doctor` green: pinned encoder 1184, classifier ≥1190, engine, corpus,
+  signing key, codex CLI all resolve.
+
+### Open bulk PRs to drain (as of this writing)
+
+- **New-state, fail the coverage gate → need sync** (`unstick`): #614-616 (oh),
+  #619-620 (or), #621 (ri), #623/#627 (va), #624-626 (ut), #629-633 (wv),
+  #634-636 (hi), #638 (az).
+- **Mapped, pass validate but stale → need up-to-date** (`unstick`, sync no-op):
+  #589-594 (il), #622 (sc), #637 (az).
+
+Branch protection is `strict` (up-to-date required) and the pending lane is one
+repo-root file, so unstick PRs merge **sequentially** (`unstick --wait`, rebuild
+each on the newly-advanced main). This file is rewritten by `local_drain.py
+drain` each chunk with per-entry results and the paused/limit state.

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Local bulk-encode drain runner.
+
+Drains ``bulk/worklist.yaml`` on the operator's machine using the local Codex
+CLI (ChatGPT subscription, ``gpt-5.5``) instead of the cloud ``bulk-encode.yml``
+dispatcher, opening the identical one-PR-per-module with auto-merge. It is a
+faithful local mirror of ``.github/workflows/bulk-encode.yml`` plus the
+oracle-coverage-pending declaration step the cloud dispatcher is missing (that
+missing step is why every new-state bulk PR fails the changed-file oracle
+coverage gate; see ``unstick`` below and the workflow fix in the same PR as this
+script).
+
+Two decisions matter and are baked in here so PRs go green:
+
+* **Generation uses the toolchain-pinned encoder** (``.axiom/toolchain.toml``
+  ``axiom_encode_version``, currently 0.2.1184). The required ``validate /
+  validate`` check validates with that same pin, so generating with anything
+  newer risks schema/manifest skew. Do NOT "upgrade" the generation encoder to
+  match a brief that says ">=0.2.1190" -- that number refers only to the
+  *coverage/sync* tool below, not to generation.
+* **Coverage declaration uses axiom-encode main (>=0.2.1190)**, because the CI
+  changed-file coverage classifier (``oracle-coverage-axiom-encode-ref``,
+  default ``main``) is what reclassifies declared-pending outputs from
+  ``unmapped`` to ``pending_classification``. The pinned 1184 encoder does not
+  even have the ``oracle-coverage-pending`` subcommand.
+
+Everything runs foreground. The loop is chunked (``--max-seconds``,
+``--max-entries``) and every unit of durable state (pushed branch, opened PR,
+worklist status flip, PROGRESS.md) is committed per entry, so a jetsam kill
+between chunks loses nothing: re-run and it resumes. On a Codex
+subscription-limit signal it PAUSES (never hammers), writes state, and exits 0.
+
+Toolchain layout (override via env): a sibling ``_bulk_drain`` workspace holds
+pinned checkouts + venvs built once by the operator:
+
+    _bulk_drain/
+      axiom-encode/            # worktree @ pinned axiom_encode_ref (1184)
+      .venv/                   # pinned encoder venv  -> generation
+      axiom-encode-cov/        # worktree @ axiom-encode main (>=1190)
+      .venv-cov/               # coverage/sync venv   -> oracle-coverage-pending
+      axiom-rules-engine/      # worktree @ pinned engine ref, cargo build
+      axiom-corpus/            # worktree @ pinned corpus ref
+      wt/<slug>/rulespec-us/   # per-entry generation worktrees (leaf MUST be rulespec-us)
+
+Usage:
+    python bulk/local_drain.py drain   [--limit N] [--batch A] [--concurrency 3]
+                                       [--max-entries N] [--max-seconds 540]
+    python bulk/local_drain.py unstick [--pr N ...] [--all] [--wait]
+    python bulk/local_drain.py doctor  # verify toolchain + auth + signing key
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import tomllib
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+REPO = "TheAxiomFoundation/rulespec-us"
+REPO_NAME = "rulespec-us"
+HERE = Path(__file__).resolve().parent           # <checkout>/bulk
+CHECKOUT = HERE.parent                            # this checkout root
+
+# --- toolchain / workspace resolution ---------------------------------------
+DRAIN_BASE = Path(
+    os.environ.get("DRAIN_BASE", Path.home() / "TheAxiomFoundation" / "_bulk_drain")
+).resolve()
+GEN_AE = Path(os.environ.get("DRAIN_GEN_AE", DRAIN_BASE / ".venv/bin/axiom-encode"))
+COV_AE = Path(os.environ.get("DRAIN_COV_AE", DRAIN_BASE / ".venv-cov/bin/axiom-encode"))
+COV_PY = Path(os.environ.get("DRAIN_COV_PY", DRAIN_BASE / ".venv-cov/bin/python"))
+ENGINE = Path(os.environ.get("DRAIN_ENGINE", DRAIN_BASE / "axiom-rules-engine"))
+CORPUS = Path(os.environ.get("DRAIN_CORPUS", DRAIN_BASE / "axiom-corpus"))
+ENGINE_BIN = ENGINE / "target" / "debug"
+WT_ROOT = DRAIN_BASE / "wt"
+
+BACKEND = os.environ.get("DRAIN_BACKEND", "codex")
+MODEL = os.environ.get("DRAIN_MODEL", "gpt-5.5")
+
+# Codex subscription-limit signatures. On any of these we PAUSE the whole drain.
+LIMIT_SIGNS = re.compile(
+    r"rate.?limit|usage limit|quota|insufficient_quota|too many requests|"
+    r"\b429\b|reached your (usage|limit)|plan limit|overloaded",
+    re.I,
+)
+
+_print_lock = threading.Lock()
+_wt_lock = threading.Lock()          # git worktree add/remove is not concurrency-safe
+_PAUSE = threading.Event()
+
+
+def log(msg: str) -> None:
+    with _print_lock:
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def run(cmd, cwd=None, env=None, capture=True, check=False, timeout=None):
+    """Run a subprocess, returning (rc, combined_output)."""
+    full = dict(os.environ)
+    if env:
+        full.update(env)
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        env=full,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+        text=True,
+        timeout=timeout,
+    )
+    out = proc.stdout or "" if capture else ""
+    if check and proc.returncode != 0:
+        raise RuntimeError(f"cmd failed ({proc.returncode}): {' '.join(map(str, cmd))}\n{out}")
+    return proc.returncode, out
+
+
+def signing_key() -> str:
+    key = os.environ.get("AXIOM_ENCODE_APPLY_SIGNING_KEY", "").strip()
+    if key:
+        return key
+    agent_secret = str(Path.home() / "bin/agent-secret")
+    for cmd in (
+        [agent_secret, "get", "agent/axiom-encode-apply-signing-key"],
+        ["agent-secret", "get", "agent/axiom-encode-apply-signing-key"],
+    ):
+        try:
+            rc, out = run(cmd)
+            if rc == 0 and out.strip():
+                return out.strip()
+        except FileNotFoundError:
+            continue
+    raise SystemExit("Signing key AXIOM_ENCODE_APPLY_SIGNING_KEY unavailable "
+                     "(tried env + agent-secret + manage-secret.sh).")
+
+
+def pinned_toolchain() -> dict:
+    data = tomllib.loads((CHECKOUT / ".axiom/toolchain.toml").read_text())
+    return data.get("toolchain", data)
+
+
+def citation_slug(citation: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", citation.strip().lower())
+    return slug.strip("-")
+
+
+def gh_json(args):
+    rc, out = run(["gh", *args])
+    if rc != 0:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+# --- worktree helpers -------------------------------------------------------
+def make_worktree(slug: str, ref: str) -> Path:
+    """Fresh generation worktree whose leaf dir is exactly ``rulespec-us``
+    (the --apply resolver requirement) with sibling engine/corpus symlinks."""
+    parent = WT_ROOT / slug
+    leaf = parent / REPO_NAME
+    with _wt_lock:
+        if leaf.exists():
+            run(["git", "-C", str(CHECKOUT), "worktree", "remove", "--force", str(leaf)])
+        parent.mkdir(parents=True, exist_ok=True)
+        run(["git", "-C", str(CHECKOUT), "fetch", "origin", "main", "--quiet"])
+        run(["git", "-C", str(CHECKOUT), "worktree", "add", "--detach", str(leaf), ref])
+    for name, target in (("axiom-rules-engine", ENGINE), ("axiom-corpus", CORPUS)):
+        link = parent / name
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(target)
+    return leaf
+
+
+def drop_worktree(leaf: Path) -> None:
+    with _wt_lock:
+        run(["git", "-C", str(CHECKOUT), "worktree", "remove", "--force", str(leaf)])
+
+
+def regen_index(leaf: Path) -> None:
+    script = leaf / "tests/generate_reverse_index.py"
+    if script.exists():
+        run([str(COV_PY), str(script)], cwd=leaf)
+
+
+def sync_pending(leaf: Path) -> str:
+    """Write oracle-coverage-pending.yaml for REPO_NAME using the >=1190 tool.
+    Returns the sync summary line."""
+    rc, out = run([str(COV_AE), "oracle-coverage-pending", "sync",
+                   "--root", str(leaf.parent), "--repo", REPO_NAME, "--source", "bulk"],
+                  env={"PATH": f"{ENGINE_BIN}:{os.environ['PATH']}"})
+    if rc != 0:
+        raise RuntimeError(f"oracle-coverage-pending sync failed:\n{out}")
+    return out.strip().splitlines()[-1] if out.strip() else "(no output)"
+
+
+def finalize_pending(leaf: Path) -> bool:
+    """Keep oracle-coverage-pending.yaml only when it declares entries or is
+    already tracked on the branch. A fully-mapped module syncs an *empty*
+    declaration; committing that empty repo-root file would needlessly flip the
+    PR to full-matrix validation. Drop it so mapped modules stay shard-scoped.
+    Returns True when a pending file remains to stage."""
+    pf = leaf / "oracle-coverage-pending.yaml"
+    if not pf.exists():
+        return False
+    tracked = run(["git", "-C", str(leaf), "ls-files", "--error-unmatch",
+                   "oracle-coverage-pending.yaml"])[0] == 0
+    has_entries = "- legal_id:" in pf.read_text(encoding="utf-8")
+    if not has_entries and not tracked:
+        pf.unlink()
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# PART A: unstick already-open new-state bulk PRs (priority).
+# ---------------------------------------------------------------------------
+def open_bulk_prs():
+    data = gh_json(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "200",
+                    "--json", "number,headRefName,mergeStateStatus,statusCheckRollup"])
+    prs = []
+    for pr in data or []:
+        if not pr["headRefName"].startswith("bulk/"):
+            continue
+        vv = next((c.get("conclusion") or c.get("state")
+                   for c in pr.get("statusCheckRollup") or []
+                   if c.get("name") == "validate / validate"), None)
+        prs.append({"number": pr["number"], "branch": pr["headRefName"],
+                    "merge": pr["mergeStateStatus"], "validate": vv})
+    return sorted(prs, key=lambda p: p["number"])
+
+
+def unstick_pr(branch: str, wait: bool) -> str:
+    """Rebuild the stuck PR branch as origin/main + the module artifacts + a
+    fresh oracle-coverage-pending sync + reverse index.
+
+    Overlay (not merge): a fresh main-based branch with the module's RuleSpec
+    artifacts re-applied and the derived files (pending lane, reverse index)
+    regenerated. This is always up-to-date with main (strict branch protection)
+    and never conflicts on the shared oracle-coverage-pending.yaml as siblings
+    merge one after another.
+    """
+    slug = branch.split("/", 1)[1]
+    leaf = make_worktree(f"unstick-{slug}", "origin/main")
+    try:
+        run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
+        run(["git", "-C", str(leaf), "fetch", "origin", branch, "--quiet"])
+        _, diff = run(["git", "-C", str(leaf), "diff", "--name-only",
+                       f"origin/main...FETCH_HEAD"])
+        artifacts = [f for f in diff.splitlines()
+                     if (MODULE_RE.match(f) or f.endswith(".test.yaml")
+                         or "/.axiom/encoding-manifests/" in f)]
+        if not artifacts:
+            return f"{branch}: no module artifacts in diff (already merged?)"
+        run(["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],
+            check=True)
+        summary = sync_pending(leaf)
+        keep_pending = finalize_pending(leaf)
+        regen_index(leaf)
+        add_files = [*artifacts, ".axiom/index/provisions_to_rules.json"]
+        if keep_pending:
+            add_files.append("oracle-coverage-pending.yaml")
+        run(["git", "-C", str(leaf), "add", "--", *add_files])
+        module = next((a for a in artifacts if MODULE_RE.match(a)
+                       and not a.endswith(".test.yaml")), artifacts[0])
+        msg = (f"Encode {module.rsplit('/', 1)[0]} + declare oracle-coverage "
+               f"pending lane ({slug}, bulk)\n\n"
+               "Rebuilt on origin/main with the module's unmapped outputs "
+               "declared in oracle-coverage-pending.yaml so the changed-file "
+               "PolicyEngine oracle-coverage gate passes.\n\n"
+               "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
+        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
+             "-c", "user.name=bulk-encode", "commit", "-q", "-m", msg])
+        run(["git", "-C", str(leaf), "push", "-f", "origin", f"HEAD:{branch}"], check=True)
+        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
+        result = f"rebuilt+pushed {branch}: {summary}"
+        if wait:
+            result += "; " + wait_for_merge(branch)
+        return result
+    finally:
+        drop_worktree(leaf)
+
+
+def wait_for_merge(branch: str, timeout_s: int = 1500) -> str:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        pr = gh_json(["pr", "view", branch, "--repo", REPO,
+                      "--json", "state,mergeStateStatus,statusCheckRollup"])
+        if not pr:
+            return "poll-error"
+        if pr["state"] == "MERGED":
+            return "MERGED"
+        vv = next((c.get("conclusion") or c.get("state")
+                   for c in pr.get("statusCheckRollup") or []
+                   if c.get("name") == "validate / validate"), None)
+        if vv in ("FAILURE", "ERROR"):
+            return f"validate={vv} (needs triage)"
+        time.sleep(30)
+    return "timeout-waiting-merge"
+
+
+# ---------------------------------------------------------------------------
+# PART B: generate + PR one pending worklist entry via local Codex.
+# ---------------------------------------------------------------------------
+MODULE_RE = re.compile(
+    r"^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$")
+
+
+def already_handled(slug: str) -> bool:
+    pr = gh_json(["pr", "list", "--repo", REPO, "--head", f"bulk/{slug}",
+                  "--state", "all", "--json", "number,state"])
+    return bool(pr)
+
+
+def encode_entry(item: dict) -> dict:
+    """Full local mirror of bulk-encode.yml for one entry. Returns a result dict."""
+    citation, slug = item["citation"], item["slug"]
+    res = {"citation": citation, "slug": slug, "status": "failed", "detail": ""}
+    if _PAUSE.is_set():
+        res["detail"] = "paused"
+        return res
+    if already_handled(slug):
+        res["status"] = "skipped"
+        res["detail"] = "bulk/<slug> PR already exists"
+        return res
+    leaf = make_worktree(slug, "origin/main")
+    tmp = WT_ROOT / slug / "encode-out"
+    env = {
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": signing_key(),
+        "AXIOM_CORPUS_REPO": str(CORPUS),
+        "AXIOM_RULESPEC_REPO_ROOTS": str(leaf),
+        # The pinned encoder's bin MUST be on PATH: the --apply manifest step
+        # resolves axiom-encode git provenance via the on-PATH entrypoint, and
+        # without it apply fails "git provenance is unavailable".
+        "PATH": f"{GEN_AE.parent}:{ENGINE_BIN}:{os.environ['PATH']}",
+    }
+    try:
+        rc, out = run(
+            [str(GEN_AE), "encode", citation, "--backend", BACKEND, "--model", MODEL,
+             "--policy-repo-path", str(leaf),
+             "--axiom-rules-engine-path", str(ENGINE),
+             "--corpus-path", str(CORPUS),
+             "--output", str(tmp), "--apply", "--no-sync"],
+            cwd=leaf, env=env, timeout=3600)
+        if LIMIT_SIGNS.search(out):
+            _PAUSE.set()
+            res["status"], res["detail"] = "paused", "codex subscription-limit signal"
+            return res
+        _, st = run(["git", "-C", str(leaf), "status", "--porcelain", "-uall"])
+        applied = [ln[3:] for ln in st.splitlines()
+                   if MODULE_RE.match(ln[3:]) and not ln[3:].endswith(".test.yaml")]
+        if rc != 0 or not applied:
+            res["detail"] = f"encode/apply failed (rc={rc}); see {tmp}"
+            return res
+        module = applied[0]
+        test_file = module[:-5] + ".test.yaml"
+        juris = module.split("/", 1)[0]
+        rest = module[len(juris) + 1:]
+        manifest = f"{juris}/.axiom/encoding-manifests/{rest[:-5]}.json"
+        if not (leaf / manifest).exists():
+            hits = list((leaf / juris / ".axiom/encoding-manifests").rglob(
+                Path(module).stem + ".json"))
+            manifest = str(hits[0].relative_to(leaf)) if hits else manifest
+        regen_index(leaf)
+
+        # gate battery (fail-closed pre-check, PR-CI order)
+        run(["git", "-C", str(leaf), "add", "--", module, test_file, manifest,
+             ".axiom/index/provisions_to_rules.json"])
+        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
+             "-c", "user.name=bulk-encode", "commit", "-q", "-m", f"wip: {citation}"])
+        roots = subprocess.run([str(COV_PY), str(leaf / "bulk/roots_for.py"), module],
+                               capture_output=True, text=True).stdout.strip() or "us"
+        for gate in (
+            [str(GEN_AE), "guard-generated", "--repo", str(leaf),
+             "--base-ref", "origin/main", "--head-ref", "HEAD", "--roots", roots],
+            [str(GEN_AE), "validate", str(leaf / module), "--skip-reviewers"],
+            [str(GEN_AE), "proof-validate", str(leaf / module)],
+        ):
+            grc, gout = run(gate, cwd=leaf, env=env)
+            if grc != 0:
+                res["detail"] = f"gate failed: {gate[1]}\n{gout[-800:]}"
+                return res
+        trc, _ = run([str(GEN_AE), "test", "--root", str(leaf),
+                      "--axiom-rules-engine-path", str(ENGINE), str(leaf / test_file)],
+                     cwd=leaf, env=env)
+        gate_status = "green" if trc == 0 else "needs-fixtures"
+
+        # declare oracle-coverage pending lane (the step the cloud dispatcher lacks)
+        sync_summary = sync_pending(leaf)
+        keep_pending = finalize_pending(leaf)
+        regen_index(leaf)
+
+        branch = f"bulk/{slug}"
+        title = f"Encode {citation} (bulk)"
+        if gate_status == "needs-fixtures":
+            title = f"Encode {citation} (bulk, needs-fixtures)"
+        add_files = [".axiom/index/provisions_to_rules.json"]
+        if keep_pending:
+            add_files.append("oracle-coverage-pending.yaml")
+        run(["git", "-C", str(leaf), "add", "--", *add_files])
+        commit_msg = (f"Encode {citation} via local drain\n\n"
+                      f"Produced by axiom-encode encode {citation} --apply "
+                      f"(backend {BACKEND}, model {MODEL}, pinned encoder). "
+                      f"{sync_summary}\n\n"
+                      "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
+        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
+             "-c", "user.name=bulk-encode", "commit", "-q", "--amend", "-m", commit_msg])
+        run(["git", "-C", str(leaf), "push", "-f", "origin", f"HEAD:{branch}"], check=True)
+        run(["gh", "label", "create", "bulk-encode", "--repo", REPO,
+             "--color", "1f6feb", "-d", "Opened by the bulk-encode dispatcher"])
+        body = (f"## Locally bulk-encoded module\n\n- Citation: `{citation}`\n"
+                f"- Module: `{module}`\n- Encoder: `{BACKEND}:{MODEL}` "
+                f"(toolchain-pinned axiom-encode)\n- Local gate: **{gate_status}**\n"
+                f"- {sync_summary}\n\nProduced by `bulk/local_drain.py` "
+                "(local Codex mirror of the bulk-encode dispatcher). The "
+                "authoritative gate is the required `validate / validate` check.")
+        bf = WT_ROOT / slug / "pr-body.md"
+        bf.write_text(body)
+        run(["gh", "pr", "create", "--repo", REPO, "--base", "main", "--head", branch,
+             "--title", title, "--body-file", str(bf), "--label", "bulk-encode"])
+        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
+        res["status"] = gate_status
+        res["detail"] = f"PR opened on {branch}; {sync_summary}"
+        return res
+    except subprocess.TimeoutExpired:
+        res["detail"] = "encode timed out (>3600s)"
+        return res
+    finally:
+        drop_worktree(leaf)
+
+
+# --- worklist status flips (small, reviewable, batched) ---------------------
+def flip_statuses(updates: dict) -> None:
+    """updates: {citation: status}. Commits to worklist on a small branch + PR."""
+    if not updates:
+        return
+    leaf = make_worktree("worklist-flip", "origin/main")
+    try:
+        run(["git", "-C", str(leaf), "checkout", "-B", "bulk/worklist-status-flip"])
+        for citation, status in updates.items():
+            run([str(COV_PY), str(leaf / "bulk/compute_matrix.py"),
+                 "--set-status", citation, status], cwd=leaf)
+        run(["git", "-C", str(leaf), "add", "bulk/worklist.yaml"])
+        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
+             "-c", "user.name=bulk-encode", "commit", "-q", "-m",
+             "Flip drained worklist statuses (bulk)\n\n"
+             "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"])
+        run(["git", "-C", str(leaf), "push", "-f", "origin",
+             "HEAD:bulk/worklist-status-flip"], check=True)
+        run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
+             "--head", "bulk/worklist-status-flip", "--title",
+             "Flip drained worklist statuses (bulk)", "--body",
+             "Status flips for locally-drained entries.", "--label", "bulk-encode"])
+        run(["gh", "pr", "merge", "bulk/worklist-status-flip", "--repo", REPO,
+             "--auto", "--squash"])
+    finally:
+        drop_worktree(leaf)
+
+
+# --- PROGRESS.md ------------------------------------------------------------
+def write_progress(results: list, remaining: int, paused: bool) -> None:
+    p = CHECKOUT / "bulk" / "PROGRESS-local-drain.md"
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [f"# Local drain progress ({now})", ""]
+    if paused:
+        lines += ["> **PAUSED on Codex subscription-limit signal.** Re-run after "
+                  "the window resets; the drain resumes idempotently.", ""]
+    lines += [f"- Remaining pending: {remaining}",
+              f"- Handled this run: {len(results)}", "",
+              "| citation | result | detail |", "| --- | --- | --- |"]
+    for r in results:
+        d = r["detail"].splitlines()[0][:80] if r["detail"] else ""
+        lines.append(f"| `{r['citation']}` | {r['status']} | {d} |")
+    p.write_text("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+def cmd_doctor(_args) -> int:
+    tc = pinned_toolchain()
+    print(f"DRAIN_BASE           : {DRAIN_BASE}")
+    for label, ae, want_pending in (("gen encoder (pin)", GEN_AE, False),
+                                    ("cov encoder (main)", COV_AE, True)):
+        has_pending = ae.exists() and run(
+            [str(ae), "oracle-coverage-pending", "--help"])[0] == 0
+        ok = ae.exists() and (has_pending == want_pending)
+        print(f"{label:20s}: {'OK' if ok else 'CHECK'} "
+              f"(oracle-coverage-pending {'present' if has_pending else 'absent'})")
+    print(f"pinned encoder ver   : {tc.get('axiom_encode_version')}")
+    print(f"engine bin           : {'OK' if ENGINE_BIN.exists() else 'MISSING'} {ENGINE_BIN}")
+    print(f"corpus               : {'OK' if CORPUS.exists() else 'MISSING'} {CORPUS}")
+    try:
+        print(f"signing key          : present (len {len(signing_key())})")
+    except SystemExit as e:
+        print(f"signing key          : {e}")
+    rc, out = run(["codex", "--version"])
+    print(f"codex CLI            : {'OK ' + out.strip() if rc == 0 else 'MISSING'}")
+    return 0
+
+
+def cmd_unstick(args) -> int:
+    prs = open_bulk_prs()
+    if args.pr:
+        targets = [p for p in prs if p["number"] in set(args.pr)]
+    elif args.all:
+        targets = [p for p in prs if p["validate"] in (None, "FAILURE", "ERROR", "PENDING")]
+    else:
+        print("Specify --pr N [N ...] or --all. Open bulk PRs:")
+        for p in prs:
+            print(f"  #{p['number']:4d} {p['branch']:40s} validate={p['validate']} merge={p['merge']}")
+        return 0
+    log(f"unstick {len(targets)} PR(s): {[p['number'] for p in targets]}")
+    for p in targets:
+        try:
+            log(f"#{p['number']} {p['branch']}: {unstick_pr(p['branch'], wait=args.wait)}")
+        except Exception as exc:  # noqa: BLE001 - operator tool, report and continue
+            log(f"#{p['number']} {p['branch']}: ERROR {exc}")
+    return 0
+
+
+def cmd_drain(args) -> int:
+    matrix = json.loads(subprocess.run(
+        [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
+         "--status", "pending", "--format", "matrix",
+         *(["--batch", args.batch] if args.batch else []),
+         *(["--limit", str(args.limit)] if args.limit else [])],
+        capture_output=True, text=True, cwd=CHECKOUT).stdout)["include"]
+    if args.max_entries:
+        matrix = matrix[: args.max_entries]
+    log(f"drain {len(matrix)} entr(ies), concurrency={args.concurrency}")
+    results, flips = [], {}
+    deadline = time.time() + args.max_seconds
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futs = {}
+        for item in matrix:
+            if time.time() > deadline or _PAUSE.is_set():
+                break
+            futs[ex.submit(encode_entry, item)] = item
+        for fut in concurrent.futures.as_completed(futs):
+            r = fut.result()
+            results.append(r)
+            log(f"{r['citation']}: {r['status']} - {r['detail'].splitlines()[0] if r['detail'] else ''}")
+            if r["status"] in ("green", "needs-fixtures"):
+                flips[r["citation"]] = "pr-open" if r["status"] == "green" else "needs-fixtures"
+            elif r["status"] == "failed":
+                flips[r["citation"]] = "failed"
+    remaining = int(subprocess.run(
+        [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
+         "--status", "pending", "--format", "count"],
+        capture_output=True, text=True, cwd=CHECKOUT).stdout or 0)
+    write_progress(results, remaining, _PAUSE.is_set())
+    try:
+        flip_statuses(flips)
+    except Exception as exc:  # noqa: BLE001
+        log(f"worklist flip deferred: {exc}")
+    log(f"chunk done: {len(results)} handled, {remaining} pending remain, "
+        f"paused={_PAUSE.is_set()}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    d = sub.add_parser("drain", help="Encode pending worklist entries via local Codex.")
+    d.add_argument("--limit", type=int)
+    d.add_argument("--batch")
+    d.add_argument("--concurrency", type=int, default=3)
+    d.add_argument("--max-entries", type=int)
+    d.add_argument("--max-seconds", type=int, default=540)
+    d.set_defaults(func=cmd_drain)
+    u = sub.add_parser("unstick", help="Sync-declare + rebase open new-state bulk PRs.")
+    u.add_argument("--pr", type=int, nargs="*", default=[])
+    u.add_argument("--all", action="store_true")
+    u.add_argument("--wait", action="store_true", help="Poll each PR until merged.")
+    u.set_defaults(func=cmd_unstick)
+    doc = sub.add_parser("doctor", help="Verify toolchain, auth, signing key.")
+    doc.set_defaults(func=cmd_doctor)
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -52,6 +52,13 @@ def allowed_yaml_roots() -> set[str]:
         "known-dangling.yaml",
         "known-missing-money-atoms.yaml",
         "known-validation-gaps.yaml",
+        # Declared oracle-coverage debt lane, written at the repo root by
+        # `axiom-encode oracle-coverage-pending sync`. The changed-file oracle
+        # coverage gate reclassifies these outputs from unmapped to
+        # pending_classification; the bulk-encode dispatcher (and bulk/
+        # local_drain.py) sync it for every new-state module so the required
+        # validate check passes instead of hanging on `... : unmapped`.
+        "oracle-coverage-pending.yaml",
         *(d.name for d in jurisdiction_dirs()),
     }
 


### PR DESCRIPTION
## Complete the oracle-coverage pending-lane integration + local Codex drain runner

**Problem.** Every new-state bulk PR (#614-616, #619-636, …) fails the required `validate / validate` check on the changed-file PolicyEngine oracle-coverage gate — the modules' executable outputs are `unmapped` and nothing declares them. The `oracle-coverage-pending` tool shipped in axiom-encode without its rulespec-us repo side, so `oracle-coverage-pending sync` alone still trips two whole-repo gates.

**Fix (repo side).**
- `tests/test_repository_layout.py`: allowlist `oracle-coverage-pending.yaml` (written at the repo root by `sync`) so the whole-repo layout gate stops flagging it as a stray root YAML.
- `.github/workflows/bulk-encode.yml`: install the axiom-encode `main` oracle-coverage classifier (the `oracle-coverage-axiom-encode-ref` default) in an isolated venv and run `oracle-coverage-pending sync` after `--apply`, staging the declaration into the module commit so new-state PRs self-declare and pass the gate.

**Runner.** `bulk/local_drain.py` mirrors the dispatcher locally using the Codex CLI (`gpt-5.5`): pinned-encoder generation, the same gate battery + sync, one PR per module with auto-merge, worklist status flips, jetsam-safe chunking, and a pause (never hammer) on a Codex subscription-limit signal. `unstick` mode declares the pending lane on the already-open new-state PRs; `doctor` verifies the toolchain.

Verified end-to-end on #614 (us-oh/5747.02): sync flips its 10 outputs `unmapped → pending_classification` and the `validate / validate (us-oh)` shard goes green. The authoritative gate remains the required `validate / validate` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)