### PR TITLE
Encode us-ny/statute/TAX/616 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16720,6 +16720,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/616": [
+      {
+        "module": "us-ny/statutes/TAX/616.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/672": [
       {
         "module": "us-ny/statutes/TAX/672.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/616.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/616.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/616.yaml",
+      "sha256": "66d17d37659e2d14cae3360777c87de7f84a3cae051f557ff3a749c228378cd1"
+    },
+    {
+      "path": "statutes/TAX/616.test.yaml",
+      "sha256": "b48ae2dfe5e70aff0eec145d44e4f63f77430f764f6f029f1a251a9e7dae2387"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/616",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-616/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-616/workspace/context-manifest.json",
+  "context_manifest_sha256": "3adb0493fcf409df8664bbddce59aeadaff235726e881c0446bbfbe5f0ee645a",
+  "generated_at": "2026-07-08T14:35:23.685817+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-616/encode-out/codex-gpt-5.5/statutes/TAX/616.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-616/encode-out",
+  "generated_output_sha256": "66d17d37659e2d14cae3360777c87de7f84a3cae051f557ff3a749c228378cd1",
+  "generation_prompt_sha256": "b6e8eaff25d8729b0505a07fc8b49b676c31d7fe2f0ea10f554d2e1158ee2bad",
+  "model": "gpt-5.5",
+  "run_id": "71ccb544",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "990ca346488c9db339a462da9c0f0bc4e54f6bef81de9102b597ed2843d9718f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-616/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-616.json",
+  "trace_sha256": "96f408726da6ced98208da03f4ffd4bea86dd1d1b3aa19328d05bd12e5ba147c"
+}

--- a/us-ny/statutes/TAX/616.test.yaml
+++ b/us-ny/statutes/TAX/616.test.yaml
@@ -1,0 +1,56 @@
+- name: later_year_regular_exemption_uses_one_thousand_per_federal_exemption
+  period:
+    period_kind: tax_year
+    start: '1988-01-01'
+    end: '1988-12-31'
+  input:
+    us-ny:statutes/TAX/616#input.taxable_year_is_initial_exemption_period: false
+    us-ny:statutes/TAX/616#input.taxpayer_federal_exemption_amount_is_zero: false
+    us-ny:statutes/TAX/616#input.spouses_required_separate_new_york_taxes_but_federal_income_tax_determined_on_joint_return: false
+    us-ny:statutes/TAX/616#input.exemption_count_for_which_taxpayer_is_entitled_to_deduction_under_section_151_c: 2
+    ? us-ny:statutes/TAX/616#input.exemption_count_separately_entitled_if_federal_income_taxes_had_been_determined_on_separate_returns
+    : 1
+  output:
+    us-ny:statutes/TAX/616#new_york_exemptions_of_resident_individual: 2000
+- name: initial_year_regular_exemption_uses_nine_hundred_per_federal_exemption
+  period:
+    period_kind: tax_year
+    start: '1987-01-01'
+    end: '1987-12-31'
+  input:
+    us-ny:statutes/TAX/616#input.taxable_year_is_initial_exemption_period: true
+    us-ny:statutes/TAX/616#input.taxpayer_federal_exemption_amount_is_zero: false
+    us-ny:statutes/TAX/616#input.spouses_required_separate_new_york_taxes_but_federal_income_tax_determined_on_joint_return: false
+    us-ny:statutes/TAX/616#input.exemption_count_for_which_taxpayer_is_entitled_to_deduction_under_section_151_c: 3
+    ? us-ny:statutes/TAX/616#input.exemption_count_separately_entitled_if_federal_income_taxes_had_been_determined_on_separate_returns
+    : 1
+  output:
+    us-ny:statutes/TAX/616#new_york_exemptions_of_resident_individual: 2700
+- name: initial_year_zero_federal_exemption_amount_blocks_new_york_exemption
+  period:
+    period_kind: tax_year
+    start: '1987-01-01'
+    end: '1987-12-31'
+  input:
+    us-ny:statutes/TAX/616#input.taxable_year_is_initial_exemption_period: true
+    us-ny:statutes/TAX/616#input.taxpayer_federal_exemption_amount_is_zero: true
+    us-ny:statutes/TAX/616#input.spouses_required_separate_new_york_taxes_but_federal_income_tax_determined_on_joint_return: false
+    us-ny:statutes/TAX/616#input.exemption_count_for_which_taxpayer_is_entitled_to_deduction_under_section_151_c: 3
+    ? us-ny:statutes/TAX/616#input.exemption_count_separately_entitled_if_federal_income_taxes_had_been_determined_on_separate_returns
+    : 1
+  output:
+    us-ny:statutes/TAX/616#new_york_exemptions_of_resident_individual: 0
+- name: spouse_with_separate_new_york_tax_and_joint_federal_return_uses_separate_return_count
+  period:
+    period_kind: tax_year
+    start: '1988-01-01'
+    end: '1988-12-31'
+  input:
+    us-ny:statutes/TAX/616#input.taxable_year_is_initial_exemption_period: false
+    us-ny:statutes/TAX/616#input.taxpayer_federal_exemption_amount_is_zero: false
+    us-ny:statutes/TAX/616#input.spouses_required_separate_new_york_taxes_but_federal_income_tax_determined_on_joint_return: true
+    us-ny:statutes/TAX/616#input.exemption_count_for_which_taxpayer_is_entitled_to_deduction_under_section_151_c: 3
+    ? us-ny:statutes/TAX/616#input.exemption_count_separately_entitled_if_federal_income_taxes_had_been_determined_on_separate_returns
+    : 1
+  output:
+    us-ny:statutes/TAX/616#new_york_exemptions_of_resident_individual: 1000

--- a/us-ny/statutes/TAX/616.yaml
+++ b/us-ny/statutes/TAX/616.yaml
@@ -1,0 +1,73 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/616
+  summary: "Resident individuals are allowed a New York exemption of \"one thousand\
+    \ dollars\" after 1987 for each exemption deductible under IRC \xA7 151(c); for\
+    \ taxable years beginning in 1987, other than taxpayers whose federal exemption\
+    \ amount is zero, the amount is \"nine hundred dollars\" for each federal income\
+    \ tax exemption. If spouses' New York income taxes are separately determined but\
+    \ their federal tax is joint, each spouse receives the exemptions each would have\
+    \ had on separate federal returns."
+rules:
+- name: new_york_exemption_amount_per_federal_exemption
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "NY Tax Law \xA7 616(a)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ny/statute/TAX/616
+          excerpt: taxable years beginning in nineteen hundred eighty-seven ... nine
+            hundred dollars
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ny/statute/TAX/616
+          excerpt: taxable years beginning after nineteen hundred eighty-seven ...
+            one thousand dollars
+  versions:
+  - effective_from: '1987-01-01'
+    formula: '900'
+  - effective_from: '1988-01-01'
+    formula: '1000'
+- name: new_york_exemptions_of_resident_individual
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "NY Tax Law \xA7 616(a)-(b)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ny/statute/TAX/616
+          excerpt: for each exemption for which he is entitled to a deduction
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ny/statute/TAX/616
+          excerpt: other than a taxpayer whose federal exemption amount is zero
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ny/statute/TAX/616
+          excerpt: If the New York income taxes of a husband and wife are required
+            to be separately determined but their federal income tax is determined
+            on a joint return
+  versions:
+  - effective_from: '1987-01-01'
+    formula: 'if taxable_year_is_initial_exemption_period and taxpayer_federal_exemption_amount_is_zero:
+      0 else: new_york_exemption_amount_per_federal_exemption * (if spouses_required_separate_new_york_taxes_but_federal_income_tax_determined_on_joint_return:
+      exemption_count_separately_entitled_if_federal_income_taxes_had_been_determined_on_separate_returns
+      else: exemption_count_for_which_taxpayer_is_entitled_to_deduction_under_section_151_c)'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/616`
- Module: `us-ny/statutes/TAX/616.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-616/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.