### PR TITLE
Encode us-ky/statute/11/141.069 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9880,6 +9880,15 @@
         ]
       }
     ],
+    "us-ky/statute/11/141.069": [
+      {
+        "module": "us-ky/statutes/11/141/069.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-la/manual/dcfs/economic-independence/b-640-fitap-income-limits-398921": [
       {
         "module": "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,20 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 16
 entries:
+  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_carryforward_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_rate
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-ky/.axiom/encoding-manifests/statutes/11/141/069.json
+++ b/us-ky/.axiom/encoding-manifests/statutes/11/141/069.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/11/141/069.yaml",
+      "sha256": "fe8100b2e594101760ca79b162c81d4bf7b982eb0f47286fe0d0e8e6367bef3e"
+    },
+    {
+      "path": "statutes/11/141/069.test.yaml",
+      "sha256": "20b68e66b71cae7c201e1e9140b57446fc93f256a1ab43facd5ef167e8edd278"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ky/statute/11/141.069",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-069/encode-out/_eval_workspaces/codex-gpt-5.5/us-ky-statute-11-141.069/workspace/context-manifest.json",
+  "context_manifest_sha256": "3688c153eaa20ffa189798109f606bed5c7eacb0a1bd3c0bd7bdf0df5610c467",
+  "generated_at": "2026-07-08T15:03:26.257109+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-069/encode-out/codex-gpt-5.5/statutes/11/141/069.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-069/encode-out",
+  "generated_output_sha256": "fe8100b2e594101760ca79b162c81d4bf7b982eb0f47286fe0d0e8e6367bef3e",
+  "generation_prompt_sha256": "295e2453dee66428f9933c450715302dc4f16f39396aee22ffb59a8a0d260b3f",
+  "model": "gpt-5.5",
+  "run_id": "4791c893",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1f31fbb376396bcf409d5502dd2f04973254ceeb16d89f3f7eb34bef7385e637"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-069/encode-out/traces/codex-gpt-5.5/us-ky-statute-11-141.069.json",
+  "trace_sha256": "28d1e3898c3c72a8b31c53b5de7a9fa97759e48515c0b6a9d82ebb522b019558"
+}

--- a/us-ky/statutes/11/141/069.test.yaml
+++ b/us-ky/statutes/11/141/069.test.yaml
@@ -1,0 +1,72 @@
+- name: credit_limited_to_twenty_five_percent_of_federal_credit_and_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ky:statutes/11/141/069#input.qualified_tuition_and_related_expenses_required_for_enrollment_or_attendance_at_eligible_kentucky_education_institution
+    : true
+    us-ky:statutes/11/141/069#input.expenses_are_for_graduate_level_course_study: false
+    us-ky:statutes/11/141/069#input.taxpayer_is_married_individual_under_section_7703: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_joint_return_or_separately_on_combined_form: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_separate_returns: false
+    us-ky:statutes/11/141/069#input.tax_computed_under_krs_141_020: 600
+    ? us-ky:statutes/11/141/069#input.federal_credit_allowable_under_section_25a_for_eligible_kentucky_education_institution_expenses
+    : 2000
+  output:
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed: holds
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit: 500
+- name: nonrefundable_credit_cannot_exceed_tax_computed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ky:statutes/11/141/069#input.qualified_tuition_and_related_expenses_required_for_enrollment_or_attendance_at_eligible_kentucky_education_institution
+    : true
+    us-ky:statutes/11/141/069#input.expenses_are_for_graduate_level_course_study: false
+    us-ky:statutes/11/141/069#input.taxpayer_is_married_individual_under_section_7703: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_joint_return_or_separately_on_combined_form: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_separate_returns: false
+    us-ky:statutes/11/141/069#input.tax_computed_under_krs_141_020: 300
+    ? us-ky:statutes/11/141/069#input.federal_credit_allowable_under_section_25a_for_eligible_kentucky_education_institution_expenses
+    : 2000
+  output:
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed: holds
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit: 300
+- name: graduate_level_course_study_blocks_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ky:statutes/11/141/069#input.qualified_tuition_and_related_expenses_required_for_enrollment_or_attendance_at_eligible_kentucky_education_institution
+    : true
+    us-ky:statutes/11/141/069#input.expenses_are_for_graduate_level_course_study: true
+    us-ky:statutes/11/141/069#input.taxpayer_is_married_individual_under_section_7703: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_joint_return_or_separately_on_combined_form: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_separate_returns: false
+    us-ky:statutes/11/141/069#input.tax_computed_under_krs_141_020: 600
+    ? us-ky:statutes/11/141/069#input.federal_credit_allowable_under_section_25a_for_eligible_kentucky_education_institution_expenses
+    : 2000
+  output:
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed: not_holds
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit: 0
+- name: married_separate_returns_block_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-ky:statutes/11/141/069#input.qualified_tuition_and_related_expenses_required_for_enrollment_or_attendance_at_eligible_kentucky_education_institution
+    : true
+    us-ky:statutes/11/141/069#input.expenses_are_for_graduate_level_course_study: false
+    us-ky:statutes/11/141/069#input.taxpayer_is_married_individual_under_section_7703: true
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_joint_return_or_separately_on_combined_form: false
+    us-ky:statutes/11/141/069#input.taxpayer_and_spouse_file_separate_returns: true
+    us-ky:statutes/11/141/069#input.tax_computed_under_krs_141_020: 600
+    ? us-ky:statutes/11/141/069#input.federal_credit_allowable_under_section_25a_for_eligible_kentucky_education_institution_expenses
+    : 2000
+  output:
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed: not_holds
+    us-ky:statutes/11/141/069#kentucky_education_tuition_credit: 0

--- a/us-ky/statutes/11/141/069.yaml
+++ b/us-ky/statutes/11/141/069.yaml
@@ -1,0 +1,103 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ky/statute/11/141.069
+  summary: For taxable years beginning after December 31, 2004, an individual may
+    deduct a nonrefundable credit for qualified tuition and related expenses at an
+    eligible Kentucky education institution. The credit is twenty-five percent (25%)
+    of the federal credit allowable under Section 25A, is not allowed for graduate
+    level course study, married individuals must file jointly or separately on a combined
+    form, and unused credit may be carried forward five (5) years.
+rules:
+- name: kentucky_education_tuition_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: KRS 141.069(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ky/statute/11/141.069
+          excerpt: twenty-five percent (25%)
+  versions:
+  - effective_from: '2005-01-01'
+    formula: '0.25'
+- name: kentucky_education_tuition_credit_carryforward_years
+  kind: parameter
+  dtype: Count
+  source: KRS 141.069(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ky/statute/11/141.069
+          excerpt: carried forward five (5) years
+  versions:
+  - effective_from: '2005-01-01'
+    formula: '5'
+- name: kentucky_education_tuition_credit_allowed
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: KRS 141.069(2)-(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ky/statute/11/141.069
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ky/statute/11/141.069
+          excerpt: shall not be allowed for expenses for graduate level course study
+  versions:
+  - effective_from: '2005-01-01'
+    formula: 'qualified_tuition_and_related_expenses_required_for_enrollment_or_attendance_at_eligible_kentucky_education_institution
+
+      and not expenses_are_for_graduate_level_course_study
+
+      and (not taxpayer_is_married_individual_under_section_7703 or taxpayer_and_spouse_file_joint_return_or_separately_on_combined_form)
+
+      and not taxpayer_and_spouse_file_separate_returns'
+- name: kentucky_education_tuition_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: KRS 141.069(2)-(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ky/statute/11/141.069
+          excerpt: The credit shall be twenty-five percent (25%) of the federal credit
+            allowable
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_rate
+          output: kentucky_education_tuition_credit_rate
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed
+          output: kentucky_education_tuition_credit_allowed
+          hash: sha256:local
+  versions:
+  - effective_from: '2005-01-01'
+    formula: 'if kentucky_education_tuition_credit_allowed: min(tax_computed_under_krs_141_020,
+      kentucky_education_tuition_credit_rate * max(0, federal_credit_allowable_under_section_25a_for_eligible_kentucky_education_institution_expenses))
+      else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ky/statute/11/141.069`
- Module: `us-ky/statutes/11/141/069.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ky-statute-11-141-069/rulespec-us/oracle-coverage-pending.yaml: 14 declared (+4 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.