### PR TITLE
Encode us-il/statute/35/5/604 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/604": [
+      {
+        "module": "us-il/statutes/35/5/604.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/604.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/604.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/604.yaml",
+      "sha256": "8c234ec4c94f7bd37eeb434cfe9886ccdccf3a3bb9e97fdec8def97a2519d6c4"
+    },
+    {
+      "path": "statutes/35/5/604.test.yaml",
+      "sha256": "e287cb8edbb4ad86d43fac039fdeb5027fe11ff6672ed08a2816d70a6af22cbd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/604",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-604/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-604/workspace/context-manifest.json",
+  "context_manifest_sha256": "83efa6c54ca75c6d459680ccb91f978b2db79ef5798987b2169d2b0c242b8458",
+  "generated_at": "2026-07-08T14:07:00.762098+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-604/encode-out/codex-gpt-5.5/statutes/35/5/604.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-604/encode-out",
+  "generated_output_sha256": "8c234ec4c94f7bd37eeb434cfe9886ccdccf3a3bb9e97fdec8def97a2519d6c4",
+  "generation_prompt_sha256": "e1e14d98acb2114323ea813170615eccf1304a0e35deb3709c090975d96359d2",
+  "model": "gpt-5.5",
+  "run_id": "e3441186",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1cb1a1ab17bdbca89cc3c6a07631e6592f5642cdc4abc217f5ebd8d99aab76f2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-604/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-604.json",
+  "trace_sha256": "6a77a7520c698b4125f5c79027e4b435a4a96b32fc5a34ebcd01787df2c183e5"
+}

--- a/us-il/statutes/35/5/604.test.yaml
+++ b/us-il/statutes/35/5/604.test.yaml
@@ -1,0 +1,42 @@
+- name: nonpayable_check_not_equal_amount_owed_must_be_returned
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/604#input.payment_to_department: true
+    us-il:statutes/35/5/604#input.payment_made_by_check_not_payable_to_department: true
+    us-il:statutes/35/5/604#input.payment_made_by_money_order_not_payable_to_department: false
+    us-il:statutes/35/5/604#input.payment_amount_equals_amount_owed_to_state_of_illinois: false
+  output:
+    us-il:statutes/35/5/604#nonpayable_check_or_money_order_must_be_returned: holds
+    us-il:statutes/35/5/604#department_may_deposit_nonpayable_check_equal_to_amount_owed: not_holds
+- name: nonpayable_money_order_not_equal_amount_owed_must_be_returned
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/604#input.payment_to_department: true
+    us-il:statutes/35/5/604#input.payment_made_by_check_not_payable_to_department: false
+    us-il:statutes/35/5/604#input.payment_made_by_money_order_not_payable_to_department: true
+    us-il:statutes/35/5/604#input.payment_amount_equals_amount_owed_to_state_of_illinois: false
+  output:
+    us-il:statutes/35/5/604#nonpayable_check_or_money_order_must_be_returned: holds
+    us-il:statutes/35/5/604#department_may_deposit_nonpayable_check_equal_to_amount_owed: not_holds
+- name: nonpayable_check_equal_amount_owed_may_be_deposited
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/604#input.payment_to_department: true
+    us-il:statutes/35/5/604#input.payment_made_by_check_not_payable_to_department: true
+    us-il:statutes/35/5/604#input.payment_made_by_money_order_not_payable_to_department: false
+    us-il:statutes/35/5/604#input.payment_amount_equals_amount_owed_to_state_of_illinois: true
+  output:
+    us-il:statutes/35/5/604#nonpayable_check_or_money_order_must_be_returned: not_holds
+    us-il:statutes/35/5/604#department_may_deposit_nonpayable_check_equal_to_amount_owed: holds

--- a/us-il/statutes/35/5/604.yaml
+++ b/us-il/statutes/35/5/604.yaml
@@ -1,0 +1,65 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/604
+  summary: |-
+    Any payment to the Department made by a check or money order not payable to the Department shall, within 15 days after receipt, be returned to the taxpayer, or, if the payment equals the amount owed to Illinois, the Department may deposit such check.
+rules:
+  - name: nonpayable_instrument_return_deadline_days
+    kind: parameter
+    dtype: Count
+    source: 35 ILCS 5/604
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-il/statute/35/5/604
+              excerpt: "within 15 days after receipt"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          15
+
+  - name: nonpayable_check_or_money_order_must_be_returned
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/604
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/604
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          payment_to_department
+          and (payment_made_by_check_not_payable_to_department or payment_made_by_money_order_not_payable_to_department)
+          and not payment_amount_equals_amount_owed_to_state_of_illinois
+
+  - name: department_may_deposit_nonpayable_check_equal_to_amount_owed
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/604
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/604
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          payment_to_department
+          and payment_made_by_check_not_payable_to_department
+          and payment_amount_equals_amount_owed_to_state_of_illinois


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/604`
- Module: `us-il/statutes/35/5/604.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-604/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.