### PR TITLE
Encode us-de/statute/30/1102 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1102": [
+      {
+        "module": "us-de/statutes/30/1102.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1102.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1102.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1102.yaml",
+      "sha256": "87507247ef94c8670e301b9acc1b4b554d156b37bb41e9bd49dd2750825fb1c5"
+    },
+    {
+      "path": "statutes/30/1102.test.yaml",
+      "sha256": "7c5aeb93dde0ea8d9888fa317e74d6b4de3ac48b7c336989f5eb6f7ffe502402"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1102",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1102/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1102/workspace/context-manifest.json",
+  "context_manifest_sha256": "1887948d77d425f4bc78f4430ad6a4a1eda68e7c676408a3bc35d506839d55e5",
+  "generated_at": "2026-07-08T15:04:30.506599+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1102/encode-out/codex-gpt-5.5/statutes/30/1102.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1102/encode-out",
+  "generated_output_sha256": "87507247ef94c8670e301b9acc1b4b554d156b37bb41e9bd49dd2750825fb1c5",
+  "generation_prompt_sha256": "1923de4394c8253da5a67949f063011bb0a571284e34dbe8027befa6c871ecac",
+  "model": "gpt-5.5",
+  "run_id": "2990e2ba",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d18271d653859edcc9bc2d5be4b1dc45351891cd53ed1f98214401392a563c42"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1102/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1102.json",
+  "trace_sha256": "539659ca4790486c00980ec0f281cf8ab5cb74d6ced906c80b7ab816849f4336"
+}

--- a/us-de/statutes/30/1102.test.yaml
+++ b/us-de/statutes/30/1102.test.yaml
@@ -1,0 +1,51 @@
+- name: tax_table_method_applies_under_default_ceiling
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1102#input.tax_table_income: 50000
+    us-de:statutes/30/1102#input.director_determined_lesser_tax_table_income_ceiling_applies: false
+    us-de:statutes/30/1102#input.director_determined_tax_table_income_ceiling: 30000
+    us-de:statutes/30/1102#input.individual_is_estate_or_trust: false
+  output:
+    us-de:statutes/30/1102#applicable_tax_table_income_ceiling: 60000
+    us-de:statutes/30/1102#tax_table_method_applies: holds
+- name: tax_table_method_blocked_above_director_ceiling
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1102#input.tax_table_income: 45000
+    us-de:statutes/30/1102#input.director_determined_lesser_tax_table_income_ceiling_applies: true
+    us-de:statutes/30/1102#input.director_determined_tax_table_income_ceiling: 40000
+    us-de:statutes/30/1102#input.individual_is_estate_or_trust: false
+  output:
+    us-de:statutes/30/1102#applicable_tax_table_income_ceiling: 40000
+    us-de:statutes/30/1102#tax_table_method_applies: not_holds
+- name: tax_table_method_uses_minimum_director_ceiling
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1102#input.tax_table_income: 25000
+    us-de:statutes/30/1102#input.director_determined_lesser_tax_table_income_ceiling_applies: true
+    us-de:statutes/30/1102#input.director_determined_tax_table_income_ceiling: 10000
+    us-de:statutes/30/1102#input.individual_is_estate_or_trust: false
+  output:
+    us-de:statutes/30/1102#applicable_tax_table_income_ceiling: 20000
+    us-de:statutes/30/1102#tax_table_method_applies: not_holds
+- name: tax_table_method_does_not_apply_to_estate_or_trust
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1102#input.tax_table_income: 50000
+    us-de:statutes/30/1102#input.director_determined_lesser_tax_table_income_ceiling_applies: false
+    us-de:statutes/30/1102#input.director_determined_tax_table_income_ceiling: 30000
+    us-de:statutes/30/1102#input.individual_is_estate_or_trust: true
+  output:
+    us-de:statutes/30/1102#tax_table_method_applies: not_holds

--- a/us-de/statutes/30/1102.yaml
+++ b/us-de/statutes/30/1102.yaml
@@ -1,0 +1,100 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1102
+  summary: "1102(d): In lieu of subsection (a) tax, an individual whose tax table\
+    \ income does not exceed $60,000, or a lesser Director-determined amount not less\
+    \ than $20,000, is taxed under Director-prescribed tables computed from subsection\
+    \ (a) rates. Tax table income means Delaware taxable income under \xA7\xA7 1105\
+    \ and 1121. This subsection does not apply to an estate or trust."
+  deferred_outputs:
+  - output: us-de:statutes/30/1102/d#tax_table_tax_amount
+    reason: The source requires tax determined under tables prescribed by the Director
+      of Revenue and computed from subsection (a) rates; the prescribed tax tables
+      are not supplied in this source slice.
+    source_values:
+    - us-de:statutes/30/1102#statutory_tax_table_income_ceiling
+    - us-de:statutes/30/1102#minimum_director_tax_table_income_ceiling
+rules:
+- name: statutory_tax_table_income_ceiling
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 1102(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-de/statute/30/1102
+          excerpt: tax table income for the taxable year does not exceed $60,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '60000'
+- name: minimum_director_tax_table_income_ceiling
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 1102(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-de/statute/30/1102
+          excerpt: in any event not less than $20,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '20000'
+- name: applicable_tax_table_income_ceiling
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 1102(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-de/statute/30/1102
+          excerpt: or such lesser amount as the Director may determine but in any
+            event not less than $20,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if director_determined_lesser_tax_table_income_ceiling_applies: max(minimum_director_tax_table_income_ceiling,
+      min(director_determined_tax_table_income_ceiling, statutory_tax_table_income_ceiling))
+      else: statutory_tax_table_income_ceiling'
+- name: tax_table_method_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 1102(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-de/statute/30/1102
+          excerpt: on the tax table income of every individual whose tax table income
+            for the taxable year does not exceed $60,000
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-de/statute/30/1102
+          excerpt: This subsection shall not apply to an estate or trust.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'tax_table_income <= applicable_tax_table_income_ceiling
+
+      and not individual_is_estate_or_trust'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1102`
- Module: `us-de/statutes/30/1102.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1102/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.