### PR TITLE
Encode us-al/statute/40-18-5 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1030,6 +1030,15 @@
         ]
       }
     ],
+    "us-al/statute/40-18-5": [
+      {
+        "module": "us-al/statutes/40-18-5.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ar/policy/dhs/tea/manual/2024/page-58": [
       {
         "module": "us-ar/policies/dhs/tea/manual/2024/resource-eligibility.yaml",

--- a/us-al/.axiom/encoding-manifests/statutes/40-18-5.json
+++ b/us-al/.axiom/encoding-manifests/statutes/40-18-5.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/40-18-5.yaml",
+      "sha256": "bc42eec985bfdb457576c67b8e9b6a0bcccdf7fa80be31b5537c33ef7e665542"
+    },
+    {
+      "path": "statutes/40-18-5.test.yaml",
+      "sha256": "0ba865120587ecec4cda42c14c95ff6307dd7a57392b5859946f07b576668e47"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-al/statute/40-18-5",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-5/encode-out/_eval_workspaces/codex-gpt-5.5/us-al-statute-40-18-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "090cad484bc3dc856ec48f6e2b65c33884d960605dd7bfd78081084e9f7acfcd",
+  "generated_at": "2026-07-08T15:08:49.551947+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-5/encode-out/codex-gpt-5.5/statutes/40-18-5.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-5/encode-out",
+  "generated_output_sha256": "bc42eec985bfdb457576c67b8e9b6a0bcccdf7fa80be31b5537c33ef7e665542",
+  "generation_prompt_sha256": "81a5384e0094bf5d28eccec77ed43139b4694d6457e7d67fb8998ecb439eab1a",
+  "model": "gpt-5.5",
+  "run_id": "3e2db048",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c439a186f74e49bf0513dd70d6900a3e523509678ce9ac9a79979766e27935da"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-5/encode-out/traces/codex-gpt-5.5/us-al-statute-40-18-5.json",
+  "trace_sha256": "0214c6efe36f4d5876891910000a8b1eb81c5c208397dcc7511bb4770ac1f1c2"
+}

--- a/us-al/statutes/40-18-5.test.yaml
+++ b/us-al/statutes/40-18-5.test.yaml
@@ -1,0 +1,40 @@
+- name: single_or_separate_second_bracket_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-5#input.taxable_income: 2500
+    us-al:statutes/40-18-5#input.married_persons_filing_joint_return: false
+  output:
+    us-al:statutes/40-18-5#tax_computed_under_section_40_18_5: 90
+- name: single_or_separate_third_bracket_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-5#input.taxable_income: 4000
+    us-al:statutes/40-18-5#input.married_persons_filing_joint_return: false
+  output:
+    us-al:statutes/40-18-5#tax_computed_under_section_40_18_5: 160
+- name: joint_second_bracket_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-5#input.taxable_income: 5000
+    us-al:statutes/40-18-5#input.married_persons_filing_joint_return: true
+  output:
+    us-al:statutes/40-18-5#tax_computed_under_section_40_18_5: 180
+- name: joint_third_bracket_tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-5#input.taxable_income: 8000
+    us-al:statutes/40-18-5#input.married_persons_filing_joint_return: true
+  output:
+    us-al:statutes/40-18-5#tax_computed_under_section_40_18_5: 320

--- a/us-al/statutes/40-18-5.yaml
+++ b/us-al/statutes/40-18-5.yaml
@@ -1,0 +1,280 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-5
+  summary: |-
+    The tax levied by Section 40-18-2 is computed at 2%, 4%, and 5% rates, with taxable-income brackets of $500/$3,000 for single, head of family, or separate returns and $1,000/$6,000 for married joint returns.
+rules:
+  - name: single_first_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Two percent of taxable income not in excess of five hundred dollars ($500)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.02
+  - name: single_first_bracket_upper_taxable_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of five hundred dollars ($500)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          500
+  - name: single_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Four percent of taxable income in excess of five hundred dollars ($500) and not in excess of three thousand dollars ($3,000)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.04
+  - name: single_second_bracket_lower_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "in excess of five hundred dollars ($500)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          500
+  - name: single_second_bracket_upper_taxable_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of three thousand dollars ($3,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+  - name: single_third_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(1)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Five percent of taxable income in excess of three thousand dollars ($3,000)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.05
+  - name: single_third_bracket_lower_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "in excess of three thousand dollars ($3,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+  - name: joint_first_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Two percent of taxable income not in excess of one thousand dollars ($1,000)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.02
+  - name: joint_first_bracket_upper_taxable_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of one thousand dollars ($1,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1000
+  - name: joint_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Four percent of taxable income in excess of one thousand dollars ($1,000) and not in excess of six thousand dollars ($6,000)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.04
+  - name: joint_second_bracket_lower_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "in excess of one thousand dollars ($1,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1000
+  - name: joint_second_bracket_upper_taxable_income
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of six thousand dollars ($6,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6000
+  - name: joint_third_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Ala. Code § 40-18-5(2)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Five percent of taxable income in excess of six thousand dollars ($6,000)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.05
+  - name: joint_third_bracket_lower_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "in excess of six thousand dollars ($6,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6000
+  - name: tax_computed_under_section_40_18_5
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ala. Code § 40-18-5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "For a single person, head of family, or married persons filing separate returns"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "For married persons filing a joint return"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if married_persons_filing_joint_return:
+            if taxable_income <= joint_first_bracket_upper_taxable_income:
+              joint_first_bracket_rate * max(0, taxable_income)
+            else:
+              if taxable_income <= joint_second_bracket_upper_taxable_income:
+                (joint_first_bracket_rate * joint_first_bracket_upper_taxable_income) + (joint_second_bracket_rate * max(0, taxable_income - joint_second_bracket_lower_excess_threshold))
+              else:
+                (joint_first_bracket_rate * joint_first_bracket_upper_taxable_income) + (joint_second_bracket_rate * max(0, joint_second_bracket_upper_taxable_income - joint_second_bracket_lower_excess_threshold)) + (joint_third_bracket_rate * max(0, taxable_income - joint_third_bracket_lower_excess_threshold))
+          else:
+            if taxable_income <= single_first_bracket_upper_taxable_income:
+              single_first_bracket_rate * max(0, taxable_income)
+            else:
+              if taxable_income <= single_second_bracket_upper_taxable_income:
+                (single_first_bracket_rate * single_first_bracket_upper_taxable_income) + (single_second_bracket_rate * max(0, taxable_income - single_second_bracket_lower_excess_threshold))
+              else:
+                (single_first_bracket_rate * single_first_bracket_upper_taxable_income) + (single_second_bracket_rate * max(0, single_second_bracket_upper_taxable_income - single_second_bracket_lower_excess_threshold)) + (single_third_bracket_rate * max(0, taxable_income - single_third_bracket_lower_excess_threshold))


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-al/statute/40-18-5`
- Module: `us-al/statutes/40-18-5.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-5/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.