### PR TITLE
Encode us-ny/statute/TAX/618 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16720,6 +16720,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/618": [
+      {
+        "module": "us-ny/statutes/TAX/618.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/672": [
       {
         "module": "us-ny/statutes/TAX/672.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/618.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/618.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/618.yaml",
+      "sha256": "be0e26df82caca4940379aa9b2bf897baaea78e28551654f890f6810729e351d"
+    },
+    {
+      "path": "statutes/TAX/618.test.yaml",
+      "sha256": "2073f2da408262a00af4dd479f4f65d79d8c33133705a5a8f7f5bb4b591d38f4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/618",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-618/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-618/workspace/context-manifest.json",
+  "context_manifest_sha256": "ce59d720291261784d035be495e031e6a5d301bd8f2a181a2fa14a6bc45587fe",
+  "generated_at": "2026-07-08T14:36:27.349767+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-618/encode-out/codex-gpt-5.5/statutes/TAX/618.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-618/encode-out",
+  "generated_output_sha256": "be0e26df82caca4940379aa9b2bf897baaea78e28551654f890f6810729e351d",
+  "generation_prompt_sha256": "adea1274fc89a6cb7eae79cabc60053dd87d87e4797206d07ae698103358d300",
+  "model": "gpt-5.5",
+  "run_id": "4e56d756",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a8c753a37643707a7b1aa06e0b76f154a1654066c599623910740b1d3d1485e2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-618/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-618.json",
+  "trace_sha256": "c8f3c59794890b6164fe569144778be2f913223967a7912602e71857ed3e7e7e"
+}

--- a/us-ny/statutes/TAX/618.test.yaml
+++ b/us-ny/statutes/TAX/618.test.yaml
@@ -1,0 +1,26 @@
+- name: resident_estate_or_trust_taxable_income_applies_additions_and_subtractions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/618#input.federal_taxable_income: 100000
+    us-ny:statutes/TAX/618#input.new_york_fiduciary_adjustment_share_under_section_619: -3000
+    us-ny:statutes/TAX/618#input.resident_estate_or_trust_modifications_under_section_612: 7000
+    us-ny:statutes/TAX/618#input.includible_gain_taxed_under_internal_revenue_code_section_644_net_of_allocable_deductions: 5000
+    us-ny:statutes/TAX/618#input.section_612_c_4_and_5_gain_modifications_excluded_from_federal_distributable_net_income: 2000
+  output:
+    us-ny:statutes/TAX/618#new_york_taxable_income_of_resident_estate_or_trust: 107000
+- name: resident_estate_or_trust_taxable_income_not_negative
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/618#input.federal_taxable_income: 1000
+    us-ny:statutes/TAX/618#input.new_york_fiduciary_adjustment_share_under_section_619: -2000
+    us-ny:statutes/TAX/618#input.resident_estate_or_trust_modifications_under_section_612: -500
+    us-ny:statutes/TAX/618#input.includible_gain_taxed_under_internal_revenue_code_section_644_net_of_allocable_deductions: 0
+    us-ny:statutes/TAX/618#input.section_612_c_4_and_5_gain_modifications_excluded_from_federal_distributable_net_income: 1000
+  output:
+    us-ny:statutes/TAX/618#new_york_taxable_income_of_resident_estate_or_trust: 0

--- a/us-ny/statutes/TAX/618.yaml
+++ b/us-ny/statutes/TAX/618.yaml
@@ -1,0 +1,48 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/618
+  summary: |-
+    "The New York taxable income of a resident estate or trust means its federal taxable income ... with the following modifications": subtract specified section 612(c)(4) and (5) gain modifications excluded from federal distributable net income; add or subtract the estate or trust share of the section 619 New York fiduciary adjustment; add or subtract specified section 612(b) and (c) modifications; and for a trust add net includible gain taxed under Internal Revenue Code section 644.
+rules:
+  - name: new_york_taxable_income_of_resident_estate_or_trust
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: NY Tax Law § 618
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/618
+              excerpt: "New York taxable income of a resident estate or trust means its federal taxable income"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/618
+              excerpt: "There shall be subtracted the modifications described in paragraphs (4) and (5) of subsection (c) of section six hundred twelve"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/618
+              excerpt: "There shall be added or subtracted ... the share of the estate or trust in the New York fiduciary adjustment determined under section six hundred nineteen"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/618
+              excerpt: "There shall be added or subtracted ... the modifications described in ... section six hundred twelve"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/618
+              excerpt: "In the case of a trust, there shall be added the amount of any includible gain, reduced by any deductions properly allocable thereto"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, federal_taxable_income + new_york_fiduciary_adjustment_share_under_section_619 + resident_estate_or_trust_modifications_under_section_612 + includible_gain_taxed_under_internal_revenue_code_section_644_net_of_allocable_deductions - section_612_c_4_and_5_gain_modifications_excluded_from_federal_distributable_net_income)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/618`
- Module: `us-ny/statutes/TAX/618.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-618/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.