### PR TITLE
Encode us-ca/statute/rtc/17061 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4804,6 +4804,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17061": [
+      {
+        "module": "us-ca/statutes/rtc/17061.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/wic/11450.12": [
       {
         "module": "us-ca/policies/cdss/calworks/financial-eligibility-income-tests.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17061.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17061.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17061.yaml",
+      "sha256": "03b83e1e599e6ef1e5ea21cd2c263d77c0dbaf9c91108b0b60bcdf72c2b75eeb"
+    },
+    {
+      "path": "statutes/rtc/17061.test.yaml",
+      "sha256": "ab1459f325269fc938df38d4d1e39a01e53fa7edeb3500ec6cd217d89e218c0c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17061",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17061/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17061/workspace/context-manifest.json",
+  "context_manifest_sha256": "d9d46e080e3edff509d97de2600b24d89845a09e504442763c93f8459a91339c",
+  "generated_at": "2026-07-08T14:05:20.964045+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17061/encode-out/codex-gpt-5.5/statutes/rtc/17061.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17061/encode-out",
+  "generated_output_sha256": "03b83e1e599e6ef1e5ea21cd2c263d77c0dbaf9c91108b0b60bcdf72c2b75eeb",
+  "generation_prompt_sha256": "54832b9752b43be62d7aebe9beb901a0695452ca6aa5b953bd1a1fadf37c3fb2",
+  "model": "gpt-5.5",
+  "run_id": "ca3e0d57",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9393f022b42a2933b32bda4a45958ecc3e998a6caf2ca2229bb80f9e593e5923"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17061/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17061.json",
+  "trace_sha256": "f908fe5a0deee33a428d60361831633fa8f55787e0bb8a79e3e6aafc44f1cacc"
+}

--- a/us-ca/statutes/rtc/17061.test.yaml
+++ b/us-ca/statutes/rtc/17061.test.yaml
@@ -1,0 +1,69 @@
+- name: section_1176_refund_credit_and_excess_refund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17061#input.entitled_to_refund_under_unemployment_insurance_code_section_1176: true
+    us-ca:statutes/rtc/17061#input.refund_amount_under_unemployment_insurance_code_section_1176: 500
+    us-ca:statutes/rtc/17061#input.tax_due_after_deduction_of_any_other_credit_under_this_part: 300
+    us-ca:statutes/rtc/17061#input.franchise_tax_board_disallows_section_credit_or_refund: false
+    ? us-ca:statutes/rtc/17061#input.claimant_files_protest_with_director_of_employment_development_under_unemployment_insurance_code_section_1176_5
+    : false
+  output:
+    us-ca:statutes/rtc/17061#unemployment_insurance_section_1176_refund_credit: 500
+    us-ca:statutes/rtc/17061#unemployment_insurance_section_1176_excess_credit_tax_refund: 200
+- name: no_section_1176_entitlement_produces_no_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17061#input.entitled_to_refund_under_unemployment_insurance_code_section_1176: false
+    us-ca:statutes/rtc/17061#input.refund_amount_under_unemployment_insurance_code_section_1176: 500
+    us-ca:statutes/rtc/17061#input.tax_due_after_deduction_of_any_other_credit_under_this_part: 300
+    us-ca:statutes/rtc/17061#input.franchise_tax_board_disallows_section_credit_or_refund: false
+    ? us-ca:statutes/rtc/17061#input.claimant_files_protest_with_director_of_employment_development_under_unemployment_insurance_code_section_1176_5
+    : false
+  output:
+    us-ca:statutes/rtc/17061#unemployment_insurance_section_1176_refund_credit: 0
+    us-ca:statutes/rtc/17061#unemployment_insurance_section_1176_excess_credit_tax_refund: 0
+- name: disallowed_claim_without_protest_is_final_and_remedies_unavailable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17061#input.entitled_to_refund_under_unemployment_insurance_code_section_1176: true
+    us-ca:statutes/rtc/17061#input.refund_amount_under_unemployment_insurance_code_section_1176: 500
+    us-ca:statutes/rtc/17061#input.tax_due_after_deduction_of_any_other_credit_under_this_part: 300
+    us-ca:statutes/rtc/17061#input.franchise_tax_board_disallows_section_credit_or_refund: true
+    ? us-ca:statutes/rtc/17061#input.claimant_files_protest_with_director_of_employment_development_under_unemployment_insurance_code_section_1176_5
+    : false
+  output:
+    us-ca:statutes/rtc/17061#franchise_tax_board_action_on_section_credit_or_refund_final: holds
+    us-ca:statutes/rtc/17061#remedies_under_this_part_available_for_disallowed_section_credit_or_refund_claim: not_holds
+- name: protest_prevents_finality_after_disallowance
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17061#input.entitled_to_refund_under_unemployment_insurance_code_section_1176: true
+    us-ca:statutes/rtc/17061#input.refund_amount_under_unemployment_insurance_code_section_1176: 500
+    us-ca:statutes/rtc/17061#input.tax_due_after_deduction_of_any_other_credit_under_this_part: 300
+    us-ca:statutes/rtc/17061#input.franchise_tax_board_disallows_section_credit_or_refund: true
+    ? us-ca:statutes/rtc/17061#input.claimant_files_protest_with_director_of_employment_development_under_unemployment_insurance_code_section_1176_5
+    : true
+  output:
+    us-ca:statutes/rtc/17061#franchise_tax_board_action_on_section_credit_or_refund_final: not_holds
+    us-ca:statutes/rtc/17061#remedies_under_this_part_available_for_disallowed_section_credit_or_refund_claim: not_holds
+- name: auto_positive_remedies_under_this_part_available_for_disallowed_section_credit_or_refund_claim
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ca:statutes/rtc/17061#input.franchise_tax_board_disallows_section_credit_or_refund: false
+  output:
+    us-ca:statutes/rtc/17061#remedies_under_this_part_available_for_disallowed_section_credit_or_refund_claim: holds

--- a/us-ca/statutes/rtc/17061.yaml
+++ b/us-ca/statutes/rtc/17061.yaml
@@ -1,0 +1,92 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17061
+  summary: |-
+    In the case of a person entitled to a refund pursuant to Section 1176 of the Unemployment Insurance Code, there shall be a credit against the tax imposed under this part in the amount of such refund. If the remaining tax due is less than the credit, the difference shall be a tax refund. If the Franchise Tax Board disallows the refund or credit, specified protest and remedy limits apply.
+rules:
+  - name: unemployment_insurance_section_1176_refund_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Cal. Rev. & Tax. Code § 17061(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17061
+              excerpt: "there shall be a credit against the tax imposed under this part in the amount of such refund"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17061
+              excerpt: "person entitled to a refund pursuant to Section 1176 of the Unemployment Insurance Code"
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          if entitled_to_refund_under_unemployment_insurance_code_section_1176: refund_amount_under_unemployment_insurance_code_section_1176 else: 0
+
+  - name: unemployment_insurance_section_1176_excess_credit_tax_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Cal. Rev. & Tax. Code § 17061(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17061
+              excerpt: "If the tax due after deduction of any other credit under this part is less than the credit allowable pursuant to this section, the difference shall be a tax refund."
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          max(0, unemployment_insurance_section_1176_refund_credit - tax_due_after_deduction_of_any_other_credit_under_this_part)
+
+  - name: franchise_tax_board_action_on_section_credit_or_refund_final
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17061(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17061
+              excerpt: "The Franchise Tax Board’s action upon the credit or refund is final unless the claimant files a protest with the Director of Employment Development pursuant to Section 1176.5"
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          franchise_tax_board_disallows_section_credit_or_refund
+          and not claimant_files_protest_with_director_of_employment_development_under_unemployment_insurance_code_section_1176_5
+
+  - name: remedies_under_this_part_available_for_disallowed_section_credit_or_refund_claim
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17061(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17061
+              excerpt: "None of the remedies provided by this part shall be available to such claimant."
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          not franchise_tax_board_disallows_section_credit_or_refund


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17061`
- Module: `us-ca/statutes/rtc/17061.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17061/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.