### PR TITLE
Encode us-il/statute/35/5/913 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/913": [
+      {
+        "module": "us-il/statutes/35/5/913.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/913.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/913.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/913.yaml",
+      "sha256": "64d6591bb305930403042ba4bf699abe14d2deb1281954ff1186a015b479b840"
+    },
+    {
+      "path": "statutes/35/5/913.test.yaml",
+      "sha256": "f7bc756f4342dee04f5d7c96d656bc211208a65b30fcf2678a4c61a5969ebdb5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/913",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-913/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-913/workspace/context-manifest.json",
+  "context_manifest_sha256": "f6f33daeb4c7f0b821599a936d99d41043399132ee2c302857b94603e53d2b0c",
+  "generated_at": "2026-07-08T14:07:47.768494+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-913/encode-out/codex-gpt-5.5/statutes/35/5/913.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-913/encode-out",
+  "generated_output_sha256": "64d6591bb305930403042ba4bf699abe14d2deb1281954ff1186a015b479b840",
+  "generation_prompt_sha256": "c45f6e25d32d9e76f9eb7a7e551ced6a4875cfb334562395b0a5f9ba95f81785",
+  "model": "gpt-5.5",
+  "run_id": "d8c38d78",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2d0614e62a01a99cd2751eb9ef322e8597189e5fc5f2412310920e7879737565"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-913/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-913.json",
+  "trace_sha256": "1e971fc7f37767644adc5416515001bc257367a70d372accc124c8904ac92444"
+}

--- a/us-il/statutes/35/5/913.test.yaml
+++ b/us-il/statutes/35/5/913.test.yaml
@@ -1,0 +1,65 @@
+- name: required_record_available_for_department_business_hours_inspection
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/913#input.item_is_book_record_paper_or_document: true
+    us-il:statutes/35/5/913#input.act_requires_item_to_be_kept: true
+    us-il:statutes/35/5/913#input.inspection_occurs_during_business_hours: true
+    us-il:statutes/35/5/913#input.inspector_is_department_or_duly_authorized_agent_or_employee: true
+  output:
+    us-il:statutes/35/5/913#records_subject_to_department_inspection: holds
+- name: non_document_item_not_subject_under_section
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/913#input.item_is_book_record_paper_or_document: false
+    us-il:statutes/35/5/913#input.act_requires_item_to_be_kept: true
+    us-il:statutes/35/5/913#input.inspection_occurs_during_business_hours: true
+    us-il:statutes/35/5/913#input.inspector_is_department_or_duly_authorized_agent_or_employee: true
+  output:
+    us-il:statutes/35/5/913#records_subject_to_department_inspection: not_holds
+- name: item_not_required_by_act_to_be_kept
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/913#input.item_is_book_record_paper_or_document: true
+    us-il:statutes/35/5/913#input.act_requires_item_to_be_kept: false
+    us-il:statutes/35/5/913#input.inspection_occurs_during_business_hours: true
+    us-il:statutes/35/5/913#input.inspector_is_department_or_duly_authorized_agent_or_employee: true
+  output:
+    us-il:statutes/35/5/913#records_subject_to_department_inspection: not_holds
+- name: inspection_outside_business_hours
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/913#input.item_is_book_record_paper_or_document: true
+    us-il:statutes/35/5/913#input.act_requires_item_to_be_kept: true
+    us-il:statutes/35/5/913#input.inspection_occurs_during_business_hours: false
+    us-il:statutes/35/5/913#input.inspector_is_department_or_duly_authorized_agent_or_employee: true
+  output:
+    us-il:statutes/35/5/913#records_subject_to_department_inspection: not_holds
+- name: inspector_not_department_or_authorized_representative
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/913#input.item_is_book_record_paper_or_document: true
+    us-il:statutes/35/5/913#input.act_requires_item_to_be_kept: true
+    us-il:statutes/35/5/913#input.inspection_occurs_during_business_hours: true
+    us-il:statutes/35/5/913#input.inspector_is_department_or_duly_authorized_agent_or_employee: false
+  output:
+    us-il:statutes/35/5/913#records_subject_to_department_inspection: not_holds

--- a/us-il/statutes/35/5/913.yaml
+++ b/us-il/statutes/35/5/913.yaml
@@ -1,0 +1,29 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/913
+  summary: |-
+    "All books and records and other papers and documents which are required by this Act to be kept shall, at all times during business hours of the day, be subject to inspection by the Department or its duly authorized agents and employees."
+rules:
+  - name: records_subject_to_department_inspection
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/913
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/913
+    versions:
+      - effective_from: '1997-02-14'
+        formula: |-
+          item_is_book_record_paper_or_document
+          and act_requires_item_to_be_kept
+          and inspection_occurs_during_business_hours
+          and inspector_is_department_or_duly_authorized_agent_or_employee


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/913`
- Module: `us-il/statutes/35/5/913.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-913/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.