### PR TITLE
Encode us-ny/statute/TAX/621 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16720,6 +16720,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/621": [
+      {
+        "module": "us-ny/statutes/TAX/621.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ny/statute/TAX/672": [
       {
         "module": "us-ny/statutes/TAX/672.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/621.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/621.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/621.yaml",
+      "sha256": "0c6731b0572247dd537a0f69ca74b6caf6a34456317ce1f58dc8ef5a200f7a0f"
+    },
+    {
+      "path": "statutes/TAX/621.test.yaml",
+      "sha256": "1571eed485cb1cfe920da85aa6c75d0ab1f2d0b9ed8c6c7cef3f734cc79b7901"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/621",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-621/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-621/workspace/context-manifest.json",
+  "context_manifest_sha256": "1c547497cd948c6595ed3ee5328f8289f0a6dd315c983e14b282c9487ebfa552",
+  "generated_at": "2026-07-08T14:37:14.854189+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-621/encode-out/codex-gpt-5.5/statutes/TAX/621.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-621/encode-out",
+  "generated_output_sha256": "0c6731b0572247dd537a0f69ca74b6caf6a34456317ce1f58dc8ef5a200f7a0f",
+  "generation_prompt_sha256": "d1ec9fc8f920e202c919d998fff32d9b424aec94746bc97d3853901e4db66560",
+  "model": "gpt-5.5",
+  "run_id": "8aab4d65",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9ca526e1541a6331cff71003fa76a66cc2b607104295dd7856d794a2b026745d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-621/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-621.json",
+  "trace_sha256": "8aacfe9fc3c854dbe55d15c9fe38f752be9ca8a10a499ecc6a1d27f7c31f0287"
+}

--- a/us-ny/statutes/TAX/621.test.yaml
+++ b/us-ny/statutes/TAX/621.test.yaml
@@ -1,0 +1,60 @@
+- name: both_credit_branches_limited_by_subsection_b
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/621#input.resident_beneficiary_of_trust: true
+    us-ny:statutes/TAX/621#input.new_york_adjusted_gross_income_includes_accumulation_distribution_by_trust: true
+    us-ny:statutes/TAX/621#input.proportionate_part_of_trust_new_york_tax_not_payable_if_timely_distributed: 300
+    us-ny:statutes/TAX/621#input.trust_other_jurisdiction_income_tax_imposed_on_qualifying_income: 250
+    us-ny:statutes/TAX/621#input.tax_otherwise_due_under_this_article: 1000
+    ? us-ny:statutes/TAX/621#input.portion_of_income_taxable_to_trust_in_other_jurisdiction_and_to_beneficiary_under_this_article
+    : 2000
+    us-ny:statutes/TAX/621#input.beneficiary_total_new_york_income: 10000
+    us-ny:statutes/TAX/621#input.tax_due_if_accumulation_distribution_excluded_from_new_york_adjusted_gross_income: 600
+  output:
+    us-ny:statutes/TAX/621#resident_beneficiary_receiving_accumulation_distribution: holds
+    us-ny:statutes/TAX/621#trust_new_york_tax_accumulation_distribution_credit_before_limitation: 300
+    us-ny:statutes/TAX/621#trust_other_jurisdiction_income_tax_credit_before_limitation: 200
+    us-ny:statutes/TAX/621#accumulation_distribution_credit_after_limitation: 400
+- name: nonresident_beneficiary_does_not_qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/621#input.resident_beneficiary_of_trust: false
+    us-ny:statutes/TAX/621#input.new_york_adjusted_gross_income_includes_accumulation_distribution_by_trust: true
+    us-ny:statutes/TAX/621#input.proportionate_part_of_trust_new_york_tax_not_payable_if_timely_distributed: 300
+    us-ny:statutes/TAX/621#input.trust_other_jurisdiction_income_tax_imposed_on_qualifying_income: 250
+    us-ny:statutes/TAX/621#input.tax_otherwise_due_under_this_article: 1000
+    ? us-ny:statutes/TAX/621#input.portion_of_income_taxable_to_trust_in_other_jurisdiction_and_to_beneficiary_under_this_article
+    : 2000
+    us-ny:statutes/TAX/621#input.beneficiary_total_new_york_income: 10000
+    us-ny:statutes/TAX/621#input.tax_due_if_accumulation_distribution_excluded_from_new_york_adjusted_gross_income: 600
+  output:
+    us-ny:statutes/TAX/621#resident_beneficiary_receiving_accumulation_distribution: not_holds
+    us-ny:statutes/TAX/621#trust_new_york_tax_accumulation_distribution_credit_before_limitation: 0
+    us-ny:statutes/TAX/621#trust_other_jurisdiction_income_tax_credit_before_limitation: 0
+    us-ny:statutes/TAX/621#accumulation_distribution_credit_after_limitation: 0
+- name: resident_without_accumulation_distribution_does_not_qualify
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/621#input.resident_beneficiary_of_trust: true
+    us-ny:statutes/TAX/621#input.new_york_adjusted_gross_income_includes_accumulation_distribution_by_trust: false
+    us-ny:statutes/TAX/621#input.proportionate_part_of_trust_new_york_tax_not_payable_if_timely_distributed: 300
+    us-ny:statutes/TAX/621#input.trust_other_jurisdiction_income_tax_imposed_on_qualifying_income: 250
+    us-ny:statutes/TAX/621#input.tax_otherwise_due_under_this_article: 1000
+    ? us-ny:statutes/TAX/621#input.portion_of_income_taxable_to_trust_in_other_jurisdiction_and_to_beneficiary_under_this_article
+    : 2000
+    us-ny:statutes/TAX/621#input.beneficiary_total_new_york_income: 10000
+    us-ny:statutes/TAX/621#input.tax_due_if_accumulation_distribution_excluded_from_new_york_adjusted_gross_income: 600
+  output:
+    us-ny:statutes/TAX/621#resident_beneficiary_receiving_accumulation_distribution: not_holds
+    us-ny:statutes/TAX/621#trust_new_york_tax_accumulation_distribution_credit_before_limitation: 0
+    us-ny:statutes/TAX/621#trust_other_jurisdiction_income_tax_credit_before_limitation: 0
+    us-ny:statutes/TAX/621#accumulation_distribution_credit_after_limitation: 0

--- a/us-ny/statutes/TAX/621.yaml
+++ b/us-ny/statutes/TAX/621.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/621
+  summary: |-
+    A resident beneficiary of a trust whose New York adjusted gross income includes all or part of an accumulation distribution shall be allowed credits for specified trust taxes, but the credits shall not reduce the beneficiary's tax below the amount due if the accumulation distribution were excluded.
+rules:
+  - name: resident_beneficiary_receiving_accumulation_distribution
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: N.Y. Tax Law § 621(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/621
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          resident_beneficiary_of_trust
+          and new_york_adjusted_gross_income_includes_accumulation_distribution_by_trust
+
+  - name: trust_new_york_tax_accumulation_distribution_credit_before_limitation
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 621(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/621
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if resident_beneficiary_receiving_accumulation_distribution: max(0, proportionate_part_of_trust_new_york_tax_not_payable_if_timely_distributed) else: 0
+
+  - name: trust_other_jurisdiction_income_tax_credit_before_limitation
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 621(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/621
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if resident_beneficiary_receiving_accumulation_distribution and beneficiary_total_new_york_income > 0: min(max(0, trust_other_jurisdiction_income_tax_imposed_on_qualifying_income), max(0, max(0, tax_otherwise_due_under_this_article) * max(0, portion_of_income_taxable_to_trust_in_other_jurisdiction_and_to_beneficiary_under_this_article) / beneficiary_total_new_york_income)) else: 0
+
+  - name: accumulation_distribution_credit_after_limitation
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 621(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/621
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(max(0, trust_new_york_tax_accumulation_distribution_credit_before_limitation + trust_other_jurisdiction_income_tax_credit_before_limitation), max(0, tax_otherwise_due_under_this_article - tax_due_if_accumulation_distribution_excluded_from_new_york_adjusted_gross_income))


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/621`
- Module: `us-ny/statutes/TAX/621.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-621/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.