### PR TITLE
Encode us-wa/statute/82/82.87/82.87.080 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21601,6 +21601,15 @@
         ]
       }
     ],
+    "us-wa/statute/82/82.87/82.87.080": [
+      {
+        "module": "us-wa/statutes/82/82.87/82/87/080.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wy/manual/dfs/snap-power-policy-manual/1100-extended-menu/block-1": [
       {
         "module": "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 17
 entries:
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
@@ -43,5 +43,20 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/080#nonprofit_organization
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/080#principally_directed_and_managed_within_washington
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/080#qualified_organization
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_maximum_charitable_donation_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_minimum_qualifying_charitable_donation_amount
     source: bulk
     since: 2026-07-08

--- a/us-wa/.axiom/encoding-manifests/statutes/82/82.87/82/87/080.json
+++ b/us-wa/.axiom/encoding-manifests/statutes/82/82.87/82/87/080.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/82/82.87/82/87/080.yaml",
+      "sha256": "b32eb4fd7ea55a3ef59a1dd4204779b9661c276d0720a26f4d19e732c8f32f2e"
+    },
+    {
+      "path": "statutes/82/82.87/82/87/080.test.yaml",
+      "sha256": "36b51b86b5b1125cf93872feb7ccf39a1d4394438b839a9a0d9f1a3d9c551124"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-wa/statute/82/82.87/82.87.080",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-080/encode-out/_eval_workspaces/codex-gpt-5.5/us-wa-statute-82-82.87-82.87.080/workspace/context-manifest.json",
+  "context_manifest_sha256": "a5d2c1c83b94237182c7f6fd0c612eb7a4901550f2e084e4de8eb24b3f149960",
+  "generated_at": "2026-07-08T14:50:30.722783+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-080/encode-out/codex-gpt-5.5/statutes/82/82.87/82/87/080.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-080/encode-out",
+  "generated_output_sha256": "b32eb4fd7ea55a3ef59a1dd4204779b9661c276d0720a26f4d19e732c8f32f2e",
+  "generation_prompt_sha256": "ffe299f4c3f5be26e778428fea4743a229220a84fc4b75849dfe98c842dcb79f",
+  "model": "gpt-5.5",
+  "run_id": "8a75c1ec",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "043e9e809226fa1c07407b333b3795f28e1bfbc8776bedd840dfbf29705376c6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-080/encode-out/traces/codex-gpt-5.5/us-wa-statute-82-82.87-82.87.080.json",
+  "trace_sha256": "bb46b25da53013c6d8f7fb938bf667f3459aa34195e03fa926f8f4f01b763609"
+}

--- a/us-wa/statutes/82/82.87/82/87/080.test.yaml
+++ b/us-wa/statutes/82/82.87/82/87/080.test.yaml
@@ -1,0 +1,40 @@
+- name: organization_meets_all_definition_requirements
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/080#input.organization_exempt_from_tax_under_501_c_3: true
+    ? us-wa:statutes/82/82.87/82/87/080#input.organization_activities_primarily_directed_controlled_and_coordinated_within_washington
+    : true
+    us-wa:statutes/82/82.87/82/87/080#input.organization_eligible_to_receive_charitable_contribution_under_170_c: true
+  output:
+    us-wa:statutes/82/82.87/82/87/080#nonprofit_organization: holds
+    us-wa:statutes/82/82.87/82/87/080#principally_directed_and_managed_within_washington: holds
+    us-wa:statutes/82/82.87/82/87/080#qualified_organization: holds
+- name: organization_not_principally_managed_in_washington
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/080#input.organization_exempt_from_tax_under_501_c_3: true
+    ? us-wa:statutes/82/82.87/82/87/080#input.organization_activities_primarily_directed_controlled_and_coordinated_within_washington
+    : false
+    us-wa:statutes/82/82.87/82/87/080#input.organization_eligible_to_receive_charitable_contribution_under_170_c: true
+  output:
+    us-wa:statutes/82/82.87/82/87/080#principally_directed_and_managed_within_washington: not_holds
+    us-wa:statutes/82/82.87/82/87/080#qualified_organization: not_holds
+- name: organization_not_eligible_under_170_c
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-wa:statutes/82/82.87/82/87/080#input.organization_exempt_from_tax_under_501_c_3: false
+    ? us-wa:statutes/82/82.87/82/87/080#input.organization_activities_primarily_directed_controlled_and_coordinated_within_washington
+    : true
+    us-wa:statutes/82/82.87/82/87/080#input.organization_eligible_to_receive_charitable_contribution_under_170_c: false
+  output:
+    us-wa:statutes/82/82.87/82/87/080#nonprofit_organization: not_holds
+    us-wa:statutes/82/82.87/82/87/080#qualified_organization: not_holds

--- a/us-wa/statutes/82/82.87/82/87/080.yaml
+++ b/us-wa/statutes/82/82.87/82/87/080.yaml
@@ -1,0 +1,105 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+  summary: |-
+    A taxpayer may deduct donations to qualified organizations during the same taxable year in excess of the minimum qualifying charitable donation amount. The minimum amount equals $250,000, adjusted under RCW 82.87.150. The deduction may not exceed $100,000, adjusted under RCW 82.87.150, and may not be carried forward or backward. Definitions are provided for nonprofit organization, principally directed and managed, and qualified organization.
+  deferred_outputs:
+    - output: us-wa:statutes/82/82.87/82/87/080#charitable_donation_deduction
+      reason: The final deduction depends on inflation-adjusted minimum and maximum amounts under RCW 82.87.150, which is not supplied in this source context.
+      source_values:
+        - us-wa:statutes/82/82.87/82/87/080#statutory_minimum_qualifying_charitable_donation_amount
+        - us-wa:statutes/82/82.87/82/87/080#statutory_maximum_charitable_donation_deduction
+rules:
+  - name: statutory_minimum_qualifying_charitable_donation_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 82.87.080(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+              excerpt: "minimum qualifying charitable donation amount equals $250,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          250000
+
+  - name: statutory_maximum_charitable_donation_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 82.87.080(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+              excerpt: "may not exceed $100,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          100000
+
+  - name: nonprofit_organization
+    kind: derived
+    entity: Organization
+    dtype: Judgment
+    period: Year
+    source: 82.87.080(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          organization_exempt_from_tax_under_501_c_3
+
+  - name: principally_directed_and_managed_within_washington
+    kind: derived
+    entity: Organization
+    dtype: Judgment
+    period: Year
+    source: 82.87.080(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          organization_activities_primarily_directed_controlled_and_coordinated_within_washington
+
+  - name: qualified_organization
+    kind: derived
+    entity: Organization
+    dtype: Judgment
+    period: Year
+    source: 82.87.080(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-wa/statute/82/82.87/82.87.080
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          organization_eligible_to_receive_charitable_contribution_under_170_c
+          and principally_directed_and_managed_within_washington


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-wa/statute/82/82.87/82.87.080`
- Module: `us-wa/statutes/82/82.87/82/87/080.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-wa-statute-82-82-87-82-87-080/rulespec-us/oracle-coverage-pending.yaml: 15 declared (+5 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.