### PR TITLE
Encode us-de/statute/30/1114 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1114": [
+      {
+        "module": "us-de/statutes/30/1114.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1114.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1114.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1114.yaml",
+      "sha256": "793cd5eed73c53ad5d2e0754881024261101031b2164b4b5cdf13e6e7b5390e1"
+    },
+    {
+      "path": "statutes/30/1114.test.yaml",
+      "sha256": "e7736824c091a470c8a2c7ea16a3abc15755385bcf8e07169e0503663be0386a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1114",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1114/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1114/workspace/context-manifest.json",
+  "context_manifest_sha256": "efff120c585eadadee68c881138eedc9aec86db678d8edd2143e57b3396377e4",
+  "generated_at": "2026-07-08T15:05:10.673386+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1114/encode-out/codex-gpt-5.5/statutes/30/1114.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1114/encode-out",
+  "generated_output_sha256": "793cd5eed73c53ad5d2e0754881024261101031b2164b4b5cdf13e6e7b5390e1",
+  "generation_prompt_sha256": "b585b00bff363f6636e9a603d5d2fb656c0e84c548eb82d41f7685dcd3b395c1",
+  "model": "gpt-5.5",
+  "run_id": "6c0ecd25",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "052934f7db5f4088abd0cd23254d84b27c0b370b80c462163e526e7d796e204a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1114/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1114.json",
+  "trace_sha256": "749c2b46f1776076069fd81d12391c224dab1f8a7fe51dc27f236df508d01c14"
+}

--- a/us-de/statutes/30/1114.test.yaml
+++ b/us-de/statutes/30/1114.test.yaml
@@ -1,0 +1,52 @@
+- name: resident_credit_equals_half_federal_credit_when_below_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1114#input.resident_individual: true
+    us-de:statutes/30/1114#input.spouses_file_joint_federal_return_but_separate_delaware_taxes: false
+    us-de:statutes/30/1114#input.spouse_has_lower_taxable_income_computed_without_credit: false
+    us-de:statutes/30/1114#input.federal_return_child_and_dependent_care_expense_credit: 1000
+    us-de:statutes/30/1114#input.delaware_tax_otherwise_due_under_chapter: 800
+  output:
+    us-de:statutes/30/1114#delaware_child_and_dependent_care_credit: 500
+- name: credit_capped_by_delaware_tax_otherwise_due
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1114#input.resident_individual: true
+    us-de:statutes/30/1114#input.spouses_file_joint_federal_return_but_separate_delaware_taxes: false
+    us-de:statutes/30/1114#input.spouse_has_lower_taxable_income_computed_without_credit: false
+    us-de:statutes/30/1114#input.federal_return_child_and_dependent_care_expense_credit: 1000
+    us-de:statutes/30/1114#input.delaware_tax_otherwise_due_under_chapter: 300
+  output:
+    us-de:statutes/30/1114#delaware_child_and_dependent_care_credit: 300
+- name: separate_delaware_taxes_credit_only_for_lower_income_spouse
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1114#input.resident_individual: true
+    us-de:statutes/30/1114#input.spouses_file_joint_federal_return_but_separate_delaware_taxes: true
+    us-de:statutes/30/1114#input.spouse_has_lower_taxable_income_computed_without_credit: true
+    us-de:statutes/30/1114#input.federal_return_child_and_dependent_care_expense_credit: 1000
+    us-de:statutes/30/1114#input.delaware_tax_otherwise_due_under_chapter: 800
+  output:
+    us-de:statutes/30/1114#delaware_child_and_dependent_care_credit: 500
+- name: separate_delaware_taxes_no_credit_for_non_lower_income_spouse
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1114#input.resident_individual: true
+    us-de:statutes/30/1114#input.spouses_file_joint_federal_return_but_separate_delaware_taxes: true
+    us-de:statutes/30/1114#input.spouse_has_lower_taxable_income_computed_without_credit: false
+    us-de:statutes/30/1114#input.federal_return_child_and_dependent_care_expense_credit: 1000
+    us-de:statutes/30/1114#input.delaware_tax_otherwise_due_under_chapter: 800
+  output:
+    us-de:statutes/30/1114#delaware_child_and_dependent_care_credit: 0

--- a/us-de/statutes/30/1114.yaml
+++ b/us-de/statutes/30/1114.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1114
+  summary: |-
+    A resident individual is entitled to a credit equal to 50 percent of the federal child and dependent care expense credit allowable for the same tax year, not exceeding Delaware tax otherwise due. For spouses filing a joint federal return but separate Delaware taxes, the credit may only be applied against the spouse with the lower taxable income and may not exceed that spouse's tax.
+rules:
+  - name: child_and_dependent_care_credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: 30 Del. C. § 1114(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1114
+              excerpt: "50 percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.50
+
+  - name: delaware_child_and_dependent_care_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. § 1114(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1114
+              excerpt: "50 percent of the child and dependent care expense credit allowable for federal income tax purposes"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-de/statute/30/1114
+              excerpt: "shall not exceed such tax"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if resident_individual and (not spouses_file_joint_federal_return_but_separate_delaware_taxes or spouse_has_lower_taxable_income_computed_without_credit): min(delaware_tax_otherwise_due_under_chapter, child_and_dependent_care_credit_percentage * max(0, federal_return_child_and_dependent_care_expense_credit)) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1114`
- Module: `us-de/statutes/30/1114.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1114/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.