### PR TITLE
Encode us-ca/statute/rtc/17014 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17014": [
+      {
+        "module": "us-ca/statutes/rtc/17014.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17014.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17014.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17014.yaml",
+      "sha256": "f38f490666dd280fb2533bd941f9946c4f645c432ea1b711e6940f6474f33fbb"
+    },
+    {
+      "path": "statutes/rtc/17014.test.yaml",
+      "sha256": "839c5e6d46b4fc8ca831701a503b1186f01a7017a367f9ba514a234d12d8cb2b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17014",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17014/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17014/workspace/context-manifest.json",
+  "context_manifest_sha256": "a0b4d4e748a7eff2b219160cc03ecd627b84eedc8b578a565e6a8e84ccb1d474",
+  "generated_at": "2026-07-08T14:39:51.470570+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17014/encode-out/codex-gpt-5.5/statutes/rtc/17014.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17014/encode-out",
+  "generated_output_sha256": "f38f490666dd280fb2533bd941f9946c4f645c432ea1b711e6940f6474f33fbb",
+  "generation_prompt_sha256": "b6481363875f8810047a2b82959b487a5ddf942802e32d66b2a2f72766fa56c6",
+  "model": "gpt-5.5",
+  "run_id": "c20fbdce",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b9e942ce8c226093c6c19f1dcd71cda0500cb7f59364eebcd0c7a413ab0c44d3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17014/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17014.json",
+  "trace_sha256": "7697fa4b43ecd0e82e25fca0f51d4fdaa6c943bb6acdbd18234a17757fa68470"
+}

--- a/us-ca/statutes/rtc/17014.test.yaml
+++ b/us-ca/statutes/rtc/17014.test.yaml
@@ -1,0 +1,109 @@
+- name: federal executive appointee is temporarily outside California
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.domiciled_in_california: true
+    us-ca:statutes/rtc/17014#input.holds_elective_office_of_united_states_government: false
+    us-ca:statutes/rtc/17014#input.employed_on_staff_of_united_states_legislative_branch_elective_officer: false
+    us-ca:statutes/rtc/17014#input.holds_appointive_office_in_federal_executive_branch: true
+    us-ca:statutes/rtc/17014#input.appointment_was_by_president: true
+    us-ca:statutes/rtc/17014#input.appointment_was_subject_to_senate_confirmation: true
+    us-ca:statutes/rtc/17014#input.tenure_is_at_pleasure_of_president: true
+    us-ca:statutes/rtc/17014#input.holds_armed_forces_office: false
+    us-ca:statutes/rtc/17014#input.is_career_appointee_in_united_states_foreign_service: false
+    us-ca:statutes/rtc/17014#input.spouse_has_qualifying_federal_service_under_this_subdivision: false
+  output:
+    us-ca:statutes/rtc/17014#federal_executive_appointive_office_qualifies_for_temporary_absence: holds
+    us-ca:statutes/rtc/17014#california_domiciliary_outside_state_for_temporary_or_transitory_purpose_due_to_federal_service: holds
+- name: armed forces office blocks federal executive appointee path
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.domiciled_in_california: true
+    us-ca:statutes/rtc/17014#input.holds_elective_office_of_united_states_government: false
+    us-ca:statutes/rtc/17014#input.employed_on_staff_of_united_states_legislative_branch_elective_officer: false
+    us-ca:statutes/rtc/17014#input.holds_appointive_office_in_federal_executive_branch: true
+    us-ca:statutes/rtc/17014#input.appointment_was_by_president: true
+    us-ca:statutes/rtc/17014#input.appointment_was_subject_to_senate_confirmation: true
+    us-ca:statutes/rtc/17014#input.tenure_is_at_pleasure_of_president: true
+    us-ca:statutes/rtc/17014#input.holds_armed_forces_office: true
+    us-ca:statutes/rtc/17014#input.is_career_appointee_in_united_states_foreign_service: false
+    us-ca:statutes/rtc/17014#input.spouse_has_qualifying_federal_service_under_this_subdivision: false
+  output:
+    us-ca:statutes/rtc/17014#federal_executive_appointive_office_qualifies_for_temporary_absence: not_holds
+    us-ca:statutes/rtc/17014#california_domiciliary_outside_state_for_temporary_or_transitory_purpose_due_to_federal_service: not_holds
+- name: employment contract absence qualifies
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.domiciled_in_california: true
+    us-ca:statutes/rtc/17014#input.absent_from_california_under_employment_related_contract: true
+    us-ca:statutes/rtc/17014#input.consecutive_absence_days: 546
+    us-ca:statutes/rtc/17014#input.california_return_days_during_taxable_year: 45
+    us-ca:statutes/rtc/17014#input.income_from_intangible_personal_property: 200000
+    us-ca:statutes/rtc/17014#input.principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part: false
+  output:
+    us-ca:statutes/rtc/17014#employment_contract_intangible_income_exception_applies: not_holds
+    us-ca:statutes/rtc/17014#outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract: holds
+- name: intangible income excess blocks employment contract absence
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.domiciled_in_california: true
+    us-ca:statutes/rtc/17014#input.absent_from_california_under_employment_related_contract: true
+    us-ca:statutes/rtc/17014#input.consecutive_absence_days: 546
+    us-ca:statutes/rtc/17014#input.california_return_days_during_taxable_year: 45
+    us-ca:statutes/rtc/17014#input.income_from_intangible_personal_property: 200001
+    us-ca:statutes/rtc/17014#input.principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part: false
+  output:
+    us-ca:statutes/rtc/17014#employment_contract_intangible_income_exception_applies: holds
+    us-ca:statutes/rtc/17014#outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract: not_holds
+- name: auto_output_spouse_outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.absent_from_california_to_accompany_spouse: false
+    us-ca:statutes/rtc/17014#input.absent_from_california_under_employment_related_contract: false
+    us-ca:statutes/rtc/17014#input.appointment_was_by_president: false
+    us-ca:statutes/rtc/17014#input.appointment_was_subject_to_senate_confirmation: false
+    us-ca:statutes/rtc/17014#input.california_return_days_during_taxable_year: 0
+    us-ca:statutes/rtc/17014#input.consecutive_absence_days: 0
+    us-ca:statutes/rtc/17014#input.domiciled_in_california: false
+    us-ca:statutes/rtc/17014#input.employed_on_staff_of_united_states_legislative_branch_elective_officer: false
+    us-ca:statutes/rtc/17014#input.holds_appointive_office_in_federal_executive_branch: false
+    us-ca:statutes/rtc/17014#input.holds_armed_forces_office: false
+    us-ca:statutes/rtc/17014#input.holds_elective_office_of_united_states_government: false
+    us-ca:statutes/rtc/17014#input.income_from_intangible_personal_property: 0
+    us-ca:statutes/rtc/17014#input.is_career_appointee_in_united_states_foreign_service: false
+    us-ca:statutes/rtc/17014#input.principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part: false
+    us-ca:statutes/rtc/17014#input.spouse_has_qualifying_federal_service_under_this_subdivision: false
+    ? us-ca:statutes/rtc/17014#input.spouse_is_considered_outside_state_for_other_than_temporary_or_transitory_purpose_under_this_subdivision
+    : false
+    us-ca:statutes/rtc/17014#input.tenure_is_at_pleasure_of_president: false
+  output:
+    us-ca:statutes/rtc/17014#spouse_outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract: not_holds
+- name: auto_positive_spouse_outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ca:statutes/rtc/17014#input.absent_from_california_to_accompany_spouse: true
+    us-ca:statutes/rtc/17014#input.california_return_days_during_taxable_year: 0
+    us-ca:statutes/rtc/17014#input.consecutive_absence_days: 999999
+    us-ca:statutes/rtc/17014#input.income_from_intangible_personal_property: 0
+    us-ca:statutes/rtc/17014#input.principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part: false
+    ? us-ca:statutes/rtc/17014#input.spouse_is_considered_outside_state_for_other_than_temporary_or_transitory_purpose_under_this_subdivision
+    : true
+  output:
+    us-ca:statutes/rtc/17014#spouse_outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract: holds

--- a/us-ca/statutes/rtc/17014.yaml
+++ b/us-ca/statutes/rtc/17014.yaml
@@ -1,0 +1,171 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17014
+  summary: |-
+    "Resident" includes individuals in California for other than a temporary or transitory purpose, California domiciliaries temporarily outside the state, and residents temporarily absent. California domiciliaries in specified federal offices or staff roles are treated as outside California temporarily. For taxable years beginning on or after January 1, 1994, certain California domiciliaries absent at least 546 consecutive days under an employment-related contract are treated as outside California for other than a temporary or transitory purpose, subject to return-day, intangible-income, spousal-accompaniment, and tax-avoidance rules.
+rules:
+  - name: employment_contract_absence_day_threshold
+    kind: parameter
+    dtype: Count
+    source: 17014(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+              excerpt: "at least 546 consecutive days"
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          546
+
+  - name: california_return_day_disregard_limit
+    kind: parameter
+    dtype: Count
+    source: 17014(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+              excerpt: "not more than 45 days during a taxable year"
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          45
+
+  - name: intangible_personal_property_income_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 17014(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+              excerpt: "in excess of two hundred thousand dollars ($200,000)"
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          200000
+
+  - name: federal_executive_appointive_office_qualifies_for_temporary_absence
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 17014(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          holds_appointive_office_in_federal_executive_branch
+          and appointment_was_by_president
+          and appointment_was_subject_to_senate_confirmation
+          and tenure_is_at_pleasure_of_president
+          and not holds_armed_forces_office
+          and not is_career_appointee_in_united_states_foreign_service
+
+  - name: california_domiciliary_outside_state_for_temporary_or_transitory_purpose_due_to_federal_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 17014(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          domiciled_in_california
+          and (
+            holds_elective_office_of_united_states_government
+            or employed_on_staff_of_united_states_legislative_branch_elective_officer
+            or federal_executive_appointive_office_qualifies_for_temporary_absence
+            or spouse_has_qualifying_federal_service_under_this_subdivision
+          )
+
+  - name: employment_contract_intangible_income_exception_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 17014(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          income_from_intangible_personal_property > intangible_personal_property_income_limit
+
+  - name: outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 17014(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          domiciled_in_california
+          and absent_from_california_under_employment_related_contract
+          and consecutive_absence_days >= employment_contract_absence_day_threshold
+          and california_return_days_during_taxable_year <= california_return_day_disregard_limit
+          and not employment_contract_intangible_income_exception_applies
+          and not principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part
+
+  - name: spouse_outside_state_for_other_than_temporary_or_transitory_purpose_under_employment_contract
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 17014(d)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17014
+    versions:
+      - effective_from: '1994-01-01'
+        formula: |-
+          absent_from_california_to_accompany_spouse
+          and spouse_is_considered_outside_state_for_other_than_temporary_or_transitory_purpose_under_this_subdivision
+          and consecutive_absence_days >= employment_contract_absence_day_threshold
+          and california_return_days_during_taxable_year <= california_return_day_disregard_limit
+          and not employment_contract_intangible_income_exception_applies
+          and not principal_purpose_of_absence_is_to_avoid_tax_imposed_by_this_part


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17014`
- Module: `us-ca/statutes/rtc/17014.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17014/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.