### PR TITLE
Encode us-de/statute/30/1110 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1110": [
+      {
+        "module": "us-de/statutes/30/1110.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1110.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1110.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1110.yaml",
+      "sha256": "a19ee5a14062e5f015026010b53d1714a3986e028f6681b09029f7f094c0d94b"
+    },
+    {
+      "path": "statutes/30/1110.test.yaml",
+      "sha256": "f2f3ac7410c5d672556514467d24cb2c3bcc816e3fb352602974dbe9c5c7ad7f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1110",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1110/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1110/workspace/context-manifest.json",
+  "context_manifest_sha256": "90a4b80d7fc50094606ac202e3dd71a0e1309bee558f06dd9a3dfe9f9e66983f",
+  "generated_at": "2026-07-08T15:04:55.086045+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1110/encode-out/codex-gpt-5.5/statutes/30/1110.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1110/encode-out",
+  "generated_output_sha256": "a19ee5a14062e5f015026010b53d1714a3986e028f6681b09029f7f094c0d94b",
+  "generation_prompt_sha256": "6d5ecd20e3f97e59571ea4be22ac4d1000d23feb7e3e8f8f7c5ace659c550a28",
+  "model": "gpt-5.5",
+  "run_id": "e06ab024",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "26f9d8cff60829d54f2779990e757d9fc1de52c35514fe2c297caf96d2b48e57"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1110/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1110.json",
+  "trace_sha256": "365c90534c8df49f7e1b83825bafbb061dbd77d2e56c0d03468295c0f014080e"
+}

--- a/us-de/statutes/30/1110.test.yaml
+++ b/us-de/statutes/30/1110.test.yaml
@@ -1,0 +1,34 @@
+- name: pre_1996_exemption_includes_additional_age_60_exemption
+  period:
+    period_kind: tax_year
+    start: '1995-01-01'
+    end: '1995-12-31'
+  input:
+    us-de:statutes/30/1110#input.federal_personal_exemption_count: 2
+    us-de:statutes/30/1110#input.resident_person_age_60_or_over: true
+  output:
+    us-de:statutes/30/1110#resident_personal_exemption_before_1996: 3750
+- name: post_1995_credit_below_tax_due
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1110#input.federal_personal_exemption_count: 2
+    us-de:statutes/30/1110#input.resident_person_age_60_or_over: true
+    us-de:statutes/30/1110#input.tax_otherwise_due_under_chapter: 500
+  output:
+    us-de:statutes/30/1110#resident_personal_credit_before_cap: 330
+    us-de:statutes/30/1110#resident_personal_credit: 330
+- name: post_1995_credit_capped_at_tax_due
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1110#input.federal_personal_exemption_count: 2
+    us-de:statutes/30/1110#input.resident_person_age_60_or_over: false
+    us-de:statutes/30/1110#input.tax_otherwise_due_under_chapter: 100
+  output:
+    us-de:statutes/30/1110#resident_personal_credit_before_cap: 220
+    us-de:statutes/30/1110#resident_personal_credit: 100

--- a/us-de/statutes/30/1110.yaml
+++ b/us-de/statutes/30/1110.yaml
@@ -1,0 +1,121 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1110
+  summary: |-
+    Resident personal exemption was $1,250 per federal exemption for tax years ending before January 1, 1996, with one additional personal exemption for resident persons age 60 or over. For tax years beginning after December 31, 1995, resident individuals receive a $110 personal credit per federal personal exemption plus an additional $110 for each resident person age 60 or over, capped at tax otherwise due.
+rules:
+  - name: pre_1996_personal_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1110(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "$1,250 for each exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1250
+
+  - name: post_1995_personal_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1110(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "$110 for each personal exemption"
+    versions:
+      - effective_from: '1996-01-01'
+        formula: |-
+          110
+
+  - name: resident_personal_exemption_before_1996
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1110(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "$1,250 for each exemption"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "age 60 or over shall be allowed one additional personal exemption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          pre_1996_personal_exemption_amount * federal_personal_exemption_count + (if resident_person_age_60_or_over: pre_1996_personal_exemption_amount else: 0)
+
+  - name: resident_personal_credit_before_cap
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1110(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "$110 for each personal exemption"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "additional $110 in the case of each resident person age 60 or over"
+    versions:
+      - effective_from: '1996-01-01'
+        formula: |-
+          post_1995_personal_credit_amount * federal_personal_exemption_count + (if resident_person_age_60_or_over: post_1995_personal_credit_amount else: 0)
+
+  - name: resident_personal_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1110(b)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "credit allowed under subsection (b)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "shall ... exceed the tax otherwise due"
+    versions:
+      - effective_from: '1996-01-01'
+        formula: |-
+          min(resident_personal_credit_before_cap, max(0, tax_otherwise_due_under_chapter))


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1110`
- Module: `us-de/statutes/30/1110.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1110/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.