### PR TITLE
Allow oracle-coverage-pending.yaml as a root file in repository-structure

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -67,6 +67,7 @@ allowed_root_files:
   - known-dangling.yaml
   - known-missing-money-atoms.yaml
   - known-validation-gaps.yaml
+  - oracle-coverage-pending.yaml
 path_rules:
   - patterns:
       - ".axiom/**"


### PR DESCRIPTION
Second half of the oracle-coverage pending-lane integration (after #640). The org validate workflow's config-driven repository-structure check reads `.axiom/repository-structure.yaml` `allowed_root_files` and rejected the synced `oracle-coverage-pending.yaml` with "top-level file is not allowed", failing every new-state bulk PR. Allowlist it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)