### PR TITLE
Encode us-ca/statute/rtc/17053.6 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4789,6 +4789,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17053.6": [
+      {
+        "module": "us-ca/statutes/rtc/17053/6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17054": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17053/6.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17053/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17053/6.yaml",
+      "sha256": "19375d1ad0aca376912d7416f4232e2068c1136c63b66484df1d56fb327984fc"
+    },
+    {
+      "path": "statutes/rtc/17053/6.test.yaml",
+      "sha256": "f83d2d2a8f8631c5b826918f812ee71e073bbdfd21df7747360cbf24a5a769c8"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17053.6",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17053-6/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17053.6/workspace/context-manifest.json",
+  "context_manifest_sha256": "572a445b53bec26fd1ff7024dfd32c6d4954fe90e2f28da12131f1acb488bd1c",
+  "generated_at": "2026-07-08T14:03:46.400881+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17053-6/encode-out/codex-gpt-5.5/statutes/rtc/17053/6.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17053-6/encode-out",
+  "generated_output_sha256": "19375d1ad0aca376912d7416f4232e2068c1136c63b66484df1d56fb327984fc",
+  "generation_prompt_sha256": "95f739ff78106b2578e8bdb5415d1cbaa1a0155e2a091fd5d0ee585d139ab0b7",
+  "model": "gpt-5.5",
+  "run_id": "8b00d875",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "36888f98d3264f0b341f6d4e8965ba273c4099ac99e271034bd22214743dd5b2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17053-6/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17053.6.json",
+  "trace_sha256": "cc545ef5863984e4f98d8a2b5fadb08582c0a95549b6ea71dd5a555f447dbbec"
+}

--- a/us-ca/statutes/rtc/17053/6.test.yaml
+++ b/us-ca/statutes/rtc/17053/6.test.yaml
@@ -1,0 +1,52 @@
+- name: qualifying prisoner wages receive ten percent credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17053/6#input.person_is_prisoner: true
+    us-ca:statutes/rtc/17053/6#input.person_is_employed_in_joint_venture_program_established_under_penal_code_article_1_5: true
+    us-ca:statutes/rtc/17053/6#input.employment_is_through_agreement_with_director_of_corrections: true
+    us-ca:statutes/rtc/17053/6#input.wages_paid_or_incurred_during_taxable_year: 5000
+  output:
+    us-ca:statutes/rtc/17053/6#wages_qualify_for_prisoner_joint_venture_credit: holds
+    us-ca:statutes/rtc/17053/6#prisoner_joint_venture_wage_credit: 500
+- name: nonprisoner wages do not qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17053/6#input.person_is_prisoner: false
+    us-ca:statutes/rtc/17053/6#input.person_is_employed_in_joint_venture_program_established_under_penal_code_article_1_5: true
+    us-ca:statutes/rtc/17053/6#input.employment_is_through_agreement_with_director_of_corrections: true
+    us-ca:statutes/rtc/17053/6#input.wages_paid_or_incurred_during_taxable_year: 5000
+  output:
+    us-ca:statutes/rtc/17053/6#wages_qualify_for_prisoner_joint_venture_credit: not_holds
+    us-ca:statutes/rtc/17053/6#prisoner_joint_venture_wage_credit: 0
+- name: prisoner outside joint venture program does not qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17053/6#input.person_is_prisoner: true
+    us-ca:statutes/rtc/17053/6#input.person_is_employed_in_joint_venture_program_established_under_penal_code_article_1_5: false
+    us-ca:statutes/rtc/17053/6#input.employment_is_through_agreement_with_director_of_corrections: true
+    us-ca:statutes/rtc/17053/6#input.wages_paid_or_incurred_during_taxable_year: 5000
+  output:
+    us-ca:statutes/rtc/17053/6#wages_qualify_for_prisoner_joint_venture_credit: not_holds
+    us-ca:statutes/rtc/17053/6#prisoner_joint_venture_wage_credit: 0
+- name: missing director agreement does not qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17053/6#input.person_is_prisoner: true
+    us-ca:statutes/rtc/17053/6#input.person_is_employed_in_joint_venture_program_established_under_penal_code_article_1_5: true
+    us-ca:statutes/rtc/17053/6#input.employment_is_through_agreement_with_director_of_corrections: false
+    us-ca:statutes/rtc/17053/6#input.wages_paid_or_incurred_during_taxable_year: 5000
+  output:
+    us-ca:statutes/rtc/17053/6#wages_qualify_for_prisoner_joint_venture_credit: not_holds
+    us-ca:statutes/rtc/17053/6#prisoner_joint_venture_wage_credit: 0

--- a/us-ca/statutes/rtc/17053/6.yaml
+++ b/us-ca/statutes/rtc/17053/6.yaml
@@ -1,0 +1,77 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17053.6
+  summary: |-
+    "There shall be allowed as a credit against the 'net tax' ... an amount equal to 10 percent of the amount of wages paid or incurred during the taxable year to each prisoner who is employed in a joint venture program..."
+rules:
+  - name: prisoner_joint_venture_wage_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: RTC 17053.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17053.6
+              excerpt: "10 percent of the amount of wages"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.10
+
+  - name: wages_qualify_for_prisoner_joint_venture_credit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: RTC 17053.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17053.6
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          person_is_prisoner
+          and person_is_employed_in_joint_venture_program_established_under_penal_code_article_1_5
+          and employment_is_through_agreement_with_director_of_corrections
+
+  - name: prisoner_joint_venture_wage_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: RTC 17053.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17053.6
+              excerpt: "10 percent of the amount of wages paid or incurred during the taxable year to each prisoner"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:statutes/rtc/17053/6#prisoner_joint_venture_wage_credit_rate
+              output: prisoner_joint_venture_wage_credit_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:statutes/rtc/17053/6#wages_qualify_for_prisoner_joint_venture_credit
+              output: wages_qualify_for_prisoner_joint_venture_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if wages_qualify_for_prisoner_joint_venture_credit: prisoner_joint_venture_wage_credit_rate * max(0, wages_paid_or_incurred_during_taxable_year) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17053.6`
- Module: `us-ca/statutes/rtc/17053/6.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17053-6/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.