### PR TITLE
Encode us-ct/statute/12-704e (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8072,6 +8072,15 @@
         ]
       }
     ],
+    "us-ct/statute/12-704e": [
+      {
+        "module": "us-ct/statutes/12-704e.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/statute/17b-104": [
       {
         "module": "us-ct/statutes/17b-104.yaml",

--- a/us-ct/.axiom/encoding-manifests/statutes/12-704e.json
+++ b/us-ct/.axiom/encoding-manifests/statutes/12-704e.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/12-704e.yaml",
+      "sha256": "8b55e8f87522b80d20b36e1be6d854918c1d4efb6ac12714b8fe0b61ad8316ec"
+    },
+    {
+      "path": "statutes/12-704e.test.yaml",
+      "sha256": "abee2589a683f1c7515eb62e65ce96d68336cf7ab6b0859c324719e585b18448"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ct/statute/12-704e",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704e/encode-out/_eval_workspaces/codex-gpt-5.5/us-ct-statute-12-704e/workspace/context-manifest.json",
+  "context_manifest_sha256": "8e7793496fd46a2509e5126c311e94561fed7a104cde555f8025b532987ec49d",
+  "generated_at": "2026-07-08T14:57:30.928652+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704e/encode-out/codex-gpt-5.5/statutes/12-704e.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704e/encode-out",
+  "generated_output_sha256": "8b55e8f87522b80d20b36e1be6d854918c1d4efb6ac12714b8fe0b61ad8316ec",
+  "generation_prompt_sha256": "4a809cc584ccb26716371447202c016d5f2496f288d61f81f8447394872af291",
+  "model": "gpt-5.5",
+  "run_id": "40b435d4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "60009e152c2a730762b63eb026fdcc4248f450592d87f0498f39e65e80e43653"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704e/encode-out/traces/codex-gpt-5.5/us-ct-statute-12-704e.json",
+  "trace_sha256": "8f929ecb0271362e6cbde3442823eeeeded0cd088d25b847a65626a12ff4adda"
+}

--- a/us-ct/statutes/12-704e.test.yaml
+++ b/us-ct/statutes/12-704e.test.yaml
@@ -1,0 +1,61 @@
+- name: current_rate_child_addition_and_refundable_excess
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704e#input.resident_of_this_state_under_section_12_701_a_1: true
+    us-ct:statutes/12-704e#input.subject_to_tax_imposed_under_this_chapter: true
+    us-ct:statutes/12-704e#input.federal_earned_income_credit_claimed_and_allowed: 1000
+    us-ct:statutes/12-704e#input.filed_joint_federal_income_tax_return_and_required_to_file_separate_connecticut_return: false
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_separate_connecticut_return: 50000
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_joint_federal_return: 100000
+    us-ct:statutes/12-704e#input.has_at_least_one_qualifying_child_for_federal_income_tax_purposes: true
+    us-ct:statutes/12-704e#input.tax_liability_imposed_under_this_chapter: 500
+  output:
+    us-ct:statutes/12-704e#ct_eitc_eligible: holds
+    us-ct:statutes/12-704e#ct_eitc_base_credit: 400
+    us-ct:statutes/12-704e#ct_eitc_credit_before_child_addition: 400
+    us-ct:statutes/12-704e#ct_eitc_credit_allowed: 650
+    us-ct:statutes/12-704e#ct_eitc_excess_over_tax_liability: 150
+- name: separate_connecticut_return_proration
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704e#input.resident_of_this_state_under_section_12_701_a_1: true
+    us-ct:statutes/12-704e#input.subject_to_tax_imposed_under_this_chapter: true
+    us-ct:statutes/12-704e#input.federal_earned_income_credit_claimed_and_allowed: 1000
+    us-ct:statutes/12-704e#input.filed_joint_federal_income_tax_return_and_required_to_file_separate_connecticut_return: true
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_separate_connecticut_return: 25000
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_joint_federal_return: 100000
+    us-ct:statutes/12-704e#input.has_at_least_one_qualifying_child_for_federal_income_tax_purposes: false
+    us-ct:statutes/12-704e#input.tax_liability_imposed_under_this_chapter: 50
+  output:
+    us-ct:statutes/12-704e#ct_eitc_eligible: holds
+    us-ct:statutes/12-704e#married_separate_ct_eitc_fraction: 0.25
+    us-ct:statutes/12-704e#ct_eitc_base_credit: 400
+    us-ct:statutes/12-704e#ct_eitc_credit_before_child_addition: 100
+    us-ct:statutes/12-704e#ct_eitc_credit_allowed: 100
+    us-ct:statutes/12-704e#ct_eitc_excess_over_tax_liability: 50
+- name: not_resident_not_eligible
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704e#input.resident_of_this_state_under_section_12_701_a_1: false
+    us-ct:statutes/12-704e#input.subject_to_tax_imposed_under_this_chapter: true
+    us-ct:statutes/12-704e#input.federal_earned_income_credit_claimed_and_allowed: 1000
+    us-ct:statutes/12-704e#input.filed_joint_federal_income_tax_return_and_required_to_file_separate_connecticut_return: false
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_separate_connecticut_return: 50000
+    us-ct:statutes/12-704e#input.federal_adjusted_gross_income_reported_on_joint_federal_return: 100000
+    us-ct:statutes/12-704e#input.has_at_least_one_qualifying_child_for_federal_income_tax_purposes: false
+    us-ct:statutes/12-704e#input.tax_liability_imposed_under_this_chapter: 0
+  output:
+    us-ct:statutes/12-704e#ct_eitc_eligible: not_holds
+    us-ct:statutes/12-704e#ct_eitc_base_credit: 0
+    us-ct:statutes/12-704e#ct_eitc_credit_before_child_addition: 0
+    us-ct:statutes/12-704e#ct_eitc_credit_allowed: 0
+    us-ct:statutes/12-704e#ct_eitc_excess_over_tax_liability: 0

--- a/us-ct/statutes/12-704e.yaml
+++ b/us-ct/statutes/12-704e.yaml
@@ -1,0 +1,195 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/12-704e
+  summary: |-
+    Resident taxpayers subject to Connecticut income tax are allowed a credit equal to the applicable percentage of the federal earned income credit claimed and allowed. The applicable percentage is 23%, 30.5%, or 40% depending on taxable-year commencement. Excess credit is refundable without interest, subject to sections 12-739 and 12-742, and taxpayers with at least one federal qualifying child receive an additional $250. Married individuals filing a joint federal return but separate Connecticut return prorate the credit by separate-return federal AGI over joint-return federal AGI.
+  deferred_outputs:
+    - output: us-ct:statutes/12-704e/b#refundable_excess_credit_after_sections_12_739_and_12_742
+      reason: Refund treatment depends on the operative exceptions in sections 12-739 and 12-742, which are not supplied as copied RuleSpec context.
+    - output: us-ct:statutes/12-704e/d#earned_income_tax_credit_excluded_from_need_based_income_and_resources
+      reason: Subsection (d) applies across state and federal need-based benefit programs and depends on program-specific income and resource eligibility determinations outside this tax-credit module.
+rules:
+  - name: ct_eitc_applicable_percentage
+    kind: parameter
+    dtype: Rate
+    source: 12-704e(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "twenty-three per cent for taxable years commencing prior to January 1, 2021"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "thirty and one-half per cent for taxable years commencing on or after January 1, 2021"
+          - path: versions[2].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "forty per cent for taxable years commencing on or after January 1, 2023"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.23
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.305
+      - effective_from: '2023-01-01'
+        formula: |-
+          0.40
+
+  - name: qualifying_child_additional_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 12-704e(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "at least one qualifying child for federal income tax purposes... additional two hundred fifty dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          250
+
+  - name: ct_eitc_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 12-704e(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          resident_of_this_state_under_section_12_701_a_1
+          and subject_to_tax_imposed_under_this_chapter
+          and federal_earned_income_credit_claimed_and_allowed > 0
+
+  - name: ct_eitc_base_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-704e(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "applicable percentage of the earned income credit claimed and allowed"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if ct_eitc_eligible: ct_eitc_applicable_percentage * federal_earned_income_credit_claimed_and_allowed else: 0
+
+  - name: married_separate_ct_eitc_fraction
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 12-704e(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "numerator... federal adjusted gross income... separate return... denominator... joint federal income tax return"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          federal_adjusted_gross_income_reported_on_separate_connecticut_return / federal_adjusted_gross_income_reported_on_joint_federal_return
+
+  - name: ct_eitc_credit_before_child_addition
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-704e(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "filed a joint federal income tax return... required to file a separate return"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if filed_joint_federal_income_tax_return_and_required_to_file_separate_connecticut_return: ct_eitc_base_credit * married_separate_ct_eitc_fraction else: ct_eitc_base_credit
+
+  - name: ct_eitc_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-704e(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "at least one qualifying child... additional two hundred fifty dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          ct_eitc_credit_before_child_addition + (if has_at_least_one_qualifying_child_for_federal_income_tax_purposes: qualifying_child_additional_credit_amount else: 0)
+
+  - name: ct_eitc_excess_over_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-704e(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "If the amount of the credit... exceeds the taxpayer's liability"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, ct_eitc_credit_allowed - tax_liability_imposed_under_this_chapter)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ct/statute/12-704e`
- Module: `us-ct/statutes/12-704e.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704e/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.