### PR TITLE
Encode us-ga/statute/48/48-7-29.10 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9471,6 +9471,15 @@
         ]
       }
     ],
+    "us-ga/statute/48/48-7-29.10": [
+      {
+        "module": "us-ga/statutes/48/48-7-29/10.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-hi/regulation/har/17/680/page-11": [
       {
         "module": "us-hi/regulations/har/17/680/17-680-12.yaml",

--- a/us-ga/.axiom/encoding-manifests/statutes/48/48-7-29/10.json
+++ b/us-ga/.axiom/encoding-manifests/statutes/48/48-7-29/10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/48/48-7-29/10.yaml",
+      "sha256": "20b03223506d5073e7266e04fdc7777930213c991e5aac196a462e292764f36f"
+    },
+    {
+      "path": "statutes/48/48-7-29/10.test.yaml",
+      "sha256": "fd0ffcded1688673cdb21837dd88d5521c5c447ba25800ac9f5ec671226a9413"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ga/statute/48/48-7-29.10",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-29-10/encode-out/_eval_workspaces/codex-gpt-5.5/us-ga-statute-48-48-7-29.10/workspace/context-manifest.json",
+  "context_manifest_sha256": "ace12553995b9d4a2fd500e2672e293fd3ca67f9a440d555377cf393e0f92d6b",
+  "generated_at": "2026-07-08T15:06:47.620770+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-29-10/encode-out/codex-gpt-5.5/statutes/48/48-7-29/10.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-29-10/encode-out",
+  "generated_output_sha256": "20b03223506d5073e7266e04fdc7777930213c991e5aac196a462e292764f36f",
+  "generation_prompt_sha256": "a6cb5a68b0fb483d4ba88672f70e4e23b776dda2065b5bb4cc907431989a2918",
+  "model": "gpt-5.5",
+  "run_id": "a66cf0c9",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cda9519390a77e8e04fdd6433f09926939fcd4e3e77bcae590e3f7fe19c15e5f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-29-10/encode-out/traces/codex-gpt-5.5/us-ga-statute-48-48-7-29.10.json",
+  "trace_sha256": "2056be078e061b479ad3f0c2471f18fb3d346cf865dd3b3b647bd8db0ba0c50f"
+}

--- a/us-ga/statutes/48/48-7-29/10.test.yaml
+++ b/us-ga/statutes/48/48-7-29/10.test.yaml
@@ -1,0 +1,32 @@
+- name: credit equals 30 percent of federal credit when below liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7-29/10#input.georgia_income_tax_liability: 1000
+    us-ga:statutes/48/48-7-29/10#input.federal_child_and_dependent_care_credit_claimed_and_allowed: 2000
+  output:
+    us-ga:statutes/48/48-7-29/10#child_and_dependent_care_tax_credit: 600
+    us-ga:statutes/48/48-7-29/10#unused_child_and_dependent_care_tax_credit_carryforward_allowed: not_holds
+    us-ga:statutes/48/48-7-29/10#child_and_dependent_care_tax_credit_against_prior_year_liability_allowed: not_holds
+- name: credit is capped by Georgia income tax liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7-29/10#input.georgia_income_tax_liability: 400
+    us-ga:statutes/48/48-7-29/10#input.federal_child_and_dependent_care_credit_claimed_and_allowed: 2000
+  output:
+    us-ga:statutes/48/48-7-29/10#child_and_dependent_care_tax_credit: 400
+- name: 2007 taxable year uses 20 percent rate
+  period:
+    period_kind: tax_year
+    start: '2007-01-01'
+    end: '2007-12-31'
+  input:
+    us-ga:statutes/48/48-7-29/10#input.georgia_income_tax_liability: 1000
+    us-ga:statutes/48/48-7-29/10#input.federal_child_and_dependent_care_credit_claimed_and_allowed: 2000
+  output:
+    us-ga:statutes/48/48-7-29/10#child_and_dependent_care_tax_credit: 400

--- a/us-ga/statutes/48/48-7-29/10.yaml
+++ b/us-ga/statutes/48/48-7-29/10.yaml
@@ -1,0 +1,105 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/statute/48/48-7-29.10
+  summary: |-
+    A taxpayer shall be allowed a credit against the tax imposed by Code Section 48-7-20 for qualified child and dependent care expenses. The credit is a percentage of the Section 21 Internal Revenue Code credit claimed and allowed: ten percent for taxable years beginning on or after January 1, 2006 and before January 1, 2007; twenty percent for taxable years beginning on or after January 1, 2007 and before January 1, 2008; and thirty percent for taxable years beginning on or after January 1, 2008. The credit may not exceed income tax liability, may not be carried forward, and may not be allowed against prior years' liability.
+rules:
+  - name: child_and_dependent_care_credit_percentage
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: O.C.G.A. § 48-7-29.10(a)(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "Ten percent for all taxable years beginning on or after January 1, 2006, and prior to January 1, 2007"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "Twenty percent for all taxable years beginning on or after January 1, 2007, and prior to January 1, 2008"
+          - path: versions[2].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "Thirty percent for all taxable years beginning on or after January 1, 2008"
+    versions:
+      - effective_from: '2006-01-01'
+        formula: |-
+          0.10
+      - effective_from: '2007-01-01'
+        formula: |-
+          0.20
+      - effective_from: '2008-01-01'
+        formula: |-
+          0.30
+
+  - name: child_and_dependent_care_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-29.10(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "determined by applying a percentage to the amount of the credit provided for in Section 21 of the Internal Revenue Code which is claimed and allowed"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "In no event shall the total amount of the tax credit under this Code section for a taxable year exceed the taxpayer's income tax liability."
+    versions:
+      - effective_from: '2006-01-01'
+        formula: |-
+          min(max(0, georgia_income_tax_liability), child_and_dependent_care_credit_percentage * max(0, federal_child_and_dependent_care_credit_claimed_and_allowed))
+
+  - name: unused_child_and_dependent_care_tax_credit_carryforward_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: O.C.G.A. § 48-7-29.10(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "Any unused tax credit shall not be allowed to be carried forward to apply to the taxpayer's succeeding years' tax liability."
+    versions:
+      - effective_from: '2006-01-01'
+        formula: |-
+          false
+
+  - name: child_and_dependent_care_tax_credit_against_prior_year_liability_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: O.C.G.A. § 48-7-29.10(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "No such tax credit shall be allowed the taxpayer against prior years' tax liability."
+    versions:
+      - effective_from: '2006-01-01'
+        formula: |-
+          false


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ga/statute/48/48-7-29.10`
- Module: `us-ga/statutes/48/48-7-29/10.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-29-10/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.