### PR TITLE
Encode us-ca/statute/rtc/17017 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17017": [
+      {
+        "module": "us-ca/statutes/rtc/17017.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17017.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17017.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17017.yaml",
+      "sha256": "ad3c319d3693def0081f7d1281360d3a17900946a7e2622112357a2d496c761a"
+    },
+    {
+      "path": "statutes/rtc/17017.test.yaml",
+      "sha256": "e73ce8cc87979bfd74e8306b1d71ca05f7aa4abe39c13973838f8de4ab4dfadc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17017",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17017/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17017/workspace/context-manifest.json",
+  "context_manifest_sha256": "1dc79799e011ef2e5bd8995279524f8e56a80528bb30a22918e430f732fa8e02",
+  "generated_at": "2026-07-08T14:40:28.807569+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17017/encode-out/codex-gpt-5.5/statutes/rtc/17017.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17017/encode-out",
+  "generated_output_sha256": "ad3c319d3693def0081f7d1281360d3a17900946a7e2622112357a2d496c761a",
+  "generation_prompt_sha256": "b3efde7b5f0dd7202cb1834b838c441b69f36bc091294cf7ce2ff9baf480f93d",
+  "model": "gpt-5.5",
+  "run_id": "921f8ec4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cc13a996e0952e693e6dd7f2dc7904d2ec29afd9409a344f5b16ae7eb7a72cc3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17017/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17017.json",
+  "trace_sha256": "fc94bc85728b7e157bebd27c4fe0ec5eb8ea425763db1f427654ea068f5c60d8"
+}

--- a/us-ca/statutes/rtc/17017.test.yaml
+++ b/us-ca/statutes/rtc/17017.test.yaml
@@ -1,0 +1,44 @@
+- name: state_is_united_states
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17017#input.geographic_area_is_state: true
+    us-ca:statutes/rtc/17017#input.geographic_area_is_district_of_columbia: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_possession_of_united_states: false
+  output:
+    us-ca:statutes/rtc/17017#united_states: holds
+- name: district_of_columbia_is_united_states
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17017#input.geographic_area_is_state: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_district_of_columbia: true
+    us-ca:statutes/rtc/17017#input.geographic_area_is_possession_of_united_states: false
+  output:
+    us-ca:statutes/rtc/17017#united_states: holds
+- name: possession_is_united_states
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17017#input.geographic_area_is_state: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_district_of_columbia: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_possession_of_united_states: true
+  output:
+    us-ca:statutes/rtc/17017#united_states: holds
+- name: outside_list_is_not_united_states
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17017#input.geographic_area_is_state: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_district_of_columbia: false
+    us-ca:statutes/rtc/17017#input.geographic_area_is_possession_of_united_states: false
+  output:
+    us-ca:statutes/rtc/17017#united_states: not_holds

--- a/us-ca/statutes/rtc/17017.yaml
+++ b/us-ca/statutes/rtc/17017.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17017
+  summary: |-
+    "United States," when used in a geographical sense, includes the states, the District of Columbia, and the possessions of the United States.
+rules:
+  - name: united_states
+    kind: derived
+    entity: GeographicArea
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17017
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17017
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          geographic_area_is_state
+          or geographic_area_is_district_of_columbia
+          or geographic_area_is_possession_of_united_states


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17017`
- Module: `us-ca/statutes/rtc/17017.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17017/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.