### PR TITLE
Encode us-ny/statute/TAX/675 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16738,6 +16738,15 @@
         ]
       }
     ],
+    "us-ny/statute/TAX/675": [
+      {
+        "module": "us-ny/statutes/TAX/675.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-oh/statute/5747.02": [
       {
         "module": "us-oh/statutes/5747/02.yaml",

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/675.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/675.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/TAX/675.yaml",
+      "sha256": "1e400096ab08fdfcc4f8be453b718a1385aa23ee06993455da133a8baf788ec4"
+    },
+    {
+      "path": "statutes/TAX/675.test.yaml",
+      "sha256": "4c9aa5b921cc1bca67d5ebc2a9757a8f3e465868bc2be35f9a29fedd24b07ff4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ny/statute/TAX/675",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-675/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-675/workspace/context-manifest.json",
+  "context_manifest_sha256": "b88b1e91c1f54d868b280763a600d8885534399af01271418c00df9830b2d843",
+  "generated_at": "2026-07-08T14:39:12.232344+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-675/encode-out/codex-gpt-5.5/statutes/TAX/675.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-675/encode-out",
+  "generated_output_sha256": "1e400096ab08fdfcc4f8be453b718a1385aa23ee06993455da133a8baf788ec4",
+  "generation_prompt_sha256": "2723abd566611de7db8b64fc54fb52f938671e940a95808846d82a0311c3e503",
+  "model": "gpt-5.5",
+  "run_id": "22730f94",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1d033535580d499cec9492fa1814d6d477a54caf4eab164d19d064ee77a88d13"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-675/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-675.json",
+  "trace_sha256": "2b81734b640dd293d0994e01ec828d850d23210d1d7c47d1d5a1c68dd6622abe"
+}

--- a/us-ny/statutes/TAX/675.test.yaml
+++ b/us-ny/statutes/TAX/675.test.yaml
@@ -1,0 +1,63 @@
+- name: required_employer_liability_and_trust_amounts
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/675#input.employer_required_to_deduct_and_withhold_tax_under_this_article: true
+    us-ny:statutes/TAX/675#input.tax_required_to_be_withheld_and_paid_over_to_tax_commission: 1000
+    us-ny:statutes/TAX/675#input.additions_to_tax_penalties_and_interest_with_respect_to_required_withholding: 150
+    us-ny:statutes/TAX/675#input.tax_actually_deducted_and_withheld_under_this_article: 900
+  output:
+    us-ny:statutes/TAX/675#employer_required_withholding_tax_liability: 1000
+    us-ny:statutes/TAX/675#employer_tax_for_assessment_and_collection: 1150
+    us-ny:statutes/TAX/675#special_fund_in_trust_for_tax_commission_amount: 900
+- name: employer_not_required_has_no_required_withholding_liability
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/675#input.employer_required_to_deduct_and_withhold_tax_under_this_article: false
+    us-ny:statutes/TAX/675#input.tax_required_to_be_withheld_and_paid_over_to_tax_commission: 1000
+    us-ny:statutes/TAX/675#input.additions_to_tax_penalties_and_interest_with_respect_to_required_withholding: 150
+    us-ny:statutes/TAX/675#input.tax_actually_deducted_and_withheld_under_this_article: 900
+  output:
+    us-ny:statutes/TAX/675#employer_required_withholding_tax_liability: 0
+    us-ny:statutes/TAX/675#employer_tax_for_assessment_and_collection: 1150
+    us-ny:statutes/TAX/675#special_fund_in_trust_for_tax_commission_amount: 900
+- name: employee_lacks_action_when_withheld_wages_paid_over
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/675#input.moneys_deducted_and_withheld_from_employee_wages: true
+    us-ny:statutes/TAX/675#input.moneys_paid_over_to_tax_commission_in_compliance_or_intended_compliance_with_this_article: true
+  output:
+    us-ny:statutes/TAX/675#employee_lacks_right_of_action_for_paid_over_withheld_wages: holds
+- name: employee_action_bar_does_not_apply_without_paid_over_compliance
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/675#input.moneys_deducted_and_withheld_from_employee_wages: true
+    us-ny:statutes/TAX/675#input.moneys_paid_over_to_tax_commission_in_compliance_or_intended_compliance_with_this_article: false
+  output:
+    us-ny:statutes/TAX/675#employee_lacks_right_of_action_for_paid_over_withheld_wages: not_holds
+- name: employee_action_bar_does_not_apply_without_withheld_wages
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ny:statutes/TAX/675#input.moneys_deducted_and_withheld_from_employee_wages: false
+    us-ny:statutes/TAX/675#input.moneys_paid_over_to_tax_commission_in_compliance_or_intended_compliance_with_this_article: true
+  output:
+    us-ny:statutes/TAX/675#employee_lacks_right_of_action_for_paid_over_withheld_wages: not_holds

--- a/us-ny/statutes/TAX/675.yaml
+++ b/us-ny/statutes/TAX/675.yaml
@@ -1,0 +1,95 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/675
+  summary: |-
+    Every employer required to deduct and withhold tax under this article is liable for such tax; required withholding amounts, additions, penalties and interest are considered the employer's tax for assessment and collection; actually withheld tax is a special fund in trust for the tax commission; no employee has a right of action for withheld wages paid over in compliance or intended compliance with this article.
+rules:
+  - name: employer_required_withholding_tax_liability
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 675
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "Every employer required to deduct and withhold tax under this article"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "is hereby made liable for such tax"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if employer_required_to_deduct_and_withhold_tax_under_this_article: tax_required_to_be_withheld_and_paid_over_to_tax_commission else: 0
+  - name: employer_tax_for_assessment_and_collection
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 675
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "any amount required to be withheld and paid over to the tax commission, and any additions to tax, penalties and interest with respect thereto, shall be considered the tax of the employer"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_required_to_be_withheld_and_paid_over_to_tax_commission + additions_to_tax_penalties_and_interest_with_respect_to_required_withholding
+  - name: special_fund_in_trust_for_tax_commission_amount
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.Y. Tax Law § 675
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "Any amount of tax actually deducted and withheld under this article shall be held to be a special fund in trust for the tax commission"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          tax_actually_deducted_and_withheld_under_this_article
+  - name: employee_lacks_right_of_action_for_paid_over_withheld_wages
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: N.Y. Tax Law § 675
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "No employee shall have any right of action against his employer"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ny/statute/TAX/675
+              excerpt: "moneys deducted and withheld from his wages and paid over to the tax commission in compliance or in intended compliance with this article"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          moneys_deducted_and_withheld_from_employee_wages
+          and moneys_paid_over_to_tax_commission_in_compliance_or_intended_compliance_with_this_article


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/675`
- Module: `us-ny/statutes/TAX/675.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-675/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.