### PR TITLE
Encode us-de/statute/30/1108 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1108": [
+      {
+        "module": "us-de/statutes/30/1108.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1108.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1108.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1108.yaml",
+      "sha256": "efe1da8c17954115ee7698e477c2589f7cdf8dda4c174f4a239cb17dcca7fba2"
+    },
+    {
+      "path": "statutes/30/1108.test.yaml",
+      "sha256": "57cb1174f3e17262548ba047505037e5c4498de3f40daa1680baece816155e66"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1108",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1108/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1108/workspace/context-manifest.json",
+  "context_manifest_sha256": "e1b9d9541e285c21c7bd5de5c5c0ff45675e9647aa92223f747c0ee91ea1eaf2",
+  "generated_at": "2026-07-08T15:05:05.262109+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1108/encode-out/codex-gpt-5.5/statutes/30/1108.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1108/encode-out",
+  "generated_output_sha256": "efe1da8c17954115ee7698e477c2589f7cdf8dda4c174f4a239cb17dcca7fba2",
+  "generation_prompt_sha256": "a9b91a461911ff89e2b4417716318e89e691cbe749cc2b7c52a59e324ae1545d",
+  "model": "gpt-5.5",
+  "run_id": "b6436023",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6b5778e11cecd88d7d480e68bc7147ead0cd229fbc5c263a8af776408cea6d01"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1108/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1108.json",
+  "trace_sha256": "6e278416caa604d026f28a8de390bb7e4d8a0eb4da8cd53eed91bf0f42491908"
+}

--- a/us-de/statutes/30/1108.test.yaml
+++ b/us-de/statutes/30/1108.test.yaml
@@ -1,0 +1,67 @@
+- name: single_taxpayer_no_additional_deduction_current_period
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1108#input.resident_spouses_file_joint_return: false
+    us-de:statutes/30/1108#input.resident_spouses_file_separate_returns: false
+    us-de:statutes/30/1108#input.taxpayer_attained_age_65_before_close_of_taxable_year: false
+    us-de:statutes/30/1108#input.taxpayer_and_spouse_do_not_make_joint_return: false
+    us-de:statutes/30/1108#input.spouse_attained_age_65_before_close_of_taxable_year: false
+    us-de:statutes/30/1108#input.spouse_has_no_gross_income_for_calendar_year: false
+    us-de:statutes/30/1108#input.spouse_is_dependent_of_another_taxpayer: false
+    us-de:statutes/30/1108#input.taxpayer_is_blind_at_close_of_taxable_year: false
+    us-de:statutes/30/1108#input.taxpayer_makes_separate_return: false
+    us-de:statutes/30/1108#input.spouse_is_blind_for_subsection_b_4: false
+  output:
+    us-de:statutes/30/1108#additional_standard_deduction_circumstance_count: 0
+    us-de:statutes/30/1108#standard_deduction: 3250
+- name: joint_spouses_taxpayer_age_65_and_blind_current_period
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1108#input.resident_spouses_file_joint_return: true
+    us-de:statutes/30/1108#input.resident_spouses_file_separate_returns: false
+    us-de:statutes/30/1108#input.taxpayer_attained_age_65_before_close_of_taxable_year: true
+    us-de:statutes/30/1108#input.taxpayer_and_spouse_do_not_make_joint_return: false
+    us-de:statutes/30/1108#input.spouse_attained_age_65_before_close_of_taxable_year: true
+    us-de:statutes/30/1108#input.spouse_has_no_gross_income_for_calendar_year: true
+    us-de:statutes/30/1108#input.spouse_is_dependent_of_another_taxpayer: false
+    us-de:statutes/30/1108#input.taxpayer_is_blind_at_close_of_taxable_year: true
+    us-de:statutes/30/1108#input.taxpayer_makes_separate_return: false
+    us-de:statutes/30/1108#input.spouse_is_blind_for_subsection_b_4: true
+  output:
+    us-de:statutes/30/1108#additional_standard_deduction_circumstance_count: 2
+    us-de:statutes/30/1108#standard_deduction: 11500
+- name: separate_spouse_age_and_blind_qualify_current_period
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1108#input.resident_spouses_file_joint_return: false
+    us-de:statutes/30/1108#input.resident_spouses_file_separate_returns: true
+    us-de:statutes/30/1108#input.taxpayer_attained_age_65_before_close_of_taxable_year: false
+    us-de:statutes/30/1108#input.taxpayer_and_spouse_do_not_make_joint_return: true
+    us-de:statutes/30/1108#input.spouse_attained_age_65_before_close_of_taxable_year: true
+    us-de:statutes/30/1108#input.spouse_has_no_gross_income_for_calendar_year: true
+    us-de:statutes/30/1108#input.spouse_is_dependent_of_another_taxpayer: false
+    us-de:statutes/30/1108#input.taxpayer_is_blind_at_close_of_taxable_year: false
+    us-de:statutes/30/1108#input.taxpayer_makes_separate_return: true
+    us-de:statutes/30/1108#input.spouse_is_blind_for_subsection_b_4: true
+  output:
+    us-de:statutes/30/1108#additional_standard_deduction_circumstance_count: 2
+    us-de:statutes/30/1108#standard_deduction: 8250
+- name: individual_blind_by_visual_field
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1108#input.better_eye_visual_acuity_with_correcting_lenses: 0.2
+    us-de:statutes/30/1108#input.widest_diameter_visual_field_angle_degrees: 15
+  output:
+    us-de:statutes/30/1108#individual_is_blind: holds

--- a/us-de/statutes/30/1108.yaml
+++ b/us-de/statutes/30/1108.yaml
@@ -1,0 +1,239 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1108
+  summary: |-
+    Standard deduction: resident individual $1,300 before 1999, $3,250 for taxable periods beginning after 1998; resident spouses $1,600 joint/$800 separate before 1999, $4,000 joint/$2,000 separate for 1999, and $6,500 joint/$3,250 separate after 1999. Add $2,500 for each age-65 or blind circumstance described in subsection (b). Blindness is central visual acuity not over 20/200 with correction, or visual field widest diameter no greater than 20 degrees.
+rules:
+  - name: resident_individual_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1108(a)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "taxable periods ending before January 1, 1999 ... resident individual shall be $1,300"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "taxable periods beginning after December 31, 1998 ... resident individual shall be $3,250"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1300
+      - effective_from: '1999-01-01'
+        formula: |-
+          3250
+
+  - name: resident_spouses_joint_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1108(a)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "resident spouses shall be $1,600 if they file a joint return"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "resident spouses shall be $4,000 if they file a joint return"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "resident spouses shall be $6,500 if they file a joint return"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1600
+      - effective_from: '1999-01-01'
+        formula: |-
+          4000
+      - effective_from: '2000-01-01'
+        formula: |-
+          6500
+
+  - name: resident_spouses_separate_standard_deduction_each
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1108(a)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "$800 each if they file separate returns"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "$2,000 each if they file separate returns"
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "$3,250 each if they file separate returns"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          800
+      - effective_from: '1999-01-01'
+        formula: |-
+          2000
+      - effective_from: '2000-01-01'
+        formula: |-
+          3250
+
+  - name: additional_standard_deduction_per_circumstance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1108(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "The sum of $2,500 shall be added"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2500
+
+  - name: better_eye_visual_acuity_numerator_limit
+    kind: parameter
+    dtype: Decimal
+    source: 30 Del. C. § 1108(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "20/200 in the better eye"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20
+
+  - name: better_eye_visual_acuity_denominator
+    kind: parameter
+    dtype: Decimal
+    source: 30 Del. C. § 1108(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "20/200 in the better eye"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200
+
+  - name: visual_field_angle_limit_degrees
+    kind: parameter
+    dtype: Decimal
+    source: 30 Del. C. § 1108(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "visual field subtends an angle no greater than 20 degrees"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20
+
+  - name: individual_is_blind
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 30 Del. C. § 1108(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "central visual acuity does not exceed 20/200 ... or ... visual field ... no greater than 20 degrees"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          better_eye_visual_acuity_with_correcting_lenses <= better_eye_visual_acuity_numerator_limit / better_eye_visual_acuity_denominator
+          or (better_eye_visual_acuity_with_correcting_lenses > better_eye_visual_acuity_numerator_limit / better_eye_visual_acuity_denominator
+          and widest_diameter_visual_field_angle_degrees <= visual_field_angle_limit_degrees)
+
+  - name: additional_standard_deduction_circumstance_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    source: 30 Del. C. § 1108(b)(1)-(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "in each of the following circumstances"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (if taxpayer_attained_age_65_before_close_of_taxable_year: 1 else: 0)
+          + (if taxpayer_and_spouse_do_not_make_joint_return and spouse_attained_age_65_before_close_of_taxable_year and spouse_has_no_gross_income_for_calendar_year and not spouse_is_dependent_of_another_taxpayer: 1 else: 0)
+          + (if taxpayer_is_blind_at_close_of_taxable_year: 1 else: 0)
+          + (if taxpayer_makes_separate_return and spouse_is_blind_for_subsection_b_4 and spouse_has_no_gross_income_for_calendar_year and not spouse_is_dependent_of_another_taxpayer: 1 else: 0)
+
+  - name: standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 30 Del. C. § 1108(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "shall be added to the standard deduction determined under subsection (a)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (if resident_spouses_file_joint_return: resident_spouses_joint_standard_deduction else: if resident_spouses_file_separate_returns: resident_spouses_separate_standard_deduction_each else: resident_individual_standard_deduction)
+          + additional_standard_deduction_per_circumstance * additional_standard_deduction_circumstance_count


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1108`
- Module: `us-de/statutes/30/1108.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1108/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.