### PR TITLE
Encode us-de/statute/30/1109 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1109": [
+      {
+        "module": "us-de/statutes/30/1109.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1109.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1109.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1109.yaml",
+      "sha256": "ace1926a7bb8c6fa276a3e395204f8a64febacc1df2c0fc2cb120e87aea3ad9a"
+    },
+    {
+      "path": "statutes/30/1109.test.yaml",
+      "sha256": "ed46230103c3e1ede5091fdab00bc8fccd737171290ef7dc048f0e278e5b14b2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1109",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1109/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1109/workspace/context-manifest.json",
+  "context_manifest_sha256": "905d82d4ad9e031bc37cb28304504d5d71697a47d127f771009d3ad19eea63fc",
+  "generated_at": "2026-07-08T15:04:59.239012+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1109/encode-out/codex-gpt-5.5/statutes/30/1109.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1109/encode-out",
+  "generated_output_sha256": "ace1926a7bb8c6fa276a3e395204f8a64febacc1df2c0fc2cb120e87aea3ad9a",
+  "generation_prompt_sha256": "3255694e1ec054a594cb71246a657ba8058f8b098e8f73d814f3c15013c46217",
+  "model": "gpt-5.5",
+  "run_id": "ede684f3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e3ebe1e675591eca59b9567a5536e9246b531610efa57ff9fddaffbc615532db"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1109/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1109.json",
+  "trace_sha256": "d066595e9085b1c972195abea3bb460a3c1557337ea2fecc5633b5f60eaecbf6"
+}

--- a/us-de/statutes/30/1109.test.yaml
+++ b/us-de/statutes/30/1109.test.yaml
@@ -1,0 +1,87 @@
+- name: self-employed medical insurance increase allowed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1109#input.gross_income_share_derived_from_trade_business_or_profession: 0.75
+    us-de:statutes/30/1109#input.gross_income_is_derived_as_employee: false
+    us-de:statutes/30/1109#input.income_is_interest_dividends_or_other_investment_income: false
+    us-de:statutes/30/1109#input.total_cost_of_health_care_insurance: 3000
+    us-de:statutes/30/1109#input.gross_income_from_trade_business_or_profession: 10000
+    us-de:statutes/30/1109#input.health_care_insurance_paid: 3000
+    us-de:statutes/30/1109#input.deduction_allowed_under_section_162_l: 1000
+  output:
+    us-de:statutes/30/1109#self_employed_taxpayer: holds
+    us-de:statutes/30/1109#self_employed_medical_insurance_itemized_deduction_increase: 2000
+- name: labor organization increase capped and reduced by nondeductible categories
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1109#input.resident_individual_is_active_member_of_labor_organization: true
+    us-de:statutes/30/1109#input.federal_return_deducted_any_labor_organization_membership_cost: false
+    us-de:statutes/30/1109#input.annual_cost_to_maintain_labor_organization_membership: 800
+    us-de:statutes/30/1109#input.employee_benefit_pension_or_similar_labor_organization_payments: 100
+    ? us-de:statutes/30/1109#input.lobbying_political_settlement_investigatory_or_government_assessment_labor_organization_payments
+    : 50
+  output:
+    us-de:statutes/30/1109#labor_organization_membership_itemized_deduction_increase: 350
+- name: labor organization increase blocked by federal deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1109#input.resident_individual_is_active_member_of_labor_organization: true
+    us-de:statutes/30/1109#input.federal_return_deducted_any_labor_organization_membership_cost: true
+    us-de:statutes/30/1109#input.annual_cost_to_maintain_labor_organization_membership: 400
+    us-de:statutes/30/1109#input.employee_benefit_pension_or_similar_labor_organization_payments: 0
+    ? us-de:statutes/30/1109#input.lobbying_political_settlement_investigatory_or_government_assessment_labor_organization_payments
+    : 0
+  output:
+    us-de:statutes/30/1109#labor_organization_membership_itemized_deduction_increase: 0
+- name: spouses required to file must both elect itemization
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1109#input.both_spouses_are_required_to_file_returns: true
+    us-de:statutes/30/1109#input.both_spouses_elect_to_itemize_deductions: false
+  output:
+    us-de:statutes/30/1109#spouses_may_itemize_deductions: not_holds
+- name: auto_zero_self_employed_medical_insurance_itemized_deduction_increase
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:statutes/30/1109#input.annual_cost_to_maintain_labor_organization_membership: 0
+    us-de:statutes/30/1109#input.both_spouses_are_required_to_file_returns: false
+    us-de:statutes/30/1109#input.both_spouses_elect_to_itemize_deductions: false
+    us-de:statutes/30/1109#input.deduction_allowed_under_section_162_l: 0
+    us-de:statutes/30/1109#input.employee_benefit_pension_or_similar_labor_organization_payments: 0
+    us-de:statutes/30/1109#input.federal_return_deducted_any_labor_organization_membership_cost: false
+    us-de:statutes/30/1109#input.gross_income_from_trade_business_or_profession: 0
+    us-de:statutes/30/1109#input.gross_income_is_derived_as_employee: false
+    us-de:statutes/30/1109#input.gross_income_share_derived_from_trade_business_or_profession: 0
+    us-de:statutes/30/1109#input.health_care_insurance_paid: 0
+    us-de:statutes/30/1109#input.income_is_interest_dividends_or_other_investment_income: false
+    ? us-de:statutes/30/1109#input.lobbying_political_settlement_investigatory_or_government_assessment_labor_organization_payments
+    : 0
+    us-de:statutes/30/1109#input.resident_individual_is_active_member_of_labor_organization: false
+    us-de:statutes/30/1109#input.total_cost_of_health_care_insurance: 0
+  output:
+    us-de:statutes/30/1109#self_employed_medical_insurance_itemized_deduction_increase: 0
+- name: auto_positive_spouses_may_itemize_deductions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:statutes/30/1109#input.both_spouses_are_required_to_file_returns: false
+    us-de:statutes/30/1109#input.both_spouses_elect_to_itemize_deductions: false
+  output:
+    us-de:statutes/30/1109#spouses_may_itemize_deductions: holds

--- a/us-de/statutes/30/1109.yaml
+++ b/us-de/statutes/30/1109.yaml
@@ -1,0 +1,158 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1109
+  summary: |-
+    Resident individual itemized deductions are federal itemized deductions in lieu of the standard deduction, reduced by specified state and other taxes/credits, and increased by specified charitable mileage, self-employed medical insurance, temporary 12% amount, and labor organization membership amounts. Spouses required to file may itemize only if both elect to do so. State and credited other-state income-tax itemized deduction amounts are deemed reduced by the IRC § 68(a) percentage.
+  deferred_outputs:
+    - output: us-de:statutes/30/1109/c#income_tax_itemized_deduction_amount_after_section_68_reduction
+      reason: The formula depends on the percentage determined under Internal Revenue Code section 68(a), and no exact imported RuleSpec output for that percentage is supplied in context.
+rules:
+  - name: self_employment_gross_income_share_threshold
+    kind: parameter
+    dtype: Rate
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+              excerpt: "gross income is more than ½ derived from a trade, business or profession"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1 / 2
+
+  - name: temporary_itemized_deduction_increase_rate
+    kind: parameter
+    dtype: Rate
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+              excerpt: "before January 1, 1988, an amount equal to 12%"
+    versions:
+      - effective_from: '1987-01-01'
+        formula: |-
+          0.12
+
+  - name: labor_organization_membership_cost_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+              excerpt: "not to exceed $500"
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          500
+
+  - name: self_employed_taxpayer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:statutes/30/1109#self_employment_gross_income_share_threshold
+              output: self_employment_gross_income_share_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          gross_income_share_derived_from_trade_business_or_profession > self_employment_gross_income_share_threshold
+          and not gross_income_is_derived_as_employee
+          and not income_is_interest_dividends_or_other_investment_income
+
+  - name: self_employed_medical_insurance_itemized_deduction_increase
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:statutes/30/1109#self_employed_taxpayer
+              output: self_employed_taxpayer
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if self_employed_taxpayer and total_cost_of_health_care_insurance <= gross_income_from_trade_business_or_profession: max(0, health_care_insurance_paid - deduction_allowed_under_section_162_l) else: 0
+
+  - name: labor_organization_membership_itemized_deduction_increase
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 1109(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:statutes/30/1109#labor_organization_membership_cost_cap
+              output: labor_organization_membership_cost_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          if resident_individual_is_active_member_of_labor_organization and not federal_return_deducted_any_labor_organization_membership_cost: min(annual_cost_to_maintain_labor_organization_membership, labor_organization_membership_cost_cap) - employee_benefit_pension_or_similar_labor_organization_payments - lobbying_political_settlement_investigatory_or_government_assessment_labor_organization_payments else: 0
+
+  - name: spouses_may_itemize_deductions
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 1109(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-de/statute/30/1109
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not both_spouses_are_required_to_file_returns
+          or both_spouses_elect_to_itemize_deductions


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1109`
- Module: `us-de/statutes/30/1109.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1109/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.