### PR TITLE
Encode us-ny/statute/TAX/614 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16716,7 +16716,8 @@
       {
         "module": "us-ny/statutes/TAX/614.yaml",
         "via": [
-          "module"
+          "module",
+          "proof_atom"
         ]
       }
     ],

--- a/us-ny/.axiom/encoding-manifests/statutes/TAX/614.json
+++ b/us-ny/.axiom/encoding-manifests/statutes/TAX/614.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/TAX/614.yaml",
-      "sha256": "b739dce1363d86ce0021d9608c74218cb1b16682bc7d9956217fdab3a3e3dff6"
+      "sha256": "3ba36cbd15ec565af1315e28b6dd27d773337155fea554d81db0c42db7c50a65"
     },
     {
       "path": "statutes/TAX/614.test.yaml",
@@ -10,32 +10,41 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "7b676fc891f524717fbffcbc9eb9f195ed78ca8e",
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/statetax-cany-20260706/ny/axiom-encode",
-    "version": "0.2.1171",
-    "version_commit": "7b676fc891f524717fbffcbc9eb9f195ed78ca8e"
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
   },
-  "axiom_encode_version": "0.2.1171",
+  "axiom_encode_version": "0.2.1184",
   "backend": "codex",
   "citation": "us-ny/statute/TAX/614",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-614/workspace/context-manifest.json",
-  "context_manifest_sha256": "000f2de57d826e130074c705fff299e114f133a6dc5233f23c8e3a3621e5dfe2",
-  "generated_at": "2026-07-06T11:43:04.382930+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/TAX/614.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "b739dce1363d86ce0021d9608c74218cb1b16682bc7d9956217fdab3a3e3dff6",
-  "generation_prompt_sha256": "a4c9f99b0dd38bed3fd86d8ed28b71cbc9b9da3c24b803b55e48ad634859c6c7",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-614/encode-out/_eval_workspaces/codex-gpt-5.5/us-ny-statute-TAX-614/workspace/context-manifest.json",
+  "context_manifest_sha256": "b3d1f5ff35127ac610a735fb5a210d9c91cdfbdf0eeb2656d8ced50fc12bfe89",
+  "generated_at": "2026-07-08T14:45:07.007596+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-614/encode-out/codex-gpt-5.5/statutes/TAX/614.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-614/encode-out",
+  "generated_output_sha256": "3ba36cbd15ec565af1315e28b6dd27d773337155fea554d81db0c42db7c50a65",
+  "generation_prompt_sha256": "bf74999157680eac42804e79ad6372a1a780ebcdcb06f14e05b09d11e1fb0bf1",
   "model": "gpt-5.5",
-  "run_id": "e8459e8e",
+  "run_id": "22f0834c",
   "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "f134bca8eedd95ba7e083bf39094f4e917c83d7737a5ced90b38f4eb614f525b"
+    "value": "cbcdddb84d6794d6c7d501f37b9e6b4e14c18b952f1ca6dd451a77306bfdfcd4"
+  },
+  "supersedes": {
+    "backend": "codex",
+    "generated_at": "2026-07-06T11:43:04.382930+00:00",
+    "generation_prompt_sha256": "a4c9f99b0dd38bed3fd86d8ed28b71cbc9b9da3c24b803b55e48ad634859c6c7",
+    "manifest_sha256": "1ea9017d04195af780fcaab7b3332c4e219e92e417086c8028478bf3b5ad051c",
+    "prior_signature": "f134bca8eedd95ba7e083bf39094f4e917c83d7737a5ced90b38f4eb614f525b",
+    "run_id": "e8459e8e",
+    "tool": "axiom-encode encode --apply"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-ny-statute-TAX-614.json",
-  "trace_sha256": "b1d30799b25581fbbd551289b4b28c6b57c523397be20262f228859f12e147e3"
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-614/encode-out/traces/codex-gpt-5.5/us-ny-statute-TAX-614.json",
+  "trace_sha256": "f90a96140f276a7ae4c0c72248b249d348734ced5188a7f98289afdfca916e1e"
 }

--- a/us-ny/statutes/TAX/614.yaml
+++ b/us-ny/statutes/TAX/614.yaml
@@ -1,6 +1,5 @@
 format: rulespec/v1
 module:
-  status: deferred
   proof_validation:
     required: true
   source_verification:
@@ -8,6 +7,253 @@ module:
   summary: |-
     New York standard deduction amounts are stated for resident individuals by filing category: unmarried, joint/surviving spouse, head of household, married filing separately, and dependent individuals. For taxable years beginning after 2017, the standard deductions are adjusted by the cost of living adjustment prescribed in section 601-a for tax years 2013 through 2017.
   deferred_outputs:
-    - output: us-ny:statutes/TAX/614#ny_standard_deduction
-      reason: The current post-2017 standard deduction requires the cost-of-living adjustment prescribed in section 601-a, and no RuleSpec context for that referenced adjustment is supplied. The output also depends on upstream filing-status classifications that RuleSpec instructions prohibit modeling as local filing-status inputs.
-rules: []
+    - output: us-ny:statutes/TAX/614#new_york_standard_deduction_of_resident_individual
+      reason: The final resident-individual standard deduction requires selecting among filing-status classifications including unmarried individual, joint return, surviving spouse, head of household, married filing separately, and dependent individual. No executable upstream filing-status RuleSpec output is supplied, and RuleSpec instructions prohibit replacing filing status with local filing-status inputs. The post-2017 final amount also requires applying the section 601-a cost-of-living adjustment to the applicable source-stated base amount.
+      source_values:
+        - us-ny:statutes/TAX/614#unmarried_individual_base_standard_deduction
+        - us-ny:statutes/TAX/614#joint_return_or_surviving_spouse_base_standard_deduction
+        - us-ny:statutes/TAX/614#head_of_household_base_standard_deduction
+        - us-ny:statutes/TAX/614#married_separate_return_base_standard_deduction
+        - us-ny:statutes/TAX/614#dependent_individual_base_standard_deduction
+rules:
+  - name: unmarried_individual_base_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 614(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred eighty-nine and before nineteen hundred ninety-five ... six thousand dollars"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-five ... six thousand six hundred dollars"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-six ... seven thousand four hundred dollars"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning after nineteen hundred ninety-six ... seven thousand five hundred dollars"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          6000
+      - effective_from: '1995-01-01'
+        formula: |-
+          6600
+      - effective_from: '1996-01-01'
+        formula: |-
+          7400
+      - effective_from: '1997-01-01'
+        formula: |-
+          7500
+
+  - name: joint_return_or_surviving_spouse_base_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 614(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred eighty-nine and before nineteen hundred ninety-five ... nine thousand five hundred dollars"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-five ... ten thousand eight hundred dollars"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-six ... twelve thousand three hundred fifty dollars"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred ninety-six and before two thousand one ... thirteen thousand dollars"
+          - path: versions[4].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in two thousand one ... thirteen thousand four hundred dollars"
+          - path: versions[5].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in two thousand two ... fourteen thousand two hundred dollars"
+          - path: versions[6].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after two thousand two and before two thousand six ... fourteen thousand six hundred dollars"
+          - path: versions[7].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning after two thousand five ... fifteen thousand dollars"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          9500
+      - effective_from: '1995-01-01'
+        formula: |-
+          10800
+      - effective_from: '1996-01-01'
+        formula: |-
+          12350
+      - effective_from: '1997-01-01'
+        formula: |-
+          13000
+      - effective_from: '2001-01-01'
+        formula: |-
+          13400
+      - effective_from: '2002-01-01'
+        formula: |-
+          14200
+      - effective_from: '2003-01-01'
+        formula: |-
+          14600
+      - effective_from: '2006-01-01'
+        formula: |-
+          15000
+
+  - name: head_of_household_base_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 614(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred eighty-nine and before nineteen hundred ninety-five ... seven thousand dollars"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-five ... eight thousand one hundred fifty dollars"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-six ... ten thousand dollars"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning after nineteen hundred ninety-six ... ten thousand five hundred dollars"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          7000
+      - effective_from: '1995-01-01'
+        formula: |-
+          8150
+      - effective_from: '1996-01-01'
+        formula: |-
+          10000
+      - effective_from: '1997-01-01'
+        formula: |-
+          10500
+
+  - name: married_separate_return_base_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 614(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred eighty-nine and before nineteen hundred ninety-five ... four thousand seven hundred fifty dollars"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-five ... five thousand four hundred dollars"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-six ... six thousand one hundred seventy-five dollars"
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred ninety-six and before two thousand six ... six thousand five hundred dollars"
+          - path: versions[4].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning after two thousand five ... seven thousand five hundred dollars"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4750
+      - effective_from: '1995-01-01'
+        formula: |-
+          5400
+      - effective_from: '1996-01-01'
+        formula: |-
+          6175
+      - effective_from: '1997-01-01'
+        formula: |-
+          6500
+      - effective_from: '2006-01-01'
+        formula: |-
+          7500
+
+  - name: dependent_individual_base_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.Y. Tax Law § 614(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "after nineteen hundred eighty-nine and before nineteen hundred ninety-six ... two thousand eight hundred dollars"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning in nineteen hundred ninety-six ... two thousand nine hundred dollars"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/614
+              excerpt: "beginning after nineteen hundred ninety-six ... three thousand dollars"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          2800
+      - effective_from: '1996-01-01'
+        formula: |-
+          2900
+      - effective_from: '1997-01-01'
+        formula: |-
+          3000


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ny/statute/TAX/614`
- Module: `us-ny/statutes/TAX/614.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ny-statute-tax-614/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.