### PR TITLE
Encode us-wa/statute/82/82.87/82.87.040 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21601,6 +21601,15 @@
         ]
       }
     ],
+    "us-wa/statute/82/82.87/82.87.040": [
+      {
+        "module": "us-wa/statutes/82/82.87/82/87/040.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1": [
       {
         "module": "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 16
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,17 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_base_excise_tax_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax
     source: bulk
     since: 2026-07-08

--- a/us-wa/.axiom/encoding-manifests/statutes/82/82.87/82/87/040.json
+++ b/us-wa/.axiom/encoding-manifests/statutes/82/82.87/82/87/040.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/82/82.87/82/87/040.yaml",
+      "sha256": "e7018a7d47f2886e7cbd9c9ac61df9de3acddd4416a892374fa600fcce36a08a"
+    },
+    {
+      "path": "statutes/82/82.87/82/87/040.test.yaml",
+      "sha256": "9555667db1e1185a3644fea257df16f443d5c74c603b796ab86b5d1a5463fee0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-wa/statute/82/82.87/82.87.040",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-040/encode-out/_eval_workspaces/codex-gpt-5.5/us-wa-statute-82-82.87-82.87.040/workspace/context-manifest.json",
+  "context_manifest_sha256": "801ec66139c1805995fe2190fb831a40d5b30b75151079cca1de44b2388f1752",
+  "generated_at": "2026-07-08T14:49:00.956404+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-040/encode-out/codex-gpt-5.5/statutes/82/82.87/82/87/040.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-040/encode-out",
+  "generated_output_sha256": "e7018a7d47f2886e7cbd9c9ac61df9de3acddd4416a892374fa600fcce36a08a",
+  "generation_prompt_sha256": "ea2607eab0e046d41b81cefb3ec2744bf568bce015e339ef542b135db91aea7f",
+  "model": "gpt-5.5",
+  "run_id": "b3382254",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b9d138ec2d3421259d9296167d34988e2a93fc8ee6bd15500a4e1e0ec9101c47"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-040/encode-out/traces/codex-gpt-5.5/us-wa-statute-82-82.87-82.87.040.json",
+  "trace_sha256": "6ecf85f0633b6331e6738894ecabb0bf055f27606a0c044f205c190a6e149c7e"
+}

--- a/us-wa/statutes/82/82.87/82/87/040.test.yaml
+++ b/us-wa/statutes/82/82.87/82/87/040.test.yaml
@@ -1,0 +1,27 @@
+- name: base tax applies to positive Washington capital gains
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/040#input.washington_capital_gains: 500000
+  output:
+    us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax: 35000
+- name: additional tax applies only to gains above threshold
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/040#input.washington_capital_gains: 1200000
+  output:
+    us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax: 89800
+- name: no tax due when Washington capital gains are negative
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/040#input.washington_capital_gains: -1000
+  output:
+    us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax: 0

--- a/us-wa/statutes/82/82.87/82/87/040.yaml
+++ b/us-wa/statutes/82/82.87/82/87/040.yaml
@@ -1,0 +1,103 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+  summary: |-
+    "(1)(a) Beginning January 1, 2022, an excise tax is imposed on the sale or exchange of long-term capital assets. Only individuals are subject to payment of the tax, which equals seven percent multiplied by an individual's Washington capital gains. (b) Beginning January 1, 2025, an additional excise tax is imposed ... which equals 2.90 percent multiplied by the portion of an individual's Washington capital gains exceeding $1,000,000. ... If an individual's Washington capital gains are less than zero for a taxable year, no tax is due under this section..."
+rules:
+  - name: capital_gains_base_excise_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: RCW 82.87.040(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "Beginning January 1, 2022 ... equals seven percent multiplied by an individual's Washington capital gains"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.07
+
+  - name: capital_gains_additional_excise_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: RCW 82.87.040(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "Beginning January 1, 2025, an additional excise tax is imposed"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "equals 2.90 percent multiplied by the portion"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0
+      - effective_from: '2025-01-01'
+        formula: |-
+          0.029
+
+  - name: capital_gains_additional_excise_tax_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: RCW 82.87.040(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "Washington capital gains exceeding $1,000,000"
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          1000000
+
+  - name: washington_capital_gains_excise_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: RCW 82.87.040(1), (3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "Only individuals are subject to payment of the tax"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "seven percent multiplied by an individual's Washington capital gains"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "2.90 percent multiplied by the portion ... exceeding $1,000,000"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.040
+              excerpt: "If an individual's Washington capital gains are less than zero ... no tax is due"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          if washington_capital_gains < 0: 0 else: (capital_gains_base_excise_tax_rate * washington_capital_gains) + (capital_gains_additional_excise_tax_rate * max(0, washington_capital_gains - capital_gains_additional_excise_tax_threshold))


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-wa/statute/82/82.87/82.87.040`
- Module: `us-wa/statutes/82/82.87/82/87/040.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-040/rulespec-us/oracle-coverage-pending.yaml: 14 declared (+4 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.