### PR TITLE
Encode us-va/statute/58.1/58.1-339.8 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-va/statute/58.1/58.1-339.8": [
+      {
+        "module": "us-va/statutes/58.1/58/1-339/8.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 23
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,38 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#disqualifying_subtraction_or_deduction_claimed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_nonrefundable_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_refundable_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_amount_per_counted_person
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_nonrefundable_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-339/8#poverty_guideline_percentage_limit
     source: bulk
     since: 2026-07-08

--- a/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-339/8.json
+++ b/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-339/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/58.1/58/1-339/8.yaml",
+      "sha256": "024c23e281a67ef322cb07994ebf442b4cfbafe3661cbc46bfcacab7a5d378a0"
+    },
+    {
+      "path": "statutes/58.1/58/1-339/8.test.yaml",
+      "sha256": "1d4b5a9fe6adbcc6a1a59dadd50790325fd7778c96451dda13bbaeb224e8dd6f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-va/statute/58.1/58.1-339.8",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-339-8/encode-out/_eval_workspaces/codex-gpt-5.5/us-va-statute-58.1-58.1-339.8/workspace/context-manifest.json",
+  "context_manifest_sha256": "f5781e5e6fee6b9a92d9fb00070c84d60bb95181b160ad6f9af4adf8ca197c88",
+  "generated_at": "2026-07-08T14:49:33.847020+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-339-8/encode-out/codex-gpt-5.5/statutes/58.1/58/1-339/8.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-339-8/encode-out",
+  "generated_output_sha256": "024c23e281a67ef322cb07994ebf442b4cfbafe3661cbc46bfcacab7a5d378a0",
+  "generation_prompt_sha256": "78fc2da518421896a9a296cc711c0bd636682ddc7c14ab1fff5b531f759d69cc",
+  "model": "gpt-5.5",
+  "run_id": "a52cf634",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dcd7e44d06a4e87a697699694e683d8f819896c37ca3ab5e2daab225500d069f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-339-8/encode-out/traces/codex-gpt-5.5/us-va-statute-58.1-58.1-339.8.json",
+  "trace_sha256": "8e704fe6ce7f2263d315ebee5816b3cd1852a82ec98c493913fa16f8c93a9992"
+}

--- a/us-va/statutes/58.1/58/1-339/8.test.yaml
+++ b/us-va/statutes/58.1/58/1-339/8.test.yaml
@@ -1,0 +1,160 @@
+- name: low_income_credit_capped_by_tax_liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.family_virginia_adjusted_gross_income: 18000
+    us-va:statutes/58.1/58/1-339/8#input.poverty_guideline_amount_for_household_size: 20000
+    us-va:statutes/58.1/58/1-339/8#input.separate_married_returns_claim_this_credit_on_only_one_return: true
+    us-va:statutes/58.1/58/1-339/8#input.taxpayer_is_dependent_of_another_individual_or_married_individuals: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: true
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 500
+    us-va:statutes/58.1/58/1-339/8#input.counted_individual_spouse_and_dependent_count: 2
+  output:
+    us-va:statutes/58.1/58/1-339/8#disqualifying_subtraction_or_deduction_claimed: not_holds
+    us-va:statutes/58.1/58/1-339/8#low_income_credit_allowed: holds
+    us-va:statutes/58.1/58/1-339/8#low_income_nonrefundable_credit: 500
+- name: low_income_credit_blocked_by_listed_subtraction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.family_virginia_adjusted_gross_income: 18000
+    us-va:statutes/58.1/58/1-339/8#input.poverty_guideline_amount_for_household_size: 20000
+    us-va:statutes/58.1/58/1-339/8#input.separate_married_returns_claim_this_credit_on_only_one_return: true
+    us-va:statutes/58.1/58/1-339/8#input.taxpayer_is_dependent_of_another_individual_or_married_individuals: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: true
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: true
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 500
+    us-va:statutes/58.1/58/1-339/8#input.counted_individual_spouse_and_dependent_count: 2
+  output:
+    us-va:statutes/58.1/58/1-339/8#disqualifying_subtraction_or_deduction_claimed: holds
+    us-va:statutes/58.1/58/1-339/8#low_income_credit_allowed: not_holds
+    us-va:statutes/58.1/58/1-339/8#low_income_nonrefundable_credit: 0
+- name: federal_eitc_nonrefundable_credit_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.eligible_for_federal_credit_pursuant_to_section_32: true
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: true
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 300
+    us-va:statutes/58.1/58/1-339/8#input.federal_section_32_credit_claimed: 2000
+  output:
+    us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit_allowed: holds
+- name: federal_eitc_nonrefundable_credit_capped_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.eligible_for_federal_credit_pursuant_to_section_32: true
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: true
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 300
+    us-va:statutes/58.1/58/1-339/8#input.federal_section_32_credit_claimed: 2000
+  output:
+    us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit: 300
+- name: refundable_eitc_credit_not_capped_for_resident
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.taxable_year_is_in_refundable_eitc_credit_effective_window: true
+    us-va:statutes/58.1/58/1-339/8#input.eligible_for_federal_credit_pursuant_to_section_32: true
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: true
+    us-va:statutes/58.1/58/1-339/8#input.nonresident_or_person_to_which_section_58_1_303_applies: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 100
+    us-va:statutes/58.1/58/1-339/8#input.federal_section_32_credit_claimed: 2000
+  output:
+    us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit_allowed: holds
+    us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit: 300
+- name: auto_zero_earned_income_nonrefundable_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.counted_individual_spouse_and_dependent_count: 0
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.eligible_for_federal_credit_pursuant_to_section_32: false
+    us-va:statutes/58.1/58/1-339/8#input.family_virginia_adjusted_gross_income: 0
+    us-va:statutes/58.1/58/1-339/8#input.federal_section_32_credit_claimed: 0
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.nonresident_or_person_to_which_section_58_1_303_applies: false
+    us-va:statutes/58.1/58/1-339/8#input.poverty_guideline_amount_for_household_size: 0
+    us-va:statutes/58.1/58/1-339/8#input.separate_married_returns_claim_this_credit_on_only_one_return: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.taxable_year_is_in_refundable_eitc_credit_effective_window: false
+    us-va:statutes/58.1/58/1-339/8#input.taxpayer_is_dependent_of_another_individual_or_married_individuals: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 0
+  output:
+    us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit: 0
+- name: auto_zero_earned_income_refundable_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:statutes/58.1/58/1-339/8#input.additional_personal_exemption_for_blind_or_aged_taxpayers_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.counted_individual_spouse_and_dependent_count: 0
+    us-va:statutes/58.1/58/1-339/8#input.deduction_under_section_58_1_322_03_subdivision_5_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.eligible_for_federal_credit_pursuant_to_section_32: false
+    us-va:statutes/58.1/58/1-339/8#input.family_virginia_adjusted_gross_income: 0
+    us-va:statutes/58.1/58/1-339/8#input.federal_section_32_credit_claimed: 0
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_1_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_2_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.household_claims_subdivision_3_credit: false
+    us-va:statutes/58.1/58/1-339/8#input.nonresident_or_person_to_which_section_58_1_303_applies: false
+    us-va:statutes/58.1/58/1-339/8#input.poverty_guideline_amount_for_household_size: 0
+    us-va:statutes/58.1/58/1-339/8#input.separate_married_returns_claim_this_credit_on_only_one_return: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_15_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_16_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.subtraction_under_section_58_1_322_02_subdivision_8_claimed: false
+    us-va:statutes/58.1/58/1-339/8#input.taxable_year_is_in_refundable_eitc_credit_effective_window: false
+    us-va:statutes/58.1/58/1-339/8#input.taxpayer_is_dependent_of_another_individual_or_married_individuals: false
+    us-va:statutes/58.1/58/1-339/8#input.virginia_income_tax_liability: 0
+  output:
+    us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit: 0

--- a/us-va/statutes/58.1/58/1-339/8.yaml
+++ b/us-va/statutes/58.1/58/1-339/8.yaml
@@ -1,0 +1,263 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-va/statute/58.1/58.1-339.8
+  summary: "For taxable years beginning on and after January 1, 2000, qualifying individuals\
+    \ or joint filers whose family Virginia adjusted gross income does not exceed\
+    \ 100 percent of the applicable poverty guideline amount are allowed a nonrefundable\
+    \ $300 credit for the individual, spouse, and dependents. For taxable years beginning\
+    \ on and after January 1, 2006, taxpayers eligible for the federal \xA7 32 credit\
+    \ may instead claim a nonrefundable credit equal to 20 percent of that federal\
+    \ credit. For taxable years beginning on and after January 1, 2022, but before\
+    \ January 1, 2026, they may instead claim a refundable credit equal to 15 percent\
+    \ of the federal \xA7 32 credit. The B 1 and B 2 credits, and B 3 for nonresidents\
+    \ or persons subject to \xA7 58.1-303, may not exceed Virginia income tax liability.\
+    \ No subsection B credit is allowed when listed Virginia subtractions or deductions\
+    \ are claimed."
+rules:
+- name: poverty_guideline_percentage_limit
+  kind: parameter
+  dtype: Rate
+  source: "Va. Code \xA7 58.1-339.8(B)(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: does not exceed 100 percent of the poverty guideline amount
+  versions:
+  - effective_from: '2000-01-01'
+    formula: '1'
+- name: low_income_credit_amount_per_counted_person
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "Va. Code \xA7 58.1-339.8(B)(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: in an amount equal to $300 each
+  versions:
+  - effective_from: '2000-01-01'
+    formula: '300'
+- name: federal_eitc_nonrefundable_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: "Va. Code \xA7 58.1-339.8(B)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: an amount equal to 20 percent of the credit claimed
+  versions:
+  - effective_from: '2006-01-01'
+    formula: '0.20'
+- name: federal_eitc_refundable_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: "Va. Code \xA7 58.1-339.8(B)(3)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: an amount equal to 15 percent of the credit claimed
+  versions:
+  - effective_from: '2022-01-01'
+    formula: '0.15'
+- name: disqualifying_subtraction_or_deduction_claimed
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-339.8(D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+  versions:
+  - effective_from: '2000-01-01'
+    formula: 'subtraction_under_section_58_1_322_02_subdivision_8_claimed
+
+      or subtraction_under_section_58_1_322_02_subdivision_15_claimed
+
+      or subtraction_under_section_58_1_322_02_subdivision_16_claimed
+
+      or additional_personal_exemption_for_blind_or_aged_taxpayers_claimed
+
+      or deduction_under_section_58_1_322_03_subdivision_5_claimed'
+- name: low_income_credit_allowed
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-339.8(B)(1), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+  versions:
+  - effective_from: '2000-01-01'
+    formula: 'family_virginia_adjusted_gross_income <= poverty_guideline_percentage_limit
+      * poverty_guideline_amount_for_household_size
+
+      and separate_married_returns_claim_this_credit_on_only_one_return
+
+      and not taxpayer_is_dependent_of_another_individual_or_married_individuals
+
+      and not disqualifying_subtraction_or_deduction_claimed'
+- name: low_income_nonrefundable_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-339.8(B)(1), (C), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: $300 each
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: "shall not exceed the individual\u2019s or married individuals\u2019\
+            \ Virginia income tax liability"
+  versions:
+  - effective_from: '2000-01-01'
+    formula: |-
+      if household_claims_subdivision_1_credit and low_income_credit_allowed and not household_claims_subdivision_2_credit and not household_claims_subdivision_3_credit: min(max(0, virginia_income_tax_liability), max(0, low_income_credit_amount_per_counted_person * counted_individual_spouse_and_dependent_count)) else: 0
+- name: earned_income_nonrefundable_credit_allowed
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-339.8(B)(2), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'eligible_for_federal_credit_pursuant_to_section_32
+
+      and not disqualifying_subtraction_or_deduction_claimed'
+- name: earned_income_nonrefundable_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-339.8(B)(2), (C), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: 20 percent of the credit claimed
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: "shall not exceed the individual\u2019s or married individuals\u2019\
+            \ Virginia income tax liability"
+  versions:
+  - effective_from: '2006-01-01'
+    formula: |-
+      if household_claims_subdivision_2_credit and earned_income_nonrefundable_credit_allowed and not household_claims_subdivision_1_credit and not household_claims_subdivision_3_credit: min(max(0, virginia_income_tax_liability), federal_eitc_nonrefundable_credit_rate * federal_section_32_credit_claimed) else: 0
+- name: earned_income_refundable_credit_allowed
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Va. Code \xA7 58.1-339.8(B)(3), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: on and after January 1, 2022, but before January 1, 2026
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+  versions:
+  - effective_from: '2022-01-01'
+    formula: 'taxable_year_is_in_refundable_eitc_credit_effective_window
+
+      and eligible_for_federal_credit_pursuant_to_section_32
+
+      and not disqualifying_subtraction_or_deduction_claimed'
+- name: earned_income_refundable_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Va. Code \xA7 58.1-339.8(B)(3), (C), (D)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: 15 percent of the credit claimed
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-va/statute/58.1/58.1-339.8
+          excerpt: "in the case of a nonresident or a person to which \xA7 58.1-303\
+            \ applies, subdivision B 3"
+  versions:
+  - effective_from: '2022-01-01'
+    formula: |-
+      if household_claims_subdivision_3_credit and earned_income_refundable_credit_allowed and not household_claims_subdivision_1_credit and not household_claims_subdivision_2_credit:
+        if nonresident_or_person_to_which_section_58_1_303_applies:
+          min(max(0, virginia_income_tax_liability), federal_eitc_refundable_credit_rate * federal_section_32_credit_claimed)
+        else:
+          federal_eitc_refundable_credit_rate * federal_section_32_credit_claimed
+      else:
+        0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-va/statute/58.1/58.1-339.8`
- Module: `us-va/statutes/58.1/58/1-339/8.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-339-8/rulespec-us/oracle-coverage-pending.yaml: 21 declared (+11 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.