### PR TITLE
Encode us-il/statute/35/5/918 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9747,6 +9747,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/918": [
+      {
+        "module": "us-il/statutes/35/5/918.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-in/manual/dfr/snap-tanf-program-policy-manual/page-296": [
       {
         "module": "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/918.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/918.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/918.yaml",
+      "sha256": "4e215f11dd769b17b6906a903fc27c7d8fbfc77d98cbfd58d7cd0de81e03d03a"
+    },
+    {
+      "path": "statutes/35/5/918.test.yaml",
+      "sha256": "380aa44a9b576d92f1be5477b05f30dd07326919f9c6cbfe9a88758df6495782"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/918",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-918/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-918/workspace/context-manifest.json",
+  "context_manifest_sha256": "718f7b59b9a3185d9904d864335dbf9c7a7aae6d912c31d2decb5d93ea305a28",
+  "generated_at": "2026-07-08T14:29:22.571012+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-918/encode-out/codex-gpt-5.5/statutes/35/5/918.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-918/encode-out",
+  "generated_output_sha256": "4e215f11dd769b17b6906a903fc27c7d8fbfc77d98cbfd58d7cd0de81e03d03a",
+  "generation_prompt_sha256": "83246d23bee80ecfe91ae2da08f57a3c4379e95ab5b28776f4deb7d4f657e819",
+  "model": "gpt-5.5",
+  "run_id": "8c2121d8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7f86d992467fa21eaa0b51deb0fbc19afa42e9b70249ba7f938734eb9aedc0b9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-918/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-918.json",
+  "trace_sha256": "5e04a68aea29eeaf43138224bfc64823a4a729bbb6c35984762ee4d990a63582"
+}

--- a/us-il/statutes/35/5/918.test.yaml
+++ b/us-il/statutes/35/5/918.test.yaml
@@ -1,0 +1,56 @@
+- name: hearing_for_illinois_non_cook_taxpayer_at_nearest_department_office
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us-il:statutes/35/5/918#input.hearing_provided_for_in_this_act: true
+    us-il:statutes/35/5/918#input.hearing_delegated_to_illinois_independent_tax_tribunal: false
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_illinois: true
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_cook_county: false
+  output:
+    us-il:statutes/35/5/918#hearing_held_at_nearest_department_office: holds
+    us-il:statutes/35/5/918#hearing_held_in_cook_county: not_holds
+- name: hearing_for_cook_county_taxpayer_in_cook_county
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us-il:statutes/35/5/918#input.hearing_provided_for_in_this_act: true
+    us-il:statutes/35/5/918#input.hearing_delegated_to_illinois_independent_tax_tribunal: false
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_illinois: true
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_cook_county: true
+  output:
+    us-il:statutes/35/5/918#hearing_held_at_nearest_department_office: not_holds
+    us-il:statutes/35/5/918#hearing_held_in_cook_county: holds
+- name: hearing_for_taxpayer_without_illinois_residence_or_domicile_in_cook_county
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us-il:statutes/35/5/918#input.hearing_provided_for_in_this_act: true
+    us-il:statutes/35/5/918#input.hearing_delegated_to_illinois_independent_tax_tribunal: false
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_illinois: false
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_cook_county: false
+  output:
+    us-il:statutes/35/5/918#hearing_held_at_nearest_department_office: not_holds
+    us-il:statutes/35/5/918#hearing_held_in_cook_county: holds
+- name: delegated_hearing_not_placed_by_section_918
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-15'
+    end: '2026-01-15'
+  input:
+    us-il:statutes/35/5/918#input.hearing_provided_for_in_this_act: true
+    us-il:statutes/35/5/918#input.hearing_delegated_to_illinois_independent_tax_tribunal: true
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_illinois: true
+    us-il:statutes/35/5/918#input.taxpayer_has_residence_or_commercial_domicile_in_cook_county: false
+  output:
+    us-il:statutes/35/5/918#hearing_held_at_nearest_department_office: not_holds
+    us-il:statutes/35/5/918#hearing_held_in_cook_county: not_holds

--- a/us-il/statutes/35/5/918.yaml
+++ b/us-il/statutes/35/5/918.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/918
+  summary: |-
+    Hearings provided for in the Act and not otherwise delegated to the Illinois Independent Tax Tribunal are held at the Department office nearest an Illinois taxpayer's residence or commercial domicile, except Cook County taxpayers are heard in Cook County; taxpayers without Illinois residence or commercial domicile are also heard in Cook County.
+rules:
+  - name: hearing_held_at_nearest_department_office
+    kind: derived
+    entity: Hearing
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/918
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "All hearings provided for in this Act and not otherwise delegated to the Illinois Independent Tax Tribunal"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "taxpayer having his residence or commercial domicile in this State"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "except that if the taxpayer has his residence or commercial domicile in Cook County"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "shall be held at the Department's office nearest to the location of such residence or domicile"
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          hearing_provided_for_in_this_act
+          and not hearing_delegated_to_illinois_independent_tax_tribunal
+          and taxpayer_has_residence_or_commercial_domicile_in_illinois
+          and not taxpayer_has_residence_or_commercial_domicile_in_cook_county
+  - name: hearing_held_in_cook_county
+    kind: derived
+    entity: Hearing
+    dtype: Judgment
+    period: Day
+    source: 35 ILCS 5/918
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "All hearings provided for in this Act and not otherwise delegated to the Illinois Independent Tax Tribunal"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "if the taxpayer has his residence or commercial domicile in Cook County"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "If the taxpayer does not have his residence or commercial domicile in this State"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-il/statute/35/5/918
+              excerpt: "such hearing shall be held in Cook County"
+    versions:
+      - effective_from: '2012-08-28'
+        formula: |-
+          hearing_provided_for_in_this_act
+          and not hearing_delegated_to_illinois_independent_tax_tribunal
+          and (taxpayer_has_residence_or_commercial_domicile_in_cook_county or not taxpayer_has_residence_or_commercial_domicile_in_illinois)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/918`
- Module: `us-il/statutes/35/5/918.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-918/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.