### PR TITLE
Encode us-ca/statute/rtc/17054.7 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4804,6 +4804,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17054.7": [
+      {
+        "module": "us-ca/statutes/rtc/17054/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/wic/11450.12": [
       {
         "module": "us-ca/policies/cdss/calworks/financial-eligibility-income-tests.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17054/7.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17054/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17054/7.yaml",
+      "sha256": "154ab2fc5f1adaccc7fce69cf0b5e9f30cd13b2ed9c2c42949d6e12ca2b08964"
+    },
+    {
+      "path": "statutes/rtc/17054/7.test.yaml",
+      "sha256": "11641615c745ee96ea5c4ce416128c100100962c10e9bbfda3559ddb6475e634"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17054.7",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17054-7/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17054.7/workspace/context-manifest.json",
+  "context_manifest_sha256": "73dc8891ab1403caf1f7f64cdf6639343f85222e94ab15341be75bb051ce68d9",
+  "generated_at": "2026-07-08T14:03:40.383282+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17054-7/encode-out/codex-gpt-5.5/statutes/rtc/17054/7.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17054-7/encode-out",
+  "generated_output_sha256": "154ab2fc5f1adaccc7fce69cf0b5e9f30cd13b2ed9c2c42949d6e12ca2b08964",
+  "generation_prompt_sha256": "660febe50cfbb1ca7314f1985b66dca1cd7b7061e34c3d353a0a8685758551b5",
+  "model": "gpt-5.5",
+  "run_id": "597f8c3e",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ff491bf501c2cd78428200d1163774c2b53fa036fcb1ea17d496577ab3c92a54"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17054-7/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17054.7.json",
+  "trace_sha256": "84bcc72734d176e24cc292bc26c24f00a96a5ccb0a8a8e7156ab3068d5204d53"
+}

--- a/us-ca/statutes/rtc/17054/7.test.yaml
+++ b/us-ca/statutes/rtc/17054/7.test.yaml
@@ -1,0 +1,12 @@
+- name: recomputed_agi_limit_rounds_to_nearest_dollar
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ca:statutes/rtc/17054/7#input.california_consumer_price_index_percentage_change_modified_for_rental_equivalent_home_ownership_all_items
+    : 0.04
+    us-ca:statutes/rtc/17054/7#input.immediately_preceding_taxable_year_adjusted_gross_income_limitation: 50000
+  output:
+    us-ca:statutes/rtc/17054/7#adjusted_gross_income_inflation_adjustment_factor: 1.04
+    us-ca:statutes/rtc/17054/7#recomputed_adjusted_gross_income_limit: 52000

--- a/us-ca/statutes/rtc/17054/7.yaml
+++ b/us-ca/statutes/rtc/17054/7.yaml
@@ -1,0 +1,110 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17054.7
+  summary: |-
+    Allows a credit for a "qualified senior head of household" equal to 2 percent of taxable income. Defines that status by age 65 before year end, head-of-household qualification under Section 17042 for either of the two preceding taxable years by providing a household for a qualifying individual who died during either preceding year, and adjusted gross income not exceeding $37,500, with annual recomputation of that adjusted gross income limit.
+  deferred_outputs:
+    - output: us-ca:statutes/rtc/17054/7/c#qualified_senior_head_of_household
+      reason: Qualification depends on the head-of-household definition in Section 17042, which is cited by this source but not available in copied context.
+      source_values:
+        - us-ca:statutes/rtc/17054/7#qualified_senior_head_of_household_minimum_age
+        - us-ca:statutes/rtc/17054/7#statutory_adjusted_gross_income_limit
+    - output: us-ca:statutes/rtc/17054/7#a_credit_amount_for_qualified_senior_head_of_household
+      reason: The credit is available only for a qualified senior head of household, and that status depends on unavailable Section 17042 head-of-household mechanics.
+      source_values:
+        - us-ca:statutes/rtc/17054/7#senior_head_of_household_credit_rate
+rules:
+  - name: senior_head_of_household_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: 17054.7(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17054.7
+              excerpt: "an amount equal to 2 percent of the taxable income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.02
+
+  - name: statutory_adjusted_gross_income_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 17054.7(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17054.7
+              excerpt: "does not exceed thirty-seven thousand five hundred dollars ($37,500)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          37500
+
+  - name: qualified_senior_head_of_household_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: 17054.7(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17054.7
+              excerpt: "Attained the age of 65 before the close of the taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+
+  - name: adjusted_gross_income_inflation_adjustment_factor
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 17054.7(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17054.7
+              excerpt: "add 100 percent to the percentage change figure ... and divide the result by 100"
+    versions:
+      - effective_from: '1991-01-01'
+        formula: |-
+          (california_consumer_price_index_percentage_change_modified_for_rental_equivalent_home_ownership_all_items + 1)
+
+  - name: recomputed_adjusted_gross_income_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 17054.7(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17054.7
+              excerpt: "multiply the amount for the immediately preceding taxable year ... by the inflation adjustment factor ... and round off ... to the nearest one dollar ($1)"
+    versions:
+      - effective_from: '1991-01-01'
+        formula: |-
+          floor((immediately_preceding_taxable_year_adjusted_gross_income_limitation * adjusted_gross_income_inflation_adjustment_factor) + 0.5)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17054.7`
- Module: `us-ca/statutes/rtc/17054/7.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17054-7/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.