### PR TITLE
Encode us-az/statute/43-1072.01 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1432,6 +1432,15 @@
         ]
       }
     ],
+    "us-az/statute/43-1072.01": [
+      {
+        "module": "us-az/statutes/43-1072/01.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/guidance/cdss/acin-2025-i-46-25/page-4": [
       {
         "module": "us-ca/policies/cdss/snap/standard-utility-allowance.yaml",

--- a/us-az/.axiom/encoding-manifests/statutes/43-1072/01.json
+++ b/us-az/.axiom/encoding-manifests/statutes/43-1072/01.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/43-1072/01.yaml",
+      "sha256": "cade2299dd6630aaedd44332f651a68a1dbb24ab43200104effae3119a90a399"
+    },
+    {
+      "path": "statutes/43-1072/01.test.yaml",
+      "sha256": "b3269ff3d036f6a480e606ae6b1c0a23df05940c3ff0bc2d54190b38af666008"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-az/statute/43-1072.01",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072-01/encode-out/_eval_workspaces/codex-gpt-5.5/us-az-statute-43-1072.01/workspace/context-manifest.json",
+  "context_manifest_sha256": "590ec410683d8662a8bb14f71c911c7c6b3d0bd42ab811bcf9e081a23d895903",
+  "generated_at": "2026-07-08T14:54:29.894962+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072-01/encode-out/codex-gpt-5.5/statutes/43-1072/01.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072-01/encode-out",
+  "generated_output_sha256": "cade2299dd6630aaedd44332f651a68a1dbb24ab43200104effae3119a90a399",
+  "generation_prompt_sha256": "79e15ddf114fa0fa6b6fba639c9f9410cd62ea8ca471000502b0a9e8f7aee7de",
+  "model": "gpt-5.5",
+  "run_id": "078210ad",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2ca875c0f6a0bc14cf87964a90504182e90ac90643873064282101ae7a1a91bd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072-01/encode-out/traces/codex-gpt-5.5/us-az-statute-43-1072.01.json",
+  "trace_sha256": "af71924a57251b4c6caee12bfcc2da60b3ff9b660e64d4ad44a3286cdf591cfe"
+}

--- a/us-az/statutes/43-1072/01.test.yaml
+++ b/us-az/statutes/43-1072/01.test.yaml
@@ -1,0 +1,39 @@
+- name: custody sentence threshold makes person ineligible
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072/01#input.days_sentenced_to_specified_custody_during_taxable_year: 60
+  output:
+    us-az:statutes/43-1072/01#ineligible_to_claim_credit_due_to_custody_sentence: holds
+- name: custody sentence below threshold does not trigger disqualification
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072/01#input.days_sentenced_to_specified_custody_during_taxable_year: 59
+  output:
+    us-az:statutes/43-1072/01#ineligible_to_claim_credit_due_to_custody_sentence: not_holds
+- name: required identification information provided
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072/01#input.claimant_has_social_security_number_valid_for_employment: true
+    us-az:statutes/43-1072/01#input.spouse_and_qualifying_children_have_valid_ssn_or_itin: true
+  output:
+    us-az:statutes/43-1072/01#required_identification_information_provided: holds
+- name: missing claimant employment-valid social security number fails identification
+    requirement
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072/01#input.claimant_has_social_security_number_valid_for_employment: false
+    us-az:statutes/43-1072/01#input.spouse_and_qualifying_children_have_valid_ssn_or_itin: true
+  output:
+    us-az:statutes/43-1072/01#required_identification_information_provided: not_holds

--- a/us-az/statutes/43-1072/01.yaml
+++ b/us-az/statutes/43-1072/01.yaml
@@ -1,0 +1,148 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-az/statute/43-1072.01
+  deferred_outputs:
+    - output: us-az:statutes/43-1072/01#increased_excise_tax_credit
+      reason: The credit amount depends on filing-status categories and cross-referenced exemption/person-count mechanics under sections 43-1023(B)(1), 43-1043, and household definition under section 43-1072 that are not supplied as executable RuleSpec context here.
+      source_values:
+        - us-az:statutes/43-1072/01#married_or_head_of_household_federal_agi_limit
+        - us-az:statutes/43-1072/01#single_or_married_filing_separately_federal_agi_limit
+        - us-az:statutes/43-1072/01#credit_amount_per_eligible_person
+        - us-az:statutes/43-1072/01#household_credit_cap
+  summary: |-
+    For taxable years beginning after December 31, 2000, a credit is allowed for a taxpayer not claimed as a dependent whose federal adjusted gross income is not more than $25,000 for a married couple or head of household, or $12,500 for a single person or married person filing separately. The credit is not more than $25 for each resident person for whom specified exemptions are allowed, capped at $100 per household. For taxable years beginning after December 31, 2002, a person sentenced for at least 60 days of the taxable year to specified custody is not eligible to claim the credit. For taxable years beginning after December 31, 2014, the return or claim form must include specified SSN/ITIN information.
+rules:
+  - name: married_or_head_of_household_federal_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. 43-1072.01(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "Twenty-five thousand dollars or less for a married couple or a single person who is a head of a household."
+    versions:
+      - effective_from: '2001-01-01'
+        formula: |-
+          25000
+  - name: single_or_married_filing_separately_federal_agi_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. 43-1072.01(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "Twelve thousand five hundred dollars or less for a single person or a married person filing separately."
+    versions:
+      - effective_from: '2001-01-01'
+        formula: |-
+          12500
+  - name: credit_amount_per_eligible_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. 43-1072.01(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "shall not exceed twenty-five dollars for each person"
+    versions:
+      - effective_from: '2001-01-01'
+        formula: |-
+          25
+  - name: household_credit_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: A.R.S. 43-1072.01(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "not more than one hundred dollars for all persons in the taxpayer's household"
+    versions:
+      - effective_from: '2001-01-01'
+        formula: |-
+          100
+  - name: custody_sentence_day_threshold
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: A.R.S. 43-1072.01(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "sentenced for at least sixty days of the taxable year"
+    versions:
+      - effective_from: '2003-01-01'
+        formula: |-
+          60
+  - name: ineligible_to_claim_credit_due_to_custody_sentence
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: A.R.S. 43-1072.01(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+              excerpt: "sentenced for at least sixty days of the taxable year to the custody of the federal bureau of prisons, the state department of corrections or a county jail"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-az:statutes/43-1072/01#custody_sentence_day_threshold
+              output: custody_sentence_day_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2003-01-01'
+        formula: |-
+          days_sentenced_to_specified_custody_during_taxable_year >= custody_sentence_day_threshold
+  - name: required_identification_information_provided
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: A.R.S. 43-1072.01(G)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-az/statute/43-1072.01
+    versions:
+      - effective_from: '2015-01-01'
+        formula: |-
+          claimant_has_social_security_number_valid_for_employment
+          and spouse_and_qualifying_children_have_valid_ssn_or_itin


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-az/statute/43-1072.01`
- Module: `us-az/statutes/43-1072/01.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072-01/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.