### PR TITLE
Encode us-ma/statute/62/42 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11861,6 +11861,15 @@
         ]
       }
     ],
+    "us-ma/statute/62/42": [
+      {
+        "module": "us-ma/statutes/62/42.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/statute/62/6": [
       {
         "module": "us-ma/statutes/62/6.yaml",

--- a/us-ma/.axiom/encoding-manifests/statutes/62/42.json
+++ b/us-ma/.axiom/encoding-manifests/statutes/62/42.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/62/42.yaml",
+      "sha256": "62f08252a09df601c8f4a5313315054acd449187a59959dee1f717dd4bef1017"
+    },
+    {
+      "path": "statutes/62/42.test.yaml",
+      "sha256": "f08913602da7ebc1626322a71dac13c216f4312ff30bf0e5ecbda83488dfae68"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ma/statute/62/42",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-42/encode-out/_eval_workspaces/codex-gpt-5.5/us-ma-statute-62-42/workspace/context-manifest.json",
+  "context_manifest_sha256": "4f8bce89f9931971fd44996582d59005eb0a8cc129188eceaf28c396d7132ad1",
+  "generated_at": "2026-07-08T14:30:41.017640+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-42/encode-out/codex-gpt-5.5/statutes/62/42.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-42/encode-out",
+  "generated_output_sha256": "62f08252a09df601c8f4a5313315054acd449187a59959dee1f717dd4bef1017",
+  "generation_prompt_sha256": "0dac3708630a437e31987366c11fb269f8199234126fe20f2758e96c8ff56b9d",
+  "model": "gpt-5.5",
+  "run_id": "b37dd34c",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7a9a146720bba5a4fa70cf116234688e93a6f3712abcf07dfc49fa731c741e33"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-42/encode-out/traces/codex-gpt-5.5/us-ma-statute-62-42.json",
+  "trace_sha256": "4c10efe71158e88319fdc859c1977bcead4710ef50f1dc5231ef8376deb9112d"
+}

--- a/us-ma/statutes/62/42.test.yaml
+++ b/us-ma/statutes/62/42.test.yaml
@@ -1,0 +1,24 @@
+- name: fiduciary liable for assessed tax and allowed amount paid
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ma:statutes/62/42#input.fiduciary_is_executor_administrator_trustee_or_other_fiduciary: true
+    us-ma:statutes/62/42#input.chapter_tax_assessed_on_income_received_by_fiduciary: 1200
+    us-ma:statutes/62/42#input.amount_paid_by_fiduciary_for_chapter_tax_assessed_on_income_received_by_fiduciary: 900
+  output:
+    us-ma:statutes/62/42#fiduciary_personal_liability_for_chapter_tax: 1200
+    us-ma:statutes/62/42#fiduciary_account_allowance_for_chapter_tax_paid: 900
+- name: non-fiduciary has no liability or allowance under this section
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ma:statutes/62/42#input.fiduciary_is_executor_administrator_trustee_or_other_fiduciary: false
+    us-ma:statutes/62/42#input.chapter_tax_assessed_on_income_received_by_fiduciary: 1200
+    us-ma:statutes/62/42#input.amount_paid_by_fiduciary_for_chapter_tax_assessed_on_income_received_by_fiduciary: 900
+  output:
+    us-ma:statutes/62/42#fiduciary_personal_liability_for_chapter_tax: 0
+    us-ma:statutes/62/42#fiduciary_account_allowance_for_chapter_tax_paid: 0

--- a/us-ma/statutes/62/42.yaml
+++ b/us-ma/statutes/62/42.yaml
@@ -1,0 +1,45 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/statute/62/42
+  summary: |-
+    Executors, administrators, trustees or other fiduciaries shall be personally liable for tax assessed on income received by them and may be allowed in their accounts for amounts paid.
+rules:
+  - name: fiduciary_personal_liability_for_chapter_tax
+    kind: derived
+    entity: Fiduciary
+    dtype: Money
+    period: Year
+    unit: USD
+    source: M.G.L. c. 62, § 42
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/42
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if fiduciary_is_executor_administrator_trustee_or_other_fiduciary: max(0, chapter_tax_assessed_on_income_received_by_fiduciary) else: 0
+  - name: fiduciary_account_allowance_for_chapter_tax_paid
+    kind: derived
+    entity: Fiduciary
+    dtype: Money
+    period: Year
+    unit: USD
+    source: M.G.L. c. 62, § 42
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/42
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if fiduciary_is_executor_administrator_trustee_or_other_fiduciary: max(0, amount_paid_by_fiduciary_for_chapter_tax_assessed_on_income_received_by_fiduciary) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ma/statute/62/42`
- Module: `us-ma/statutes/62/42.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-42/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.