### PR TITLE
Encode us-il/statute/35/5/506.5 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/506.5": [
+      {
+        "module": "us-il/statutes/35/5/506/5.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/506/5.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/506/5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/506/5.yaml",
+      "sha256": "2c476c9b28953d7b6d24c37ab7bed00a878ca65c3213118ce1bb7b5e7862dfa2"
+    },
+    {
+      "path": "statutes/35/5/506/5.test.yaml",
+      "sha256": "b2cd6e9f1c5d2e3405350c2182c366e570501457aba5baa6eb0c4ff18372eadb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/506.5",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-506-5/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-506.5/workspace/context-manifest.json",
+  "context_manifest_sha256": "df10f268d60b9a682f9c4b5c1ad20e5c00ec595e4278d27eb9595816a582eca8",
+  "generated_at": "2026-07-08T13:58:01.284860+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-506-5/encode-out/codex-gpt-5.5/statutes/35/5/506/5.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-506-5/encode-out",
+  "generated_output_sha256": "2c476c9b28953d7b6d24c37ab7bed00a878ca65c3213118ce1bb7b5e7862dfa2",
+  "generation_prompt_sha256": "3d919c59d3ed531d44d3bc51bf8de934ab60bf7fee1c9e3aefc6186c5a36ad1c",
+  "model": "gpt-5.5",
+  "run_id": "64808fa4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fbdc863f8eb93129f7a5411e4c1ad02a32ebe02fbd28bc0f8cf969c14761d858"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-506-5/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-506.5.json",
+  "trace_sha256": "04c6e3158ae16b8a172772265bc3fa53ccd5f1fc66a0ede5f0bc01af8099acb9"
+}

--- a/us-il/statutes/35/5/506/5.test.yaml
+++ b/us-il/statutes/35/5/506/5.test.yaml
@@ -1,0 +1,64 @@
+- name: substitute_w2_return_presumption_holds_when_all_conditions_met
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/506/5#input.received_wages_from_employer_in_illinois: true
+    us-il:statutes/35/5/506/5#input.lost_w2_form: true
+    us-il:statutes/35/5/506/5#input.was_not_provided_w2_form: false
+    us-il:statutes/35/5/506/5#input.unable_to_obtain_duplicate_w2_form_from_employer: true
+    us-il:statutes/35/5/506/5#input.obtained_substitute_w2_form_from_internal_revenue_service: true
+    us-il:statutes/35/5/506/5#input.substitute_w2_form_indicates_appropriate_federal_taxes_withheld: true
+    us-il:statutes/35/5/506/5#input.filed_copy_of_substitute_w2_form_with_illinois_income_tax_return: true
+    us-il:statutes/35/5/506/5#input.provided_mailing_address_for_correspondence_or_refund: true
+  output:
+    us-il:statutes/35/5/506/5#tax_withholding_presumed_appropriate_for_substitute_w2_return: holds
+- name: substitute_w2_return_presumption_fails_without_illinois_wages
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/506/5#input.received_wages_from_employer_in_illinois: false
+    us-il:statutes/35/5/506/5#input.lost_w2_form: true
+    us-il:statutes/35/5/506/5#input.was_not_provided_w2_form: false
+    us-il:statutes/35/5/506/5#input.unable_to_obtain_duplicate_w2_form_from_employer: true
+    us-il:statutes/35/5/506/5#input.obtained_substitute_w2_form_from_internal_revenue_service: true
+    us-il:statutes/35/5/506/5#input.substitute_w2_form_indicates_appropriate_federal_taxes_withheld: true
+    us-il:statutes/35/5/506/5#input.filed_copy_of_substitute_w2_form_with_illinois_income_tax_return: true
+    us-il:statutes/35/5/506/5#input.provided_mailing_address_for_correspondence_or_refund: true
+  output:
+    us-il:statutes/35/5/506/5#tax_withholding_presumed_appropriate_for_substitute_w2_return: not_holds
+- name: substitute_w2_return_presumption_fails_when_w2_was_neither_lost_nor_not_provided
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/506/5#input.received_wages_from_employer_in_illinois: true
+    us-il:statutes/35/5/506/5#input.lost_w2_form: false
+    us-il:statutes/35/5/506/5#input.was_not_provided_w2_form: false
+    us-il:statutes/35/5/506/5#input.unable_to_obtain_duplicate_w2_form_from_employer: true
+    us-il:statutes/35/5/506/5#input.obtained_substitute_w2_form_from_internal_revenue_service: true
+    us-il:statutes/35/5/506/5#input.substitute_w2_form_indicates_appropriate_federal_taxes_withheld: true
+    us-il:statutes/35/5/506/5#input.filed_copy_of_substitute_w2_form_with_illinois_income_tax_return: true
+    us-il:statutes/35/5/506/5#input.provided_mailing_address_for_correspondence_or_refund: true
+  output:
+    us-il:statutes/35/5/506/5#tax_withholding_presumed_appropriate_for_substitute_w2_return: not_holds
+- name: substitute_w2_return_presumption_fails_without_mailing_address
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/506/5#input.received_wages_from_employer_in_illinois: true
+    us-il:statutes/35/5/506/5#input.lost_w2_form: true
+    us-il:statutes/35/5/506/5#input.was_not_provided_w2_form: false
+    us-il:statutes/35/5/506/5#input.unable_to_obtain_duplicate_w2_form_from_employer: true
+    us-il:statutes/35/5/506/5#input.obtained_substitute_w2_form_from_internal_revenue_service: true
+    us-il:statutes/35/5/506/5#input.substitute_w2_form_indicates_appropriate_federal_taxes_withheld: true
+    us-il:statutes/35/5/506/5#input.filed_copy_of_substitute_w2_form_with_illinois_income_tax_return: true
+    us-il:statutes/35/5/506/5#input.provided_mailing_address_for_correspondence_or_refund: false
+  output:
+    us-il:statutes/35/5/506/5#tax_withholding_presumed_appropriate_for_substitute_w2_return: not_holds

--- a/us-il/statutes/35/5/506/5.yaml
+++ b/us-il/statutes/35/5/506/5.yaml
@@ -1,0 +1,40 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/506.5
+  summary: For a taxpayer who received wages from an employer in Illinois, lacks a
+    W-2, cannot obtain a duplicate from the employer, and obtains an IRS substitute
+    W-2, Illinois tax withholding is presumed appropriate if the substitute W-2 shows
+    appropriate federal withholding, the taxpayer files a copy with the Illinois return,
+    and provides a mailing address.
+rules:
+- name: tax_withholding_presumed_appropriate_for_substitute_w2_return
+  kind: derived
+  entity: Employer
+  dtype: Judgment
+  period: Year
+  source: 35 ILCS 5/506.5
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-il/statute/35/5/506.5
+  versions:
+  - effective_from: '2006-12-26'
+    formula: 'received_wages_from_employer_in_illinois
+
+      and (lost_w2_form or was_not_provided_w2_form)
+
+      and unable_to_obtain_duplicate_w2_form_from_employer
+
+      and obtained_substitute_w2_form_from_internal_revenue_service
+
+      and substitute_w2_form_indicates_appropriate_federal_taxes_withheld
+
+      and filed_copy_of_substitute_w2_form_with_illinois_income_tax_return
+
+      and provided_mailing_address_for_correspondence_or_refund'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/506.5`
- Module: `us-il/statutes/35/5/506/5.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-506-5/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.