### PR TITLE
Encode us-il/statute/35/5/916 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/916": [
+      {
+        "module": "us-il/statutes/35/5/916.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/916.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/916.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/916.yaml",
+      "sha256": "637b5c4feb06868af333ae6f3d2802bc5551cea50e1abb478737f463dac8ac84"
+    },
+    {
+      "path": "statutes/35/5/916.test.yaml",
+      "sha256": "15f4ca8f2f62f0567982e696c109d49e792177c05dc55f1dbccfbce42c3cf649"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/916",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-916/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-916/workspace/context-manifest.json",
+  "context_manifest_sha256": "21b6128275509a5e0e0786605639270863f9423c29642479cdf8dc0d36c6382c",
+  "generated_at": "2026-07-08T14:08:25.104883+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-916/encode-out/codex-gpt-5.5/statutes/35/5/916.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-916/encode-out",
+  "generated_output_sha256": "637b5c4feb06868af333ae6f3d2802bc5551cea50e1abb478737f463dac8ac84",
+  "generation_prompt_sha256": "64c537175c0b7eacbabbaafca78dad59cc01926a3df43799206722b3baebcdee",
+  "model": "gpt-5.5",
+  "run_id": "faeb0b18",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3a4b68a805d18870d346cc4b55238756fe7f48590c3ebe17c6ad671ea707f301"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-916/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-916.json",
+  "trace_sha256": "6faa1cc7cb27278c997c9cff3eb7a9bdf01bf172ecdfe41011d141d384beb56f"
+}

--- a/us-il/statutes/35/5/916.test.yaml
+++ b/us-il/statutes/35/5/916.test.yaml
@@ -1,0 +1,67 @@
+- name: department_subpoena_issuance_required_on_written_request
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/916#input.subpoena_requires_attendance_testimony_or_record_production: true
+    us-il:statutes/35/5/916#input.department_acts_on_own_instance: false
+    us-il:statutes/35/5/916#input.director_designated_department_officer_or_employee_acts_on_own_instance: false
+    us-il:statutes/35/5/916#input.other_party_to_proceeding_makes_written_request: true
+  output:
+    us-il:statutes/35/5/916#department_subpoena_issuance_required: holds
+- name: subpoena_service_person_must_be_of_full_age
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/916#input.person_is_of_full_age: false
+  output:
+    us-il:statutes/35/5/916#subpoena_service_person_qualified: not_holds
+- name: witness_fee_charge_available_for_non_department_request
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/916#input.witness_subpoenaed_at_instance_of_non_department_party: true
+  output:
+    us-il:statutes/35/5/916#witness_fee_may_be_charged_to_requesting_party: holds
+- name: court_enforcement_blocked_when_hearing_delegated_to_tax_tribunal
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/916#input.application_for_circuit_court_enforcement_made: true
+    us-il:statutes/35/5/916#input.enforcement_seeks_attendance_production_or_testimony: true
+    us-il:statutes/35/5/916#input.department_investigation_or_hearing_is_conducted: true
+    us-il:statutes/35/5/916#input.hearing_is_delegated_to_illinois_independent_tax_tribunal: true
+  output:
+    us-il:statutes/35/5/916#court_enforcement_available: not_holds
+- name: auto_positive_subpoena_service_person_qualified
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/916#input.person_is_of_full_age: true
+  output:
+    us-il:statutes/35/5/916#subpoena_service_person_qualified: holds
+- name: auto_positive_court_enforcement_available
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-il:statutes/35/5/916#input.application_for_circuit_court_enforcement_made: true
+    us-il:statutes/35/5/916#input.department_investigation_or_hearing_is_conducted: true
+    us-il:statutes/35/5/916#input.enforcement_seeks_attendance_production_or_testimony: true
+    us-il:statutes/35/5/916#input.hearing_is_delegated_to_illinois_independent_tax_tribunal: false
+  output:
+    us-il:statutes/35/5/916#court_enforcement_available: holds

--- a/us-il/statutes/35/5/916.yaml
+++ b/us-il/statutes/35/5/916.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/916
+  summary: |-
+    Sec. 916 provides that the Department, or a Director-designated officer or employee, shall issue subpoenas and subpoenas duces tecum at its own instance or on another party's written request; subpoenas may be served by any person of full age. Witness fees match Circuit Court witness fees, and courts may compel attendance, production, and testimony for Department investigations or hearings not delegated to the Illinois Independent Tax Tribunal.
+rules:
+  - name: department_subpoena_issuance_required
+    kind: derived
+    entity: StateAgency
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/916(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/916
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          subpoena_requires_attendance_testimony_or_record_production
+          and (department_acts_on_own_instance or director_designated_department_officer_or_employee_acts_on_own_instance or other_party_to_proceeding_makes_written_request)
+
+  - name: subpoena_service_person_qualified
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/916(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/916
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          person_is_of_full_age
+
+  - name: witness_fee_may_be_charged_to_requesting_party
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/916(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/916
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          witness_subpoenaed_at_instance_of_non_department_party
+
+  - name: court_enforcement_available
+    kind: derived
+    entity: StateAgency
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/916(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/916
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          application_for_circuit_court_enforcement_made
+          and enforcement_seeks_attendance_production_or_testimony
+          and department_investigation_or_hearing_is_conducted
+          and not hearing_is_delegated_to_illinois_independent_tax_tribunal


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/916`
- Module: `us-il/statutes/35/5/916.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-916/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.