### PR TITLE
Encode us-il/statute/35/5/512 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/512": [
+      {
+        "module": "us-il/statutes/35/5/512.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/512.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/512.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/512.yaml",
+      "sha256": "75cfa20ececa094c4269a3e1cfebaf472fbe0d9dca28dabcfb12fa22f7a6854c"
+    },
+    {
+      "path": "statutes/35/5/512.test.yaml",
+      "sha256": "283143c8fd86b2beb64c3b05ba550a56694b59902e635cc40e22b32d56f0b4eb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/512",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-512/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-512/workspace/context-manifest.json",
+  "context_manifest_sha256": "36a5bac633fb754859945e2f9a32b2d8603279710b991b04d4f04b649ad9f14d",
+  "generated_at": "2026-07-08T14:06:40.024622+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-512/encode-out/codex-gpt-5.5/statutes/35/5/512.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-512/encode-out",
+  "generated_output_sha256": "75cfa20ececa094c4269a3e1cfebaf472fbe0d9dca28dabcfb12fa22f7a6854c",
+  "generation_prompt_sha256": "ef4c32c8b160e3ce3a6040a5363f3a6a9d0152e9b38d78445e71b2e5909cd734",
+  "model": "gpt-5.5",
+  "run_id": "ce76934a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9b520c043e204067a738f39b31946302cc3b380649dd1b520c838da1b9fd77ad"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-512/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-512.json",
+  "trace_sha256": "8e770e34d69e29016056c8ecaf7648be693cdf039f9f1d05274a08b8a6abfc50"
+}

--- a/us-il/statutes/35/5/512.test.yaml
+++ b/us-il/statutes/35/5/512.test.yaml
@@ -1,0 +1,38 @@
+- name: individual_return_form_in_window_requires_school_district_space
+  period:
+    period_kind: tax_year
+    start: '1994-01-01'
+    end: '1994-12-31'
+  input:
+    us-il:statutes/35/5/512#input.form_is_individual_income_tax_return_form: true
+    us-il:statutes/35/5/512#input.taxable_year_ending_in_school_district_return_form_window: true
+  output:
+    us-il:statutes/35/5/512#school_district_residence_space_required_on_individual_income_tax_return_form: holds
+- name: nonindividual_form_does_not_trigger_school_district_space_requirement
+  period:
+    period_kind: tax_year
+    start: '1994-01-01'
+    end: '1994-12-31'
+  input:
+    us-il:statutes/35/5/512#input.form_is_individual_income_tax_return_form: false
+    us-il:statutes/35/5/512#input.taxable_year_ending_in_school_district_return_form_window: true
+  output:
+    us-il:statutes/35/5/512#school_district_residence_space_required_on_individual_income_tax_return_form: not_holds
+- name: omission_of_school_district_information_does_not_invalidate_return
+  period:
+    period_kind: tax_year
+    start: '1994-01-01'
+    end: '1994-12-31'
+  input: {}
+  output:
+    us-il:statutes/35/5/512#return_invalidated_by_school_district_information_omission: not_holds
+- name: department_reporting_required_for_receipts_window
+  period:
+    period_kind: tax_year
+    start: '1996-01-01'
+    end: '1996-12-31'
+  input:
+    us-il:statutes/35/5/512#input.agency_is_department: true
+    us-il:statutes/35/5/512#input.taxable_year_ending_in_school_district_receipts_reporting_window: true
+  output:
+    us-il:statutes/35/5/512#department_school_district_receipts_information_required_for_state_board_of_education: holds

--- a/us-il/statutes/35/5/512.yaml
+++ b/us-il/statutes/35/5/512.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/512
+  summary: |-
+    Individual income tax return forms for tax years ending December 31, 1986 through December 30, 1995 must contain space for the taxpayer's high school district or unit school district name and number; failure to insert that information does not invalidate the return. For tax years ending December 31, 1995 and thereafter, the Department shall provide the State Board of Education with individual income tax receipts by school district from Department GIS data.
+rules:
+  - name: school_district_residence_space_required_on_individual_income_tax_return_form
+    kind: derived
+    entity: TaxReturnForm
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/512(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/512
+              excerpt: "All individual income tax return forms for tax years ending December 31, 1986 through December 30, 1995 shall contain an appropriate space"
+    versions:
+      - effective_from: '1986-12-31'
+        formula: |-
+          form_is_individual_income_tax_return_form
+          and taxable_year_ending_in_school_district_return_form_window
+  - name: return_invalidated_by_school_district_information_omission
+    kind: derived
+    entity: TaxReturn
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/512(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-il/statute/35/5/512
+              excerpt: "Failure of the taxpayer to insert such information shall not invalidate the return."
+    versions:
+      - effective_from: '1986-12-31'
+        formula: |-
+          false
+  - name: department_school_district_receipts_information_required_for_state_board_of_education
+    kind: derived
+    entity: StateAgency
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/512(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/512
+              excerpt: "For all tax years ending December 31, 1995 and thereafter, the Department shall provide the State Board of Education with information on individual income tax receipts by school district"
+    versions:
+      - effective_from: '1995-12-31'
+        formula: |-
+          agency_is_department
+          and taxable_year_ending_in_school_district_receipts_reporting_window


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/512`
- Module: `us-il/statutes/35/5/512.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-512/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.