### PR TITLE
Encode us-il/statute/35/5/705 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/705": [
+      {
+        "module": "us-il/statutes/35/5/705.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/705.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/705.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/705.yaml",
+      "sha256": "bd4378f2589092181e484000247542437363a96c9ed3ad346a79425410594636"
+    },
+    {
+      "path": "statutes/35/5/705.test.yaml",
+      "sha256": "0ced501d7b9e63b49d4c9233120984d9cacc651628464641c6b69b73d4ab3ac4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/705",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-705/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-705/workspace/context-manifest.json",
+  "context_manifest_sha256": "2144a1b3c7daf72f839e59cdcace0191a75e7d1c37d798fec1aef5a562c2cb29",
+  "generated_at": "2026-07-08T14:05:33.826752+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-705/encode-out/codex-gpt-5.5/statutes/35/5/705.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-705/encode-out",
+  "generated_output_sha256": "bd4378f2589092181e484000247542437363a96c9ed3ad346a79425410594636",
+  "generation_prompt_sha256": "f7b4fb060f109388644df25bbd211b38d740a72695bd50e3f4db79836e03c27a",
+  "model": "gpt-5.5",
+  "run_id": "8a26ef14",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aece1f2e997b854bfcf844bddda53a9f8111b074d8de7e8ef054394ca21124a1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-705/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-705.json",
+  "trace_sha256": "b7f9954ffe7ba274fe3a23de2ef4f7c5f9c1f20b92d25df1831d2841622631e2"
+}

--- a/us-il/statutes/35/5/705.test.yaml
+++ b/us-il/statutes/35/5/705.test.yaml
@@ -1,0 +1,53 @@
+- name: employer_withheld_tax_rules_apply_when_employer_withholds
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/705#input.employer_deducts_and_withholds_tax_under_act: true
+    us-il:statutes/35/5/705#input.employer_required_to_deduct_and_withhold_tax_under_act: false
+    us-il:statutes/35/5/705#input.amount_withheld_or_required_to_be_withheld_and_paid_over_to_department: 1000
+    us-il:statutes/35/5/705#input.penalties_and_interest_with_respect_to_withheld_tax: 50
+    us-il:statutes/35/5/705#input.tax_actually_deducted_and_withheld_under_act: 900
+  output:
+    us-il:statutes/35/5/705#employer_liable_for_withheld_tax: holds
+    us-il:statutes/35/5/705#employer_tax_for_assessment_and_collection: 1050
+    us-il:statutes/35/5/705#tax_held_in_trust_for_department: 900
+- name: employer_liable_when_required_to_withhold
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/705#input.employer_deducts_and_withholds_tax_under_act: false
+    us-il:statutes/35/5/705#input.employer_required_to_deduct_and_withhold_tax_under_act: true
+    us-il:statutes/35/5/705#input.amount_withheld_or_required_to_be_withheld_and_paid_over_to_department: 800
+    us-il:statutes/35/5/705#input.penalties_and_interest_with_respect_to_withheld_tax: 20
+    us-il:statutes/35/5/705#input.tax_actually_deducted_and_withheld_under_act: 0
+  output:
+    us-il:statutes/35/5/705#employer_liable_for_withheld_tax: holds
+    us-il:statutes/35/5/705#employer_tax_for_assessment_and_collection: 820
+    us-il:statutes/35/5/705#tax_held_in_trust_for_department: 0
+- name: employer_not_liable_when_neither_withheld_nor_required
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/705#input.employer_deducts_and_withholds_tax_under_act: false
+    us-il:statutes/35/5/705#input.employer_required_to_deduct_and_withhold_tax_under_act: false
+    us-il:statutes/35/5/705#input.amount_withheld_or_required_to_be_withheld_and_paid_over_to_department: 0
+    us-il:statutes/35/5/705#input.penalties_and_interest_with_respect_to_withheld_tax: 0
+    us-il:statutes/35/5/705#input.tax_actually_deducted_and_withheld_under_act: 0
+  output:
+    us-il:statutes/35/5/705#employer_liable_for_withheld_tax: not_holds
+    us-il:statutes/35/5/705#employer_tax_for_assessment_and_collection: 0
+    us-il:statutes/35/5/705#tax_held_in_trust_for_department: 0
+- name: employee_has_no_right_of_action_for_department_paid_withheld_wages
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us-il:statutes/35/5/705#employee_right_of_action_for_department_paid_withheld_wages: not_holds

--- a/us-il/statutes/35/5/705.yaml
+++ b/us-il/statutes/35/5/705.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/705
+  summary: |-
+    Every employer who deducts and withholds or is required to deduct and withhold tax under this Act is liable for such tax. Amounts withheld or required to be withheld and paid over, plus related penalties and interest, are considered the employer's tax for assessment and collection. Amounts actually deducted and withheld are held as a special fund in trust for the Department, and employees have no right of action for withheld wages paid over in compliance or intended compliance with the Act.
+rules:
+  - name: employer_liable_for_withheld_tax
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/705
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/705
+              excerpt: "Every employer who deducts and withholds or is required to deduct and withhold tax under this Act is liable"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          employer_deducts_and_withholds_tax_under_act
+          or employer_required_to_deduct_and_withhold_tax_under_act
+  - name: employer_tax_for_assessment_and_collection
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 35 ILCS 5/705
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/705
+              excerpt: "any amount withheld or required to be withheld and paid over to the Department, and any penalties and interest with respect thereto, shall be considered the tax of the employer"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          amount_withheld_or_required_to_be_withheld_and_paid_over_to_department + penalties_and_interest_with_respect_to_withheld_tax
+  - name: tax_held_in_trust_for_department
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 35 ILCS 5/705
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/705
+              excerpt: "Any amount of tax actually deducted and withheld under this Act shall be held to be a special fund in trust for the Department"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          tax_actually_deducted_and_withheld_under_act
+  - name: employee_right_of_action_for_department_paid_withheld_wages
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/705
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-il/statute/35/5/705
+              excerpt: "No employee shall have any right of action against his employer"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          false


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/705`
- Module: `us-il/statutes/35/5/705.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-705/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.