### PR TITLE
Encode us-ma/statute/62/14 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11831,6 +11831,15 @@
         ]
       }
     ],
+    "us-ma/statute/62/14": [
+      {
+        "module": "us-ma/statutes/62/14.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/statute/62/3": [
       {
         "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ma/.axiom/encoding-manifests/statutes/62/14.json
+++ b/us-ma/.axiom/encoding-manifests/statutes/62/14.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/62/14.yaml",
+      "sha256": "20a27ef4d31b0af0f520ffc04da49f1deaaad24740b361ffdf3fcc5a188ed395"
+    },
+    {
+      "path": "statutes/62/14.test.yaml",
+      "sha256": "fc20cfc9be05bb0594c234f4c75947765bb7bb68625a8fdd87735c792eb8c3c3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ma/statute/62/14",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-14/encode-out/_eval_workspaces/codex-gpt-5.5/us-ma-statute-62-14/workspace/context-manifest.json",
+  "context_manifest_sha256": "1bcaee97df2131395fe1a549e472a687d53b4cdf11aef32976c7ca9542ec9a19",
+  "generated_at": "2026-07-08T14:31:07.533084+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-14/encode-out/codex-gpt-5.5/statutes/62/14.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-14/encode-out",
+  "generated_output_sha256": "20a27ef4d31b0af0f520ffc04da49f1deaaad24740b361ffdf3fcc5a188ed395",
+  "generation_prompt_sha256": "2c45128a46c3607236eb8410b42639adc592afead24516f69a34c0413dc441fe",
+  "model": "gpt-5.5",
+  "run_id": "a4368da1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7a9efc5e7250d4071e777c24b4994452e46933e26c76a3f19e76188141ba6fa2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-14/encode-out/traces/codex-gpt-5.5/us-ma-statute-62-14.json",
+  "trace_sha256": "174ee28e7a984188e763e95dbac480d01bbfc157b5fee8ba1ed9362685bf6b0f"
+}

--- a/us-ma/statutes/62/14.test.yaml
+++ b/us-ma/statutes/62/14.test.yaml
@@ -1,0 +1,64 @@
+- name: fiduciary_corporation_income_subject_to_chapter_without_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/14#input.corporation_acting_as_trustee_or_other_fiduciary: true
+    us-ma:statutes/62/14#input.income_received_by_corporation_in_that_capacity: true
+    us-ma:statutes/62/14#input.property_income_would_be_taxable_if_received_by_individual_inhabitant: true
+    ? us-ma:statutes/62/14#input.property_held_by_corporation_as_mortgagee_or_pledge_to_secure_payment_of_bonds_notes_or_other_evidences_of_indebtedness
+    : false
+    us-ma:statutes/62/14#input.interest_on_secured_indebtedness_subject_to_taxation_to_individual_inhabitants_who_received_it: true
+    us-ma:statutes/62/14#input.principal_of_secured_indebtedness_exempt_from_taxation_under_laws_other_than_this_chapter: false
+  output:
+    us-ma:statutes/62/14#fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies: not_holds
+    us-ma:statutes/62/14#fiduciary_corporation_income_subject_to_chapter: holds
+- name: mortgagee_or_pledgee_exception_blocks_chapter_taxability
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/14#input.corporation_acting_as_trustee_or_other_fiduciary: true
+    us-ma:statutes/62/14#input.income_received_by_corporation_in_that_capacity: true
+    us-ma:statutes/62/14#input.property_income_would_be_taxable_if_received_by_individual_inhabitant: true
+    ? us-ma:statutes/62/14#input.property_held_by_corporation_as_mortgagee_or_pledge_to_secure_payment_of_bonds_notes_or_other_evidences_of_indebtedness
+    : true
+    us-ma:statutes/62/14#input.interest_on_secured_indebtedness_subject_to_taxation_to_individual_inhabitants_who_received_it: true
+    us-ma:statutes/62/14#input.principal_of_secured_indebtedness_exempt_from_taxation_under_laws_other_than_this_chapter: false
+  output:
+    us-ma:statutes/62/14#fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies: holds
+    us-ma:statutes/62/14#fiduciary_corporation_income_subject_to_chapter: not_holds
+- name: principal_exemption_alternative_triggers_exception
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/14#input.corporation_acting_as_trustee_or_other_fiduciary: true
+    us-ma:statutes/62/14#input.income_received_by_corporation_in_that_capacity: true
+    us-ma:statutes/62/14#input.property_income_would_be_taxable_if_received_by_individual_inhabitant: true
+    ? us-ma:statutes/62/14#input.property_held_by_corporation_as_mortgagee_or_pledge_to_secure_payment_of_bonds_notes_or_other_evidences_of_indebtedness
+    : true
+    us-ma:statutes/62/14#input.interest_on_secured_indebtedness_subject_to_taxation_to_individual_inhabitants_who_received_it: false
+    us-ma:statutes/62/14#input.principal_of_secured_indebtedness_exempt_from_taxation_under_laws_other_than_this_chapter: true
+  output:
+    us-ma:statutes/62/14#fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies: holds
+    us-ma:statutes/62/14#fiduciary_corporation_income_subject_to_chapter: not_holds
+- name: no_chapter_taxability_when_income_not_received_in_fiduciary_capacity
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/14#input.corporation_acting_as_trustee_or_other_fiduciary: true
+    us-ma:statutes/62/14#input.income_received_by_corporation_in_that_capacity: false
+    us-ma:statutes/62/14#input.property_income_would_be_taxable_if_received_by_individual_inhabitant: true
+    ? us-ma:statutes/62/14#input.property_held_by_corporation_as_mortgagee_or_pledge_to_secure_payment_of_bonds_notes_or_other_evidences_of_indebtedness
+    : false
+    us-ma:statutes/62/14#input.interest_on_secured_indebtedness_subject_to_taxation_to_individual_inhabitants_who_received_it: true
+    us-ma:statutes/62/14#input.principal_of_secured_indebtedness_exempt_from_taxation_under_laws_other_than_this_chapter: false
+  output:
+    us-ma:statutes/62/14#fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies: not_holds
+    us-ma:statutes/62/14#fiduciary_corporation_income_subject_to_chapter: not_holds

--- a/us-ma/statutes/62/14.yaml
+++ b/us-ma/statutes/62/14.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/statute/62/14
+  summary: |-
+    Corporations acting as trustee or in any other fiduciary capacity are subject to this chapter with respect to income received in that capacity, in the same manner as individual inhabitants acting similarly, except for specified mortgagee or pledge property and income.
+rules:
+  - name: fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies
+    kind: derived
+    entity: Corporation
+    dtype: Judgment
+    period: Year
+    source: M.G.L. c. 62, § 14
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: no such corporation shall be taxed on account of any property the income of which would be taxable if received by an individual inhabitant
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: if such property is held by such corporation as mortgagee or pledge to secure the payment of bonds, notes or other evidences of indebtedness
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: the interest on which is subject to taxation to such individual inhabitants of the commonwealth as received it
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: or the principal of which is exempt from taxation under laws other than this chapter
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          property_income_would_be_taxable_if_received_by_individual_inhabitant
+          and property_held_by_corporation_as_mortgagee_or_pledge_to_secure_payment_of_bonds_notes_or_other_evidences_of_indebtedness
+          and (interest_on_secured_indebtedness_subject_to_taxation_to_individual_inhabitants_who_received_it
+          or principal_of_secured_indebtedness_exempt_from_taxation_under_laws_other_than_this_chapter)
+  - name: fiduciary_corporation_income_subject_to_chapter
+    kind: derived
+    entity: Corporation
+    dtype: Judgment
+    period: Year
+    source: M.G.L. c. 62, § 14
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: Corporations acting as trustee or in any other fiduciary capacity
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: with respect to the income received by them in that capacity
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/14
+              excerpt: shall ... be subject to this chapter in the same manner and under the same conditions as individual inhabitants
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ma:statutes/62/14#fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies
+              output: fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          corporation_acting_as_trustee_or_other_fiduciary
+          and income_received_by_corporation_in_that_capacity
+          and not fiduciary_corporation_mortgagee_or_pledgee_tax_exception_applies


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ma/statute/62/14`
- Module: `us-ma/statutes/62/14.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-14/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.