### PR TITLE
Encode us-ca/statute/rtc/17029 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17029": [
+      {
+        "module": "us-ca/statutes/rtc/17029.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17029.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17029.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17029.yaml",
+      "sha256": "ae69cf8631075b4da90d7e53228b544110c7e5dd0278730bde70ee95e3615051"
+    },
+    {
+      "path": "statutes/rtc/17029.test.yaml",
+      "sha256": "1e1ff7e35373c7a61176c07a794097a2a0804ad9e9dc97df39242ed46b3c2b64"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17029",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17029/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17029/workspace/context-manifest.json",
+  "context_manifest_sha256": "2c984d259af96458df46b74c2caebe69d5cfd4bed27fd84da124728db2b7e277",
+  "generated_at": "2026-07-08T14:41:54.971656+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17029/encode-out/codex-gpt-5.5/statutes/rtc/17029.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17029/encode-out",
+  "generated_output_sha256": "ae69cf8631075b4da90d7e53228b544110c7e5dd0278730bde70ee95e3615051",
+  "generation_prompt_sha256": "fd60547806db081e9ec6b841759dc9d2ab3be548e8b4fcb42fb993e4f6bb5699",
+  "model": "gpt-5.5",
+  "run_id": "670df768",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2f7e1bf84b890612fd56d0b7bc4695bf81ada228e69d5ccb37478c98cdd0868d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17029/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17029.json",
+  "trace_sha256": "52841a8ab18e4b91244ba796f867949f9e191119ac9b6e03d02c532bdcd50c14"
+}

--- a/us-ca/statutes/rtc/17029.test.yaml
+++ b/us-ca/statutes/rtc/17029.test.yaml
@@ -1,0 +1,52 @@
+- name: act done before repeal preserves right or liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17029#input.provision_of_personal_income_tax_law_repealed: true
+    us-ca:statutes/rtc/17029#input.right_or_liability_arises_under_personal_income_tax_law: true
+    us-ca:statutes/rtc/17029#input.act_done_before_repeal: true
+    us-ca:statutes/rtc/17029#input.right_accruing_or_accrued_before_repeal: false
+    us-ca:statutes/rtc/17029#input.suit_or_proceeding_in_civil_cause_had_or_commenced_before_repeal: false
+  output:
+    us-ca:statutes/rtc/17029#pre_repeal_right_or_liability_survives_repeal: holds
+- name: right accrued before repeal preserves right or liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17029#input.provision_of_personal_income_tax_law_repealed: true
+    us-ca:statutes/rtc/17029#input.right_or_liability_arises_under_personal_income_tax_law: true
+    us-ca:statutes/rtc/17029#input.act_done_before_repeal: false
+    us-ca:statutes/rtc/17029#input.right_accruing_or_accrued_before_repeal: true
+    us-ca:statutes/rtc/17029#input.suit_or_proceeding_in_civil_cause_had_or_commenced_before_repeal: false
+  output:
+    us-ca:statutes/rtc/17029#pre_repeal_right_or_liability_survives_repeal: holds
+- name: civil suit commenced before repeal preserves right or liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17029#input.provision_of_personal_income_tax_law_repealed: true
+    us-ca:statutes/rtc/17029#input.right_or_liability_arises_under_personal_income_tax_law: true
+    us-ca:statutes/rtc/17029#input.act_done_before_repeal: false
+    us-ca:statutes/rtc/17029#input.right_accruing_or_accrued_before_repeal: false
+    us-ca:statutes/rtc/17029#input.suit_or_proceeding_in_civil_cause_had_or_commenced_before_repeal: true
+  output:
+    us-ca:statutes/rtc/17029#pre_repeal_right_or_liability_survives_repeal: holds
+- name: no pre repeal act right or civil proceeding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17029#input.provision_of_personal_income_tax_law_repealed: true
+    us-ca:statutes/rtc/17029#input.right_or_liability_arises_under_personal_income_tax_law: true
+    us-ca:statutes/rtc/17029#input.act_done_before_repeal: false
+    us-ca:statutes/rtc/17029#input.right_accruing_or_accrued_before_repeal: false
+    us-ca:statutes/rtc/17029#input.suit_or_proceeding_in_civil_cause_had_or_commenced_before_repeal: false
+  output:
+    us-ca:statutes/rtc/17029#pre_repeal_right_or_liability_survives_repeal: not_holds

--- a/us-ca/statutes/rtc/17029.yaml
+++ b/us-ca/statutes/rtc/17029.yaml
@@ -1,0 +1,32 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17029
+  summary: |-
+    "The repeal of any provision of the Personal Income Tax Law shall not affect any act done or any right accruing or accrued, or any suit or proceeding had or commenced in any civil cause, before such repeal"; rights and liabilities continue as if repeal had not been made.
+rules:
+  - name: pre_repeal_right_or_liability_survives_repeal
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17029
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17029
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          provision_of_personal_income_tax_law_repealed
+          and right_or_liability_arises_under_personal_income_tax_law
+          and (
+            act_done_before_repeal
+            or right_accruing_or_accrued_before_repeal
+            or suit_or_proceeding_in_civil_cause_had_or_commenced_before_repeal
+          )


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17029`
- Module: `us-ca/statutes/rtc/17029.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17029/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.