### PR TITLE
Encode us-ga/statute/48/48-7-27 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9471,6 +9471,15 @@
         ]
       }
     ],
+    "us-ga/statute/48/48-7-27": [
+      {
+        "module": "us-ga/statutes/48/48-7-27.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-hi/regulation/har/17/680/page-11": [
       {
         "module": "us-hi/regulations/har/17/680/17-680-12.yaml",

--- a/us-ga/.axiom/encoding-manifests/statutes/48/48-7-27.json
+++ b/us-ga/.axiom/encoding-manifests/statutes/48/48-7-27.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/48/48-7-27.yaml",
+      "sha256": "b44c3b89bbb15d54b39824126fc882304e4ec02bf9b1ad5f7a93f2b6b5ed8c1a"
+    },
+    {
+      "path": "statutes/48/48-7-27.test.yaml",
+      "sha256": "e8b8e42ec769ef5e4f5353de43f2973a5c7b25fab30b5f02f18138d223448006"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ga/statute/48/48-7-27",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-27/encode-out/_eval_workspaces/codex-gpt-5.5/us-ga-statute-48-48-7-27/workspace/context-manifest.json",
+  "context_manifest_sha256": "15309a18e6d208e5b1d8a29307e323b257ef4ff998e5e519f4dd7bb2460d996d",
+  "generated_at": "2026-07-08T15:07:40.744569+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-27/encode-out/codex-gpt-5.5/statutes/48/48-7-27.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-27/encode-out",
+  "generated_output_sha256": "b44c3b89bbb15d54b39824126fc882304e4ec02bf9b1ad5f7a93f2b6b5ed8c1a",
+  "generation_prompt_sha256": "b5bb0543a90376b6bee2b00ff4cced343f374b4c189073208178016a02c44547",
+  "model": "gpt-5.5",
+  "run_id": "53ad61e8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "da00845a3f9706eeb57dc031b1d57ed59ef2b036b7e32a2d3420a6d5abc4dc15"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-27/encode-out/traces/codex-gpt-5.5/us-ga-statute-48-48-7-27.json",
+  "trace_sha256": "723d17590dcec24875473528e34640bcea41fb53219322194f629c35be3b2aae"
+}

--- a/us-ga/statutes/48/48-7-27.test.yaml
+++ b/us-ga/statutes/48/48-7-27.test.yaml
@@ -1,0 +1,20 @@
+- name: auto_output_retirement_income_exclusion_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_current_retirement_exclusion_period: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_1: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_10: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_11: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_2: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_3: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_4: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_5: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_6: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_7: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_8: false
+    us-ga:statutes/48/48-7-27#input.taxable_year_is_prior_retirement_exclusion_band_9: false
+  output:
+    us-ga:statutes/48/48-7-27#retirement_income_exclusion_band: 0

--- a/us-ga/statutes/48/48-7-27.yaml
+++ b/us-ga/statutes/48/48-7-27.yaml
@@ -1,0 +1,466 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/statute/48/48-7-27
+  summary: |-
+    Georgia taxable net income of an individual is federal adjusted gross income less specified deductions, exemptions, exclusions, and adjustments. The section states standard deduction amounts, additional age/blindness deductions, retirement-income exclusions, military retirement exclusions, education-savings deductions, disaster relief exclusions, military and veteran exclusions, organ-donation and health-plan deductions, addbacks and subtractions to taxable income, depreciation-election adjustments, and S corporation, partnership, and LLC adjustment rules.
+  deferred_outputs:
+    - output: us-ga:statutes/48/48-7-27/a#georgia_taxable_net_income
+      reason: The top-level Georgia taxable net income computation depends on multiple unavailable upstream legal definitions and cross-referenced computations, including exemptions under Code Section 48-7-26, qualified payments under Code Section 48-7-38, federal-return deduction mechanics, Code Sections 25-3-23, 45-9-85, 48-7-28.3, 48-7-21.1, 48-7-53, 48-7-23, and 48-7-39.
+      source_values:
+        - us-ga:statutes/48/48-7-27#single_or_head_of_household_standard_deduction
+        - us-ga:statutes/48/48-7-27#married_separate_standard_deduction
+        - us-ga:statutes/48/48-7-27#married_joint_standard_deduction
+        - us-ga:statutes/48/48-7-27#age_additional_deduction
+        - us-ga:statutes/48/48-7-27#blindness_additional_deduction
+        - us-ga:statutes/48/48-7-27#retirement_income_exclusion_amount
+        - us-ga:statutes/48/48-7-27#retirement_income_earned_income_cap
+        - us-ga:statutes/48/48-7-27#military_retirement_base_exclusion_under_age_threshold
+        - us-ga:statutes/48/48-7-27#military_retirement_additional_exclusion_under_age_threshold
+        - us-ga:statutes/48/48-7-27#military_retirement_additional_exclusion_earned_income_threshold
+        - us-ga:statutes/48/48-7-27#education_savings_account_single_or_separate_deduction_cap
+        - us-ga:statutes/48/48-7-27#education_savings_account_joint_deduction_cap
+        - us-ga:statutes/48/48-7-27#organ_donation_expense_exclusion_cap
+    - output: us-ga:statutes/48/48-7-27/d#pass_through_entity_income_adjustment
+      reason: Subsection (d) depends on unavailable upstream definitions and external state-tax facts, including the definition of individual in Code Section 48-1-2 and recognition or entity-level taxation rules for Subchapter S corporations, partnerships, and limited liability companies.
+rules:
+  - name: single_or_head_of_household_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "single taxpayer or a head of household, $5,400.00"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          5400
+
+  - name: married_separate_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "married taxpayer filing a separate return, $3,550.00"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          3550
+
+  - name: married_joint_standard_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "married couple filing a joint return, $7,100.00"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          7100
+
+  - name: age_additional_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(1)(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "additional deduction of $1,300.00"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1300
+
+  - name: blindness_additional_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(1)(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "additional deduction of $1,300.00"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1300
+
+  - name: retirement_income_exclusion_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: 48-7-27(a)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "For taxable years beginning on or after January 1, 1989"
+    versions:
+      - effective_from: '1989-01-01'
+        formula: |-
+          if taxable_year_is_current_retirement_exclusion_period: 12 else: if taxable_year_is_prior_retirement_exclusion_band_11: 11 else: if taxable_year_is_prior_retirement_exclusion_band_10: 10 else: if taxable_year_is_prior_retirement_exclusion_band_9: 9 else: if taxable_year_is_prior_retirement_exclusion_band_8: 8 else: if taxable_year_is_prior_retirement_exclusion_band_7: 7 else: if taxable_year_is_prior_retirement_exclusion_band_6: 6 else: if taxable_year_is_prior_retirement_exclusion_band_5: 5 else: if taxable_year_is_prior_retirement_exclusion_band_4: 4 else: if taxable_year_is_prior_retirement_exclusion_band_3: 3 else: if taxable_year_is_prior_retirement_exclusion_band_2: 2 else: if taxable_year_is_prior_retirement_exclusion_band_1: 1 else: 0
+
+  - name: retirement_income_exclusion_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: retirement_income_exclusion_band
+    source: 48-7-27(a)(5)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              table:
+                header: retirement income exclusion amount by taxable year
+                row_key: retirement_income_exclusion_band
+                column_key: exclusion_amount
+    versions:
+      - effective_from: '1989-01-01'
+        values:
+          0: 8000
+          1: 10000
+          2: 11000
+          3: 12000
+          4: 13000
+          5: 13500
+          6: 14000
+          7: 14500
+          8: 15000
+          9: 25000
+          10: 30000
+          11: 35000
+          12: 65000
+
+  - name: retirement_income_lower_age_threshold
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(5)(D)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Is 62 years of age or older but less than 65 years of age"
+    versions:
+      - effective_from: '1989-01-01'
+        formula: |-
+          62
+
+  - name: retirement_income_upper_age_threshold
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(5)(D)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "less than 65 years of age"
+    versions:
+      - effective_from: '1989-01-01'
+        formula: |-
+          65
+
+  - name: retirement_income_earned_income_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(5)(E)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "no more than $4,000.00 of an individual’s earned income"
+    versions:
+      - effective_from: '1989-01-01'
+        formula: |-
+          4000
+
+  - name: military_retirement_age_threshold
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(5.1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "individual who is less than 62 years of age"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          62
+
+  - name: military_retirement_base_exclusion_under_age_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(5.1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Up to $17,500.00 of income"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          17500
+
+  - name: military_retirement_additional_exclusion_under_age_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(5.1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "additional amount of up to $17,500.00"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          17500
+
+  - name: military_retirement_additional_exclusion_earned_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(5.1)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Georgia earned income ... exceeds $17,500.00"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          17500
+
+  - name: education_savings_account_single_or_separate_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(11.1)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "not exceeding $4,000.00 per beneficiary"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          4000
+
+  - name: education_savings_account_joint_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(11.1)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "joint return ... shall not exceed $8,000.00 per beneficiary"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          8000
+
+  - name: disabled_veteran_disability_percentage_threshold
+    kind: parameter
+    dtype: Rate
+    source: 48-7-27(a)(12.1)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "at least 90 percent totally and permanently disabled"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.90
+
+  - name: impaired_vision_central_acuity_numerator
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(12.1)(B)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Central visual acuity of 20/200 or less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20
+
+  - name: impaired_vision_central_acuity_denominator
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(12.1)(B)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Central visual acuity of 20/200 or less"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200
+
+  - name: impaired_vision_field_diameter_threshold
+    kind: parameter
+    dtype: Integer
+    source: 48-7-27(a)(12.1)(B)(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "no greater than 20 degrees"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          20
+
+  - name: organ_donation_expense_exclusion_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 48-7-27(a)(13)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "not to exceed the amount of $25,000.00"
+    versions:
+      - effective_from: '2022-07-01'
+        formula: |-
+          25000
+
+  - name: firefighter_premium_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 48-7-27(a)(12.3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "100 percent of any premium paid"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: disabled_first_responder_payment_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    source: 48-7-27(a)(12.4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "100 percent of the payments made to and received"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          1
+
+  - name: high_deductible_health_plan_premium_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 48-7-27(a)(13.1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "100 percent of the premium paid"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ga/statute/48/48-7-27`
- Module: `us-ga/statutes/48/48-7-27.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7-27/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.