### PR TITLE
Encode us-ny/statute/TAX/620-A (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16720,6 +16720,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/620-A": [
+      {
+        "module": "us-ny/statutes/TAX/620-A.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/672": [
       {
         "module": "us-ny/statutes/TAX/672.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/620-A.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/620-A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/620-A.yaml",
+      "sha256": "15b7ce64f2fbc7e130c7fb72cdafac5be50dd98753e51f3b8e8fa316ec74d1f7"
+    },
+    {
+      "path": "statutes/TAX/620-A.test.yaml",
+      "sha256": "c156f539ad59550fed0e5991eae472f337b0d55ea8ef56a6933d0193a03f57ac"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/620-A",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-620-a/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-620-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "1c29ac15bfb56a06b322b70eb2f279f2eb6e4295d91267c0a180a15e669f280c",
+  "generated_at": "2026-07-08T14:04:54.612572+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-620-a/encode-out/codex-gpt-5.5/statutes/TAX/620-A.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-620-a/encode-out",
+  "generated_output_sha256": "15b7ce64f2fbc7e130c7fb72cdafac5be50dd98753e51f3b8e8fa316ec74d1f7",
+  "generation_prompt_sha256": "7e292b10612e9afc7c474a68042b37068342cf043b754dfd41c6fbc67da944e8",
+  "model": "gpt-5.5",
+  "run_id": "c3cd4d23",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "78054c07a8f84d39252e3117dcdd030b19ae1a44b661ed845be41f3c77367d9b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-620-a/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-620-A.json",
+  "trace_sha256": "215fc8aefa0c6f2d89faf9174a00e76c77507c176722fb26d0a9f6c1dddbf37f"
+}

--- a/us-ny/statutes/TAX/620-A.test.yaml
+++ b/us-ny/statutes/TAX/620-A.test.yaml
@@ -1,0 +1,139 @@
+- name: resident_credit_limited_by_double_taxed_income_ratio
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction
+    : false
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_entire_tax_paid: 0
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax: 0
+    us-ny:statutes/TAX/620-A#input.all_income_subject_to_other_jurisdiction_tax: 1
+    us-ny:statutes/TAX/620-A#input.income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion: 300
+    us-ny:statutes/TAX/620-A#input.income_tax_is_imposed_by_province_of_canada: false
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year: 0
+    us-ny:statutes/TAX/620-A#input.total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603: 1000
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction: 500
+    us-ny:statutes/TAX/620-A#input.tax_otherwise_due_under_section_603: 400
+    us-ny:statutes/TAX/620-A#input.tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded: 100
+    us-ny:statutes/TAX/620-A#input.taxpayer_is_resident: true
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province: true
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603
+    : true
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: false
+    us-ny:statutes/TAX/620-A#input.credit_under_this_section_previously_allowed_for_that_provincial_tax: 0
+  output:
+    us-ny:statutes/TAX/620-A#other_jurisdiction_tax_on_ordinary_income_portion: 300
+    us-ny:statutes/TAX/620-A#other_jurisdiction_tax_allowed_after_canadian_federal_claim: 300
+    us-ny:statutes/TAX/620-A#credit_limit_by_double_taxed_income_ratio: 200
+    us-ny:statutes/TAX/620-A#credit_limit_by_exclusion_comparison: 300
+    us-ny:statutes/TAX/620-A#credit_against_separate_tax: 200
+    us-ny:statutes/TAX/620-A#provincial_credit_addback_for_succeeding_year: 0
+- name: apportioned_included_income_tax_and_exclusion_limit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction
+    : true
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_entire_tax_paid: 1000
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax: 2000
+    us-ny:statutes/TAX/620-A#input.all_income_subject_to_other_jurisdiction_tax: 10000
+    us-ny:statutes/TAX/620-A#input.income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion: 0
+    us-ny:statutes/TAX/620-A#input.income_tax_is_imposed_by_province_of_canada: false
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year: 0
+    us-ny:statutes/TAX/620-A#input.total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603: 1000
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction: 1000
+    us-ny:statutes/TAX/620-A#input.tax_otherwise_due_under_section_603: 500
+    us-ny:statutes/TAX/620-A#input.tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded: 350
+    us-ny:statutes/TAX/620-A#input.taxpayer_is_resident: true
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province: true
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603
+    : true
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: false
+    us-ny:statutes/TAX/620-A#input.credit_under_this_section_previously_allowed_for_that_provincial_tax: 0
+  output:
+    us-ny:statutes/TAX/620-A#other_jurisdiction_tax_on_ordinary_income_portion: 200
+    us-ny:statutes/TAX/620-A#credit_limit_by_exclusion_comparison: 150
+    us-ny:statutes/TAX/620-A#credit_against_separate_tax: 150
+- name: canadian_provincial_tax_reduced_by_federal_claim_and_added_back_later
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction
+    : false
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_entire_tax_paid: 0
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax: 0
+    us-ny:statutes/TAX/620-A#input.all_income_subject_to_other_jurisdiction_tax: 1
+    us-ny:statutes/TAX/620-A#input.income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion: 300
+    us-ny:statutes/TAX/620-A#input.income_tax_is_imposed_by_province_of_canada: true
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year: 80
+    us-ny:statutes/TAX/620-A#input.total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603: 1000
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction: 1000
+    us-ny:statutes/TAX/620-A#input.tax_otherwise_due_under_section_603: 500
+    us-ny:statutes/TAX/620-A#input.tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded: 100
+    us-ny:statutes/TAX/620-A#input.taxpayer_is_resident: true
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province: true
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603
+    : true
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: true
+    us-ny:statutes/TAX/620-A#input.credit_under_this_section_previously_allowed_for_that_provincial_tax: 75
+  output:
+    us-ny:statutes/TAX/620-A#other_jurisdiction_tax_allowed_after_canadian_federal_claim: 220
+    us-ny:statutes/TAX/620-A#credit_against_separate_tax: 220
+    us-ny:statutes/TAX/620-A#provincial_credit_addback_for_succeeding_year: 75
+- name: nonresident_gets_no_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction
+    : false
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_entire_tax_paid: 0
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax: 0
+    us-ny:statutes/TAX/620-A#input.all_income_subject_to_other_jurisdiction_tax: 1
+    us-ny:statutes/TAX/620-A#input.income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion: 300
+    us-ny:statutes/TAX/620-A#input.income_tax_is_imposed_by_province_of_canada: false
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year: 0
+    us-ny:statutes/TAX/620-A#input.total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603: 1000
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction: 1000
+    us-ny:statutes/TAX/620-A#input.tax_otherwise_due_under_section_603: 500
+    us-ny:statutes/TAX/620-A#input.tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded: 100
+    us-ny:statutes/TAX/620-A#input.taxpayer_is_resident: false
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province: true
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603
+    : true
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: false
+    us-ny:statutes/TAX/620-A#input.credit_under_this_section_previously_allowed_for_that_provincial_tax: 0
+  output:
+    us-ny:statutes/TAX/620-A#credit_against_separate_tax: 0
+- name: auto_zero_credit_limit_by_double_taxed_income_ratio
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ny:statutes/TAX/620-A#input.all_income_subject_to_other_jurisdiction_tax: false
+    us-ny:statutes/TAX/620-A#input.credit_under_this_section_previously_allowed_for_that_provincial_tax: 0
+    us-ny:statutes/TAX/620-A#input.income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion: 0
+    us-ny:statutes/TAX/620-A#input.income_tax_is_imposed_by_province_of_canada: false
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax: 0
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction
+    : false
+    ? us-ny:statutes/TAX/620-A#input.ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603
+    : false
+    us-ny:statutes/TAX/620-A#input.ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction: 0
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_entire_tax_paid: 0
+    us-ny:statutes/TAX/620-A#input.other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province: false
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: false
+    us-ny:statutes/TAX/620-A#input.provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year: 0
+    us-ny:statutes/TAX/620-A#input.tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded: false
+    us-ny:statutes/TAX/620-A#input.tax_otherwise_due_under_section_603: 0
+    us-ny:statutes/TAX/620-A#input.taxpayer_is_resident: false
+    us-ny:statutes/TAX/620-A#input.total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603: 0
+  output:
+    us-ny:statutes/TAX/620-A#credit_limit_by_double_taxed_income_ratio: 0

--- a/us-ny/statutes/TAX/620-A.yaml
+++ b/us-ny/statutes/TAX/620-A.yaml
@@ -1,0 +1,137 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/620-A
+  summary: |-
+    "A resident shall be allowed a credit against the separate tax otherwise due under section six hundred three" for income tax imposed by another state, political subdivision, the District of Columbia, or a Canadian province on the ordinary income portion of a lump sum distribution, subject to the apportionment rule and limitations in subdivisions (a) and (b).
+rules:
+  - name: other_jurisdiction_tax_on_ordinary_income_portion
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "the portion of the tax on such income ... shall be an amount bearing the same ratio to the entire tax paid"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if ordinary_income_portion_is_not_separately_taxed_by_other_jurisdiction_but_is_included_in_income_taxed_by_that_jurisdiction: other_jurisdiction_entire_tax_paid * ordinary_income_portion_included_in_income_subject_to_other_jurisdiction_tax / all_income_subject_to_other_jurisdiction_tax else: income_tax_imposed_by_other_jurisdiction_on_ordinary_income_portion
+
+  - name: other_jurisdiction_tax_allowed_after_canadian_federal_claim
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "for income tax imposed by a province of Canada shall be allowed for that portion of the provincial tax not claimed for federal purposes"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if income_tax_is_imposed_by_province_of_canada: max(0, other_jurisdiction_tax_on_ordinary_income_portion - provincial_tax_claimed_for_federal_purposes_for_taxable_year_or_preceding_taxable_year) else: other_jurisdiction_tax_on_ordinary_income_portion
+
+  - name: credit_limit_by_double_taxed_income_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "shall not exceed the percentage of the tax otherwise due under section six hundred three determined by dividing"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603 > 0: tax_otherwise_due_under_section_603 * ordinary_income_portion_taxable_both_under_section_603_and_other_jurisdiction / total_ordinary_income_portion_of_lump_sum_distribution_taxable_under_section_603 else: 0
+
+  - name: credit_limit_by_exclusion_comparison
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "shall not reduce the tax otherwise due under section six hundred three to an amount less than would have been due"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, tax_otherwise_due_under_section_603 - tax_due_under_section_603_if_double_taxed_ordinary_income_portion_were_excluded)
+
+  - name: credit_against_separate_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(a), (b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "A resident shall be allowed a credit against the separate tax otherwise due under section six hundred three"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "The credit under this section shall not exceed"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_is_resident and other_jurisdiction_is_state_political_subdivision_district_of_columbia_or_canadian_province and ordinary_income_portion_of_lump_sum_distribution_is_derived_from_other_jurisdiction_and_subject_to_section_603: max(0, min(min(other_jurisdiction_tax_allowed_after_canadian_federal_claim, credit_limit_by_double_taxed_income_ratio), credit_limit_by_exclusion_comparison)) else: 0
+
+  - name: provincial_credit_addback_for_succeeding_year
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 620-A(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/620-A
+              excerpt: "to the extent the provincial tax is claimed for federal purposes for a succeeding taxable year, the credit under this section must be added back"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if provincial_tax_claimed_for_federal_purposes_for_succeeding_taxable_year: credit_under_this_section_previously_allowed_for_that_provincial_tax else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/620-A`
- Module: `us-ny/statutes/TAX/620-A.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-620-a/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.