### PR TITLE
Encode us-de/statute/30/1117 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8153,6 +8153,15 @@
         ]
       }
     ],
+    "us-de/statute/30/1117": [
+      {
+        "module": "us-de/statutes/30/1117.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-fl/manual/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42": [
       {
         "module": "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml",

--- a/us-de/.axiom/encoding-manifests/statutes/30/1117.json
+++ b/us-de/.axiom/encoding-manifests/statutes/30/1117.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/30/1117.yaml",
+      "sha256": "8cc23821498347b466183abcd5493e85e87735094958a397fce3ca48c77d8de1"
+    },
+    {
+      "path": "statutes/30/1117.test.yaml",
+      "sha256": "67ce07e78042799032672d80b83c0fc7e3b4cb6cd662bb83aa04799b6cbf6deb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-de/statute/30/1117",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1117/encode-out/_eval_workspaces/codex-gpt-5.5/us-de-statute-30-1117/workspace/context-manifest.json",
+  "context_manifest_sha256": "13b2e1ca34c3e358a4d0ba7b5833f00d14c6f15f3856b4e70a574668cafed3bb",
+  "generated_at": "2026-07-08T15:06:12.223516+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1117/encode-out/codex-gpt-5.5/statutes/30/1117.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1117/encode-out",
+  "generated_output_sha256": "8cc23821498347b466183abcd5493e85e87735094958a397fce3ca48c77d8de1",
+  "generation_prompt_sha256": "0b4f8fcc9163be5b33b23664af91fd962cab59cb2e2b6fa0c2c3e037457d33f1",
+  "model": "gpt-5.5",
+  "run_id": "f83b2a64",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "967fa52d2761f2400b829bb8829f2a8f09d407f9bf4365993357aab91c7f3058"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1117/encode-out/traces/codex-gpt-5.5/us-de-statute-30-1117.json",
+  "trace_sha256": "5947047a61490bc25cc3f0b5b7bbdedd99c333100cf508b9acd03fda918272de"
+}

--- a/us-de/statutes/30/1117.test.yaml
+++ b/us-de/statutes/30/1117.test.yaml
@@ -1,0 +1,60 @@
+- name: resident_pre_change_nonrefundable_credit_is_capped_by_tax
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us-de:statutes/30/1117#input.individual_is_resident_of_this_state: true
+    us-de:statutes/30/1117#input.spouses_elect_to_determine_delaware_taxes_separately_after_joint_federal_return: false
+    us-de:statutes/30/1117#input.spouse_has_greater_tax_otherwise_due_computed_without_this_credit: false
+    us-de:statutes/30/1117#input.taxable_year_begins_before_refundable_credit_option_effective_date: true
+    us-de:statutes/30/1117#input.individual_claims_refundable_earned_income_credit_option: false
+    us-de:statutes/30/1117#input.tax_otherwise_due_under_this_chapter: 150
+    us-de:statutes/30/1117#input.corresponding_federal_earned_income_credit: 1000
+  output:
+    us-de:statutes/30/1117#delaware_earned_income_credit: 150
+- name: resident_post_change_claims_refundable_option
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1117#input.individual_is_resident_of_this_state: true
+    us-de:statutes/30/1117#input.spouses_elect_to_determine_delaware_taxes_separately_after_joint_federal_return: false
+    us-de:statutes/30/1117#input.spouse_has_greater_tax_otherwise_due_computed_without_this_credit: false
+    us-de:statutes/30/1117#input.taxable_year_begins_before_refundable_credit_option_effective_date: false
+    us-de:statutes/30/1117#input.individual_claims_refundable_earned_income_credit_option: true
+    us-de:statutes/30/1117#input.tax_otherwise_due_under_this_chapter: 10
+    us-de:statutes/30/1117#input.corresponding_federal_earned_income_credit: 1000
+  output:
+    us-de:statutes/30/1117#delaware_earned_income_credit: 45
+- name: resident_post_change_claims_nonrefundable_option
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1117#input.individual_is_resident_of_this_state: true
+    us-de:statutes/30/1117#input.spouses_elect_to_determine_delaware_taxes_separately_after_joint_federal_return: false
+    us-de:statutes/30/1117#input.spouse_has_greater_tax_otherwise_due_computed_without_this_credit: false
+    us-de:statutes/30/1117#input.taxable_year_begins_before_refundable_credit_option_effective_date: false
+    us-de:statutes/30/1117#input.individual_claims_refundable_earned_income_credit_option: false
+    us-de:statutes/30/1117#input.tax_otherwise_due_under_this_chapter: 500
+    us-de:statutes/30/1117#input.corresponding_federal_earned_income_credit: 1000
+  output:
+    us-de:statutes/30/1117#delaware_earned_income_credit: 200
+- name: separate_delaware_spouse_without_greater_tax_cannot_use_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-de:statutes/30/1117#input.individual_is_resident_of_this_state: true
+    us-de:statutes/30/1117#input.spouses_elect_to_determine_delaware_taxes_separately_after_joint_federal_return: true
+    us-de:statutes/30/1117#input.spouse_has_greater_tax_otherwise_due_computed_without_this_credit: false
+    us-de:statutes/30/1117#input.taxable_year_begins_before_refundable_credit_option_effective_date: false
+    us-de:statutes/30/1117#input.individual_claims_refundable_earned_income_credit_option: false
+    us-de:statutes/30/1117#input.tax_otherwise_due_under_this_chapter: 500
+    us-de:statutes/30/1117#input.corresponding_federal_earned_income_credit: 1000
+  output:
+    us-de:statutes/30/1117#delaware_earned_income_credit: 0

--- a/us-de/statutes/30/1117.yaml
+++ b/us-de/statutes/30/1117.yaml
@@ -1,0 +1,96 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/statute/30/1117
+  summary: |-
+    Resident individual Delaware earned income credit: before January 1, 2022, 20% of the corresponding federal earned income credit, nonrefundable; on or after January 1, 2022, either 20% not exceeding tax otherwise due or 4.5% with excess refundable. Separate Delaware spouses using a joint federal return may use the credit only for the spouse with greater tax otherwise due.
+rules:
+  - name: delaware_earned_income_credit_nonrefundable_rate
+    kind: parameter
+    dtype: Rate
+    source: 30 Del. C. § 1117(a)(1), (a)(2)a
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "20% of the corresponding federal earned income credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.20
+  - name: delaware_earned_income_credit_refundable_rate
+    kind: parameter
+    dtype: Rate
+    source: 30 Del. C. § 1117(a)(2)b
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "4.5% of the corresponding federal earned income tax credit"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.045
+  - name: delaware_earned_income_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. § 1117(a)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "an individual who is a resident of this State may receive"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "may claim either of the following amounts"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "not to exceed the tax otherwise due under this chapter"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-de/statute/30/1117
+              excerpt: "may only be used by the spouse with the greater tax otherwise due"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:statutes/30/1117#delaware_earned_income_credit_nonrefundable_rate
+              output: delaware_earned_income_credit_nonrefundable_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:statutes/30/1117#delaware_earned_income_credit_refundable_rate
+              output: delaware_earned_income_credit_refundable_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_is_resident_of_this_state and (not spouses_elect_to_determine_delaware_taxes_separately_after_joint_federal_return or spouse_has_greater_tax_otherwise_due_computed_without_this_credit):
+            if taxable_year_begins_before_refundable_credit_option_effective_date:
+              min(tax_otherwise_due_under_this_chapter, max(0, delaware_earned_income_credit_nonrefundable_rate * max(0, corresponding_federal_earned_income_credit)))
+            else:
+              if individual_claims_refundable_earned_income_credit_option:
+                delaware_earned_income_credit_refundable_rate * max(0, corresponding_federal_earned_income_credit)
+              else:
+                min(tax_otherwise_due_under_this_chapter, max(0, delaware_earned_income_credit_nonrefundable_rate * max(0, corresponding_federal_earned_income_credit)))
+          else:
+            0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-de/statute/30/1117`
- Module: `us-de/statutes/30/1117.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-de-statute-30-1117/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.