### PR TITLE
Encode us-il/statute/35/5/1202 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9699,6 +9699,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/1202": [
+      {
+        "module": "us-il/statutes/35/5/1202.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/statute/35/5/201": [
       {
         "module": "us-il/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/1202.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/1202.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/1202.yaml",
+      "sha256": "86354dc12d1fd86e38a477eec99ba0decdc7cbe9546052a5809a881df44648f5"
+    },
+    {
+      "path": "statutes/35/5/1202.test.yaml",
+      "sha256": "041f484b225374a34153bd5125d9f6ca3bd16d31ce8cd47e9c3eedf3f2264f66"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/1202",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1202/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-1202/workspace/context-manifest.json",
+  "context_manifest_sha256": "edc802783e5e917b2b8de85b2fce4098627cbf59fa3b325b645a4629cea76fd2",
+  "generated_at": "2026-07-08T14:29:15.581316+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1202/encode-out/codex-gpt-5.5/statutes/35/5/1202.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1202/encode-out",
+  "generated_output_sha256": "86354dc12d1fd86e38a477eec99ba0decdc7cbe9546052a5809a881df44648f5",
+  "generation_prompt_sha256": "6682264e06f336bcf212d72cbed5e1583ac1a767a57b6fe5b492e38f11cfdbbf",
+  "model": "gpt-5.5",
+  "run_id": "13605286",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "35ee949c2db4840ed758514b5479aa2237bf074e2d58bcd4fb51b25f818619e6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1202/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-1202.json",
+  "trace_sha256": "dd8c15f50f757222de213d048a023a452886dbcc0470a968ade18cd92b1d74dd"
+}

--- a/us-il/statutes/35/5/1202.test.yaml
+++ b/us-il/statutes/35/5/1202.test.yaml
@@ -1,0 +1,56 @@
+- name: residence_or_commercial_domicile_county_circuit_court_has_review_power
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/1202#input.department_decision_is_final_administrative_decision_administering_this_act: true
+    us-il:statutes/35/5/1202#input.illinois_independent_tax_tribunal_act_provides_otherwise_for_this_decision: false
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_in_county_of_taxpayer_residence_or_commercial_domicile: true
+    us-il:statutes/35/5/1202#input.taxpayer_does_not_have_residence_or_commercial_domicile_in_this_state: false
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_cook_county: false
+  output:
+    us-il:statutes/35/5/1202#circuit_court_has_power_to_review_department_final_administrative_decision: holds
+- name: independent_tax_tribunal_act_exception_blocks_review_power
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/1202#input.department_decision_is_final_administrative_decision_administering_this_act: true
+    us-il:statutes/35/5/1202#input.illinois_independent_tax_tribunal_act_provides_otherwise_for_this_decision: true
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_in_county_of_taxpayer_residence_or_commercial_domicile: true
+    us-il:statutes/35/5/1202#input.taxpayer_does_not_have_residence_or_commercial_domicile_in_this_state: false
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_cook_county: false
+  output:
+    us-il:statutes/35/5/1202#circuit_court_has_power_to_review_department_final_administrative_decision: not_holds
+- name: cook_county_circuit_court_has_review_power_when_taxpayer_lacks_in_state_residence_or_commercial_domicile
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/1202#input.department_decision_is_final_administrative_decision_administering_this_act: true
+    us-il:statutes/35/5/1202#input.illinois_independent_tax_tribunal_act_provides_otherwise_for_this_decision: false
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_in_county_of_taxpayer_residence_or_commercial_domicile: false
+    us-il:statutes/35/5/1202#input.taxpayer_does_not_have_residence_or_commercial_domicile_in_this_state: true
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_cook_county: true
+  output:
+    us-il:statutes/35/5/1202#circuit_court_has_power_to_review_department_final_administrative_decision: holds
+- name: non_cook_county_court_without_taxpayer_in_state_residence_or_commercial_domicile_lacks_review_power
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-il:statutes/35/5/1202#input.department_decision_is_final_administrative_decision_administering_this_act: true
+    us-il:statutes/35/5/1202#input.illinois_independent_tax_tribunal_act_provides_otherwise_for_this_decision: false
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_in_county_of_taxpayer_residence_or_commercial_domicile: false
+    us-il:statutes/35/5/1202#input.taxpayer_does_not_have_residence_or_commercial_domicile_in_this_state: true
+    us-il:statutes/35/5/1202#input.reviewing_circuit_court_is_cook_county: false
+  output:
+    us-il:statutes/35/5/1202#circuit_court_has_power_to_review_department_final_administrative_decision: not_holds

--- a/us-il/statutes/35/5/1202.yaml
+++ b/us-il/statutes/35/5/1202.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/1202
+  summary: |-
+    Except as otherwise provided in the Illinois Independent Tax Tribunal Act of 2012, specified Circuit Courts have power to review final administrative decisions of the Department in administering the Act.
+rules:
+  - name: circuit_court_has_power_to_review_department_final_administrative_decision
+    kind: derived
+    entity: AdministrativeDecision
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/1202
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-il/statute/35/5/1202
+              excerpt: "Except as otherwise provided in the Illinois Independent Tax Tribunal Act of 2012"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/1202
+              excerpt: "all final administrative decisions of the Department in administering the provisions of this Act"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1202
+              excerpt: "the Circuit Court of the county wherein the taxpayer has his residence or commercial domicile"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1202
+              excerpt: "or of Cook County in those cases where the taxpayer does not have his residence or commercial domicile in this State"
+    versions:
+      - effective_from: '2013-08-16'
+        formula: |-
+          department_decision_is_final_administrative_decision_administering_this_act
+          and not illinois_independent_tax_tribunal_act_provides_otherwise_for_this_decision
+          and (
+            reviewing_circuit_court_is_in_county_of_taxpayer_residence_or_commercial_domicile
+            or (
+              taxpayer_does_not_have_residence_or_commercial_domicile_in_this_state
+              and reviewing_circuit_court_is_cook_county
+            )
+          )


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/1202`
- Module: `us-il/statutes/35/5/1202.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1202/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.