### PR TITLE
Encode us-or/statute/315.264 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16756,6 +16756,15 @@
         ]
       }
     ],
+    "us-or/statute/315.264": [
+      {
+        "module": "us-or/statutes/315/264.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-10": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-10.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 16
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,17 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/264#applicable_percentage_at_110_percent_fpl
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/264#student_low_income_comparison_expense_base
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/264#student_low_income_credit_comparison_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-or:statutes/315/264#youngest_qualifying_individual_age_category
     source: bulk
     since: 2026-07-08

--- a/us-or/.axiom/encoding-manifests/statutes/315/264.json
+++ b/us-or/.axiom/encoding-manifests/statutes/315/264.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/315/264.yaml",
+      "sha256": "84e3a289d7811f1793b7a901dca2ce7c3ed6d18ed0d98eaf47327148e23456e5"
+    },
+    {
+      "path": "statutes/315/264.test.yaml",
+      "sha256": "174b8f3c9ca58680572b0d77466c3e0373f520e434f2768d263b16bd4a84b599"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-or/statute/315.264",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-or-statute-315-264/encode-out/_eval_workspaces/codex-gpt-5.5/us-or-statute-315.264/workspace/context-manifest.json",
+  "context_manifest_sha256": "e1e4178483f9b6ed590c3609dfe2b881b7794b28edc3c9f49a43c1b637367f6c",
+  "generated_at": "2026-07-08T14:45:48.890145+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-or-statute-315-264/encode-out/codex-gpt-5.5/statutes/315/264.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-or-statute-315-264/encode-out",
+  "generated_output_sha256": "84e3a289d7811f1793b7a901dca2ce7c3ed6d18ed0d98eaf47327148e23456e5",
+  "generation_prompt_sha256": "d246c7228aa72e96bd54dccea732c3c18a65b225cb00d031e30d9474afb70697",
+  "model": "gpt-5.5",
+  "run_id": "91a4e118",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d455d07defb8c86cde1915e91035ddeb16082243b11335a67c591cb22e1fcfd0"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-or-statute-315-264/encode-out/traces/codex-gpt-5.5/us-or-statute-315.264.json",
+  "trace_sha256": "d1abf648ef3b97ac9d35063a909dd112ad82c07332edb5d0234f361c5fc03c0b"
+}

--- a/us-or/statutes/315/264.test.yaml
+++ b/us-or/statutes/315/264.test.yaml
@@ -1,0 +1,34 @@
+- name: student comparison amount under age three
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/315/264#input.youngest_qualifying_individual_under_3_years: true
+    us-or:statutes/315/264#input.youngest_qualifying_individual_at_least_3_but_less_than_6_years: false
+    ? us-or:statutes/315/264#input.youngest_qualifying_individual_at_least_6_but_less_than_13_years_or_at_least_13_but_less_than_18_and_disabled
+    : false
+    us-or:statutes/315/264#input.expenses_for_care_of_qualifying_individual: 1000
+    us-or:statutes/315/264#input.imputed_income: 1200
+    us-or:statutes/315/264#input.school_ratio: 1
+  output:
+    us-or:statutes/315/264#youngest_qualifying_individual_age_category: 0
+    us-or:statutes/315/264#student_low_income_comparison_expense_base: 1000
+    us-or:statutes/315/264#student_low_income_credit_comparison_amount: 750
+- name: student comparison amount disabled age category with lower imputed income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-or:statutes/315/264#input.youngest_qualifying_individual_under_3_years: false
+    us-or:statutes/315/264#input.youngest_qualifying_individual_at_least_3_but_less_than_6_years: false
+    ? us-or:statutes/315/264#input.youngest_qualifying_individual_at_least_6_but_less_than_13_years_or_at_least_13_but_less_than_18_and_disabled
+    : false
+    us-or:statutes/315/264#input.expenses_for_care_of_qualifying_individual: 1000
+    us-or:statutes/315/264#input.imputed_income: 800
+    us-or:statutes/315/264#input.school_ratio: 0.7
+  output:
+    us-or:statutes/315/264#youngest_qualifying_individual_age_category: 3
+    us-or:statutes/315/264#student_low_income_comparison_expense_base: 800
+    us-or:statutes/315/264#student_low_income_credit_comparison_amount: 308

--- a/us-or/statutes/315/264.yaml
+++ b/us-or/statutes/315/264.yaml
@@ -1,0 +1,110 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/statute/315.264
+  summary: Oregon allows a refundable credit against ORS chapter 316 tax for employment-related
+    care expenses, subject to Oregon/imputed-income caps, qualifying-individual count
+    caps, federal poverty level applicable percentage table, student imputed-income
+    and school-ratio rules, nonresident and short-year proration, and refund/no-interest
+    rules. Subsection (6)(b) provides a low-income student comparison amount equal
+    to the subsection (2) applicable percentage corresponding to 110 percent of federal
+    poverty level multiplied by the lesser of qualifying-individual care expenses
+    or imputed income and by the school ratio.
+  deferred_outputs:
+  - output: us-or:statutes/315/264#employment_related_day_care_credit
+    reason: Final credit computation depends on missing Internal Revenue Code section
+      21 expense-credit mechanics and section 129 exclusion coordination, which are
+      cited by this source but not supplied as RuleSpec context.
+  - output: us-or:statutes/315/264/6#student_low_income_credit_comparison_amount
+    reason: Checklist subparagraph coverage is satisfied by the executable subsection
+      (6)(b) comparison rule in this file; the full final student credit remains deferred
+      where it must compare against the subsection (2) credit and unresolved section
+      21 employment-related expense mechanics.
+rules:
+- name: youngest_qualifying_individual_age_category
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: 315.264(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-or/statute/315.264
+          excerpt: Applicable percentage based on age of youngest qualifying individual
+            on January 1 of tax year
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if youngest_qualifying_individual_under_3_years: 0 else: if youngest_qualifying_individual_at_least_3_but_less_than_6_years:
+      1 else: if youngest_qualifying_individual_at_least_6_but_less_than_13_years_or_at_least_13_but_less_than_18_and_disabled:
+      2 else: 3'
+- name: applicable_percentage_at_110_percent_fpl
+  kind: parameter
+  dtype: Rate
+  indexed_by: youngest_qualifying_individual_age_category
+  source: 315.264(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-or/statute/315.264
+          table:
+            header: Applicable percentage based on age of youngest qualifying individual
+              on January 1 of tax year
+            row_key: 90% greater than, 110% less than or equal to
+            column_key: age category
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      0: 0.75
+      1: 0.73
+      2: 0.7
+      3: 0.55
+- name: student_low_income_comparison_expense_base
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 315.264(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-or/statute/315.264
+          excerpt: The lesser of expenses for care of a qualifying individual or imputed
+            income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: min(max(0, expenses_for_care_of_qualifying_individual), max(0, imputed_income))
+- name: student_low_income_credit_comparison_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 315.264(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-or/statute/315.264
+          excerpt: The product of the applicable percentage ... corresponding to an
+            adjusted gross income percentage of 110 percent, multiplied by ... the
+            lesser of expenses for care of a qualifying individual or imputed income;
+            and ... the school ratio.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: applicable_percentage_at_110_percent_fpl[youngest_qualifying_individual_age_category]
+      * student_low_income_comparison_expense_base * school_ratio


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-or/statute/315.264`
- Module: `us-or/statutes/315/264.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-or-statute-315-264/rulespec-us/oracle-coverage-pending.yaml: 14 declared (+4 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.