### PR TITLE
Encode us-va/statute/58.1/58.1-322.03 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21547,6 +21547,15 @@
         ]
       }
     ],
+    "us-va/statute/58.1/58.1-322.03": [
+      {
+        "module": "us-va/statutes/58.1/58/1-322/03.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wa/regulation/388/388-450/388-450-0162": [
       {
         "module": "us-wa/regulations/388/388-450/388-450-0162.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 54
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,131 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_boiler_minimum_fuel_utilization_rating
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_furnace_minimum_fuel_utilization_rating
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_water_heater_minimum_energy_factor
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_married_phaseout_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_minimum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_single_phaseout_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#blind_or_aged_additional_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#bone_marrow_donor_screening_fee_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_current
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_temporary
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#central_air_conditioner_minimum_cooling_seer
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#charitable_mileage_state_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_annual_deduction_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_no_limit_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_cooling_seer
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_heating_performance_factor
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_capacity_kilowatts
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_efficiency
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_cooling_cop
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_heating_cop
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#heat_pump_water_heater_minimum_energy_factor
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_month_window
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#married_separate_standard_deduction_fraction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#permanent_foster_care_child_deduction_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#personal_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#ppp_loan_deduction_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_fagi_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_earned_income
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_general
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_temporary
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_general
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_temporary
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:statutes/58.1/58/1-322/03#tobacco_single_payment_gain_subtraction_rate
     source: bulk
     since: 2026-07-08

--- a/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-322/03.json
+++ b/us-va/.axiom/encoding-manifests/statutes/58.1/58/1-322/03.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/58.1/58/1-322/03.yaml",
+      "sha256": "9a168d06c957db48b156a4b3afb3857e81752714f2c9ecbd9347137fa5898ab2"
+    },
+    {
+      "path": "statutes/58.1/58/1-322/03.test.yaml",
+      "sha256": "c8caf86a545f06e5d49773ff528e4e4bda4f4ad3de11d38c0a53d26babe02a9e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-va/statute/58.1/58.1-322.03",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-322-03/encode-out/_eval_workspaces/codex-gpt-5.5/us-va-statute-58.1-58.1-322.03/workspace/context-manifest.json",
+  "context_manifest_sha256": "055bda40dba753ce69cc953bb90603d9385f85e7d7c792ae97a2a5fae8675041",
+  "generated_at": "2026-07-08T14:50:12.547131+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-322-03/encode-out/codex-gpt-5.5/statutes/58.1/58/1-322/03.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-322-03/encode-out",
+  "generated_output_sha256": "9a168d06c957db48b156a4b3afb3857e81752714f2c9ecbd9347137fa5898ab2",
+  "generation_prompt_sha256": "e0ce5bdf62baa65b05820ee4d6699d937fbd999f79ea1396bea1fe491976b8d7",
+  "model": "gpt-5.5",
+  "run_id": "f521a6e7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dba4e49722fdb176018378dcfb1bcecbedbb50d44cb2eb5202a3afe348b36dcf"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-322-03/encode-out/traces/codex-gpt-5.5/us-va-statute-58.1-58.1-322.03.json",
+  "trace_sha256": "6785877d7833441e0a9e1564b6cc176effb7d8e8876c39ca78a4252f2732cbc6"
+}

--- a/us-va/statutes/58.1/58/1-322/03.test.yaml
+++ b/us-va/statutes/58.1/58/1-322/03.test.yaml
@@ -1,0 +1,116 @@
+- name: bone marrow donor fee allowed when not reimbursed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.individual_paid_initial_bone_marrow_donor_screening_fee: true
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_bone_marrow_donor_screening_fee: true
+    us-va:statutes/58.1/58/1-322/03#input.bone_marrow_donor_screening_fee_paid: 75
+  output:
+    us-va:statutes/58.1/58/1-322/03#bone_marrow_donor_screening_fee_deduction: 75
+- name: teacher education deduction blocked by reimbursement
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_licensed_primary_or_secondary_school_teacher: true
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_courses_required_as_condition_of_employment: true
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_continuing_teacher_education_tuition_costs: true
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_tuition_costs: 1000
+  output:
+    us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction: 0
+- name: energy efficient property deduction capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.individual_purchased_qualifying_energy_efficient_property_for_own_use: true
+    us-va:statutes/58.1/58/1-322/03#input.qualifying_energy_efficient_property_purchase_amount: 4000
+  output:
+    us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction: 500
+- name: living organ donor deduction limited to cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_living_donor_of_organ_or_other_living_tissue: true
+    us-va:statutes/58.1/58/1-322/03#input.expenses_directly_related_to_living_donation_arose_within_allowed_period: true
+    us-va:statutes/58.1/58/1-322/03#input.individual_took_federal_medical_deduction_for_living_donor_expenses: false
+    us-va:statutes/58.1/58/1-322/03#input.unreimbursed_living_donor_out_of_pocket_expenses: 7000
+  output:
+    us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction: 5000
+- name: auto_zero_bone_marrow_donor_screening_fee_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.bone_marrow_donor_screening_fee_paid: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_courses_required_as_condition_of_employment: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_tuition_costs: 0
+    us-va:statutes/58.1/58/1-322/03#input.expenses_directly_related_to_living_donation_arose_within_allowed_period: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_licensed_primary_or_secondary_school_teacher: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_living_donor_of_organ_or_other_living_tissue: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_paid_initial_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_purchased_qualifying_energy_efficient_property_for_own_use: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_took_federal_medical_deduction_for_living_donor_expenses: false
+    us-va:statutes/58.1/58/1-322/03#input.qualifying_energy_efficient_property_purchase_amount: 0
+    us-va:statutes/58.1/58/1-322/03#input.unreimbursed_living_donor_out_of_pocket_expenses: 0
+  output:
+    us-va:statutes/58.1/58/1-322/03#bone_marrow_donor_screening_fee_deduction: 0
+- name: auto_zero_energy_efficient_property_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.bone_marrow_donor_screening_fee_paid: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_courses_required_as_condition_of_employment: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_tuition_costs: 0
+    us-va:statutes/58.1/58/1-322/03#input.expenses_directly_related_to_living_donation_arose_within_allowed_period: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_licensed_primary_or_secondary_school_teacher: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_living_donor_of_organ_or_other_living_tissue: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_paid_initial_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_purchased_qualifying_energy_efficient_property_for_own_use: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_took_federal_medical_deduction_for_living_donor_expenses: false
+    us-va:statutes/58.1/58/1-322/03#input.qualifying_energy_efficient_property_purchase_amount: 0
+    us-va:statutes/58.1/58/1-322/03#input.unreimbursed_living_donor_out_of_pocket_expenses: 0
+  output:
+    us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction: 0
+- name: auto_zero_living_organ_donor_expense_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:statutes/58.1/58/1-322/03#input.bone_marrow_donor_screening_fee_paid: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_courses_required_as_condition_of_employment: false
+    us-va:statutes/58.1/58/1-322/03#input.continuing_teacher_education_tuition_costs: 0
+    us-va:statutes/58.1/58/1-322/03#input.expenses_directly_related_to_living_donation_arose_within_allowed_period: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_claimed_federal_deduction_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_licensed_primary_or_secondary_school_teacher: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_is_living_donor_of_organ_or_other_living_tissue: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_paid_initial_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_purchased_qualifying_energy_efficient_property_for_own_use: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_bone_marrow_donor_screening_fee: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_reimbursed_for_continuing_teacher_education_tuition_costs: false
+    us-va:statutes/58.1/58/1-322/03#input.individual_took_federal_medical_deduction_for_living_donor_expenses: false
+    us-va:statutes/58.1/58/1-322/03#input.qualifying_energy_efficient_property_purchase_amount: 0
+    us-va:statutes/58.1/58/1-322/03#input.unreimbursed_living_donor_out_of_pocket_expenses: 0
+  output:
+    us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction: 0

--- a/us-va/statutes/58.1/58/1-322/03.yaml
+++ b/us-va/statutes/58.1/58/1-322/03.yaml
@@ -1,0 +1,775 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-va/statute/58.1/58.1-322.03
+  summary: |-
+    In computing Virginia taxable income pursuant to § 58.1-322, there shall be deducted from Virginia adjusted gross income specified itemized or standard deduction amounts, personal exemptions, employment-related dependent care expenses, foster care child deductions, age deductions and phaseouts, qualifying unreimbursed fees, education savings contributions, specified insurance premiums, business interest percentages, property taxes limited federally, and specified Paycheck Protection Program loan amounts.
+rules:
+  - name: charitable_mileage_state_rate
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "a rate of 18 cents per mile"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.18
+
+  - name: standard_deduction_single_general
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(1)(b)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "$3,000 for single individuals"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+
+  - name: standard_deduction_married_general
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(1)(b)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "$6,000 for married persons"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6000
+
+  - name: standard_deduction_single_temporary
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(1)(b)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "$4,500 for single individuals"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          4500
+
+  - name: standard_deduction_married_temporary
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(1)(b)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "$9,000 for married persons"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          9000
+
+  - name: married_separate_standard_deduction_fraction
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "one-half of such amounts in the case of a married individual filing a separate return"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.5
+
+  - name: personal_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "$930 for each personal exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          930
+
+  - name: blind_or_aged_additional_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "additional personal exemption in the amount of $800"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          800
+
+  - name: permanent_foster_care_child_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "An additional $1,000 deduction for each child"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1000
+
+  - name: age_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "A deduction in the amount of $12,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12000
+
+  - name: age_deduction_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: Va. Code § 58.1-322.03(5)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "have attained the age of 65"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+
+  - name: age_deduction_single_phaseout_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(5)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "exceeds $50,000 for single taxpayers"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          50000
+
+  - name: age_deduction_married_phaseout_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(5)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "exceeds $75,000 for married taxpayers"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          75000
+
+  - name: college_savings_annual_deduction_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(7)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "limited to $4,000 per prepaid tuition contract or college savings trust account"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          4000
+
+  - name: college_savings_no_limit_age
+    kind: parameter
+    dtype: Integer
+    source: Va. Code § 58.1-322.03(7)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "who has attained age 70"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          70
+
+  - name: continuing_teacher_education_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "An amount equal to 20 percent of the tuition costs"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.20
+
+  - name: tobacco_single_payment_gain_subtraction_rate
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(11)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "10 percent of the recognized gain"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.10
+
+  - name: energy_efficient_property_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "An amount equal to 20 percent of the sum paid"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.20
+
+  - name: energy_efficient_property_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "not to exceed $500 in each taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          500
+
+  - name: fuel_cell_minimum_efficiency
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(12)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "efficiency greater than 35 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.35
+
+  - name: fuel_cell_minimum_capacity_kilowatts
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "generating capacity of at least two kilowatts"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: gas_heat_pump_minimum_heating_cop
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "coefficient of performance of at least 1.25 for heating"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.25
+
+  - name: gas_heat_pump_minimum_cooling_cop
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "at least 0.70 for cooling"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.70
+
+  - name: heat_pump_water_heater_minimum_energy_factor
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "energy factor of at least 1.7"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.7
+
+  - name: electric_heat_pump_minimum_heating_performance_factor
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(v)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "heating system performance factor of at least 8.0"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          8.0
+
+  - name: electric_heat_pump_minimum_cooling_seer
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(v)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "cooling seasonal energy efficiency ratio of at least 13.0"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          13.0
+
+  - name: central_air_conditioner_minimum_cooling_seer
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(vi)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "cooling seasonal energy efficiency ratio of at least 13.5"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          13.5
+
+  - name: advanced_water_heater_minimum_energy_factor
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(vii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "energy factor of at least 0.65"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.65
+
+  - name: advanced_oil_boiler_minimum_fuel_utilization_rating
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(viii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "minimum annual fuel-utilization rating of 85"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          85
+
+  - name: advanced_oil_furnace_minimum_fuel_utilization_rating
+    kind: parameter
+    dtype: Decimal
+    source: Va. Code § 58.1-322.03(12)(ix)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "minimum annual fuel-utilization rating of 85"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          85
+
+  - name: living_organ_donor_expense_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "The lesser of $5,000 or the amount actually paid"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          5000
+
+  - name: living_organ_donor_expense_month_window
+    kind: parameter
+    dtype: Integer
+    source: Va. Code § 58.1-322.03(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "arose within 12 months of such donation"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12
+
+  - name: senior_insurance_deduction_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: Va. Code § 58.1-322.03(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "an individual age 66 or older"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          66
+
+  - name: senior_insurance_deduction_minimum_earned_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "earned income of at least $20,000"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          20000
+
+  - name: senior_insurance_deduction_fagi_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(14)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "federal adjusted gross income not in excess of $30,000"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          30000
+
+  - name: business_interest_deduction_rate_temporary
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "20 percent of business interest disallowed"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          0.20
+
+  - name: business_interest_deduction_rate_current
+    kind: parameter
+    dtype: Rate
+    source: Va. Code § 58.1-322.03(15)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "30 percent of business interest disallowed"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.30
+
+  - name: ppp_loan_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Va. Code § 58.1-322.03(17)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "up to $100,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          100000
+
+  - name: bone_marrow_donor_screening_fee_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code § 58.1-322.03(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "if (i) the individual is not reimbursed for such fee or (ii) the individual has not claimed a deduction"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_paid_initial_bone_marrow_donor_screening_fee and (not individual_reimbursed_for_bone_marrow_donor_screening_fee or not individual_claimed_federal_deduction_for_bone_marrow_donor_screening_fee): bone_marrow_donor_screening_fee_paid else: 0
+
+  - name: continuing_teacher_education_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code § 58.1-322.03(9)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "20 percent of the tuition costs ... only if ... not reimbursed ... and ... not claimed a deduction"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction_rate
+              output: continuing_teacher_education_deduction_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_is_licensed_primary_or_secondary_school_teacher and continuing_teacher_education_courses_required_as_condition_of_employment and not individual_reimbursed_for_continuing_teacher_education_tuition_costs and not individual_claimed_federal_deduction_for_continuing_teacher_education_tuition_costs: continuing_teacher_education_deduction_rate * continuing_teacher_education_tuition_costs else: 0
+
+  - name: energy_efficient_property_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code § 58.1-322.03(12)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "20 percent of the sum paid ... not to exceed $500"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_rate
+              output: energy_efficient_property_deduction_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_cap
+              output: energy_efficient_property_deduction_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_purchased_qualifying_energy_efficient_property_for_own_use: min(energy_efficient_property_deduction_cap, energy_efficient_property_deduction_rate * qualifying_energy_efficient_property_purchase_amount) else: 0
+
+  - name: living_organ_donor_expense_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code § 58.1-322.03(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "lesser of $5,000 or the amount actually paid ... unreimbursed out-of-pocket expenses"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction_cap
+              output: living_organ_donor_expense_deduction_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_is_living_donor_of_organ_or_other_living_tissue and expenses_directly_related_to_living_donation_arose_within_allowed_period and not individual_took_federal_medical_deduction_for_living_donor_expenses: min(living_organ_donor_expense_deduction_cap, unreimbursed_living_donor_out_of_pocket_expenses) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-va/statute/58.1/58.1-322.03`
- Module: `us-va/statutes/58.1/58/1-322/03.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-va-statute-58-1-58-1-322-03/rulespec-us/oracle-coverage-pending.yaml: 52 declared (+42 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.