### PR TITLE
Encode us-az/statute/43-1072 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1432,6 +1432,15 @@
         ]
       }
     ],
+    "us-az/statute/43-1072": [
+      {
+        "module": "us-az/statutes/43-1072.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ca/guidance/cdss/acin-2025-i-46-25/page-4": [
       {
         "module": "us-ca/policies/cdss/snap/standard-utility-allowance.yaml",

--- a/us-az/.axiom/encoding-manifests/statutes/43-1072.json
+++ b/us-az/.axiom/encoding-manifests/statutes/43-1072.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/43-1072.yaml",
+      "sha256": "79a41f241b1cb5598d917168ddca3c1013c587747e19a9cb34af0d992a2ec1b4"
+    },
+    {
+      "path": "statutes/43-1072.test.yaml",
+      "sha256": "51efa3be6323bbc942cf1f1e08ffb4cc11fef8ecd516e8fd9a047c4778968484"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-az/statute/43-1072",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072/encode-out/_eval_workspaces/codex-gpt-5.5/us-az-statute-43-1072/workspace/context-manifest.json",
+  "context_manifest_sha256": "fbd5a68c045b08ebc0707c74cc39fd8731405980cde2bfa56775ff6417c9a78b",
+  "generated_at": "2026-07-08T14:55:32.990208+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072/encode-out/codex-gpt-5.5/statutes/43-1072.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072/encode-out",
+  "generated_output_sha256": "79a41f241b1cb5598d917168ddca3c1013c587747e19a9cb34af0d992a2ec1b4",
+  "generation_prompt_sha256": "855dc093cd9639fc6826ab64432b48cb719dd722105ea10ea807a002e89f7097",
+  "model": "gpt-5.5",
+  "run_id": "6d6b4001",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "87b2ed34788d4cb9feb242817d3c164771755cdc6a555709d5efeb1dfe975cca"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072/encode-out/traces/codex-gpt-5.5/us-az-statute-43-1072.json",
+  "trace_sha256": "f5f352152cf5feba9fcaaf33a19eefc438aba02ce2c4ef42d6c741f0a933e2ac"
+}

--- a/us-az/statutes/43-1072.test.yaml
+++ b/us-az/statutes/43-1072.test.yaml
@@ -1,0 +1,69 @@
+- name: shared_household_claimant_gets_first_table_credit_capped_by_paid_amount
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072#input.claimant_was_resident_during_entire_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_age: 65
+    us-az:statutes/43-1072#input.claimant_is_recipient_of_public_monies_under_title_16_social_security_act: false
+    us-az:statutes/43-1072#input.claimant_paid_property_taxes_or_rent_during_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_lived_with_spouse_or_one_or_more_persons: true
+    us-az:statutes/43-1072#input.household_income: 2500
+    us-az:statutes/43-1072#input.property_taxes_or_rent_amount_paid_for_credit: 400
+    us-az:statutes/43-1072#input.gross_pension_or_annuity_amount: 1000
+    us-az:statutes/43-1072#input.pension_or_annuity_amount_exempt_under_subsection_i: 200
+  output:
+    us-az:statutes/43-1072#eligible_under_shared_household_income_path: holds
+    us-az:statutes/43-1072#claimant_meets_age_or_public_money_condition: holds
+    us-az:statutes/43-1072#shared_household_claimant_credit_eligible: holds
+    us-az:statutes/43-1072#shared_household_credit_band: 0
+    us-az:statutes/43-1072#shared_household_table_credit_amount: 502
+    us-az:statutes/43-1072#shared_household_property_tax_or_rent_credit: 400
+    us-az:statutes/43-1072#gross_pension_or_annuity_income: 800
+- name: shared_household_income_at_final_table_row_gets_56_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072#input.claimant_was_resident_during_entire_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_age: 64
+    us-az:statutes/43-1072#input.claimant_is_recipient_of_public_monies_under_title_16_social_security_act: true
+    us-az:statutes/43-1072#input.claimant_paid_property_taxes_or_rent_during_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_lived_with_spouse_or_one_or_more_persons: true
+    us-az:statutes/43-1072#input.household_income: 5500
+    us-az:statutes/43-1072#input.property_taxes_or_rent_amount_paid_for_credit: 100
+    us-az:statutes/43-1072#input.gross_pension_or_annuity_amount: 500
+    us-az:statutes/43-1072#input.pension_or_annuity_amount_exempt_under_subsection_i: 0
+  output:
+    us-az:statutes/43-1072#eligible_under_shared_household_income_path: holds
+    us-az:statutes/43-1072#claimant_meets_age_or_public_money_condition: holds
+    us-az:statutes/43-1072#shared_household_claimant_credit_eligible: holds
+    us-az:statutes/43-1072#shared_household_credit_band: 20
+    us-az:statutes/43-1072#shared_household_table_credit_amount: 56
+    us-az:statutes/43-1072#shared_household_property_tax_or_rent_credit: 56
+    us-az:statutes/43-1072#gross_pension_or_annuity_income: 500
+- name: shared_household_income_limit_blocks_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-az:statutes/43-1072#input.claimant_was_resident_during_entire_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_age: 65
+    us-az:statutes/43-1072#input.claimant_is_recipient_of_public_monies_under_title_16_social_security_act: false
+    us-az:statutes/43-1072#input.claimant_paid_property_taxes_or_rent_during_taxable_year: true
+    us-az:statutes/43-1072#input.claimant_lived_with_spouse_or_one_or_more_persons: true
+    us-az:statutes/43-1072#input.household_income: 5501
+    us-az:statutes/43-1072#input.property_taxes_or_rent_amount_paid_for_credit: 100
+    us-az:statutes/43-1072#input.gross_pension_or_annuity_amount: 100
+    us-az:statutes/43-1072#input.pension_or_annuity_amount_exempt_under_subsection_i: 150
+  output:
+    us-az:statutes/43-1072#eligible_under_shared_household_income_path: not_holds
+    us-az:statutes/43-1072#claimant_meets_age_or_public_money_condition: holds
+    us-az:statutes/43-1072#shared_household_claimant_credit_eligible: not_holds
+    us-az:statutes/43-1072#shared_household_credit_band: -1
+    us-az:statutes/43-1072#shared_household_table_credit_amount: 0
+    us-az:statutes/43-1072#shared_household_property_tax_or_rent_credit: 0
+    us-az:statutes/43-1072#gross_pension_or_annuity_income: 0

--- a/us-az/statutes/43-1072.yaml
+++ b/us-az/statutes/43-1072.yaml
@@ -1,0 +1,308 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-az/statute/43-1072
+  summary: |-
+    Resident credit allowed for property taxes accrued or rent paid if the claimant is at least sixty-five or receives public monies under title 16 of the Social Security Act, paid property taxes or rent, and satisfies household income limits. For a claimant living with a spouse or one or more persons, combined household income must be less than $5,501 and the credit table ranges from $502 at $0-$2,500 income to $56 at $5,351-$5,500. Income includes the gross amount of any pension or annuity not otherwise exempted, except as provided in subsection I.
+  deferred_outputs:
+    - output: us-az:statutes/43-1072#a_subdivision_a_credit_amount
+      reason: The single-person household table and final allowable credit require broader claimant/rent/property-tax filing mechanics outside the high-signal requested branches.
+    - output: us-az:statutes/43-1072#property_tax_or_rent_credit_refund_and_setoff
+      reason: Refund, audit, setoff, filing-form, landlord statement, deadline, and one-claimant-per-household administration are procedural and not encoded as an executable tax amount here.
+rules:
+  - name: claimant_minimum_age
+    kind: parameter
+    dtype: Count
+    source: 43-1072(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "attained the age of sixty-five years"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+  - name: shared_household_income_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 43-1072(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "combined income from all sources ... was less than five thousand five hundred one dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          5501
+  - name: shared_household_credit_band_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    indexed_by: shared_household_credit_band
+    source: 43-1072(B)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              table:
+                header: "Household Income Tax Credit"
+                row_key: "Household Income"
+                column_key: "lower bound"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 0
+          1: 2501
+          2: 2651
+          3: 2801
+          4: 2951
+          5: 3101
+          6: 3251
+          7: 3401
+          8: 3551
+          9: 3701
+          10: 3851
+          11: 4001
+          12: 4151
+          13: 4301
+          14: 4451
+          15: 4601
+          16: 4751
+          17: 4901
+          18: 5051
+          19: 5201
+          20: 5351
+  - name: shared_household_credit_band_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    indexed_by: shared_household_credit_band
+    source: 43-1072(B)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              table:
+                header: "Household Income Tax Credit"
+                row_key: "Household Income"
+                column_key: "upper bound"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 2500
+          1: 2650
+          2: 2800
+          3: 2950
+          4: 3100
+          5: 3250
+          6: 3400
+          7: 3550
+          8: 3700
+          9: 3850
+          10: 4000
+          11: 4150
+          12: 4300
+          13: 4450
+          14: 4600
+          15: 4750
+          16: 4900
+          17: 5050
+          18: 5200
+          19: 5350
+          20: 5500
+  - name: shared_household_credit_table_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    indexed_by: shared_household_credit_band
+    source: 43-1072(B)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              table:
+                header: "Household Income Tax Credit"
+                row_key: "Household Income"
+                column_key: "Tax Credit"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 502
+          1: 479
+          2: 457
+          3: 435
+          4: 412
+          5: 390
+          6: 368
+          7: 345
+          8: 323
+          9: 301
+          10: 279
+          11: 256
+          12: 234
+          13: 212
+          14: 189
+          15: 167
+          16: 145
+          17: 123
+          18: 100
+          19: 78
+          20: 56
+  - name: shared_household_credit_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: 43-1072(B)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "For a person eligible under subsection A, paragraph 3, subdivision (b) ... Household Income Tax Credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if household_income >= shared_household_credit_band_lower_bound[0] and household_income <= shared_household_credit_band_upper_bound[0]: 0 else: if household_income >= shared_household_credit_band_lower_bound[1] and household_income <= shared_household_credit_band_upper_bound[1]: 1 else: if household_income >= shared_household_credit_band_lower_bound[2] and household_income <= shared_household_credit_band_upper_bound[2]: 2 else: if household_income >= shared_household_credit_band_lower_bound[3] and household_income <= shared_household_credit_band_upper_bound[3]: 3 else: if household_income >= shared_household_credit_band_lower_bound[4] and household_income <= shared_household_credit_band_upper_bound[4]: 4 else: if household_income >= shared_household_credit_band_lower_bound[5] and household_income <= shared_household_credit_band_upper_bound[5]: 5 else: if household_income >= shared_household_credit_band_lower_bound[6] and household_income <= shared_household_credit_band_upper_bound[6]: 6 else: if household_income >= shared_household_credit_band_lower_bound[7] and household_income <= shared_household_credit_band_upper_bound[7]: 7 else: if household_income >= shared_household_credit_band_lower_bound[8] and household_income <= shared_household_credit_band_upper_bound[8]: 8 else: if household_income >= shared_household_credit_band_lower_bound[9] and household_income <= shared_household_credit_band_upper_bound[9]: 9 else: if household_income >= shared_household_credit_band_lower_bound[10] and household_income <= shared_household_credit_band_upper_bound[10]: 10 else: if household_income >= shared_household_credit_band_lower_bound[11] and household_income <= shared_household_credit_band_upper_bound[11]: 11 else: if household_income >= shared_household_credit_band_lower_bound[12] and household_income <= shared_household_credit_band_upper_bound[12]: 12 else: if household_income >= shared_household_credit_band_lower_bound[13] and household_income <= shared_household_credit_band_upper_bound[13]: 13 else: if household_income >= shared_household_credit_band_lower_bound[14] and household_income <= shared_household_credit_band_upper_bound[14]: 14 else: if household_income >= shared_household_credit_band_lower_bound[15] and household_income <= shared_household_credit_band_upper_bound[15]: 15 else: if household_income >= shared_household_credit_band_lower_bound[16] and household_income <= shared_household_credit_band_upper_bound[16]: 16 else: if household_income >= shared_household_credit_band_lower_bound[17] and household_income <= shared_household_credit_band_upper_bound[17]: 17 else: if household_income >= shared_household_credit_band_lower_bound[18] and household_income <= shared_household_credit_band_upper_bound[18]: 18 else: if household_income >= shared_household_credit_band_lower_bound[19] and household_income <= shared_household_credit_band_upper_bound[19]: 19 else: if household_income >= shared_household_credit_band_lower_bound[20] and household_income <= shared_household_credit_band_upper_bound[20]: 20 else: -1
+  - name: eligible_under_shared_household_income_path
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 43-1072(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "Lived with a spouse or one or more persons and the combined income ... was less than five thousand five hundred one dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          claimant_lived_with_spouse_or_one_or_more_persons
+          and household_income < shared_household_income_limit
+  - name: claimant_meets_age_or_public_money_condition
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 43-1072(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "attained the age of sixty-five years ... or ... recipient of public monies under title 16"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          claimant_age >= claimant_minimum_age
+          or claimant_is_recipient_of_public_monies_under_title_16_social_security_act
+  - name: shared_household_claimant_credit_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 43-1072(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "if all of the following apply"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          claimant_was_resident_during_entire_taxable_year
+          and claimant_meets_age_or_public_money_condition
+          and claimant_paid_property_taxes_or_rent_during_taxable_year
+          and eligible_under_shared_household_income_path
+  - name: shared_household_table_credit_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 43-1072(B)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "according to the following table"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if shared_household_credit_band == -1: 0 else: shared_household_credit_table_amount[shared_household_credit_band]
+  - name: shared_household_property_tax_or_rent_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 43-1072(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "amount of property taxes actually paid ... or the amount computed as follows, whichever is less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if shared_household_claimant_credit_eligible: min(property_taxes_or_rent_amount_paid_for_credit, shared_household_table_credit_amount) else: 0
+  - name: gross_pension_or_annuity_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 43-1072(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1072
+              excerpt: "The gross amount of any pension or annuity not otherwise exempted except as provided in subsection I"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, gross_pension_or_annuity_amount - pension_or_annuity_amount_exempt_under_subsection_i)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-az/statute/43-1072`
- Module: `us-az/statutes/43-1072.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-az-statute-43-1072/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.