### PR TITLE
Encode us-ct/statute/12-704i (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8072,6 +8072,15 @@
         ]
       }
     ],
+    "us-ct/statute/12-704i": [
+      {
+        "module": "us-ct/statutes/12-704i.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/statute/17b-104": [
       {
         "module": "us-ct/statutes/17b-104.yaml",

--- a/us-ct/.axiom/encoding-manifests/statutes/12-704i.json
+++ b/us-ct/.axiom/encoding-manifests/statutes/12-704i.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/12-704i.yaml",
+      "sha256": "9b5187ea8d9eae68a8cc2a159a4bf9c0e34c8c3b0c5b6ba4eedbc4fb36d1d6fa"
+    },
+    {
+      "path": "statutes/12-704i.test.yaml",
+      "sha256": "e2b239b2802c8ce0ad729dfc6724bc9b8c571bdd065cee3542870e5a9cd4492b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ct/statute/12-704i",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704i/encode-out/_eval_workspaces/codex-gpt-5.5/us-ct-statute-12-704i/workspace/context-manifest.json",
+  "context_manifest_sha256": "d243beea389b30153a9598dae92bf90497a575f4eb6061ea4af40871f645a5a7",
+  "generated_at": "2026-07-08T14:57:33.773563+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704i/encode-out/codex-gpt-5.5/statutes/12-704i.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704i/encode-out",
+  "generated_output_sha256": "9b5187ea8d9eae68a8cc2a159a4bf9c0e34c8c3b0c5b6ba4eedbc4fb36d1d6fa",
+  "generation_prompt_sha256": "162e028cc09a65cf404e2bdeb924aa0e2613a50ff5515cb10b08259f00e84f9e",
+  "model": "gpt-5.5",
+  "run_id": "6e605f2d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "21f6dd901da492d9be0d2aeac5596da79334b2b225557bb2b0b04ded8871ab9c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704i/encode-out/traces/codex-gpt-5.5/us-ct-statute-12-704i.json",
+  "trace_sha256": "8e5e9a36f42499e9423eed996bf5eaaa27be5c88c47824a6eaaccd42ff2317c9"
+}

--- a/us-ct/statutes/12-704i.test.yaml
+++ b/us-ct/statutes/12-704i.test.yaml
@@ -1,0 +1,52 @@
+- name: credit_allowed_when_all_conditions_hold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704i#input.taxpayer_delivered_fetus_born_dead: true
+    us-ct:statutes/12-704i#input.fetal_death_certificate_has_been_filed: true
+    us-ct:statutes/12-704i#input.child_would_have_been_dependent_on_taxpayer_federal_income_tax_return: true
+    us-ct:statutes/12-704i#input.fetal_death_occurred_in_taxable_year: true
+  output:
+    us-ct:statutes/12-704i#taxpayer_qualifies_for_fetal_death_credit: holds
+    us-ct:statutes/12-704i#fetal_death_credit: 2500
+- name: no_credit_without_delivery_of_fetus_born_dead
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704i#input.taxpayer_delivered_fetus_born_dead: false
+    us-ct:statutes/12-704i#input.fetal_death_certificate_has_been_filed: true
+    us-ct:statutes/12-704i#input.child_would_have_been_dependent_on_taxpayer_federal_income_tax_return: true
+    us-ct:statutes/12-704i#input.fetal_death_occurred_in_taxable_year: true
+  output:
+    us-ct:statutes/12-704i#taxpayer_qualifies_for_fetal_death_credit: not_holds
+    us-ct:statutes/12-704i#fetal_death_credit: 0
+- name: no_credit_without_fetal_death_certificate
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704i#input.taxpayer_delivered_fetus_born_dead: true
+    us-ct:statutes/12-704i#input.fetal_death_certificate_has_been_filed: false
+    us-ct:statutes/12-704i#input.child_would_have_been_dependent_on_taxpayer_federal_income_tax_return: true
+    us-ct:statutes/12-704i#input.fetal_death_occurred_in_taxable_year: true
+  output:
+    us-ct:statutes/12-704i#taxpayer_qualifies_for_fetal_death_credit: not_holds
+    us-ct:statutes/12-704i#fetal_death_credit: 0
+- name: no_credit_when_child_would_not_have_been_dependent_or_death_outside_year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ct:statutes/12-704i#input.taxpayer_delivered_fetus_born_dead: true
+    us-ct:statutes/12-704i#input.fetal_death_certificate_has_been_filed: true
+    us-ct:statutes/12-704i#input.child_would_have_been_dependent_on_taxpayer_federal_income_tax_return: false
+    us-ct:statutes/12-704i#input.fetal_death_occurred_in_taxable_year: false
+  output:
+    us-ct:statutes/12-704i#taxpayer_qualifies_for_fetal_death_credit: not_holds
+    us-ct:statutes/12-704i#fetal_death_credit: 0

--- a/us-ct/statutes/12-704i.yaml
+++ b/us-ct/statutes/12-704i.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/12-704i
+  summary: |-
+    A taxpayer shall be allowed a $2,500 credit for delivery of a fetus born dead for which a fetal death certificate has been filed, if such child would have been a dependent on the taxpayer's federal income tax return. The credit is allowed for the taxable year for which the fetal death occurred.
+rules:
+  - name: fetal_death_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Conn. Gen. Stat. § 12-704i
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/statute/12-704i
+              excerpt: "in the amount of two thousand five hundred dollars"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2500
+
+  - name: taxpayer_qualifies_for_fetal_death_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Conn. Gen. Stat. § 12-704i
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/12-704i
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/statute/12-704i
+              excerpt: "for the taxable year for which a fetal death occurred"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          taxpayer_delivered_fetus_born_dead
+          and fetal_death_certificate_has_been_filed
+          and child_would_have_been_dependent_on_taxpayer_federal_income_tax_return
+          and fetal_death_occurred_in_taxable_year
+
+  - name: fetal_death_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Conn. Gen. Stat. § 12-704i
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/12-704i#fetal_death_credit_amount
+              output: fetal_death_credit_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:statutes/12-704i#taxpayer_qualifies_for_fetal_death_credit
+              output: taxpayer_qualifies_for_fetal_death_credit
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704i
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_qualifies_for_fetal_death_credit: fetal_death_credit_amount else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ct/statute/12-704i`
- Module: `us-ct/statutes/12-704i.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ct-statute-12-704i/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.