### PR TITLE
Encode us-ca/statute/rtc/17016 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17016": [
+      {
+        "module": "us-ca/statutes/rtc/17016.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17016.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17016.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17016.yaml",
+      "sha256": "c1cf7a5aa1e4b23763a6954412793b4ff59a81d221a09d20024385370abcf189"
+    },
+    {
+      "path": "statutes/rtc/17016.test.yaml",
+      "sha256": "b50c6652b34f2ec9cbe7ecc1b7d4d30c244bcbc695d7d6e7ba04f27bd4d11a95"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17016",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17016/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17016/workspace/context-manifest.json",
+  "context_manifest_sha256": "58fe00eeaed5fef5fb4fb6105f17311aa2e85ffa24ad4b8806e545fa61833a17",
+  "generated_at": "2026-07-08T14:40:00.906289+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17016/encode-out/codex-gpt-5.5/statutes/rtc/17016.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17016/encode-out",
+  "generated_output_sha256": "c1cf7a5aa1e4b23763a6954412793b4ff59a81d221a09d20024385370abcf189",
+  "generation_prompt_sha256": "55cdf479237d31dd93cef80a416cee0bb08d7ea6d8148b67d2743ebebd234060",
+  "model": "gpt-5.5",
+  "run_id": "de474814",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7d29907ab2ff02d908bfd47a7318a9e54eafcc34a5b51b1273e800bfa4b87a40"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17016/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17016.json",
+  "trace_sha256": "b6b843fee36b1ec7e5169c21744d88379a8f31b78d2c793562baabe5c3560659"
+}

--- a/us-ca/statutes/rtc/17016.test.yaml
+++ b/us-ca/statutes/rtc/17016.test.yaml
@@ -1,0 +1,30 @@
+- name: more_than_nine_months_without_temporary_evidence_presumed_resident
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17016#input.aggregate_months_spent_within_state_during_taxable_year: 10
+    us-ca:statutes/rtc/17016#input.satisfactory_evidence_individual_in_state_for_temporary_or_transitory_purpose: false
+  output:
+    us-ca:statutes/rtc/17016#individual_presumed_resident: holds
+- name: nine_months_is_not_more_than_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17016#input.aggregate_months_spent_within_state_during_taxable_year: 9
+    us-ca:statutes/rtc/17016#input.satisfactory_evidence_individual_in_state_for_temporary_or_transitory_purpose: false
+  output:
+    us-ca:statutes/rtc/17016#individual_presumed_resident: not_holds
+- name: temporary_or_transitory_evidence_overcomes_presumption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17016#input.aggregate_months_spent_within_state_during_taxable_year: 10
+    us-ca:statutes/rtc/17016#input.satisfactory_evidence_individual_in_state_for_temporary_or_transitory_purpose: true
+  output:
+    us-ca:statutes/rtc/17016#individual_presumed_resident: not_holds

--- a/us-ca/statutes/rtc/17016.yaml
+++ b/us-ca/statutes/rtc/17016.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17016
+  summary: |-
+    Every individual who spends in the aggregate more than nine months of the taxable year within this State shall be presumed to be a resident. The presumption may be overcome by satisfactory evidence that the individual is in the State for a temporary or transitory purpose.
+rules:
+  - name: resident_presumption_month_threshold
+    kind: parameter
+    dtype: Count
+    source: Cal. Rev. & Tax. Code § 17016
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17016
+              excerpt: "more than nine months"
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          9
+  - name: individual_presumed_resident
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17016
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17016
+              excerpt: "spends in the aggregate more than nine months of the taxable year within this State"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17016
+              excerpt: "overcome by satisfactory evidence that the individual is in the State for a temporary or transitory purpose"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ca:statutes/rtc/17016#resident_presumption_month_threshold
+              output: resident_presumption_month_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          aggregate_months_spent_within_state_during_taxable_year > resident_presumption_month_threshold
+          and not satisfactory_evidence_individual_in_state_for_temporary_or_transitory_purpose


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17016`
- Module: `us-ca/statutes/rtc/17016.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17016/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.