### PR TITLE
Encode us-ga/statute/48/48-7A-3 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9471,6 +9471,15 @@
         ]
       }
     ],
+    "us-ga/statute/48/48-7A-3": [
+      {
+        "module": "us-ga/statutes/48/48-7A-3.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-hi/regulation/har/17/680/page-11": [
       {
         "module": "us-hi/regulations/har/17/680/17-680-12.yaml",

--- a/us-ga/.axiom/encoding-manifests/statutes/48/48-7A-3.json
+++ b/us-ga/.axiom/encoding-manifests/statutes/48/48-7A-3.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/48/48-7A-3.yaml",
+      "sha256": "ee857810dc2b2f5f3a9607b166d395355f6967ee0ae09f2ed653472c99946520"
+    },
+    {
+      "path": "statutes/48/48-7A-3.test.yaml",
+      "sha256": "c63b8dd400676076199645aae214de4e902ba5c85623ee2d9d0d529720b4e41b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ga/statute/48/48-7A-3",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7a-3/encode-out/_eval_workspaces/codex-gpt-5.5/us-ga-statute-48-48-7A-3/workspace/context-manifest.json",
+  "context_manifest_sha256": "ccdf479358afa94b5cb3cf4d947270f860e3df0905533a316845b3d4cc48c2b6",
+  "generated_at": "2026-07-08T15:09:01.520808+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7a-3/encode-out/codex-gpt-5.5/statutes/48/48-7A-3.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7a-3/encode-out",
+  "generated_output_sha256": "ee857810dc2b2f5f3a9607b166d395355f6967ee0ae09f2ed653472c99946520",
+  "generation_prompt_sha256": "e16ca900b26394c0387eaa3ccc34386e88d1e0cec8e81ed3058b7100300be8fc",
+  "model": "gpt-5.5",
+  "run_id": "49a555b0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8f7b58b1cd54e01a011809252f0b829dc57fe4cbdafb3faddbb68a66c300f5e5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7a-3/encode-out/traces/codex-gpt-5.5/us-ga-statute-48-48-7A-3.json",
+  "trace_sha256": "df330b1e7fb0d5b930c91c64d9cdcfc984b883ac3ef7189f63b2083b1e8b8414"
+}

--- a/us-ga/statutes/48/48-7A-3.test.yaml
+++ b/us-ga/statutes/48/48-7A-3.test.yaml
@@ -1,0 +1,96 @@
+- name: qualifying_taxpayer_under_first_agi_band_gets_credit_capped_by_liability
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7A-3#input.resident_taxpayer_files_individual_income_tax_return: true
+    us-ga:statutes/48/48-7A-3#input.taxpayer_claimed_or_eligible_as_dependent_by_another: false
+    us-ga:statutes/48/48-7A-3#input.individual_receives_food_stamp_allotment_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.individual_incarcerated_or_confined_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.claim_filed_on_or_before_end_of_twelfth_month_following_close_of_taxable_year: true
+    us-ga:statutes/48/48-7A-3#input.adjusted_gross_income: 5000
+    us-ga:statutes/48/48-7A-3#input.taxpayer_is_65_years_of_age_or_over: false
+    us-ga:statutes/48/48-7A-3#input.dependents_entitled_to_claim_count: 2
+    us-ga:statutes/48/48-7A-3#input.husband_and_wife_file_separate_returns_for_year_when_joint_return_could_have_been_filed: false
+    us-ga:statutes/48/48-7A-3#input.credit_to_which_spouses_would_have_been_entitled_had_joint_return_been_filed: 0
+    us-ga:statutes/48/48-7A-3#input.individual_income_tax_liability: 40
+  output:
+    us-ga:statutes/48/48-7A-3#low_income_credit_allowed: holds
+    us-ga:statutes/48/48-7A-3#low_income_credit_claim_timely: holds
+    us-ga:statutes/48/48-7A-3#adjusted_gross_income_band: 0
+    us-ga:statutes/48/48-7A-3#age_credit_multiplier: 1
+    us-ga:statutes/48/48-7A-3#low_income_credit_before_liability_cap: 52
+    us-ga:statutes/48/48-7A-3#low_income_credit_claimable_before_liability_cap: 52
+    us-ga:statutes/48/48-7A-3#low_income_credit: 40
+- name: age_65_taxpayer_gets_double_credit_in_middle_band
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7A-3#input.resident_taxpayer_files_individual_income_tax_return: true
+    us-ga:statutes/48/48-7A-3#input.taxpayer_claimed_or_eligible_as_dependent_by_another: false
+    us-ga:statutes/48/48-7A-3#input.individual_receives_food_stamp_allotment_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.individual_incarcerated_or_confined_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.claim_filed_on_or_before_end_of_twelfth_month_following_close_of_taxable_year: true
+    us-ga:statutes/48/48-7A-3#input.adjusted_gross_income: 10000
+    us-ga:statutes/48/48-7A-3#input.taxpayer_is_65_years_of_age_or_over: true
+    us-ga:statutes/48/48-7A-3#input.dependents_entitled_to_claim_count: 3
+    us-ga:statutes/48/48-7A-3#input.husband_and_wife_file_separate_returns_for_year_when_joint_return_could_have_been_filed: false
+    us-ga:statutes/48/48-7A-3#input.credit_to_which_spouses_would_have_been_entitled_had_joint_return_been_filed: 0
+    us-ga:statutes/48/48-7A-3#input.individual_income_tax_liability: 100
+  output:
+    us-ga:statutes/48/48-7A-3#low_income_credit_allowed: holds
+    us-ga:statutes/48/48-7A-3#low_income_credit_claim_timely: holds
+    us-ga:statutes/48/48-7A-3#adjusted_gross_income_band: 3
+    us-ga:statutes/48/48-7A-3#age_credit_multiplier: 2
+    us-ga:statutes/48/48-7A-3#low_income_credit_before_liability_cap: 48
+    us-ga:statutes/48/48-7A-3#low_income_credit_claimable_before_liability_cap: 48
+    us-ga:statutes/48/48-7A-3#low_income_credit: 48
+- name: food_stamp_allotment_blocks_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7A-3#input.resident_taxpayer_files_individual_income_tax_return: true
+    us-ga:statutes/48/48-7A-3#input.taxpayer_claimed_or_eligible_as_dependent_by_another: false
+    us-ga:statutes/48/48-7A-3#input.individual_receives_food_stamp_allotment_for_any_part_of_taxable_year: true
+    us-ga:statutes/48/48-7A-3#input.individual_incarcerated_or_confined_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.claim_filed_on_or_before_end_of_twelfth_month_following_close_of_taxable_year: true
+    us-ga:statutes/48/48-7A-3#input.adjusted_gross_income: 7000
+    us-ga:statutes/48/48-7A-3#input.taxpayer_is_65_years_of_age_or_over: false
+    us-ga:statutes/48/48-7A-3#input.dependents_entitled_to_claim_count: 2
+    us-ga:statutes/48/48-7A-3#input.husband_and_wife_file_separate_returns_for_year_when_joint_return_could_have_been_filed: false
+    us-ga:statutes/48/48-7A-3#input.credit_to_which_spouses_would_have_been_entitled_had_joint_return_been_filed: 0
+    us-ga:statutes/48/48-7A-3#input.individual_income_tax_liability: 100
+  output:
+    us-ga:statutes/48/48-7A-3#low_income_credit_allowed: not_holds
+    us-ga:statutes/48/48-7A-3#low_income_credit_before_liability_cap: 0
+    us-ga:statutes/48/48-7A-3#low_income_credit_claimable_before_liability_cap: 0
+    us-ga:statutes/48/48-7A-3#low_income_credit: 0
+- name: untimely_claim_and_income_above_schedule_yields_no_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ga:statutes/48/48-7A-3#input.resident_taxpayer_files_individual_income_tax_return: true
+    us-ga:statutes/48/48-7A-3#input.taxpayer_claimed_or_eligible_as_dependent_by_another: false
+    us-ga:statutes/48/48-7A-3#input.individual_receives_food_stamp_allotment_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.individual_incarcerated_or_confined_for_any_part_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.claim_filed_on_or_before_end_of_twelfth_month_following_close_of_taxable_year: false
+    us-ga:statutes/48/48-7A-3#input.adjusted_gross_income: 20000
+    us-ga:statutes/48/48-7A-3#input.taxpayer_is_65_years_of_age_or_over: false
+    us-ga:statutes/48/48-7A-3#input.dependents_entitled_to_claim_count: 2
+    us-ga:statutes/48/48-7A-3#input.husband_and_wife_file_separate_returns_for_year_when_joint_return_could_have_been_filed: false
+    us-ga:statutes/48/48-7A-3#input.credit_to_which_spouses_would_have_been_entitled_had_joint_return_been_filed: 0
+    us-ga:statutes/48/48-7A-3#input.individual_income_tax_liability: 100
+  output:
+    us-ga:statutes/48/48-7A-3#low_income_credit_allowed: holds
+    us-ga:statutes/48/48-7A-3#low_income_credit_claim_timely: not_holds
+    us-ga:statutes/48/48-7A-3#adjusted_gross_income_band: -1
+    us-ga:statutes/48/48-7A-3#low_income_credit_before_liability_cap: 0
+    us-ga:statutes/48/48-7A-3#low_income_credit_claimable_before_liability_cap: 0
+    us-ga:statutes/48/48-7A-3#low_income_credit: 0

--- a/us-ga/statutes/48/48-7A-3.yaml
+++ b/us-ga/statutes/48/48-7A-3.yaml
@@ -1,0 +1,347 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ga/statute/48/48-7A-3
+  summary: |-
+    Resident taxpayers filing individual income tax returns may claim a credit if not claimed or otherwise eligible to be claimed as another taxpayer's dependent, except food stamp recipients and incarcerated or confined individuals. The credit schedule is based on adjusted gross income and dependents, doubled for taxpayers age 65 or over, capped by income tax liability, and waived if not filed by the end of the twelfth month after the taxable year closes.
+rules:
+  - name: low_income_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 48-7A-3(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          resident_taxpayer_files_individual_income_tax_return
+          and not taxpayer_claimed_or_eligible_as_dependent_by_another
+          and not individual_receives_food_stamp_allotment_for_any_part_of_taxable_year
+          and not individual_incarcerated_or_confined_for_any_part_of_taxable_year
+
+  - name: low_income_credit_claim_timely
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 48-7A-3(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          claim_filed_on_or_before_end_of_twelfth_month_following_close_of_taxable_year
+
+  - name: adjusted_gross_income_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          if adjusted_gross_income < agi_band_0_upper_bound: 0 else: if adjusted_gross_income >= agi_band_1_lower_bound and adjusted_gross_income <= agi_band_1_upper_bound: 1 else: if adjusted_gross_income >= agi_band_2_lower_bound and adjusted_gross_income <= agi_band_2_upper_bound: 2 else: if adjusted_gross_income >= agi_band_3_lower_bound and adjusted_gross_income <= agi_band_3_upper_bound: 3 else: if adjusted_gross_income >= agi_band_4_lower_bound and adjusted_gross_income <= agi_band_4_upper_bound: 4 else: -1
+
+  - name: agi_band_0_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "Under $6,000.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          6000
+
+  - name: agi_band_1_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "6,000.00 but not more than 7,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          6000
+
+  - name: agi_band_1_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "6,000.00 but not more than 7,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          7999
+
+  - name: agi_band_2_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "8,000.00 but not more than 9,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          8000
+
+  - name: agi_band_2_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "8,000.00 but not more than 9,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          9999
+
+  - name: agi_band_3_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "10,000.00 but not more than 14,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          10000
+
+  - name: agi_band_3_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "10,000.00 but not more than 14,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          14999
+
+  - name: agi_band_4_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "15,000.00 but not more than 19,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          15000
+
+  - name: agi_band_4_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "15,000.00 but not more than 19,999.00"
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          19999
+
+  - name: credit_amount_per_dependent
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    indexed_by: adjusted_gross_income_band
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              table:
+                header: "TAX CREDIT SCHEDULE Adjusted Gross Income Tax Credit"
+                row_key: "adjusted_gross_income_band"
+                column_key: "tax_credit"
+    versions:
+      - effective_from: '2010-01-01'
+        values:
+          0: 26
+          1: 20
+          2: 14
+          3: 8
+          4: 5
+
+  - name: age_credit_multiplier
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "Each taxpayer 65 years of age or over may claim double the tax credit."
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          if taxpayer_is_65_years_of_age_or_over: 2 else: 1
+
+  - name: low_income_credit_before_liability_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          if low_income_credit_allowed and adjusted_gross_income_band >= 0: credit_amount_per_dependent[adjusted_gross_income_band] * dependents_entitled_to_claim_count * age_credit_multiplier else: 0
+
+  - name: low_income_credit_claimable_before_liability_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          if husband_and_wife_file_separate_returns_for_year_when_joint_return_could_have_been_filed: credit_to_which_spouses_would_have_been_entitled_had_joint_return_been_filed else: low_income_credit_before_liability_cap
+
+  - name: low_income_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 48-7A-3(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2010-01-01'
+        formula: |-
+          if low_income_credit_claim_timely: min(max(0, low_income_credit_claimable_before_liability_cap), max(0, individual_income_tax_liability)) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ga/statute/48/48-7A-3`
- Module: `us-ga/statutes/48/48-7A-3.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ga-statute-48-48-7a-3/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.