### PR TITLE
Encode us-ky/statute/11/141.020 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9880,6 +9880,15 @@
         ]
       }
     ],
+    "us-ky/statute/11/141.020": [
+      {
+        "module": "us-ky/statutes/11/141/020.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921": [
       {
         "module": "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,11 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 13
 entries:
+  - legal_id: us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-ky/.axiom/encoding-manifests/statutes/11/141/020.json
+++ b/us-ky/.axiom/encoding-manifests/statutes/11/141/020.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/11/141/020.yaml",
+      "sha256": "ca9d9601bd15936c2c6254967d8b1e474f66928a87a38da61d8a2003f01d6829"
+    },
+    {
+      "path": "statutes/11/141/020.test.yaml",
+      "sha256": "4934e22f79f4aafcd28f4b96846ef5d4241739c14808d2d565afc360070fad43"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ky/statute/11/141.020",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-020/encode-out/_eval_workspaces/codex-gpt-5.5/us-ky-statute-11-141.020/workspace/context-manifest.json",
+  "context_manifest_sha256": "3e19463bd56c3b87c583351e516bad3185f536cbe738fa5cfbfe818a91c8d331",
+  "generated_at": "2026-07-08T15:02:57.672447+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-020/encode-out/codex-gpt-5.5/statutes/11/141/020.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-020/encode-out",
+  "generated_output_sha256": "ca9d9601bd15936c2c6254967d8b1e474f66928a87a38da61d8a2003f01d6829",
+  "generation_prompt_sha256": "de6fecdb5d50d9d853f4188c786dcd17bb53ddf87aabc7cbe3976162b3bc880d",
+  "model": "gpt-5.5",
+  "run_id": "b857c16b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1d795525929997bf170b486bb73b9f0d1c296afc5bcdc8c9878acfacf7608a60"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-020/encode-out/traces/codex-gpt-5.5/us-ky-statute-11-141.020.json",
+  "trace_sha256": "ee89589476c8f70072c304560da8fcb5b0629bf2b428e67f63960195c88cf302"
+}

--- a/us-ky/statutes/11/141/020.test.yaml
+++ b/us-ky/statutes/11/141/020.test.yaml
@@ -1,0 +1,22 @@
+- name: part_year_resident_tax_credits_are_prorated_by_kentucky_agi_ratio
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ky:statutes/11/141/020#input.tax_credits_allowable_under_subsection_3_before_part_year_resident_proration: 200
+    us-ky:statutes/11/141/020#input.kentucky_adjusted_gross_income_determined_under_krs_141_019: 30000
+    us-ky:statutes/11/141/020#input.federal_adjusted_gross_income: 60000
+  output:
+    us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits: 100
+- name: part_year_resident_tax_credits_are_floored_at_zero
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ky:statutes/11/141/020#input.tax_credits_allowable_under_subsection_3_before_part_year_resident_proration: 200
+    us-ky:statutes/11/141/020#input.kentucky_adjusted_gross_income_determined_under_krs_141_019: -30000
+    us-ky:statutes/11/141/020#input.federal_adjusted_gross_income: 60000
+  output:
+    us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits: 0

--- a/us-ky/statutes/11/141/020.yaml
+++ b/us-ky/statutes/11/141/020.yaml
@@ -1,0 +1,28 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ky/statute/11/141.020
+  summary: |-
+    (3)(c) In the case of a part-year resident, the tax credits allowable under this subsection shall be the portion of the credits represented by the ratio of the taxpayer's Kentucky adjusted gross income as determined by KRS 141.019 to the taxpayer's adjusted gross income as defined in Section 62 of the Internal Revenue Code.
+rules:
+  - name: part_year_resident_allowable_tax_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 141.020(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/11/141.020
+              excerpt: "part-year resident... portion of the credits represented by the ratio of the taxpayer's Kentucky adjusted gross income... to the taxpayer's adjusted gross income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, tax_credits_allowable_under_subsection_3_before_part_year_resident_proration * kentucky_adjusted_gross_income_determined_under_krs_141_019 / federal_adjusted_gross_income)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ky/statute/11/141.020`
- Module: `us-ky/statutes/11/141/020.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-020/rulespec-us/oracle-coverage-pending.yaml: 11 declared (+1 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.