### PR TITLE
Encode us-il/statute/35/5/1105 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9699,6 +9699,15 @@
         ]
       }
     ],
+    "us-il/statute/35/5/1105": [
+      {
+        "module": "us-il/statutes/35/5/1105.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/statute/35/5/201": [
       {
         "module": "us-il/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-il/.axiom/encoding-manifests/statutes/35/5/1105.json
+++ b/us-il/.axiom/encoding-manifests/statutes/35/5/1105.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/35/5/1105.yaml",
+      "sha256": "a7f8c0f1150d3785bf07ad3904f173a8c0657d5b7edf49d4b4fee327373cffcc"
+    },
+    {
+      "path": "statutes/35/5/1105.test.yaml",
+      "sha256": "13122672a3b6991adb92e665d6c9e50796b05aedceb74e0937022b9bebbac920"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-il/statute/35/5/1105",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1105/encode-out/_eval_workspaces/codex-gpt-5.5/us-il-statute-35-5-1105/workspace/context-manifest.json",
+  "context_manifest_sha256": "1b89ba1078b27b845fd75b2f6d87c035608f5d7371fd7e419771a712bbda9b5f",
+  "generated_at": "2026-07-08T14:29:48.402036+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1105/encode-out/codex-gpt-5.5/statutes/35/5/1105.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1105/encode-out",
+  "generated_output_sha256": "a7f8c0f1150d3785bf07ad3904f173a8c0657d5b7edf49d4b4fee327373cffcc",
+  "generation_prompt_sha256": "8af5d56790dfeafc68cede7a59d0c6aa353878e4a276a6fc93104de6bf2944e4",
+  "model": "gpt-5.5",
+  "run_id": "6c5869f3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "27d5a735a3250802299a273c5b4cf08be9fc8c671880e495ade3e93436ac4dcf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1105/encode-out/traces/codex-gpt-5.5/us-il-statute-35-5-1105.json",
+  "trace_sha256": "a9de06878a1f7cd24c4159ade883fe251dbe0254515f96aee524041f2c7ede8e"
+}

--- a/us-il/statutes/35/5/1105.test.yaml
+++ b/us-il/statutes/35/5/1105.test.yaml
@@ -1,0 +1,104 @@
+- name: lien_release_and_certificate_issue_when_payment_and_release_ground_hold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/1105#input.taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance: true
+    us-il:statutes/35/5/1105#input.department_determines_release_will_not_endanger_or_jeopardize_collection: true
+    us-il:statutes/35/5/1105#input.property_fair_market_value_exceeds_lien_and_prior_liens: true
+    us-il:statutes/35/5/1105#input.lien_has_become_unenforceable: false
+    us-il:statutes/35/5/1105#input.lien_amount_interest_and_penalty_paid: false
+    us-il:statutes/35/5/1105#input.satisfactory_bond_furnished_conditioned_on_lien_and_interest_payment: false
+    us-il:statutes/35/5/1105#input.circumstances_specified_in_this_section_support_release: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_taxpayer_nonliability: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_no_jeopardy_to_revenue: false
+    us-il:statutes/35/5/1105#input.taxpayer_paid_tax_penalty_interest_and_lien_release_fees_in_cash_or_guaranteed_remittance: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_covers_property: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_filed_in_state_tax_lien_registry: false
+  output:
+    us-il:statutes/35/5/1105#department_must_release_property_from_lien: holds
+    us-il:statutes/35/5/1105#department_must_issue_certificate_of_complete_or_partial_release: holds
+    us-il:statutes/35/5/1105#department_must_release_lien_after_judicial_review: not_holds
+    us-il:statutes/35/5/1105#taxpayer_liable_for_judicial_review_lien_filing_and_release_fees: not_holds
+    us-il:statutes/35/5/1105#department_must_release_jeopardy_assessment_lien_on_payment: not_holds
+    us-il:statutes/35/5/1105#certificate_conclusive_that_lien_extinguished_to_certificate_extent: not_holds
+    us-il:statutes/35/5/1105#department_must_attach_and_index_filed_release_certificate: not_holds
+- name: lien_release_blocked_when_collection_is_endangered
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/1105#input.taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance: true
+    us-il:statutes/35/5/1105#input.department_determines_release_will_not_endanger_or_jeopardize_collection: false
+    us-il:statutes/35/5/1105#input.property_fair_market_value_exceeds_lien_and_prior_liens: false
+    us-il:statutes/35/5/1105#input.lien_has_become_unenforceable: true
+    us-il:statutes/35/5/1105#input.lien_amount_interest_and_penalty_paid: false
+    us-il:statutes/35/5/1105#input.satisfactory_bond_furnished_conditioned_on_lien_and_interest_payment: false
+    us-il:statutes/35/5/1105#input.circumstances_specified_in_this_section_support_release: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_taxpayer_nonliability: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_no_jeopardy_to_revenue: false
+    us-il:statutes/35/5/1105#input.taxpayer_paid_tax_penalty_interest_and_lien_release_fees_in_cash_or_guaranteed_remittance: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_covers_property: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_filed_in_state_tax_lien_registry: false
+  output:
+    us-il:statutes/35/5/1105#department_must_release_property_from_lien: not_holds
+    us-il:statutes/35/5/1105#department_must_issue_certificate_of_complete_or_partial_release: holds
+    us-il:statutes/35/5/1105#department_must_release_lien_after_judicial_review: not_holds
+    us-il:statutes/35/5/1105#taxpayer_liable_for_judicial_review_lien_filing_and_release_fees: not_holds
+    us-il:statutes/35/5/1105#department_must_release_jeopardy_assessment_lien_on_payment: not_holds
+    us-il:statutes/35/5/1105#certificate_conclusive_that_lien_extinguished_to_certificate_extent: not_holds
+    us-il:statutes/35/5/1105#department_must_attach_and_index_filed_release_certificate: not_holds
+- name: judicial_review_and_jeopardy_payment_release_paths
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/1105#input.taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance: false
+    us-il:statutes/35/5/1105#input.department_determines_release_will_not_endanger_or_jeopardize_collection: false
+    us-il:statutes/35/5/1105#input.property_fair_market_value_exceeds_lien_and_prior_liens: false
+    us-il:statutes/35/5/1105#input.lien_has_become_unenforceable: false
+    us-il:statutes/35/5/1105#input.lien_amount_interest_and_penalty_paid: false
+    us-il:statutes/35/5/1105#input.satisfactory_bond_furnished_conditioned_on_lien_and_interest_payment: false
+    us-il:statutes/35/5/1105#input.circumstances_specified_in_this_section_support_release: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_taxpayer_nonliability: true
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_no_jeopardy_to_revenue: false
+    us-il:statutes/35/5/1105#input.taxpayer_paid_tax_penalty_interest_and_lien_release_fees_in_cash_or_guaranteed_remittance: true
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_covers_property: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_filed_in_state_tax_lien_registry: false
+  output:
+    us-il:statutes/35/5/1105#department_must_release_property_from_lien: not_holds
+    us-il:statutes/35/5/1105#department_must_issue_certificate_of_complete_or_partial_release: not_holds
+    us-il:statutes/35/5/1105#department_must_release_lien_after_judicial_review: holds
+    us-il:statutes/35/5/1105#taxpayer_liable_for_judicial_review_lien_filing_and_release_fees: holds
+    us-il:statutes/35/5/1105#department_must_release_jeopardy_assessment_lien_on_payment: holds
+    us-il:statutes/35/5/1105#certificate_conclusive_that_lien_extinguished_to_certificate_extent: not_holds
+    us-il:statutes/35/5/1105#department_must_attach_and_index_filed_release_certificate: not_holds
+- name: certificate_conclusive_and_registry_filing_duties
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-il:statutes/35/5/1105#input.taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance: false
+    us-il:statutes/35/5/1105#input.department_determines_release_will_not_endanger_or_jeopardize_collection: false
+    us-il:statutes/35/5/1105#input.property_fair_market_value_exceeds_lien_and_prior_liens: false
+    us-il:statutes/35/5/1105#input.lien_has_become_unenforceable: false
+    us-il:statutes/35/5/1105#input.lien_amount_interest_and_penalty_paid: false
+    us-il:statutes/35/5/1105#input.satisfactory_bond_furnished_conditioned_on_lien_and_interest_payment: false
+    us-il:statutes/35/5/1105#input.circumstances_specified_in_this_section_support_release: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_taxpayer_nonliability: false
+    us-il:statutes/35/5/1105#input.judicial_review_final_judgment_finds_no_jeopardy_to_revenue: true
+    us-il:statutes/35/5/1105#input.taxpayer_paid_tax_penalty_interest_and_lien_release_fees_in_cash_or_guaranteed_remittance: false
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_covers_property: true
+    us-il:statutes/35/5/1105#input.certificate_of_complete_or_partial_release_filed_in_state_tax_lien_registry: true
+  output:
+    us-il:statutes/35/5/1105#department_must_release_property_from_lien: not_holds
+    us-il:statutes/35/5/1105#department_must_issue_certificate_of_complete_or_partial_release: not_holds
+    us-il:statutes/35/5/1105#department_must_release_lien_after_judicial_review: holds
+    us-il:statutes/35/5/1105#taxpayer_liable_for_judicial_review_lien_filing_and_release_fees: holds
+    us-il:statutes/35/5/1105#department_must_release_jeopardy_assessment_lien_on_payment: not_holds
+    us-il:statutes/35/5/1105#certificate_conclusive_that_lien_extinguished_to_certificate_extent: holds
+    us-il:statutes/35/5/1105#department_must_attach_and_index_filed_release_certificate: holds

--- a/us-il/statutes/35/5/1105.yaml
+++ b/us-il/statutes/35/5/1105.yaml
@@ -1,0 +1,144 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-il/statute/35/5/1105
+  summary: |-
+    Sec. 1105 provides that the Department shall release liens, issue certificates of complete or partial release, and attach and index filed release certificates when the stated payment, judicial-review, jeopardy-lien, certificate-ground, and State Tax Lien Registry conditions are met.
+rules:
+  - name: department_must_release_property_from_lien
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance
+          and department_determines_release_will_not_endanger_or_jeopardize_collection
+
+  - name: department_must_release_lien_after_judicial_review
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          judicial_review_final_judgment_finds_taxpayer_nonliability
+          or judicial_review_final_judgment_finds_no_jeopardy_to_revenue
+
+  - name: taxpayer_liable_for_judicial_review_lien_filing_and_release_fees
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          judicial_review_final_judgment_finds_taxpayer_nonliability
+          or judicial_review_final_judgment_finds_no_jeopardy_to_revenue
+
+  - name: department_must_release_jeopardy_assessment_lien_on_payment
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          taxpayer_paid_tax_penalty_interest_and_lien_release_fees_in_cash_or_guaranteed_remittance
+
+  - name: department_must_issue_certificate_of_complete_or_partial_release
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          taxpayer_paid_lien_and_release_filing_fees_in_cash_or_guaranteed_remittance
+          and (
+            property_fair_market_value_exceeds_lien_and_prior_liens
+            or lien_has_become_unenforceable
+            or lien_amount_interest_and_penalty_paid
+            or satisfactory_bond_furnished_conditioned_on_lien_and_interest_payment
+            or circumstances_specified_in_this_section_support_release
+          )
+
+  - name: certificate_conclusive_that_lien_extinguished_to_certificate_extent
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          certificate_of_complete_or_partial_release_covers_property
+
+  - name: department_must_attach_and_index_filed_release_certificate
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 35 ILCS 5/1105(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-il/statute/35/5/1105
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          certificate_of_complete_or_partial_release_filed_in_state_tax_lien_registry


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-il/statute/35/5/1105`
- Module: `us-il/statutes/35/5/1105.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-il-statute-35-5-1105/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.