### PR TITLE
Encode us-id/statute/63-3025D (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9645,6 +9645,15 @@
         ]
       }
     ],
+    "us-id/statute/63-3025D": [
+      {
+        "module": "us-id/statutes/63-3025D.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/manual/dhs/csmm/15232/block-1": [
       {
         "module": "us-il/policies/dhs/csmm/15232/block-1.yaml",

--- a/us-id/.axiom/encoding-manifests/statutes/63-3025D.json
+++ b/us-id/.axiom/encoding-manifests/statutes/63-3025D.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/63-3025D.yaml",
+      "sha256": "59b645495d044c1f18648077a2a5c6cdc624a3a4634244366b4a1c61cf31b72a"
+    },
+    {
+      "path": "statutes/63-3025D.test.yaml",
+      "sha256": "95aae08483083d89d2fb932c90d5af9a56a5047090318392bb2fb16ac3330631"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-id/statute/63-3025D",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3025d/encode-out/_eval_workspaces/codex-gpt-5.5/us-id-statute-63-3025D/workspace/context-manifest.json",
+  "context_manifest_sha256": "62977bfa1b168d5af9841f04e47b436a1589ac2553056407b9926e9fb01ef695",
+  "generated_at": "2026-07-08T15:13:09.752011+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3025d/encode-out/codex-gpt-5.5/statutes/63-3025D.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3025d/encode-out",
+  "generated_output_sha256": "59b645495d044c1f18648077a2a5c6cdc624a3a4634244366b4a1c61cf31b72a",
+  "generation_prompt_sha256": "c7a2a513f202bb564ff310a0183cd6b99c5e818c37d0b4f453048c8158ef61e5",
+  "model": "gpt-5.5",
+  "run_id": "562ce930",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "113aefb72a32da836c18db25af484cf3de41c512890312378843ad48b8378e1c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3025d/encode-out/traces/codex-gpt-5.5/us-id-statute-63-3025D.json",
+  "trace_sha256": "8a230182398a3fee085ffe5b3b2144ae97ed638b19e436c9e019b3a18e766672"
+}

--- a/us-id/statutes/63-3025D.test.yaml
+++ b/us-id/statutes/63-3025D.test.yaml
@@ -1,0 +1,61 @@
+- name: household payment capped at three qualifying family members
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3025D#input.resident_individual_maintains_household: true
+    us-id:statutes/63-3025D#input.individual_makes_application_as_prescribed_by_state_tax_commission: true
+    us-id:statutes/63-3025D#input.qualifying_household_family_member_count: 4
+  output:
+    us-id:statutes/63-3025D#household_member_payment: 300
+- name: household payment unavailable without prescribed application
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3025D#input.resident_individual_maintains_household: true
+    us-id:statutes/63-3025D#input.individual_makes_application_as_prescribed_by_state_tax_commission: false
+    us-id:statutes/63-3025D#input.qualifying_household_family_member_count: 2
+  output:
+    us-id:statutes/63-3025D#household_member_payment: 0
+- name: immediate elderly family member qualifies
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3025D#input.family_member_is_immediate_member_residing_in_household: true
+    us-id:statutes/63-3025D#input.family_member_receives_support_from_household_maintainer: 0.75
+    us-id:statutes/63-3025D#input.family_member_age: 65
+    us-id:statutes/63-3025D#input.family_member_has_developmental_disability_as_defined_in_section_66_402_5: false
+  output:
+    us-id:statutes/63-3025D#household_family_member_qualifies_for_payment: holds
+- name: self filing person with developmental disability gets credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3025D#input.person_has_developmental_disability_as_defined_in_section_66_402_5: true
+    us-id:statutes/63-3025D#input.person_files_own_tax_return: true
+  output:
+    us-id:statutes/63-3025D#self_filing_developmental_disability_credit: 100
+- name: auto_zero_self_filing_developmental_disability_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:statutes/63-3025D#input.family_member_age: 0
+    us-id:statutes/63-3025D#input.family_member_has_developmental_disability_as_defined_in_section_66_402_5: false
+    us-id:statutes/63-3025D#input.family_member_is_immediate_member_residing_in_household: false
+    us-id:statutes/63-3025D#input.family_member_receives_support_from_household_maintainer: 0
+    us-id:statutes/63-3025D#input.individual_makes_application_as_prescribed_by_state_tax_commission: false
+    us-id:statutes/63-3025D#input.person_files_own_tax_return: false
+    us-id:statutes/63-3025D#input.person_has_developmental_disability_as_defined_in_section_66_402_5: false
+    us-id:statutes/63-3025D#input.qualifying_household_family_member_count: 0
+    us-id:statutes/63-3025D#input.resident_individual_maintains_household: false
+  output:
+    us-id:statutes/63-3025D#self_filing_developmental_disability_credit: 0

--- a/us-id/statutes/63-3025D.yaml
+++ b/us-id/statutes/63-3025D.yaml
@@ -1,0 +1,178 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-id/statute/63-3025D
+  summary: A resident individual maintaining a household with immediate family members
+    residing there who are age 65 or older or have developmental disabilities, and
+    receive more than one-half support from that individual, is entitled to $100 for
+    each such member, capped at three payments per calendar year. A person with a
+    developmental disability filing his own tax return is allowed a $100 credit.
+rules:
+- name: family_member_payment_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Idaho Code section 63-3025D(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+          excerpt: one hundred dollars ($100) for each such elderly member of the
+            family or family member with a developmental disability
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '100'
+- name: self_filing_developmental_disability_credit_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Idaho Code section 63-3025D(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+          excerpt: A credit of one hundred dollars ($100) shall be allowed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '100'
+- name: elderly_family_member_age_threshold
+  kind: parameter
+  dtype: Integer
+  source: Idaho Code section 63-3025D(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+          excerpt: sixty-five (65) years of age or older
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '65'
+- name: household_payment_support_fraction_threshold
+  kind: parameter
+  dtype: Rate
+  source: Idaho Code section 63-3025D(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+          excerpt: more than one-half (1/2) of his or her support
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1 / 2
+- name: maximum_household_member_payments_per_calendar_year
+  kind: parameter
+  dtype: Count
+  source: Idaho Code section 63-3025D(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+          excerpt: No more than three (3) such payments
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3'
+- name: household_family_member_qualifies_for_payment
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: Idaho Code section 63-3025D(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3025D#elderly_family_member_age_threshold
+          output: elderly_family_member_age_threshold
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3025D#household_payment_support_fraction_threshold
+          output: household_payment_support_fraction_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'family_member_is_immediate_member_residing_in_household
+
+      and family_member_receives_support_from_household_maintainer > household_payment_support_fraction_threshold
+
+      and (family_member_age >= elderly_family_member_age_threshold or family_member_has_developmental_disability_as_defined_in_section_66_402_5)'
+- name: household_member_payment
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3025D(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3025D#family_member_payment_amount
+          output: family_member_payment_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3025D#maximum_household_member_payments_per_calendar_year
+          output: maximum_household_member_payments_per_calendar_year
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if resident_individual_maintains_household and individual_makes_application_as_prescribed_by_state_tax_commission:
+      family_member_payment_amount * min(maximum_household_member_payments_per_calendar_year,
+      qualifying_household_family_member_count) else: 0'
+- name: self_filing_developmental_disability_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3025D(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3025D
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-id:statutes/63-3025D#self_filing_developmental_disability_credit_amount
+          output: self_filing_developmental_disability_credit_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if person_has_developmental_disability_as_defined_in_section_66_402_5
+      and person_files_own_tax_return: self_filing_developmental_disability_credit_amount
+      else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-id/statute/63-3025D`
- Module: `us-id/statutes/63-3025D.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3025d/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.