### PR TITLE
Encode us-ma/statute/62/16 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11831,6 +11831,15 @@
         ]
       }
     ],
+    "us-ma/statute/62/16": [
+      {
+        "module": "us-ma/statutes/62/16.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/statute/62/3": [
       {
         "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ma/.axiom/encoding-manifests/statutes/62/16.json
+++ b/us-ma/.axiom/encoding-manifests/statutes/62/16.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/62/16.yaml",
+      "sha256": "b624eae7454175b914fb78580cec7aa165631bbab8bdb4d621c634ad3ce42cfe"
+    },
+    {
+      "path": "statutes/62/16.test.yaml",
+      "sha256": "e648b9642830384ebb64a4d66825a73c343e51aaeeb5974277c9583c6894bd1d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ma/statute/62/16",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-16/encode-out/_eval_workspaces/codex-gpt-5.5/us-ma-statute-62-16/workspace/context-manifest.json",
+  "context_manifest_sha256": "ad16799604c86c1062442fac7ef053b3a44ab050aedf527172ee8c1bae5e955f",
+  "generated_at": "2026-07-08T14:32:12.691330+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-16/encode-out/codex-gpt-5.5/statutes/62/16.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-16/encode-out",
+  "generated_output_sha256": "b624eae7454175b914fb78580cec7aa165631bbab8bdb4d621c634ad3ce42cfe",
+  "generation_prompt_sha256": "4e66c9c12276faaf91515ec03b81e2cffa8a8006af794669098e0aab162f1c49",
+  "model": "gpt-5.5",
+  "run_id": "57ea5072",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9395d4934e9135e622554a25f1a110114d3633ee5f3a39c60387fc88281e6fbf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-16/encode-out/traces/codex-gpt-5.5/us-ma-statute-62-16.json",
+  "trace_sha256": "0295beacc79a66ae4a3f17c0b55af17459db21f1dd9dba47c4684e7e3ece29a5"
+}

--- a/us-ma/statutes/62/16.test.yaml
+++ b/us-ma/statutes/62/16.test.yaml
@@ -1,0 +1,45 @@
+- name: commissioner agreement authorized for qualifying estate taxes
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/16#input.agreement_facilitates_settlement_and_distribution_of_estate: true
+    us-ma:statutes/62/16#input.estate_held_by_trustee_or_other_fiduciary_named_in_section_thirteen: true
+    us-ma:statutes/62/16#input.taxes_are_due_or_to_become_due_from_estate_under_chapter: true
+  output:
+    us-ma:statutes/62/16#commissioner_estate_tax_settlement_agreement_authorized: holds
+- name: commissioner agreement not authorized without settlement and distribution
+    purpose
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/16#input.agreement_facilitates_settlement_and_distribution_of_estate: false
+    us-ma:statutes/62/16#input.estate_held_by_trustee_or_other_fiduciary_named_in_section_thirteen: true
+    us-ma:statutes/62/16#input.taxes_are_due_or_to_become_due_from_estate_under_chapter: true
+  output:
+    us-ma:statutes/62/16#commissioner_estate_tax_settlement_agreement_authorized: not_holds
+- name: commissioner agreement not authorized for estate outside trustee or section
+    thirteen fiduciary class
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/16#input.agreement_facilitates_settlement_and_distribution_of_estate: true
+    us-ma:statutes/62/16#input.estate_held_by_trustee_or_other_fiduciary_named_in_section_thirteen: false
+    us-ma:statutes/62/16#input.taxes_are_due_or_to_become_due_from_estate_under_chapter: true
+  output:
+    us-ma:statutes/62/16#commissioner_estate_tax_settlement_agreement_authorized: not_holds
+- name: payment under agreement fully satisfies related taxes
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:statutes/62/16#input.payment_made_in_accordance_with_estate_tax_settlement_agreement: true
+    us-ma:statutes/62/16#input.payment_relates_to_taxes_covered_by_estate_tax_settlement_agreement: true
+  output:
+    us-ma:statutes/62/16#payment_under_estate_tax_settlement_agreement_fully_satisfies_related_taxes: holds

--- a/us-ma/statutes/62/16.yaml
+++ b/us-ma/statutes/62/16.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/statute/62/16
+  summary: |-
+    The commissioner may, to facilitate settlement and distribution of estates held by trustees and fiduciaries named in section thirteen, agree on taxes due or to become due from such estates, and payment under the agreement fully satisfies the taxes to which it relates.
+rules:
+  - name: commissioner_estate_tax_settlement_agreement_authorized
+    kind: derived
+    entity: Estate
+    dtype: Judgment
+    period: Year
+    source: M.G.L. c. 62, § 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ma/statute/62/16
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/16
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/16
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          agreement_facilitates_settlement_and_distribution_of_estate
+          and estate_held_by_trustee_or_other_fiduciary_named_in_section_thirteen
+          and taxes_are_due_or_to_become_due_from_estate_under_chapter
+  - name: payment_under_estate_tax_settlement_agreement_fully_satisfies_related_taxes
+    kind: derived
+    entity: Estate
+    dtype: Judgment
+    period: Year
+    source: M.G.L. c. 62, § 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/16
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/16
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          payment_made_in_accordance_with_estate_tax_settlement_agreement
+          and payment_relates_to_taxes_covered_by_estate_tax_settlement_agreement


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ma/statute/62/16`
- Module: `us-ma/statutes/62/16.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ma-statute-62-16/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.