### PR TITLE
Encode us-ky/statute/11/141.067 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9880,6 +9880,15 @@
         ]
       }
     ],
+    "us-ky/statute/11/141.067": [
+      {
+        "module": "us-ky/statutes/11/141/067.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921": [
       {
         "module": "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,14 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 10
+ceiling: 12
 entries:
+  - legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit_rate
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-ky/.axiom/encoding-manifests/statutes/11/141/067.json
+++ b/us-ky/.axiom/encoding-manifests/statutes/11/141/067.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/11/141/067.yaml",
+      "sha256": "98711faf569c249df7926ef75c13a1920d352fad4a6f0be754efdcee6fefc07e"
+    },
+    {
+      "path": "statutes/11/141/067.test.yaml",
+      "sha256": "38ce82b48be0482144409df7e1dbc40dc485f39645bc97b49ae67f0059ddf9a4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ky/statute/11/141.067",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-067/encode-out/_eval_workspaces/codex-gpt-5.5/us-ky-statute-11-141.067/workspace/context-manifest.json",
+  "context_manifest_sha256": "19a53d287cf269064226d2d50b070d9b420793435ca476f7572e63a5580b01c2",
+  "generated_at": "2026-07-08T15:02:58.599360+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-067/encode-out/codex-gpt-5.5/statutes/11/141/067.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-067/encode-out",
+  "generated_output_sha256": "98711faf569c249df7926ef75c13a1920d352fad4a6f0be754efdcee6fefc07e",
+  "generation_prompt_sha256": "143532854ff7510aacf5ddf7c7d41c0e5424d63f487af4426b88372196b26ecb",
+  "model": "gpt-5.5",
+  "run_id": "b0245d23",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "12decde48013d83518ea9f28079779cf709eb89816a57284e65a772bd1091702"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-067/encode-out/traces/codex-gpt-5.5/us-ky-statute-11-141.067.json",
+  "trace_sha256": "4d64a37d96d2d4e26e2c8912347099888205307a4d8fa88d9d11b1b767d4d61a"
+}

--- a/us-ky/statutes/11/141/067.test.yaml
+++ b/us-ky/statutes/11/141/067.test.yaml
@@ -1,0 +1,20 @@
+- name: resident individual receives twenty percent of federal credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ky:statutes/11/141/067#input.resident_individual: true
+    us-ky:statutes/11/141/067#input.federal_household_and_dependent_care_credit: 1000
+  output:
+    us-ky:statutes/11/141/067#household_and_dependent_care_credit: 200
+- name: nonresident individual receives no credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ky:statutes/11/141/067#input.resident_individual: false
+    us-ky:statutes/11/141/067#input.federal_household_and_dependent_care_credit: 1000
+  output:
+    us-ky:statutes/11/141/067#household_and_dependent_care_credit: 0

--- a/us-ky/statutes/11/141/067.yaml
+++ b/us-ky/statutes/11/141/067.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ky/statute/11/141.067
+  summary: |-
+    A resident individual may deduct a credit for household and dependent care services necessary for gainful employment; the credit is twenty percent (20%) of the federal credit allowed under Section 21 of the Internal Revenue Code.
+rules:
+  - name: household_and_dependent_care_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: KRS 141.067
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ky/statute/11/141.067
+              excerpt: "twenty percent (20%)"
+    versions:
+      - effective_from: '1990-04-11'
+        formula: |-
+          0.20
+
+  - name: household_and_dependent_care_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: KRS 141.067
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/11/141.067
+              excerpt: "resident individual may deduct ... a credit for household and dependent care services necessary for gainful employment"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/11/141.067
+              excerpt: "twenty percent (20%) of the federal credit allowed under Section 21"
+    versions:
+      - effective_from: '1990-04-11'
+        formula: |-
+          if resident_individual: household_and_dependent_care_credit_rate * max(0, federal_household_and_dependent_care_credit) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ky/statute/11/141.067`
- Module: `us-ky/statutes/11/141/067.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-067/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+2 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.