### PR TITLE
Encode us-il/statute/35/5/706 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/706": [
+      {
+        "module": "us-il/statutes/35/5/706.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/706.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/706.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/706.yaml",
+      "sha256": "df4607ccc5522a1fa8efa122e99cbc27e34f93d11e149b08919c9e8f3b77bdfa"
+    },
+    {
+      "path": "statutes/35/5/706.test.yaml",
+      "sha256": "2840ebb54d72a998910f49baab6c61809686c6ec46154c00397b6738f5f4ec26"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/706",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-706/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-706/workspace/context-manifest.json",
+  "context_manifest_sha256": "3be779f995c875ac72a4a0abded98d7701988f3e50c3c66226052574b520b621",
+  "generated_at": "2026-07-08T14:06:30.662082+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-706/encode-out/codex-gpt-5.5/statutes/35/5/706.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-706/encode-out",
+  "generated_output_sha256": "df4607ccc5522a1fa8efa122e99cbc27e34f93d11e149b08919c9e8f3b77bdfa",
+  "generation_prompt_sha256": "fb8940a1e4423e409bd86eb3b2a564fbefe6e81c6ab9ba4bd3c5dab50582cd92",
+  "model": "gpt-5.5",
+  "run_id": "58980456",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "69ee6789fa6c02715e76590e99de3092b8ebcf16f99cb23c0f79624baa2b4066"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-706/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-706.json",
+  "trace_sha256": "1e00250a738fcd8fa120db2997bccf57c628fdf32406c4fce82636d3a709355c"
+}

--- a/us-il/statutes/35/5/706.test.yaml
+++ b/us-il/statutes/35/5/706.test.yaml
@@ -1,0 +1,48 @@
+- name: paid_tax_after_withholding_failure_bars_collection_and_preserves_penalty_interest_liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/706#input.employer_failed_to_deduct_and_withhold_tax_required_under_act: true
+    us-il:statutes/35/5/706#input.tax_on_account_of_required_withholding_amount_is_paid: true
+    us-il:statutes/35/5/706#input.penalties_or_interest_otherwise_applicable_in_respect_of_failure: true
+  output:
+    us-il:statutes/35/5/706#withheld_tax_amount_collection_bar_applies: holds
+    us-il:statutes/35/5/706#employer_remains_liable_for_applicable_penalties_or_interest: holds
+- name: no_withholding_failure_no_collection_bar_or_penalty_interest_preservation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/706#input.employer_failed_to_deduct_and_withhold_tax_required_under_act: false
+    us-il:statutes/35/5/706#input.tax_on_account_of_required_withholding_amount_is_paid: true
+    us-il:statutes/35/5/706#input.penalties_or_interest_otherwise_applicable_in_respect_of_failure: true
+  output:
+    us-il:statutes/35/5/706#withheld_tax_amount_collection_bar_applies: not_holds
+    us-il:statutes/35/5/706#employer_remains_liable_for_applicable_penalties_or_interest: not_holds
+- name: unpaid_underlying_tax_no_collection_bar_or_penalty_interest_preservation_under_this_section
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/706#input.employer_failed_to_deduct_and_withhold_tax_required_under_act: true
+    us-il:statutes/35/5/706#input.tax_on_account_of_required_withholding_amount_is_paid: false
+    us-il:statutes/35/5/706#input.penalties_or_interest_otherwise_applicable_in_respect_of_failure: true
+  output:
+    us-il:statutes/35/5/706#withheld_tax_amount_collection_bar_applies: not_holds
+    us-il:statutes/35/5/706#employer_remains_liable_for_applicable_penalties_or_interest: not_holds
+- name: collection_bar_applies_even_when_no_penalty_or_interest_is_otherwise_applicable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/706#input.employer_failed_to_deduct_and_withhold_tax_required_under_act: true
+    us-il:statutes/35/5/706#input.tax_on_account_of_required_withholding_amount_is_paid: true
+    us-il:statutes/35/5/706#input.penalties_or_interest_otherwise_applicable_in_respect_of_failure: false
+  output:
+    us-il:statutes/35/5/706#withheld_tax_amount_collection_bar_applies: holds
+    us-il:statutes/35/5/706#employer_remains_liable_for_applicable_penalties_or_interest: not_holds

--- a/us-il/statutes/35/5/706.yaml
+++ b/us-il/statutes/35/5/706.yaml
@@ -1,0 +1,48 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/706
+  summary: |-
+    If an employer fails to deduct and withhold tax as required and the tax is thereafter paid, that amount shall not be collected from the employer, but the employer is not relieved from otherwise applicable penalties or interest.
+rules:
+  - name: withheld_tax_amount_collection_bar_applies
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/706
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/706
+              excerpt: "If an employer fails to deduct and withhold any amount of tax as required under this Act, and thereafter the tax ... is paid, such amount of tax shall not be collected from the employer"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_tax_required_under_act
+          and tax_on_account_of_required_withholding_amount_is_paid
+  - name: employer_remains_liable_for_applicable_penalties_or_interest
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/706
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/706
+              excerpt: "the employer shall not be relieved from liability for penalties or interest otherwise applicable in respect of such failure to deduct and withhold"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          employer_failed_to_deduct_and_withhold_tax_required_under_act
+          and tax_on_account_of_required_withholding_amount_is_paid
+          and penalties_or_interest_otherwise_applicable_in_respect_of_failure


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/706`
- Module: `us-il/statutes/35/5/706.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-706/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.