### PR TITLE
Encode us-dc/statute/47/47-1806.03 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8117,6 +8117,15 @@
         ]
       }
     ],
+    "us-dc/statute/47/47-1806.03": [
+      {
+        "module": "us-dc/statutes/47/47-1806/03.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-de/guidance/ssa/poms/si-01415-058/delaware/block-1": [
       {
         "module": "us-de/policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,14 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 10
+ceiling: 12
 entries:
+  - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-dc/.axiom/encoding-manifests/statutes/47/47-1806/03.json
+++ b/us-dc/.axiom/encoding-manifests/statutes/47/47-1806/03.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/47/47-1806/03.yaml",
+      "sha256": "8fc820909737ddea9d00a043e4037723e5ae19cfe6ea164d8c7611a765860757"
+    },
+    {
+      "path": "statutes/47/47-1806/03.test.yaml",
+      "sha256": "7940cb36048cdc42c758272e87e01829b290a60609407efabecee965233cedf6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-dc/statute/47/47-1806.03",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-dc-statute-47-47-1806-03/encode-out/_eval_workspaces/codex-gpt-5.5/us-dc-statute-47-47-1806.03/workspace/context-manifest.json",
+  "context_manifest_sha256": "2e2621cc8ff972f65a292c2b4a8468ff4ab74044c4d6f6ec59e7b9aab79b4b3d",
+  "generated_at": "2026-07-08T15:09:16.130748+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-dc-statute-47-47-1806-03/encode-out/codex-gpt-5.5/statutes/47/47-1806/03.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-dc-statute-47-47-1806-03/encode-out",
+  "generated_output_sha256": "8fc820909737ddea9d00a043e4037723e5ae19cfe6ea164d8c7611a765860757",
+  "generation_prompt_sha256": "b4fec3bf4f4e597a99b2c91f26e2184434af1a9bc0827ec7cd51b01bfb6d16ad",
+  "model": "gpt-5.5",
+  "run_id": "69c0cf0b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f1aaeede911d0e14863397ae7ec26f3c5b8a6088352ae7b5de8fba8414905c1b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-dc-statute-47-47-1806-03/encode-out/traces/codex-gpt-5.5/us-dc-statute-47-47-1806.03.json",
+  "trace_sha256": "1803878038d4bfde400e07ee0afb5f6d58869a279442db62add94a20128a8e60"
+}

--- a/us-dc/statutes/47/47-1806/03.test.yaml
+++ b/us-dc/statutes/47/47-1806/03.test.yaml
@@ -1,0 +1,38 @@
+- name: not_living_with_spouse_or_domestic_partner_is_single_for_chapter
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-dc:statutes/47/47-1806/03#input.individual_living_with_spouse_or_domestic_partner_on_last_day_of_taxable_year: false
+  output:
+    us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter: holds
+- name: living_with_spouse_or_domestic_partner_not_single_under_subsection_c
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-dc:statutes/47/47-1806/03#input.individual_living_with_spouse_or_domestic_partner_on_last_day_of_taxable_year: true
+  output:
+    us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter: not_holds
+- name: living_together_and_filing_separate_returns_treated_single
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-dc:statutes/47/47-1806/03#input.spouse_or_domestic_partner_living_together: true
+    us-dc:statutes/47/47-1806/03#input.spouse_or_domestic_partner_files_separate_return: true
+  output:
+    us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person: holds
+- name: living_together_without_separate_returns_not_treated_single_by_subsection_e
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-dc:statutes/47/47-1806/03#input.spouse_or_domestic_partner_living_together: true
+    us-dc:statutes/47/47-1806/03#input.spouse_or_domestic_partner_files_separate_return: false
+  output:
+    us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person: not_holds

--- a/us-dc/statutes/47/47-1806/03.yaml
+++ b/us-dc/statutes/47/47-1806/03.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-dc/statute/47/47-1806.03
+  summary: |-
+    Subsection (c) provides that an individual not living with a spouse or domestic partner on the last day of the taxable year shall be considered as a single person for purposes of this chapter. Subsection (e) provides that spouses or domestic partners living together who file separate returns are each treated as a single person for purposes of this section.
+  deferred_outputs:
+    - output: us-dc:statutes/47/47-1806/03/a#resident_income_tax
+      reason: The operative tax tables referenced in subsection (a) are not included in the supplied source text, so the resident tax computation cannot be encoded from this source unit alone.
+    - output: us-dc:statutes/47/47-1806/03/b#mayor_tax_table_election_tax
+      reason: Subsection (b) depends on a tax table prescribed by the Mayor and rules or regulations not supplied in this source text.
+    - output: us-dc:statutes/47/47-1806/03/d#section_applies_to_return
+      reason: Subsection (d) controls application of the section to fiduciary returns and certain married or domestic-partner returns; faithfully computing the return-level applicability surface requires return ontology and spouse/domestic-partner return filing relationships beyond the local Person predicate encoded here.
+rules:
+  - name: considered_single_person_for_chapter
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 47-1806.03(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not individual_living_with_spouse_or_domestic_partner_on_last_day_of_taxable_year
+  - name: separate_return_living_together_treated_single_person
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 47-1806.03(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          spouse_or_domestic_partner_living_together
+          and spouse_or_domestic_partner_files_separate_return


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-dc/statute/47/47-1806.03`
- Module: `us-dc/statutes/47/47-1806/03.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-dc-statute-47-47-1806-03/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+2 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.