### PR TITLE
Encode us-id/statute/63-3024 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9645,6 +9645,15 @@
         ]
       }
     ],
+    "us-id/statute/63-3024": [
+      {
+        "module": "us-id/statutes/63-3024.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/manual/dhs/csmm/15232/block-1": [
       {
         "module": "us-il/policies/dhs/csmm/15232/block-1.yaml",

--- a/us-id/.axiom/encoding-manifests/statutes/63-3024.json
+++ b/us-id/.axiom/encoding-manifests/statutes/63-3024.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/63-3024.yaml",
+      "sha256": "943464ff714e3a06a965da01844522582ff119b1a6211b6d70be877680f1d0d6"
+    },
+    {
+      "path": "statutes/63-3024.test.yaml",
+      "sha256": "29f907ae0cd8a79d2c3a528967108a80531f3d56c979f355def3866489937b6e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-id/statute/63-3024",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024/encode-out/_eval_workspaces/codex-gpt-5.5/us-id-statute-63-3024/workspace/context-manifest.json",
+  "context_manifest_sha256": "6d36f5c1f32061c8b13e63671b4c070d85c2281b19c4e0ba6336255741a864da",
+  "generated_at": "2026-07-08T15:12:43.894613+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024/encode-out/codex-gpt-5.5/statutes/63-3024.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024/encode-out",
+  "generated_output_sha256": "943464ff714e3a06a965da01844522582ff119b1a6211b6d70be877680f1d0d6",
+  "generation_prompt_sha256": "4026597594c272ff056201f91dd19679f7433cb591e72e808964f8703940c7bd",
+  "model": "gpt-5.5",
+  "run_id": "a1819bf1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1ae0aaf4c32195d7cb821d4166e85c1898e968d60023f84069909ef3560bd0a4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024/encode-out/traces/codex-gpt-5.5/us-id-statute-63-3024.json",
+  "trace_sha256": "d40bc6f3843178f1ba45650c5de619bdbf1d4caf7b4758a11ba43daab1989906"
+}

--- a/us-id/statutes/63-3024.test.yaml
+++ b/us-id/statutes/63-3024.test.yaml
@@ -1,0 +1,62 @@
+- name: non_joint_taxable_income_above_adjusted_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3024#input.required_to_file_return_under_this_chapter: true
+    us-id:statutes/63-3024#input.return_is_joint_or_treated_as_joint_for_section_63_3024: false
+    us-id:statutes/63-3024#input.idaho_income_tax_threshold_inflation_factor: 2
+    us-id:statutes/63-3024#input.idaho_taxable_income: 20000
+  output:
+    us-id:statutes/63-3024#adjusted_non_joint_taxable_income_threshold: 5000
+    us-id:statutes/63-3024#idaho_income_tax_threshold: 5000
+- name: non_joint_taxable_income_above_adjusted_threshold_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3024#input.required_to_file_return_under_this_chapter: true
+    us-id:statutes/63-3024#input.return_is_joint_or_treated_as_joint_for_section_63_3024: false
+    us-id:statutes/63-3024#input.idaho_income_tax_threshold_inflation_factor: 2
+    us-id:statutes/63-3024#input.idaho_taxable_income: 20000
+  output:
+    us-id:statutes/63-3024#idaho_individual_trust_estate_income_tax: 795
+- name: joint_or_treated_as_joint_uses_joint_threshold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3024#input.required_to_file_return_under_this_chapter: true
+    us-id:statutes/63-3024#input.return_is_joint_or_treated_as_joint_for_section_63_3024: true
+    us-id:statutes/63-3024#input.idaho_income_tax_threshold_inflation_factor: 2
+    us-id:statutes/63-3024#input.idaho_taxable_income: 20000
+  output:
+    us-id:statutes/63-3024#adjusted_joint_taxable_income_threshold: 10000
+    us-id:statutes/63-3024#idaho_income_tax_threshold: 10000
+- name: joint_or_treated_as_joint_uses_joint_threshold_person_outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3024#input.required_to_file_return_under_this_chapter: true
+    us-id:statutes/63-3024#input.return_is_joint_or_treated_as_joint_for_section_63_3024: true
+    us-id:statutes/63-3024#input.idaho_income_tax_threshold_inflation_factor: 2
+    us-id:statutes/63-3024#input.idaho_taxable_income: 20000
+  output:
+    us-id:statutes/63-3024#idaho_individual_trust_estate_income_tax: 530
+- name: no_tax_when_not_required_to_file
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3024#input.required_to_file_return_under_this_chapter: false
+    us-id:statutes/63-3024#input.return_is_joint_or_treated_as_joint_for_section_63_3024: false
+    us-id:statutes/63-3024#input.idaho_income_tax_threshold_inflation_factor: 2
+    us-id:statutes/63-3024#input.idaho_taxable_income: 20000
+  output:
+    us-id:statutes/63-3024#idaho_individual_trust_estate_income_tax: 0

--- a/us-id/statutes/63-3024.yaml
+++ b/us-id/statutes/63-3024.yaml
@@ -1,0 +1,178 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-id/statute/63-3024
+  summary: Tax is imposed on every individual, trust, or estate required to file a
+    return. The tax is 5.3% of taxable income over $2,500, or over $5,000 for joint
+    returns; surviving spouse and head of household returns are treated as joint returns.
+    The state tax commission annually prescribes an inflation factor for the thresholds.
+rules:
+- name: individual_trust_estate_tax_rate
+  kind: parameter
+  dtype: Rate
+  source: Idaho Code section 63-3024(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: five and three-tenths percent (5.3%)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.053'
+- name: statutory_non_joint_taxable_income_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Idaho Code section 63-3024(2)(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: taxable income over two thousand five hundred dollars ($2,500)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '2500'
+- name: statutory_joint_taxable_income_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Idaho Code section 63-3024(2)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: taxable income over five thousand dollars ($5,000)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '5000'
+- name: adjusted_non_joint_taxable_income_threshold
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3024(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: 'The Idaho tax thresholds shall be adjusted as follows: multiply
+            the last threshold amount by the percentage'
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#statutory_non_joint_taxable_income_threshold
+          output: statutory_non_joint_taxable_income_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: statutory_non_joint_taxable_income_threshold * idaho_income_tax_threshold_inflation_factor
+- name: adjusted_joint_taxable_income_threshold
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3024(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: 'The Idaho tax thresholds shall be adjusted as follows: multiply
+            the last threshold amount by the percentage'
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#statutory_joint_taxable_income_threshold
+          output: statutory_joint_taxable_income_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: statutory_joint_taxable_income_threshold * idaho_income_tax_threshold_inflation_factor
+- name: idaho_income_tax_threshold
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3024(2)-(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: For taxpayers filing a joint return ... a return of a surviving
+            spouse ... and a head of household ... shall be treated as a joint return.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#adjusted_non_joint_taxable_income_threshold
+          output: adjusted_non_joint_taxable_income_threshold
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#adjusted_joint_taxable_income_threshold
+          output: adjusted_joint_taxable_income_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if return_is_joint_or_treated_as_joint_for_section_63_3024: adjusted_joint_taxable_income_threshold
+      else: adjusted_non_joint_taxable_income_threshold'
+- name: idaho_individual_trust_estate_income_tax
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3024(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: imposed upon every individual, trust, or estate required by this
+            chapter to file a return
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024
+          excerpt: computed at the rate of five and three-tenths percent (5.3%) of
+            taxable income over
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#individual_trust_estate_tax_rate
+          output: individual_trust_estate_tax_rate
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3024#idaho_income_tax_threshold
+          output: idaho_income_tax_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if required_to_file_return_under_this_chapter: individual_trust_estate_tax_rate
+      * max(0, idaho_taxable_income - idaho_income_tax_threshold) else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-id/statute/63-3024`
- Module: `us-id/statutes/63-3024.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.