### PR TITLE
Encode us-az/statute/43-1023 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1432,6 +1432,15 @@
         ]
       }
     ],
+    "us-az/statute/43-1023": [
+      {
+        "module": "us-az/statutes/43-1023.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/guidance/cdss/acin-2025-i-46-25/page-4": [
       {
         "module": "us-ca/policies/cdss/snap/standard-utility-allowance.yaml",

--- a/us-az/.axiom/encoding-manifests/statutes/43-1023.json
+++ b/us-az/.axiom/encoding-manifests/statutes/43-1023.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/43-1023.yaml",
+      "sha256": "b9a3279da8cba88cd1a1f9c9733fe143287064b2d42185f1bda731e0b097b56a"
+    },
+    {
+      "path": "statutes/43-1023.test.yaml",
+      "sha256": "7d741a49d1632e9c1203ce75f72bafaad6d5a8e77dabbea9ed17ccef3efc315d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-az/statute/43-1023",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1023/encode-out/_eval_workspaces/codex-gpt-5.5/us-az-statute-43-1023/workspace/context-manifest.json",
+  "context_manifest_sha256": "1f3aefd6cd9d9bc8545ec651723db9ba2a3dbefffcd02872114065ad221ef99d",
+  "generated_at": "2026-07-08T14:53:04.631038+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1023/encode-out/codex-gpt-5.5/statutes/43-1023.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1023/encode-out",
+  "generated_output_sha256": "b9a3279da8cba88cd1a1f9c9733fe143287064b2d42185f1bda731e0b097b56a",
+  "generation_prompt_sha256": "b0dc6d0939d940a80b288d55c6b15c8011dae4fb08b735ff835c6e07e86ad816",
+  "model": "gpt-5.5",
+  "run_id": "a0fe3e95",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ac4a614db490f80acc0345c602bfc9bebd59dcd0282a94bcd9888e8766adc2b3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1023/encode-out/traces/codex-gpt-5.5/us-az-statute-43-1023.json",
+  "trace_sha256": "cab0636dbd966ec8dcdc9f7cb82b3c6a19bc91d835d553ca69e187c43e553a03"
+}

--- a/us-az/statutes/43-1023.test.yaml
+++ b/us-az/statutes/43-1023.test.yaml
@@ -1,0 +1,68 @@
+- name: all_exemption_categories_apply
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1023#input.taxpayer_is_blind_as_described: true
+    us-az:statutes/43-1023#input.separate_return_made: true
+    us-az:statutes/43-1023#input.spouse_is_blind_as_described: true
+    us-az:statutes/43-1023#input.spouse_has_no_arizona_adjusted_gross_income: true
+    us-az:statutes/43-1023#input.spouse_is_dependent_of_another_taxpayer: false
+    us-az:statutes/43-1023#input.qualifying_older_person_care_exemption_count: 1
+    us-az:statutes/43-1023#input.stillbirth_exemption_count: 1
+    us-az:statutes/43-1023#input.qualifying_parent_or_ancestor_exemption_count: 1
+    us-az:statutes/43-1023#input.taxpayer_has_attained_age_threshold_before_close_of_taxable_year: true
+    us-az:statutes/43-1023#input.taxpayer_is_claimed_as_dependent_by_another_taxpayer: false
+    us-az:statutes/43-1023#input.joint_return_filed: true
+    us-az:statutes/43-1023#input.spouse_has_attained_age_threshold_before_close_of_taxable_year: true
+  output:
+    us-az:statutes/43-1023#blindness_exemption: 3000
+    us-az:statutes/43-1023#older_person_care_exemption: 2300
+    us-az:statutes/43-1023#stillbirth_exemption: 2300
+    us-az:statutes/43-1023#parent_or_ancestor_exemption: 10000
+    us-az:statutes/43-1023#taxpayer_or_spouse_age_exemption: 4200
+    us-az:statutes/43-1023#total_special_exemptions: 21800
+- name: spouse_blind_exemption_blocked_by_dependency
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1023#input.taxpayer_is_blind_as_described: false
+    us-az:statutes/43-1023#input.separate_return_made: true
+    us-az:statutes/43-1023#input.spouse_is_blind_as_described: true
+    us-az:statutes/43-1023#input.spouse_has_no_arizona_adjusted_gross_income: true
+    us-az:statutes/43-1023#input.spouse_is_dependent_of_another_taxpayer: true
+    us-az:statutes/43-1023#input.qualifying_older_person_care_exemption_count: 0
+    us-az:statutes/43-1023#input.stillbirth_exemption_count: 0
+    us-az:statutes/43-1023#input.qualifying_parent_or_ancestor_exemption_count: 0
+    us-az:statutes/43-1023#input.taxpayer_has_attained_age_threshold_before_close_of_taxable_year: false
+    us-az:statutes/43-1023#input.taxpayer_is_claimed_as_dependent_by_another_taxpayer: false
+    us-az:statutes/43-1023#input.joint_return_filed: false
+    us-az:statutes/43-1023#input.spouse_has_attained_age_threshold_before_close_of_taxable_year: false
+  output:
+    us-az:statutes/43-1023#blindness_exemption: 0
+    us-az:statutes/43-1023#taxpayer_or_spouse_age_exemption: 0
+    us-az:statutes/43-1023#total_special_exemptions: 0
+- name: age_exemption_blocked_when_taxpayer_dependent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1023#input.taxpayer_is_blind_as_described: false
+    us-az:statutes/43-1023#input.separate_return_made: false
+    us-az:statutes/43-1023#input.spouse_is_blind_as_described: false
+    us-az:statutes/43-1023#input.spouse_has_no_arizona_adjusted_gross_income: false
+    us-az:statutes/43-1023#input.spouse_is_dependent_of_another_taxpayer: false
+    us-az:statutes/43-1023#input.qualifying_older_person_care_exemption_count: 0
+    us-az:statutes/43-1023#input.stillbirth_exemption_count: 0
+    us-az:statutes/43-1023#input.qualifying_parent_or_ancestor_exemption_count: 0
+    us-az:statutes/43-1023#input.taxpayer_has_attained_age_threshold_before_close_of_taxable_year: true
+    us-az:statutes/43-1023#input.taxpayer_is_claimed_as_dependent_by_another_taxpayer: true
+    us-az:statutes/43-1023#input.joint_return_filed: true
+    us-az:statutes/43-1023#input.spouse_has_attained_age_threshold_before_close_of_taxable_year: true
+  output:
+    us-az:statutes/43-1023#taxpayer_or_spouse_age_exemption: 2100
+    us-az:statutes/43-1023#total_special_exemptions: 2100

--- a/us-az/statutes/43-1023.yaml
+++ b/us-az/statutes/43-1023.yaml
@@ -1,0 +1,391 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-az/statute/43-1023
+  summary: A taxpayer is allowed exemptions of $1,500 for blindness, $2,300 for qualifying
+    older-person care or stillbirth, $10,000 for a qualifying parent or ancestor living
+    in the taxpayer's principal residence, and $2,100 for a taxpayer or spouse age
+    sixty-five or older, subject to the stated return, income, dependency, care-payment,
+    support, residence, and coordination conditions.
+rules:
+- name: blind_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: A taxpayer is allowed an exemption of $1,500
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1500'
+- name: blindness_visual_acuity_numerator
+  kind: parameter
+  dtype: Decimal
+  source: A.R.S. 43-1023(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: central visual acuity does not exceed 20/200
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '20'
+- name: blindness_visual_acuity_denominator
+  kind: parameter
+  dtype: Decimal
+  source: A.R.S. 43-1023(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: central visual acuity does not exceed 20/200
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '200'
+- name: blindness_visual_field_diameter_limit_degrees
+  kind: parameter
+  dtype: Decimal
+  source: A.R.S. 43-1023(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: widest diameter of the visual field subtends an angle not greater
+            than twenty degrees
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '20'
+- name: older_person_care_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: allowed an exemption of $2,300
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '2300'
+- name: older_person_age_threshold
+  kind: parameter
+  dtype: Integer
+  source: A.R.S. 43-1023(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: Each person sixty-five years of age or older
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '65'
+- name: institution_cost_share_threshold_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: A.R.S. 43-1023(B)(1)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: pays more than one-fourth of the total cost
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '4'
+- name: institution_cost_share_threshold
+  kind: parameter
+  dtype: Rate
+  source: A.R.S. 43-1023(B)(1)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: pays more than one-fourth of the total cost
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#institution_cost_share_threshold_scalar_limit
+          output: institution_cost_share_threshold_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1 / institution_cost_share_threshold_scalar_limit
+- name: care_payment_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: payments exceed $800 in the taxable year
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '800'
+- name: stillbirth_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: allowed an exemption of $2,300
+  versions:
+  - effective_from: '2004-01-01'
+    formula: '2300'
+- name: parent_or_ancestor_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: allowed an exemption of $10,000
+  versions:
+  - effective_from: '1999-01-01'
+    formula: '10000'
+- name: parent_or_ancestor_support_share_threshold
+  kind: parameter
+  dtype: Rate
+  source: A.R.S. 43-1023(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: pays more than one-half of the person's total support and maintenance
+            costs
+  versions:
+  - effective_from: '1999-01-01'
+    formula: 1 / 2
+- name: taxpayer_or_spouse_age_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: A taxpayer is allowed an exemption of $2,100
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '2100'
+- name: taxpayer_age_exemption_threshold
+  kind: parameter
+  dtype: Integer
+  source: A.R.S. 43-1023(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: has attained sixty-five years of age before the close of the taxable
+            year
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '65'
+- name: blindness_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: For a taxpayer who is blind ... For the taxpayer's spouse if a
+            separate return is made
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#blind_exemption_amount
+          output: blind_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'blind_exemption_amount * ((if taxpayer_is_blind_as_described: 1 else:
+      0) + (if separate_return_made and spouse_is_blind_as_described and spouse_has_no_arizona_adjusted_gross_income
+      and not spouse_is_dependent_of_another_taxpayer: 1 else: 0))'
+- name: older_person_care_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: Each person sixty-five years of age or older ... payments exceed
+            $800
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#older_person_care_exemption_amount
+          output: older_person_care_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: older_person_care_exemption_amount * qualifying_older_person_care_exemption_count
+- name: stillbirth_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: each birth for which a certificate of birth resulting in stillbirth
+            has been issued
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#stillbirth_exemption_amount
+          output: stillbirth_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '2004-01-01'
+    formula: stillbirth_exemption_amount * stillbirth_exemption_count
+- name: parent_or_ancestor_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: for each parent or ancestor of a parent ... in lieu of an exemption
+            under subsection B
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#parent_or_ancestor_exemption_amount
+          output: parent_or_ancestor_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '1999-01-01'
+    formula: parent_or_ancestor_exemption_amount * qualifying_parent_or_ancestor_exemption_count
+- name: taxpayer_or_spouse_age_exemption
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+          excerpt: If the taxpayer has attained sixty-five years of age ... For the
+            taxpayer's spouse
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-az:statutes/43-1023#taxpayer_or_spouse_age_exemption_amount
+          output: taxpayer_or_spouse_age_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'taxpayer_or_spouse_age_exemption_amount * ((if taxpayer_has_attained_age_threshold_before_close_of_taxable_year
+      and not taxpayer_is_claimed_as_dependent_by_another_taxpayer: 1 else: 0) + (if
+      joint_return_filed and spouse_has_attained_age_threshold_before_close_of_taxable_year
+      and not spouse_is_dependent_of_another_taxpayer: 1 else: 0))'
+- name: total_special_exemptions
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: A.R.S. 43-1023(A)-(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-az/statute/43-1023
+  versions:
+  - effective_from: '2004-01-01'
+    formula: blindness_exemption + older_person_care_exemption + stillbirth_exemption
+      + parent_or_ancestor_exemption + taxpayer_or_spouse_age_exemption


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-az/statute/43-1023`
- Module: `us-az/statutes/43-1023.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1023/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.