### PR TITLE
Encode us-ca/statute/rtc/17034 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -4765,6 +4765,15 @@
         ]
       }
     ],
+    "us-ca/statute/rtc/17034": [
+      {
+        "module": "us-ca/statutes/rtc/17034.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/statute/rtc/17041": [
       {
         "module": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/us-ca/.axiom/encoding-manifests/statutes/rtc/17034.json
+++ b/us-ca/.axiom/encoding-manifests/statutes/rtc/17034.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/rtc/17034.yaml",
+      "sha256": "843b2573b783d129d0b0bd037ce6d2ec282015a92d6667cb53b54c26664e5f25"
+    },
+    {
+      "path": "statutes/rtc/17034.test.yaml",
+      "sha256": "d8aa9aa9832a37f3f7da5692873ac1d8aef02763455d0d029e4489856e653fcf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ca/statute/rtc/17034",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17034/encode-out/_eval_workspaces/codex-gpt-5.5/us-ca-statute-rtc-17034/workspace/context-manifest.json",
+  "context_manifest_sha256": "d841d766c4e2f09017c085f43edf0d12e94a2beb08d4734640b7647accc50a7d",
+  "generated_at": "2026-07-08T14:44:06.893780+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17034/encode-out/codex-gpt-5.5/statutes/rtc/17034.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17034/encode-out",
+  "generated_output_sha256": "843b2573b783d129d0b0bd037ce6d2ec282015a92d6667cb53b54c26664e5f25",
+  "generation_prompt_sha256": "d8b2b7a569b6a0c029afe33a7bb175fadbc20706d1fdef2d71f543acfacedd00",
+  "model": "gpt-5.5",
+  "run_id": "fcfab6de",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c4da0a4f38d5628eb3261ea92f5b1e081e36b3a7f00df7052f0cdfca4c9a2e9b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17034/encode-out/traces/codex-gpt-5.5/us-ca-statute-rtc-17034.json",
+  "trace_sha256": "a11ef4c658afc8f8200ab95d0d153c67bb8d22c35b82d2bd37eafecbc8c58ed1"
+}

--- a/us-ca/statutes/rtc/17034.test.yaml
+++ b/us-ca/statutes/rtc/17034.test.yaml
@@ -1,0 +1,46 @@
+- name: tax affecting provision applies to qualifying taxable year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17034#input.provision_affects_tax_imposition_or_computation_additions_penalties_or_credits: true
+    us-ca:statutes/rtc/17034#input.taxable_year_begins_on_or_after_default_tax_application_date: true
+    us-ca:statutes/rtc/17034#input.act_specifically_provides_other_application: false
+  output:
+    us-ca:statutes/rtc/17034#tax_affecting_act_provision_applies_to_taxable_year: holds
+- name: tax affecting provision displaced by specific act provision
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ca:statutes/rtc/17034#input.provision_affects_tax_imposition_or_computation_additions_penalties_or_credits: true
+    us-ca:statutes/rtc/17034#input.taxable_year_begins_on_or_after_default_tax_application_date: true
+    us-ca:statutes/rtc/17034#input.act_specifically_provides_other_application: true
+  output:
+    us-ca:statutes/rtc/17034#tax_affecting_act_provision_applies_to_taxable_year: not_holds
+- name: other provision applies on or after act effective date
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-06-15'
+    end: '2024-06-15'
+  input:
+    us-ca:statutes/rtc/17034#input.provision_otherwise_affects_this_part: true
+    us-ca:statutes/rtc/17034#input.day_is_on_or_after_act_effective_date: true
+    us-ca:statutes/rtc/17034#input.act_specifically_provides_other_application: false
+  output:
+    us-ca:statutes/rtc/17034#other_act_provision_applies_on_day: holds
+- name: other provision before act effective date does not apply
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-06-14'
+    end: '2024-06-14'
+  input:
+    us-ca:statutes/rtc/17034#input.provision_otherwise_affects_this_part: true
+    us-ca:statutes/rtc/17034#input.day_is_on_or_after_act_effective_date: false
+    us-ca:statutes/rtc/17034#input.act_specifically_provides_other_application: false
+  output:
+    us-ca:statutes/rtc/17034#other_act_provision_applies_on_day: not_holds

--- a/us-ca/statutes/rtc/17034.yaml
+++ b/us-ca/statutes/rtc/17034.yaml
@@ -1,0 +1,69 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ca/statute/rtc/17034
+  summary: |-
+    Unless otherwise specifically provided, provisions affecting taxes, additions to tax, penalties, or credits apply to taxable years beginning on or after January 1 of the year the act takes effect; other provisions of this part apply on and after the act's effective date.
+rules:
+  - name: tax_affecting_act_provision_applies_to_taxable_year
+    kind: derived
+    entity: ActProvision
+    dtype: Judgment
+    period: Year
+    source: Cal. Rev. & Tax. Code § 17034(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "Unless otherwise specifically provided therein"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "affect the imposition or computation of taxes, additions to tax, penalties, or the allowance of credits against the tax"
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "taxable years beginning on or after January 1 of the year in which the act takes effect"
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          provision_affects_tax_imposition_or_computation_additions_penalties_or_credits
+          and taxable_year_begins_on_or_after_default_tax_application_date
+          and not act_specifically_provides_other_application
+  - name: other_act_provision_applies_on_day
+    kind: derived
+    entity: ActProvision
+    dtype: Judgment
+    period: Day
+    source: Cal. Rev. & Tax. Code § 17034(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "Unless otherwise specifically provided therein"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "That otherwise affect the provisions of this part"
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ca/statute/rtc/17034
+              excerpt: "on and after the date the act takes effect"
+    versions:
+      - effective_from: '2009-01-01'
+        formula: |-
+          provision_otherwise_affects_this_part
+          and day_is_on_or_after_act_effective_date
+          and not act_specifically_provides_other_application


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ca/statute/rtc/17034`
- Module: `us-ca/statutes/rtc/17034.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ca-statute-rtc-17034/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.