### PR TITLE
Encode us-ny/statute/TAX/674 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16738,6 +16738,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/674": [
+      {
+        "module": "us-ny/statutes/TAX/674.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-oh/statute/5747.02": [
       {
         "module": "us-oh/statutes/5747/02.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/674.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/674.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/674.yaml",
+      "sha256": "45ab4d6ccfd5e91aabf0c3890031d189ad8e0d58390bc1e70dceb92ec17a9d7d"
+    },
+    {
+      "path": "statutes/TAX/674.test.yaml",
+      "sha256": "267e4124858b71ba7cdb0a77af72636871121e758ac2ee86fa320623e4fc3ed3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/674",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-674/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-674/workspace/context-manifest.json",
+  "context_manifest_sha256": "6379aa78d2b305a7599c055286005da3698799964b87c5680527c4d4a64b4fa0",
+  "generated_at": "2026-07-08T14:38:37.865891+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-674/encode-out/codex-gpt-5.5/statutes/TAX/674.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-674/encode-out",
+  "generated_output_sha256": "45ab4d6ccfd5e91aabf0c3890031d189ad8e0d58390bc1e70dceb92ec17a9d7d",
+  "generation_prompt_sha256": "c7f16afb02f31e2112453c2bb08b76575d6de6c2957512a731ade1c5cce4c80a",
+  "model": "gpt-5.5",
+  "run_id": "2689d74f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7cf0db2b04320e01e20c1b3413177c57dd9cb85a2780874d6cd3926839cc8516"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-674/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-674.json",
+  "trace_sha256": "0049d4fe328eeba8a48416bd8856b74e8250b8be5befb1f7b10e11d9a21ad03b"
+}

--- a/us-ny/statutes/TAX/674.test.yaml
+++ b/us-ny/statutes/TAX/674.test.yaml
@@ -1,0 +1,76 @@
+- name: payroll_return_required_at_seven_hundred_threshold_and_fifth_day_deadline
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-ny:statutes/TAX/674#input.employer_has_made_payroll: true
+    us-ny:statutes/TAX/674#input.employer_required_to_deduct_and_withhold_tax_under_this_article: true
+    us-ny:statutes/TAX/674#input.employer_has_not_paid_over_withheld_tax_for_calendar_quarter: true
+    us-ny:statutes/TAX/674#input.cumulative_aggregate_unpaid_withholding_tax_during_calendar_quarter: 700
+    us-ny:statutes/TAX/674#input.employer_is_educational_organization_under_section_nine_a_two: false
+    us-ny:statutes/TAX/674#input.employer_is_health_care_provider_under_section_nine_a_four: false
+    us-ny:statutes/TAX/674#input.withholding_tax_required_to_remit_during_calendar_year_preceding_previous_calendar_year: 14999
+  output:
+    us-ny:statutes/TAX/674#payroll_return_and_payment_required: holds
+    us-ny:statutes/TAX/674#payroll_payment_business_day_deadline: 5
+- name: payroll_return_not_required_below_threshold_and_third_day_deadline
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-16'
+    end: '2024-01-16'
+  input:
+    us-ny:statutes/TAX/674#input.employer_has_made_payroll: true
+    us-ny:statutes/TAX/674#input.employer_required_to_deduct_and_withhold_tax_under_this_article: true
+    us-ny:statutes/TAX/674#input.employer_has_not_paid_over_withheld_tax_for_calendar_quarter: true
+    us-ny:statutes/TAX/674#input.cumulative_aggregate_unpaid_withholding_tax_during_calendar_quarter: 699
+    us-ny:statutes/TAX/674#input.employer_is_educational_organization_under_section_nine_a_two: false
+    us-ny:statutes/TAX/674#input.employer_is_health_care_provider_under_section_nine_a_four: false
+    us-ny:statutes/TAX/674#input.withholding_tax_required_to_remit_during_calendar_year_preceding_previous_calendar_year: 15000
+  output:
+    us-ny:statutes/TAX/674#payroll_return_and_payment_required: not_holds
+    us-ny:statutes/TAX/674#payroll_payment_business_day_deadline: 3
+- name: quarter_close_and_quarterly_return_requirements
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-03-31'
+    end: '2024-03-31'
+  input:
+    us-ny:statutes/TAX/674#input.day_is_close_of_calendar_quarter: true
+    us-ny:statutes/TAX/674#input.employer_required_to_deduct_and_withhold_tax_under_this_article: true
+    us-ny:statutes/TAX/674#input.employer_has_not_paid_over_withheld_tax_for_calendar_quarter: true
+    us-ny:statutes/TAX/674#input.cumulative_aggregate_unpaid_withholding_tax_during_calendar_quarter: 699
+    us-ny:statutes/TAX/674#input.employer_described_in_section_six_hundred_seventy_one_a_one: true
+    ? us-ny:statutes/TAX/674#input.employer_required_to_provide_wage_reporting_information_under_section_one_hundred_seventy_one_a
+    : false
+    ? us-ny:statutes/TAX/674#input.employer_liable_for_unemployment_insurance_contributions_or_payments_under_labor_law_article_eighteen
+    : false
+    ? us-ny:statutes/TAX/674#input.quarterly_combined_return_filed_no_later_than_last_day_of_month_following_last_day_of_calendar_quarter
+    : true
+  output:
+    us-ny:statutes/TAX/674#quarter_close_payment_with_quarterly_return_required: holds
+    us-ny:statutes/TAX/674#quarterly_combined_return_required: holds
+    us-ny:statutes/TAX/674#quarterly_combined_return_filing_deadline_satisfied: holds
+- name: revenue_protection_construction_and_trust_requirements
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-04-15'
+    end: '2024-04-15'
+  input:
+    us-ny:statutes/TAX/674#input.tax_commission_believes_return_and_payment_requirement_necessary_for_protection_of_revenues: true
+    us-ny:statutes/TAX/674#input.employer_in_construction_classification_under_section_one_hundred_seventy_one_j: true
+    us-ny:statutes/TAX/674#input.employer_fails_to_collect_tax: false
+    us-ny:statutes/TAX/674#input.employer_fails_to_truthfully_account_for_tax: false
+    us-ny:statutes/TAX/674#input.employer_fails_to_pay_over_tax: true
+    us-ny:statutes/TAX/674#input.employer_fails_to_make_returns_of_tax_required_by_this_section: false
+    us-ny:statutes/TAX/674#input.tax_commission_served_trust_deposit_notice: true
+    us-ny:statutes/TAX/674#input.tax_commission_served_notice_of_cancellation: false
+  output:
+    us-ny:statutes/TAX/674#revenue_protection_return_and_payment_required: holds
+    us-ny:statutes/TAX/674#construction_quarterly_hours_and_location_reporting_required: holds
+    us-ny:statutes/TAX/674#trust_deposit_notice_may_be_served: holds
+    us-ny:statutes/TAX/674#trust_account_requirement_in_effect: holds

--- a/us-ny/statutes/TAX/674.yaml
+++ b/us-ny/statutes/TAX/674.yaml
@@ -1,0 +1,301 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/674
+  summary: |-
+    Every employer required to deduct and withhold tax shall file a withholding return and pay over the taxes. If, after payroll, unpaid withheld tax during a calendar quarter is $700 or more, the employer shall file a return and pay over the tax; prior-year remittance below $15,000 uses the fifth business day, prior-year remittance of $15,000 or more uses the third business day, except educational organizations and health care providers use the fifth business day. If unpaid withheld tax at quarter close is less than $700, the tax is paid with the quarterly combined return by the filing deadline. The tax commission may require immediate returns and payments for revenue protection and may require trust deposits after failures.
+rules:
+  - name: payroll_unpaid_withholding_tax_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 674(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+              excerpt: "a cumulative aggregate amount of seven hundred dollars or more"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          700
+
+  - name: quarter_close_unpaid_withholding_tax_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 674(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+              excerpt: "less than seven hundred dollars of tax during such calendar quarter"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          700
+
+  - name: prior_year_withholding_remittance_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 674(a)(1), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+              excerpt: "less than fifteen thousand dollars ... more than or equal to fifteen thousand dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          15000
+
+  - name: lower_prior_remittance_business_day_deadline
+    kind: parameter
+    dtype: Count
+    source: N.Y. Tax Law § 674(a)(1), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+              excerpt: "on or before the fifth business day"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          5
+
+  - name: higher_prior_remittance_business_day_deadline
+    kind: parameter
+    dtype: Count
+    source: N.Y. Tax Law § 674(a)(1), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+              excerpt: "on or before the third business day"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3
+
+  - name: payroll_return_and_payment_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/674#payroll_unpaid_withholding_tax_threshold
+              output: payroll_unpaid_withholding_tax_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_has_made_payroll
+          and employer_required_to_deduct_and_withhold_tax_under_this_article
+          and employer_has_not_paid_over_withheld_tax_for_calendar_quarter
+          and cumulative_aggregate_unpaid_withholding_tax_during_calendar_quarter >= payroll_unpaid_withholding_tax_threshold
+
+  - name: payroll_payment_business_day_deadline
+    kind: derived
+    entity: Employer
+    dtype: Count
+    period: Day
+    source: N.Y. Tax Law § 674(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/674#prior_year_withholding_remittance_threshold
+              output: prior_year_withholding_remittance_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/674#lower_prior_remittance_business_day_deadline
+              output: lower_prior_remittance_business_day_deadline
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/674#higher_prior_remittance_business_day_deadline
+              output: higher_prior_remittance_business_day_deadline
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if employer_is_educational_organization_under_section_nine_a_two or employer_is_health_care_provider_under_section_nine_a_four: lower_prior_remittance_business_day_deadline else: if withholding_tax_required_to_remit_during_calendar_year_preceding_previous_calendar_year < prior_year_withholding_remittance_threshold: lower_prior_remittance_business_day_deadline else: higher_prior_remittance_business_day_deadline
+
+  - name: quarter_close_payment_with_quarterly_return_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:statutes/TAX/674#quarter_close_unpaid_withholding_tax_threshold
+              output: quarter_close_unpaid_withholding_tax_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          day_is_close_of_calendar_quarter
+          and employer_required_to_deduct_and_withhold_tax_under_this_article
+          and employer_has_not_paid_over_withheld_tax_for_calendar_quarter
+          and cumulative_aggregate_unpaid_withholding_tax_during_calendar_quarter < quarter_close_unpaid_withholding_tax_threshold
+
+  - name: quarterly_combined_return_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_described_in_section_six_hundred_seventy_one_a_one
+          or employer_required_to_provide_wage_reporting_information_under_section_one_hundred_seventy_one_a
+          or employer_liable_for_unemployment_insurance_contributions_or_payments_under_labor_law_article_eighteen
+
+  - name: quarterly_combined_return_filing_deadline_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          quarterly_combined_return_required
+          and quarterly_combined_return_filed_no_later_than_last_day_of_month_following_last_day_of_calendar_quarter
+
+  - name: revenue_protection_return_and_payment_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_commission_believes_return_and_payment_requirement_necessary_for_protection_of_revenues
+
+  - name: construction_quarterly_hours_and_location_reporting_required
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(a)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_in_construction_classification_under_section_one_hundred_seventy_one_j
+
+  - name: trust_deposit_notice_may_be_served
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          employer_fails_to_collect_tax
+          or employer_fails_to_truthfully_account_for_tax
+          or employer_fails_to_pay_over_tax
+          or employer_fails_to_make_returns_of_tax_required_by_this_section
+
+  - name: trust_account_requirement_in_effect
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Day
+    source: N.Y. Tax Law § 674(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/674
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_commission_served_trust_deposit_notice
+          and not tax_commission_served_notice_of_cancellation


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/674`
- Module: `us-ny/statutes/TAX/674.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-674/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.