### PR TITLE
Encode us-ca/statute/rtc/17038 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17038": [
+      {
+        "module": "us-ca/statutes/rtc/17038.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17038.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17038.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17038.yaml",
+      "sha256": "fef0939cbb3dd7488d75ec5bbed58044718063d6057a800b85d3cb0ba7426258"
+    },
+    {
+      "path": "statutes/rtc/17038.test.yaml",
+      "sha256": "77266ca62d6e55c9c7620e13dbff0a37ed61f9350a9902d6c2e789f6a0d68308"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17038",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17038/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17038/workspace/context-manifest.json",
+  "context_manifest_sha256": "c84b0666d5ac6091e185d9e642f6618a25a8799e246e3009dcbd0eb81ee5e475",
+  "generated_at": "2026-07-08T14:41:18.611586+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17038/encode-out/codex-gpt-5.5/statutes/rtc/17038.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17038/encode-out",
+  "generated_output_sha256": "fef0939cbb3dd7488d75ec5bbed58044718063d6057a800b85d3cb0ba7426258",
+  "generation_prompt_sha256": "fcf4c805d84639daf4b49468ecc40c902853648e2f7f014a0131829ae7caed17",
+  "model": "gpt-5.5",
+  "run_id": "dfa1c95a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8d4d02065a522f9dd3100fbecdab5d00b4c473f7393ca18f88e4c5f52fe450be"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17038/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17038.json",
+  "trace_sha256": "7e183e887d52b6c5539ddfbebd4d5f546e3dbd455a3d23fea50b91e0580279cf"
+}

--- a/us-ca/statutes/rtc/17038.test.yaml
+++ b/us-ca/statutes/rtc/17038.test.yaml
@@ -1,0 +1,22 @@
+- name: taxable_year_before_index_series_change_uses_old_series
+  period:
+    period_kind: tax_year
+    start: '1983-01-01'
+    end: '1983-12-31'
+  input:
+    us-ca:statutes/rtc/17038#input.taxable_year_begins_before_index_series_change: true
+    us-ca:statutes/rtc/17038#input.taxable_year_begins_on_or_after_index_series_change: false
+  output:
+    us-ca:statutes/rtc/17038#california_consumer_price_index_means_old_series: holds
+    us-ca:statutes/rtc/17038#california_consumer_price_index_means_new_rental_equivalence_series: not_holds
+- name: taxable_year_on_or_after_index_series_change_uses_new_series
+  period:
+    period_kind: tax_year
+    start: '1984-01-01'
+    end: '1984-12-31'
+  input:
+    us-ca:statutes/rtc/17038#input.taxable_year_begins_before_index_series_change: false
+    us-ca:statutes/rtc/17038#input.taxable_year_begins_on_or_after_index_series_change: true
+  output:
+    us-ca:statutes/rtc/17038#california_consumer_price_index_means_old_series: not_holds
+    us-ca:statutes/rtc/17038#california_consumer_price_index_means_new_rental_equivalence_series: holds

--- a/us-ca/statutes/rtc/17038.yaml
+++ b/us-ca/statutes/rtc/17038.yaml
@@ -1,0 +1,56 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17038
+  summary: |-
+    For taxable years beginning before January 1, 1984, California Consumer Price Index means the old All Urban Consumers series; for taxable years beginning on or after January 1, 1984, it means the new series modified for rental equivalence homeownership.
+rules:
+  - name: california_consumer_price_index_means_old_series
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17038(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17038
+              excerpt: taxable years beginning before January 1, 1984
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17038
+              excerpt: California Consumer Price Index for All Urban Consumers (old series)
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          taxable_year_begins_before_index_series_change
+
+  - name: california_consumer_price_index_means_new_rental_equivalence_series
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17038(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17038
+              excerpt: taxable years beginning on or after January 1, 1984
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17038
+              excerpt: modified for rental equivalence homeownership (new series)
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          taxable_year_begins_on_or_after_index_series_change


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17038`
- Module: `us-ca/statutes/rtc/17038.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17038/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.