### PR TITLE
Encode us-ga/statute/48/48-7-26 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9471,6 +9471,15 @@
         ]
       }
     ],
+    "us-ga/statute/48/48-7-26": [
+      {
+        "module": "us-ga/statutes/48/48-7-26.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-hi/regulation/har/17/680/page-11": [
       {
         "module": "us-hi/regulations/har/17/680/17-680-12.yaml",

--- a/us-ga/.axiom/encoding-manifests/statutes/48/48-7-26.json
+++ b/us-ga/.axiom/encoding-manifests/statutes/48/48-7-26.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/48/48-7-26.yaml",
+      "sha256": "7f0830ad62d55b9f8188908a12e1870a300ea4305548b20a8f5385cbeb7f4f20"
+    },
+    {
+      "path": "statutes/48/48-7-26.test.yaml",
+      "sha256": "395423a2bdab0781cc4de455a27733bb2be46fb582594a5ebb47e1f26f061439"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ga/statute/48/48-7-26",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-26/encode-out/_eval_workspaces/codex-gpt-5.5/us-ga-statute-48-48-7-26/workspace/context-manifest.json",
+  "context_manifest_sha256": "4411e5ad219c796fcb90905837e87df8284eea0892449e601aeacf69d25ba56e",
+  "generated_at": "2026-07-08T15:07:34.704671+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-26/encode-out/codex-gpt-5.5/statutes/48/48-7-26.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-26/encode-out",
+  "generated_output_sha256": "7f0830ad62d55b9f8188908a12e1870a300ea4305548b20a8f5385cbeb7f4f20",
+  "generation_prompt_sha256": "f650e30607b0aac3e01f27384368949d75f8ace047db4d64bc270278f35aaf89",
+  "model": "gpt-5.5",
+  "run_id": "bd8f4d24",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a864e0fbab2f88155a85b7b31e943874be3ee64c77415deb89bae9ec5482815f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-26/encode-out/traces/codex-gpt-5.5/us-ga-statute-48-48-7-26.json",
+  "trace_sha256": "ca5b721bf06a8a25a47c82d79697e4c665ade8d9f196384d38bf2bfdd3df429d"
+}

--- a/us-ga/statutes/48/48-7-26.test.yaml
+++ b/us-ga/statutes/48/48-7-26.test.yaml
@@ -1,0 +1,46 @@
+- name: joint return personal exemption deduction
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input:
+    us-ga:statutes/48/48-7-26#input.joint_return_filed: true
+    us-ga:statutes/48/48-7-26#input.taxpayer_and_spouse_file_separate_returns: false
+  output:
+    us-ga:statutes/48/48-7-26#personal_exemption_deduction: 7400
+- name: separate return personal exemption deduction
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input:
+    us-ga:statutes/48/48-7-26#input.joint_return_filed: false
+    us-ga:statutes/48/48-7-26#input.taxpayer_and_spouse_file_separate_returns: true
+  output:
+    us-ga:statutes/48/48-7-26#personal_exemption_deduction: 3700
+- name: other taxpayer personal exemption deduction
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input:
+    us-ga:statutes/48/48-7-26#input.joint_return_filed: false
+    us-ga:statutes/48/48-7-26#input.taxpayer_and_spouse_file_separate_returns: false
+  output:
+    us-ga:statutes/48/48-7-26#personal_exemption_deduction: 2700
+- name: estate deduction in lieu of personal exemption
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input: {}
+  output:
+    us-ga:statutes/48/48-7-26#estate_deduction_in_lieu_of_personal_exemption: 2700
+- name: trust deduction in lieu of personal exemption
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input: {}
+  output:
+    us-ga:statutes/48/48-7-26#trust_deduction_in_lieu_of_personal_exemption: 1350

--- a/us-ga/statutes/48/48-7-26.yaml
+++ b/us-ga/statutes/48/48-7-26.yaml
@@ -1,0 +1,213 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/statute/48/48-7-26
+  summary: |-
+    (b)(1) An exemption of $7,400.00 shall be allowed as a deduction for a taxpayer and spouse only if a joint return is filed; if separate returns are filed, $3,700.00 shall be allowed to each person. (b)(2) An exemption of $2,700.00 shall be allowed for all other taxpayers. (b)(3) Commencing with taxable year beginning January 1, 2003, an exemption of $3,000.00 for each dependent shall be allowed. (c) No exemption shall be allowed for any dependent who has made a joint return with such dependent's spouse. (d) A deduction in lieu of a personal exemption deduction shall be allowed an estate, $2,700.00, and a trust, $1,350.00.
+  deferred_outputs:
+    - output: us-ga:statutes/48/48-7-26#dependent
+      reason: The definition of dependent adopts the Internal Revenue Code and adds unborn children with detectable human heartbeat as defined in Code Section 1-2-1, but the cited definitional sources are not available in copied context.
+    - output: us-ga:statutes/48/48-7-26#dependent_exemption_deduction
+      reason: Computing the deduction for each dependent requires the unavailable dependent definition, including the missing Code Section 1-2-1 definitions for the unborn-child branch.
+rules:
+  - name: joint_return_personal_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "An exemption of $7,400.00 shall be allowed"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          7400
+  - name: separate_return_personal_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "$3,700.00 shall be allowed to each person"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          3700
+  - name: other_taxpayer_personal_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "An exemption of $2,700.00 shall be allowed"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          2700
+  - name: dependent_exemption_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "an exemption of $3,000.00 for each dependent"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "Commencing with the taxable year beginning January 1, 2003"
+    versions:
+      - effective_from: '2003-01-01'
+        formula: |-
+          3000
+  - name: estate_deduction_in_lieu_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "An estate — $2,700.00"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          2700
+  - name: trust_deduction_in_lieu_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: O.C.G.A. § 48-7-26(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "A trust — $1,350.00"
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          1350
+  - name: personal_exemption_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "but only if a joint return is filed"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "If a taxpayer and spouse file separate returns"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#joint_return_personal_exemption_amount
+              output: joint_return_personal_exemption_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#separate_return_personal_exemption_amount
+              output: separate_return_personal_exemption_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#other_taxpayer_personal_exemption_amount
+              output: other_taxpayer_personal_exemption_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          if joint_return_filed: joint_return_personal_exemption_amount else: if taxpayer_and_spouse_file_separate_returns: separate_return_personal_exemption_amount else: other_taxpayer_personal_exemption_amount
+  - name: estate_deduction_in_lieu_of_personal_exemption
+    kind: derived
+    entity: Estate
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-26(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "A deduction in lieu of a personal exemption deduction shall be allowed an estate"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#estate_deduction_in_lieu_amount
+              output: estate_deduction_in_lieu_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          estate_deduction_in_lieu_amount
+  - name: trust_deduction_in_lieu_of_personal_exemption
+    kind: derived
+    entity: Trust
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-26(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-26
+              excerpt: "A deduction in lieu of a personal exemption deduction shall be allowed"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#trust_deduction_in_lieu_amount
+              output: trust_deduction_in_lieu_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          trust_deduction_in_lieu_amount


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ga/statute/48/48-7-26`
- Module: `us-ga/statutes/48/48-7-26.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-26/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.