### PR TITLE
Encode us-ny/statute/TAX/617 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16720,6 +16720,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/617": [
+      {
+        "module": "us-ny/statutes/TAX/617.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/672": [
       {
         "module": "us-ny/statutes/TAX/672.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/617.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/617.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/617.yaml",
+      "sha256": "317e96d19644978ad8b74d95891a825571973c159f25774490ef140f63fe7788"
+    },
+    {
+      "path": "statutes/TAX/617.test.yaml",
+      "sha256": "49a0d8a5bdd897959947bc676a3e6e8bd22b15db9d45eec289f3e0a734296962"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/617",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-617/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-617/workspace/context-manifest.json",
+  "context_manifest_sha256": "0c772b688b5db47e901454e2020936dd50e3a483f82f34da42e59a7170a9eb61",
+  "generated_at": "2026-07-08T14:34:51.972188+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-617/encode-out/codex-gpt-5.5/statutes/TAX/617.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-617/encode-out",
+  "generated_output_sha256": "317e96d19644978ad8b74d95891a825571973c159f25774490ef140f63fe7788",
+  "generation_prompt_sha256": "3171061bf428569d68fff935caee5682f58d67b9ba9378c7f6b85af057ebfe52",
+  "model": "gpt-5.5",
+  "run_id": "53689eb2",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2de1cec8fe817f201b6108efb05d56ebde54b8fc4b77116924de2215040e7a44"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-617/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-617.json",
+  "trace_sha256": "09b38f651ec7413efb348632c07919f0b19b9b567ddde05d05f4ce6998913890"
+}

--- a/us-ny/statutes/TAX/617.test.yaml
+++ b/us-ny/statutes/TAX/617.test.yaml
@@ -1,0 +1,54 @@
+- name: separately stated item modification uses federal item share
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/617#input.new_york_s_termination_year: false
+    us-ny:statutes/TAX/617#input.total_modification_amount_relating_to_item: 1000
+    us-ny:statutes/TAX/617#input.pro_rata_share_determined_under_subsection_s_of_section_612: 0.4
+    us-ny:statutes/TAX/617#input.item_required_to_be_taken_into_account_separately_for_federal_income_tax_purposes: true
+    us-ny:statutes/TAX/617#input.federal_share_of_item_to_which_modification_relates: 0.25
+    us-ny:statutes/TAX/617#input.federal_share_of_partnership_or_s_corporation_taxable_income_or_loss_generally: 0.6
+  output:
+    us-ny:statutes/TAX/617#resident_partner_or_shareholder_modification_amount: 250
+- name: nonseparate item modification uses general taxable income or loss share
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/617#input.new_york_s_termination_year: false
+    us-ny:statutes/TAX/617#input.total_modification_amount_relating_to_item: 1000
+    us-ny:statutes/TAX/617#input.pro_rata_share_determined_under_subsection_s_of_section_612: 0.4
+    us-ny:statutes/TAX/617#input.item_required_to_be_taken_into_account_separately_for_federal_income_tax_purposes: false
+    us-ny:statutes/TAX/617#input.federal_share_of_item_to_which_modification_relates: 0.25
+    us-ny:statutes/TAX/617#input.federal_share_of_partnership_or_s_corporation_taxable_income_or_loss_generally: 0.6
+  output:
+    us-ny:statutes/TAX/617#resident_partner_or_shareholder_modification_amount: 600
+- name: item character follows federal characterization when available
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/617#input.item_characterized_for_federal_income_tax_purposes: true
+    us-ny:statutes/TAX/617#input.federal_income_tax_character_of_item: capital_gain
+    ? us-ny:statutes/TAX/617#input.character_as_if_realized_directly_from_source_or_incurred_in_same_manner_by_partnership_or_s_corporation
+    : ordinary_income
+  output:
+    us-ny:statutes/TAX/617#partnership_or_s_corporation_item_character: capital_gain
+- name: tax avoidance special allocation is disregarded for share and modification
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/617#input.distributive_share_determined_by_special_partnership_agreement_provision_for_item: true
+    us-ny:statutes/TAX/617#input.principal_purpose_of_special_provision_is_avoidance_or_evasion_of_tax_under_this_article: true
+    us-ny:statutes/TAX/617#input.distributive_share_as_if_partnership_agreement_made_no_special_provision_for_item: 0.3
+    us-ny:statutes/TAX/617#input.federal_distributive_share_of_item: 0.8
+    us-ny:statutes/TAX/617#input.total_modification_amount_with_respect_to_item: 1000
+  output:
+    us-ny:statutes/TAX/617#distributive_share_after_new_york_tax_avoidance_rule: 0.3
+    us-ny:statutes/TAX/617#modification_amount_after_new_york_tax_avoidance_rule: 300

--- a/us-ny/statutes/TAX/617.yaml
+++ b/us-ny/statutes/TAX/617.yaml
@@ -1,0 +1,85 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/617
+  summary: |-
+    In determining New York adjusted gross income and taxable income of a resident partner or resident S corporation shareholder, covered modifications relating to partnership or S corporation items are made according to the partner's distributive share or shareholder's pro rata share; items have the same character as for federal income tax purposes, or as if realized or incurred directly when not federally characterized; special partnership allocations principally intended to avoid or evade New York tax are disregarded.
+rules:
+  - name: resident_partner_or_shareholder_modification_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: "N.Y. Tax Law § 617(a)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/617
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if new_york_s_termination_year: total_modification_amount_relating_to_item * pro_rata_share_determined_under_subsection_s_of_section_612 else: if item_required_to_be_taken_into_account_separately_for_federal_income_tax_purposes: total_modification_amount_relating_to_item * federal_share_of_item_to_which_modification_relates else: total_modification_amount_relating_to_item * federal_share_of_partnership_or_s_corporation_taxable_income_or_loss_generally
+  - name: partnership_or_s_corporation_item_character
+    kind: derived
+    entity: Person
+    dtype: String
+    period: Year
+    source: "N.Y. Tax Law § 617(b)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/617
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if item_characterized_for_federal_income_tax_purposes: federal_income_tax_character_of_item else: character_as_if_realized_directly_from_source_or_incurred_in_same_manner_by_partnership_or_s_corporation
+  - name: distributive_share_after_new_york_tax_avoidance_rule
+    kind: derived
+    entity: Person
+    dtype: Decimal
+    period: Year
+    source: "N.Y. Tax Law § 617(c)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/617
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if distributive_share_determined_by_special_partnership_agreement_provision_for_item and principal_purpose_of_special_provision_is_avoidance_or_evasion_of_tax_under_this_article: distributive_share_as_if_partnership_agreement_made_no_special_provision_for_item else: federal_distributive_share_of_item
+  - name: modification_amount_after_new_york_tax_avoidance_rule
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: "N.Y. Tax Law § 617(c)"
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/617
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/617#distributive_share_after_new_york_tax_avoidance_rule
+              output: distributive_share_after_new_york_tax_avoidance_rule
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          total_modification_amount_with_respect_to_item * distributive_share_after_new_york_tax_avoidance_rule


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/617`
- Module: `us-ny/statutes/TAX/617.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-617/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.