### PR TITLE
Encode us-al/statute/40-18-19 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1030,6 +1030,15 @@
         ]
       }
     ],
+    "us-al/statute/40-18-19": [
+      {
+        "module": "us-al/statutes/40-18-19.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ar/policy/dhs/tea/manual/2024/page-58": [
       {
         "module": "us-ar/policies/dhs/tea/manual/2024/resource-eligibility.yaml",

--- a/us-al/.axiom/encoding-manifests/statutes/40-18-19.json
+++ b/us-al/.axiom/encoding-manifests/statutes/40-18-19.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/40-18-19.yaml",
+      "sha256": "303f699a0a2c6af8a94fcf1897367c85a350bc0d380d127ca518d6eac58a7bb9"
+    },
+    {
+      "path": "statutes/40-18-19.test.yaml",
+      "sha256": "420d4e23e56c7557aa5a2e24c6b84f29e67de1003c89b80c804e87b205099e48"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-al/statute/40-18-19",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-19/encode-out/_eval_workspaces/codex-gpt-5.5/us-al-statute-40-18-19/workspace/context-manifest.json",
+  "context_manifest_sha256": "6481ce902bfa4434377238462dba2856da7b0c65b179a657a8d5c56895f0b56b",
+  "generated_at": "2026-07-08T15:11:13.950864+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-19/encode-out/codex-gpt-5.5/statutes/40-18-19.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-19/encode-out",
+  "generated_output_sha256": "303f699a0a2c6af8a94fcf1897367c85a350bc0d380d127ca518d6eac58a7bb9",
+  "generation_prompt_sha256": "847b8f671afe6bff052680bacf5a6853e3806630a4372b36c83f0e938e9b8d78",
+  "model": "gpt-5.5",
+  "run_id": "d9670149",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "970111f3339b54439a8c1d65fa9baa6d7bb22793475b95d561ddbd0e5e926a22"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-19/encode-out/traces/codex-gpt-5.5/us-al-statute-40-18-19.json",
+  "trace_sha256": "ad86b4f59cf9231da858b25c19cc18ab5262bafa64d86b2500f16bf1b6645c51"
+}

--- a/us-al/statutes/40-18-19.test.yaml
+++ b/us-al/statutes/40-18-19.test.yaml
@@ -1,0 +1,30 @@
+- name: age_65_retirement_income_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-19#input.age: 65
+    us-al:statutes/40-18-19#input.taxable_retirement_income: 7000
+  output:
+    us-al:statutes/40-18-19#taxable_retirement_income_exemption: 6000
+- name: below_age_65_no_retirement_income_exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-19#input.age: 64
+    us-al:statutes/40-18-19#input.taxable_retirement_income: 7000
+  output:
+    us-al:statutes/40-18-19#taxable_retirement_income_exemption: 0
+- name: age_65_retirement_income_below_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-al:statutes/40-18-19#input.age: 70
+    us-al:statutes/40-18-19#input.taxable_retirement_income: 4000
+  output:
+    us-al:statutes/40-18-19#taxable_retirement_income_exemption: 4000

--- a/us-al/statutes/40-18-19.yaml
+++ b/us-al/statutes/40-18-19.yaml
@@ -1,0 +1,251 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-19
+  summary: |-
+    40-18-19(a) allows Alabama individual resident taxpayer income-tax exemptions, including personal and dependent exemptions, retirement-system exemptions, 529/ABLE/foreign-earned-income exclusions, and beginning January 1, 2023, "the first six thousand dollars ($6,000) of taxable retirement income" for individual taxpayers age 65 or older.
+  deferred_outputs:
+    - output: us-al:statutes/40-18-19/a#resident_income_tax_exemptions
+      reason: The subsection enumerates multiple exemption categories, several of which depend on external retirement-system, beneficiary, federal-tax, PACT/ACES/ABLE, foreign-earned-income, and Alabama filing-status definitions not supplied in this source unit. This artifact encodes independent source-stated scalar values and the directly computable age-65 taxable-retirement-income exemption.
+rules:
+  - name: taxable_retirement_income_exemption_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "the first six thousand dollars ($6,000) of taxable retirement income"
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          6000
+
+  - name: eligible_retirement_income_exemption_age
+    kind: parameter
+    dtype: Integer
+    source: 40-18-19(a)(13)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "individual taxpayers who are 65 years of age or older"
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          65
+
+  - name: taxable_retirement_income_exemption
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 40-18-19(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "Beginning January 1, 2023, the first six thousand dollars ($6,000) of taxable retirement income."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "may only be claimed by individual taxpayers who are 65 years of age or older"
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          if age >= eligible_retirement_income_exemption_age: min(max(0, taxable_retirement_income), taxable_retirement_income_exemption_cap) else: 0
+
+  - name: single_person_personal_exemption
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "a single person or a married person not living with husband or wife, a personal exemption of one thousand five hundred dollars ($1,500)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1500
+
+  - name: head_of_family_or_married_living_with_spouse_personal_exemption
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "a head of a family or a married person living with husband or wife, a personal exemption of three thousand dollars ($3,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+
+  - name: baseline_dependent_exemption
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)a.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "Three hundred dollars ($300) for each person, other than husband or wife, dependent upon the taxpayer"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          300
+
+  - name: low_income_dependent_exemption
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)d.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "adjusted gross income equal to or less than fifty thousand dollars ($50,000), one thousand dollars ($1,000) for each person"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          1000
+
+  - name: middle_income_dependent_exemption
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)e.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "adjusted gross income in excess of fifty thousand dollars ($50,000) and equal to or less than one hundred thousand dollars ($100,000), five hundred dollars ($500)"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          500
+
+  - name: dependent_exemption_low_income_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)d.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "adjusted gross income equal to or less than fifty thousand dollars ($50,000)"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          50000
+
+  - name: dependent_exemption_middle_income_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)e.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "adjusted gross income in excess of fifty thousand dollars ($50,000)"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          50000
+
+  - name: dependent_exemption_middle_income_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(9)e.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "equal to or less than one hundred thousand dollars ($100,000)"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          100000
+
+  - name: firefighter_retirement_exemption_initial_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "The first eight thousand dollars ($8,000) of any retirement compensation"
+    versions:
+      - effective_from: '1987-01-01'
+        formula: |-
+          8000
+
+  - name: peace_officer_retirement_exemption_initial_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 40-18-19(a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-19
+              excerpt: "The first eight thousand dollars ($8,000) of any retirement compensation"
+    versions:
+      - effective_from: '1984-01-01'
+        formula: |-
+          8000


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-al/statute/40-18-19`
- Module: `us-al/statutes/40-18-19.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-al-statute-40-18-19/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.