### PR TITLE
Encode us-hi/statute/235-55.6 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9488,6 +9488,15 @@
         ]
       }
     ],
+    "us-hi/statute/235-55.6": [
+      {
+        "module": "us-hi/statutes/235-55/6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ia/regulation/iac/441/41/41.28": [
       {
         "module": "us-ia/regulations/iac/441/41/41/28.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,92 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 40
 entries:
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_0_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_lower_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_upper_bound
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#applicable_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#dependent_care_center
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#dependent_care_center_individual_count_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#dollar_limit_on_creditable_expenses
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#earned_income_limitation
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#half_of_household_cost
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#household_maintained
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#married_individual_living_apart_not_considered_married
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#married_taxpayer_joint_return_requirement_satisfied
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#multiple_qualifying_individual_expense_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#one_qualifying_individual_expense_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#percentage_of_creditable_expenses
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#refund_floor
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#spouse_monthly_deemed_earned_income_for_limitation
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#spouse_multiple_qualifying_individual_monthly_deemed_earned_income
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-hi:statutes/235-55/6#spouse_one_qualifying_individual_monthly_deemed_earned_income
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-hi/.axiom/encoding-manifests/statutes/235-55/6.json
+++ b/us-hi/.axiom/encoding-manifests/statutes/235-55/6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/235-55/6.yaml",
+      "sha256": "a5505b2625b9c3cd74695ef0aa29ce42d83d44cc98606d0a7c3923b0020e6b56"
+    },
+    {
+      "path": "statutes/235-55/6.test.yaml",
+      "sha256": "3d777ccc073d4a4d8a62aad057ad14be2cd646b8f0adabeebd30d58d82275ad5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-hi/statute/235-55.6",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-hi-statute-235-55-6/encode-out/_eval_workspaces/codex-gpt-5.5/us-hi-statute-235-55.6/workspace/context-manifest.json",
+  "context_manifest_sha256": "1ccf0dd99cff5d69729bf14b9e4bce19b78772c22b06530c0578917428375a13",
+  "generated_at": "2026-07-08T14:53:03.603304+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-hi-statute-235-55-6/encode-out/codex-gpt-5.5/statutes/235-55/6.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-hi-statute-235-55-6/encode-out",
+  "generated_output_sha256": "a5505b2625b9c3cd74695ef0aa29ce42d83d44cc98606d0a7c3923b0020e6b56",
+  "generation_prompt_sha256": "9335d88969258b25a973c9a0fe2bb539c2bd854e13e7ac6d3ef837ffef7f3c7f",
+  "model": "gpt-5.5",
+  "run_id": "76786341",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1ab5c6806a4097abb57bf04782058050cfdf16adbf07de313985132082f5b77f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-hi-statute-235-55-6/encode-out/traces/codex-gpt-5.5/us-hi-statute-235-55.6.json",
+  "trace_sha256": "8617413312afcea314e2947f8ee14e02d9293b6290189ac8678688848abac50e"
+}

--- a/us-hi/statutes/235-55/6.test.yaml
+++ b/us-hi/statutes/235-55/6.test.yaml
@@ -1,0 +1,126 @@
+- name: applicable percentage and percentage credit use income band
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.adjusted_gross_income: 32000
+    us-hi:statutes/235-55/6#input.creditable_employment_related_expenses: 10000
+  output:
+    us-hi:statutes/235-55/6#adjusted_gross_income_band: 2
+    us-hi:statutes/235-55/6#percentage_of_creditable_expenses: 2300
+- name: dependent care center definition satisfied
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.facility_provides_care_for_individual_count: 7
+    us-hi:statutes/235-55/6#input.facility_receives_fee_payment_or_grant_for_providing_services: true
+  output:
+    us-hi:statutes/235-55/6#dependent_care_center: holds
+- name: earned income limitation for married taxpayer uses lesser income with deemed
+    spouse income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.taxpayer_married_at_close_of_year: true
+    us-hi:statutes/235-55/6#input.taxpayer_earned_income: 9000
+    us-hi:statutes/235-55/6#input.spouse_earned_income: 1000
+    us-hi:statutes/235-55/6#input.spouse_deemed_earned_income_for_limitation: 2400
+  output:
+    us-hi:statutes/235-55/6#earned_income_limitation: 2400
+- name: special household and joint return rules
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.taxpayer_or_spouses_household_cost_share: 0.6
+    us-hi:statutes/235-55/6#input.taxpayer_married_at_close_of_year: true
+    us-hi:statutes/235-55/6#input.taxpayer_and_spouse_file_joint_return: true
+    us-hi:statutes/235-55/6#input.taxpayer_is_married_and_files_separate_return: true
+    us-hi:statutes/235-55/6#input.household_is_principal_abode_of_qualifying_individual_for_more_than_half_year: true
+    us-hi:statutes/235-55/6#input.taxpayer_furnishes_over_half_household_cost: true
+    us-hi:statutes/235-55/6#input.spouse_not_member_of_household_during_last_six_months: true
+  output:
+    us-hi:statutes/235-55/6#household_maintained: holds
+    us-hi:statutes/235-55/6#married_taxpayer_joint_return_requirement_satisfied: holds
+    us-hi:statutes/235-55/6#married_individual_living_apart_not_considered_married: holds
+- name: auto_output_dollar_limit_on_creditable_expenses
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.adjusted_gross_income: 0
+    us-hi:statutes/235-55/6#input.creditable_employment_related_expenses: 0
+    us-hi:statutes/235-55/6#input.dependent_care_assistance_excludable_from_gross_income: 0
+    us-hi:statutes/235-55/6#input.facility_provides_care_for_individual_count: 1
+    us-hi:statutes/235-55/6#input.facility_receives_fee_payment_or_grant_for_providing_services: false
+    us-hi:statutes/235-55/6#input.household_is_principal_abode_of_qualifying_individual_for_more_than_half_year: false
+    us-hi:statutes/235-55/6#input.qualifying_individual_count: 1
+    us-hi:statutes/235-55/6#input.spouse_deemed_earned_income_for_limitation: 0
+    us-hi:statutes/235-55/6#input.spouse_earned_income: 0
+    us-hi:statutes/235-55/6#input.spouse_is_full_time_student_or_qualifying_individual_and_special_rule_available: false
+    us-hi:statutes/235-55/6#input.spouse_not_member_of_household_during_last_six_months: false
+    us-hi:statutes/235-55/6#input.taxpayer_and_spouse_file_joint_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_earned_income: 0
+    us-hi:statutes/235-55/6#input.taxpayer_furnishes_over_half_household_cost: false
+    us-hi:statutes/235-55/6#input.taxpayer_is_married_and_files_separate_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_married_at_close_of_year: false
+    us-hi:statutes/235-55/6#input.taxpayer_or_spouses_household_cost_share: 0
+  output:
+    us-hi:statutes/235-55/6#dollar_limit_on_creditable_expenses: 10000
+- name: auto_output_spouse_monthly_deemed_earned_income_for_limitation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.adjusted_gross_income: 0
+    us-hi:statutes/235-55/6#input.creditable_employment_related_expenses: 0
+    us-hi:statutes/235-55/6#input.dependent_care_assistance_excludable_from_gross_income: 0
+    us-hi:statutes/235-55/6#input.facility_provides_care_for_individual_count: 1
+    us-hi:statutes/235-55/6#input.facility_receives_fee_payment_or_grant_for_providing_services: false
+    us-hi:statutes/235-55/6#input.household_is_principal_abode_of_qualifying_individual_for_more_than_half_year: false
+    us-hi:statutes/235-55/6#input.qualifying_individual_count: 1
+    us-hi:statutes/235-55/6#input.spouse_deemed_earned_income_for_limitation: 0
+    us-hi:statutes/235-55/6#input.spouse_earned_income: 0
+    us-hi:statutes/235-55/6#input.spouse_is_full_time_student_or_qualifying_individual_and_special_rule_available: false
+    us-hi:statutes/235-55/6#input.spouse_not_member_of_household_during_last_six_months: false
+    us-hi:statutes/235-55/6#input.taxpayer_and_spouse_file_joint_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_earned_income: 0
+    us-hi:statutes/235-55/6#input.taxpayer_furnishes_over_half_household_cost: false
+    us-hi:statutes/235-55/6#input.taxpayer_is_married_and_files_separate_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_married_at_close_of_year: false
+    us-hi:statutes/235-55/6#input.taxpayer_or_spouses_household_cost_share: 0
+  output:
+    us-hi:statutes/235-55/6#spouse_monthly_deemed_earned_income_for_limitation: 0
+- name: auto_zero_adjusted_gross_income_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-hi:statutes/235-55/6#input.adjusted_gross_income: 25000
+    us-hi:statutes/235-55/6#input.creditable_employment_related_expenses: 0
+    us-hi:statutes/235-55/6#input.dependent_care_assistance_excludable_from_gross_income: 0
+    us-hi:statutes/235-55/6#input.facility_provides_care_for_individual_count: 0
+    us-hi:statutes/235-55/6#input.facility_receives_fee_payment_or_grant_for_providing_services: false
+    us-hi:statutes/235-55/6#input.household_is_principal_abode_of_qualifying_individual_for_more_than_half_year: false
+    us-hi:statutes/235-55/6#input.qualifying_individual_count: 0
+    us-hi:statutes/235-55/6#input.spouse_deemed_earned_income_for_limitation: 0
+    us-hi:statutes/235-55/6#input.spouse_earned_income: 0
+    us-hi:statutes/235-55/6#input.spouse_is_full_time_student_or_qualifying_individual_and_special_rule_available: false
+    us-hi:statutes/235-55/6#input.spouse_not_member_of_household_during_last_six_months: false
+    us-hi:statutes/235-55/6#input.taxpayer_and_spouse_file_joint_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_earned_income: 0
+    us-hi:statutes/235-55/6#input.taxpayer_furnishes_over_half_household_cost: false
+    us-hi:statutes/235-55/6#input.taxpayer_is_married_and_files_separate_return: false
+    us-hi:statutes/235-55/6#input.taxpayer_married_at_close_of_year: false
+    us-hi:statutes/235-55/6#input.taxpayer_or_spouses_household_cost_share: 0
+  output:
+    us-hi:statutes/235-55/6#adjusted_gross_income_band: 0

--- a/us-hi/statutes/235-55/6.yaml
+++ b/us-hi/statutes/235-55/6.yaml
@@ -1,0 +1,520 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-hi/statute/235-55.6
+  summary: |-
+    Section 235-55.6 allows a refundable resident individual income tax credit equal to the applicable percentage of employment-related expenses, with AGI percentage bands of 25%, 24%, 23%, 22%, 21%, 20%, and 15%. Employment-related expenses are limited to $10,000 for one qualifying individual or $20,000 for two or more, reduced by amounts excludable under IRC section 129. The section defines qualifying individuals, employment-related expenses, dependent care centers, earned-income limitations, and special rules for maintaining a household, marital status, related-payee disallowance, student status, educational organization, and service-provider identifying information.
+  deferred_outputs:
+    - output: us-hi:statutes/235-55/6/b#qualifying_individual
+      reason: Qualifying-individual definition depends on unavailable cross-referenced dependency and deduction rules under section 235-54(a), section 152(e), and related IRC provisions.
+    - output: us-hi:statutes/235-55/6/b#employment_related_expenses
+      reason: Final employment-related expense inclusion depends on the deferred qualifying-individual definition and unavailable cross-referenced dependency rules.
+    - output: us-hi:statutes/235-55/6/e#credit_allowed_after_special_rules
+      reason: Final credit allowance under the special rules depends on deferred qualifying-individual and employment-related-expense surfaces and unavailable cross-referenced IRC dependency/exemption provisions.
+rules:
+  - name: adjusted_gross_income_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              table:
+                header: Adjusted gross income applicable percentage table
+                row_key: adjusted gross income bands
+                column_key: applicable percentage
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if adjusted_gross_income <= adjusted_gross_income_band_0_upper_bound: 0 else: if adjusted_gross_income > adjusted_gross_income_band_1_lower_bound and adjusted_gross_income <= adjusted_gross_income_band_1_upper_bound: 1 else: if adjusted_gross_income > adjusted_gross_income_band_2_lower_bound and adjusted_gross_income <= adjusted_gross_income_band_2_upper_bound: 2 else: if adjusted_gross_income > adjusted_gross_income_band_3_lower_bound and adjusted_gross_income <= adjusted_gross_income_band_3_upper_bound: 3 else: if adjusted_gross_income > adjusted_gross_income_band_4_lower_bound and adjusted_gross_income <= adjusted_gross_income_band_4_upper_bound: 4 else: if adjusted_gross_income > adjusted_gross_income_band_5_lower_bound and adjusted_gross_income <= adjusted_gross_income_band_5_upper_bound: 5 else: 6
+  - name: adjusted_gross_income_band_0_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Not over $25,000 25%
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          25000
+  - name: adjusted_gross_income_band_1_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $25,000 but not over $30,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          25000
+  - name: adjusted_gross_income_band_1_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $25,000 but not over $30,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30000
+  - name: adjusted_gross_income_band_2_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $30,000 but not over $35,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          30000
+  - name: adjusted_gross_income_band_2_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $30,000 but not over $35,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          35000
+  - name: adjusted_gross_income_band_3_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $35,000 but not over $40,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          35000
+  - name: adjusted_gross_income_band_3_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $35,000 but not over $40,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          40000
+  - name: adjusted_gross_income_band_4_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $40,000 but not over $45,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          40000
+  - name: adjusted_gross_income_band_4_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $40,000 but not over $45,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          45000
+  - name: adjusted_gross_income_band_5_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $45,000 but not over $50,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          45000
+  - name: adjusted_gross_income_band_5_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Over $45,000 but not over $50,000
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          50000
+  - name: applicable_percentage
+    kind: parameter
+    dtype: Rate
+    indexed_by: adjusted_gross_income_band
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              table:
+                header: Adjusted gross income applicable percentage table
+                row_key: adjusted gross income band
+                column_key: applicable percentage
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 0.25
+          1: 0.24
+          2: 0.23
+          3: 0.22
+          4: 0.21
+          5: 0.20
+          6: 0.15
+  - name: percentage_of_creditable_expenses
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: amount equal to the applicable percentage of the employment-related expenses
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          applicable_percentage[adjusted_gross_income_band] * max(0, creditable_employment_related_expenses)
+  - name: refund_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: no refunds or payment ... for amounts less than $1
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+  - name: dependent_care_center_individual_count_threshold
+    kind: parameter
+    dtype: Count
+    source: 235-55.6(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Provides care for more than six individuals
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6
+  - name: dependent_care_center
+    kind: derived
+    entity: Business
+    dtype: Judgment
+    period: Year
+    source: 235-55.6(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: dependent care center means any facility which provides care for more than six individuals and receives a fee, payment, or grant
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          facility_provides_care_for_individual_count > dependent_care_center_individual_count_threshold
+          and facility_receives_fee_payment_or_grant_for_providing_services
+  - name: one_qualifying_individual_expense_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: $10,000 if there is one qualifying individual
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10000
+  - name: multiple_qualifying_individual_expense_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: $20,000 if there are two or more qualifying individuals
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20000
+  - name: dollar_limit_on_creditable_expenses
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 235-55.6(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: amount determined ... shall be reduced by the aggregate amount excludable from gross income under section 129
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, (if qualifying_individual_count == 1: one_qualifying_individual_expense_limit else: if qualifying_individual_count >= 2: multiple_qualifying_individual_expense_limit else: 0) - dependent_care_assistance_excludable_from_gross_income)
+  - name: spouse_one_qualifying_individual_monthly_deemed_earned_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: $200 if subsection (c)(1) applies
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200
+  - name: spouse_multiple_qualifying_individual_monthly_deemed_earned_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 235-55.6(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: $400 if subsection (c)(2) applies
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          400
+  - name: spouse_monthly_deemed_earned_income_for_limitation
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 235-55.6(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: spouse shall be deemed for each month ... to have earned income of not less than $200 ... or $400
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if spouse_is_full_time_student_or_qualifying_individual_and_special_rule_available: if qualifying_individual_count == 1: spouse_one_qualifying_individual_monthly_deemed_earned_income else: if qualifying_individual_count >= 2: spouse_multiple_qualifying_individual_monthly_deemed_earned_income else: 0 else: 0
+  - name: earned_income_limitation
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 235-55.6(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: shall not exceed ... individual's earned income ... or ... lesser of such individual's earned income or the earned income of the individual's spouse
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, if taxpayer_married_at_close_of_year: min(taxpayer_earned_income, max(spouse_earned_income, spouse_deemed_earned_income_for_limitation)) else: taxpayer_earned_income)
+  - name: household_maintained
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 235-55.6(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: treated as maintaining a household ... only if over half the cost ... is furnished
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          taxpayer_or_spouses_household_cost_share > half_of_household_cost
+  - name: half_of_household_cost
+    kind: parameter
+    dtype: Rate
+    source: 235-55.6(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: over half the cost of maintaining the household
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.50
+  - name: married_taxpayer_joint_return_requirement_satisfied
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 235-55.6(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: If the taxpayer is married at the close of the taxable year, the credit shall be allowed ... only if ... file a joint return
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not taxpayer_married_at_close_of_year
+          or taxpayer_and_spouse_file_joint_return
+  - name: married_individual_living_apart_not_considered_married
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 235-55.6(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-hi/statute/235-55.6
+              excerpt: Certain married individuals living apart ... shall not be considered as married
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          taxpayer_is_married_and_files_separate_return
+          and household_is_principal_abode_of_qualifying_individual_for_more_than_half_year
+          and taxpayer_furnishes_over_half_household_cost
+          and spouse_not_member_of_household_during_last_six_months


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-hi/statute/235-55.6`
- Module: `us-hi/statutes/235-55/6.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-hi-statute-235-55-6/rulespec-us/oracle-coverage-pending.yaml: 38 declared (+28 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.