### PR TITLE
Encode us-id/statute/63-3024A (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9645,6 +9645,15 @@
         ]
       }
     ],
+    "us-id/statute/63-3024A": [
+      {
+        "module": "us-id/statutes/63-3024A.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/manual/dhs/csmm/15232/block-1": [
       {
         "module": "us-il/policies/dhs/csmm/15232/block-1.yaml",

--- a/us-id/.axiom/encoding-manifests/statutes/63-3024A.json
+++ b/us-id/.axiom/encoding-manifests/statutes/63-3024A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/63-3024A.yaml",
+      "sha256": "ceb2204c1c528ab8777ece0e4b58758ad26211e746803b7cb4eba89e829ee992"
+    },
+    {
+      "path": "statutes/63-3024A.test.yaml",
+      "sha256": "37013b4e448dd1b8697b32b666cc9422356e4c00416a7d1d6d52e66ff6637cf0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-id/statute/63-3024A",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024a/encode-out/_eval_workspaces/codex-gpt-5.5/us-id-statute-63-3024A/workspace/context-manifest.json",
+  "context_manifest_sha256": "29e251ea9d0327ed15b028e3d0e323e464bfb86a6b3adebb5042bff0f9dfbc72",
+  "generated_at": "2026-07-08T15:13:31.321436+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024a/encode-out/codex-gpt-5.5/statutes/63-3024A.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024a/encode-out",
+  "generated_output_sha256": "ceb2204c1c528ab8777ece0e4b58758ad26211e746803b7cb4eba89e829ee992",
+  "generation_prompt_sha256": "736993fa4f303f464b524194d4f1bce93cd7d4bc9bcf140a8f8a1da444933825",
+  "model": "gpt-5.5",
+  "run_id": "4f5ea8b8",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4e85c06eaa8668c4be01573f868a544f66ef64e474ec4ac92c47534f79d1d38f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024a/encode-out/traces/codex-gpt-5.5/us-id-statute-63-3024A.json",
+  "trace_sha256": "b7a5ca39a1a618a3534da71ebaa7e09e09aecbfa65152fcb01b5b52d348f9841"
+}

--- a/us-id/statutes/63-3024A.test.yaml
+++ b/us-id/statutes/63-3024A.test.yaml
@@ -1,0 +1,137 @@
+- name: flat credit for resident filer with two counted persons in 2025
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: true
+    us-id:statutes/63-3024A#input.taxpayer_required_to_file_idaho_income_tax_return: true
+    us-id:statutes/63-3024A#input.taxpayer_has_filed_idaho_income_tax_return: true
+    us-id:statutes/63-3024A#relation.flat_credit_persons:
+    - us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+      us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 1
+      us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 1
+      us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 1
+      us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: true
+    - us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+      us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 1
+      us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 1
+      us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 1
+      us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: true
+  output:
+    us-id:statutes/63-3024A#taxpayer_may_claim_flat_credit: holds
+    us-id:statutes/63-3024A#refundable_flat_credit: 310
+- name: flat credit blocked when return required but not filed
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: true
+    us-id:statutes/63-3024A#input.taxpayer_required_to_file_idaho_income_tax_return: true
+    us-id:statutes/63-3024A#input.taxpayer_has_filed_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#relation.flat_credit_persons:
+    - us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+      us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 1
+      us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 1
+      us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 1
+      us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: true
+  output:
+    us-id:statutes/63-3024A#taxpayer_may_claim_flat_credit: not_holds
+    us-id:statutes/63-3024A#refundable_flat_credit: 0
+- name: person flat credit prorated and illegal residence excluded
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+    us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 0.5
+    us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 0.5
+    us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 1
+  output:
+    us-id:statutes/63-3024A#flat_credit_for_person: 38.75
+- name: actual sales tax election capped per person
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: true
+    us-id:statutes/63-3024A#input.taxpayer_elects_actual_sales_tax_paid_on_food_purchases: true
+    us-id:statutes/63-3024A#input.taxpayer_indicates_election_on_return_or_application: true
+    us-id:statutes/63-3024A#input.taxpayer_submits_scanned_sales_tax_receipts: true
+    us-id:statutes/63-3024A#input.taxpayer_meets_subsection_5_food_stamp_proration_qualification: false
+    us-id:statutes/63-3024A#relation.actual_food_sales_tax_credit_persons:
+    - us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+      us-id:statutes/63-3024A#input.idaho_sales_tax_paid_on_qualifying_food_purchases: 300
+      us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: true
+    - us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+      us-id:statutes/63-3024A#input.idaho_sales_tax_paid_on_qualifying_food_purchases: 80
+      us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: true
+  output:
+    us-id:statutes/63-3024A#taxpayer_may_elect_actual_food_sales_tax_credit: holds
+    us-id:statutes/63-3024A#refundable_actual_food_sales_tax_credit: 330
+- name: auto_output_actual_food_sales_tax_credit_for_person
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 0
+    us-id:statutes/63-3024A#input.idaho_sales_tax_paid_on_qualifying_food_purchases: 0
+    us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+    us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 0
+    us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 0
+    us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: 0
+    us-id:statutes/63-3024A#input.taxpayer_elects_actual_sales_tax_paid_on_food_purchases: false
+    us-id:statutes/63-3024A#input.taxpayer_has_filed_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_indicates_election_on_return_or_application: false
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: false
+    us-id:statutes/63-3024A#input.taxpayer_meets_subsection_5_food_stamp_proration_qualification: false
+    us-id:statutes/63-3024A#input.taxpayer_required_to_file_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_submits_scanned_sales_tax_receipts: false
+  output:
+    us-id:statutes/63-3024A#actual_food_sales_tax_credit_for_person: 0
+- name: auto_zero_flat_credit_for_person
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 0
+    us-id:statutes/63-3024A#input.idaho_sales_tax_paid_on_qualifying_food_purchases: 0
+    us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+    us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 0
+    us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 0
+    us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: 0
+    us-id:statutes/63-3024A#input.taxpayer_elects_actual_sales_tax_paid_on_food_purchases: false
+    us-id:statutes/63-3024A#input.taxpayer_has_filed_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_indicates_election_on_return_or_application: false
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: false
+    us-id:statutes/63-3024A#input.taxpayer_meets_subsection_5_food_stamp_proration_qualification: false
+    us-id:statutes/63-3024A#input.taxpayer_required_to_file_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_submits_scanned_sales_tax_receipts: false
+  output:
+    us-id:statutes/63-3024A#flat_credit_for_person: 0
+- name: auto_zero_refundable_actual_food_sales_tax_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:statutes/63-3024A#input.idaho_domicile_year_fraction: 0
+    us-id:statutes/63-3024A#input.idaho_sales_tax_paid_on_qualifying_food_purchases: 0
+    us-id:statutes/63-3024A#input.individual_residing_illegally_in_united_states: false
+    us-id:statutes/63-3024A#input.no_food_stamp_assistance_year_fraction: 0
+    us-id:statutes/63-3024A#input.not_incarcerated_year_fraction: 0
+    us-id:statutes/63-3024A#input.person_credit_not_claimed_by_another_taxpayer_or_subsection: 0
+    us-id:statutes/63-3024A#input.taxpayer_elects_actual_sales_tax_paid_on_food_purchases: false
+    us-id:statutes/63-3024A#input.taxpayer_has_filed_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_indicates_election_on_return_or_application: false
+    us-id:statutes/63-3024A#input.taxpayer_is_resident_individual: false
+    us-id:statutes/63-3024A#input.taxpayer_meets_subsection_5_food_stamp_proration_qualification: false
+    us-id:statutes/63-3024A#input.taxpayer_required_to_file_idaho_income_tax_return: false
+    us-id:statutes/63-3024A#input.taxpayer_submits_scanned_sales_tax_receipts: false
+  output:
+    us-id:statutes/63-3024A#refundable_actual_food_sales_tax_credit: 0

--- a/us-id/statutes/63-3024A.yaml
+++ b/us-id/statutes/63-3024A.yaml
@@ -1,0 +1,217 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-id/statute/63-3024A
+  summary: Resident individuals filing Idaho income tax returns are allowed refundable
+    grocery tax credits for the taxpayer, spouse, and dependents. The flat credit
+    is $100 for tax year 2022, $120 for tax years 2023 and 2024, and $155 for tax
+    year 2025 and thereafter. A resident taxpayer may instead elect actual Idaho sales
+    tax paid on qualifying food purchases, capped at $250 per person, with receipt
+    submission required; no subsection (9) election is available if subsection (5)
+    food stamp proration applies.
+  deferred_outputs:
+  - output: us-id:statutes/63-3024A/a#qualifying_food_for_actual_sales_tax_credit
+    reason: The definition of food incorporates 7 U.S.C. 2012 as it existed on January
+      1, 2025 and enumerates product exclusions; a faithful item-level food classification
+      ontology is outside this artifact.
+  - output: us-id:statutes/63-3024A/b#candy_and_soda_definitions_for_actual_sales_tax_credit
+    reason: The candy and soda definitions are item/product classifications used by
+      subsection (9)(a); a faithful food-item ontology is outside this artifact.
+rules:
+- name: flat_credit_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 63-3024A(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: For tax year 2022, the credit is one hundred dollars ($100).
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: For tax years 2023 and 2024, the credit is one hundred twenty dollars
+            ($120).
+      - path: versions[2].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: For tax year 2025 and each year thereafter, the credit is one hundred
+            fifty-five dollars ($155).
+  versions:
+  - effective_from: '2022-01-01'
+    formula: '100'
+  - effective_from: '2023-01-01'
+    formula: '120'
+  - effective_from: '2025-01-01'
+    formula: '155'
+- name: actual_food_sales_tax_credit_cap_per_person
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 63-3024A(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: up to a maximum of two hundred fifty dollars ($250) per person
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '250'
+- name: taxpayer_may_claim_flat_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 63-3024A(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'taxpayer_is_resident_individual
+
+      and taxpayer_required_to_file_idaho_income_tax_return
+
+      and taxpayer_has_filed_idaho_income_tax_return'
+- name: taxpayer_may_elect_actual_food_sales_tax_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 63-3024A(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'taxpayer_is_resident_individual
+
+      and taxpayer_elects_actual_sales_tax_paid_on_food_purchases
+
+      and taxpayer_indicates_election_on_return_or_application
+
+      and taxpayer_submits_scanned_sales_tax_receipts
+
+      and not taxpayer_meets_subsection_5_food_stamp_proration_qualification'
+- name: flat_credit_for_person
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 63-3024A(1), 63-3024A(3), 63-3024A(5), 63-3024A(6), 63-3024A(7), 63-3024A(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: the credit is one hundred fifty-five dollars ($155)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if individual_residing_illegally_in_united_states: 0 else: flat_credit_amount
+      * idaho_domicile_year_fraction * no_food_stamp_assistance_year_fraction * not_incarcerated_year_fraction'
+- name: actual_food_sales_tax_credit_for_person
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 63-3024A(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+          excerpt: up to a maximum of two hundred fifty dollars ($250) per person
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if individual_residing_illegally_in_united_states: 0 else: min(max(0,
+      idaho_sales_tax_paid_on_qualifying_food_purchases), actual_food_sales_tax_credit_cap_per_person)'
+- name: flat_credit_persons
+  kind: data_relation
+  data_relation:
+    predicate: flat_credit_persons
+    arity: 2
+    arguments:
+    - name: flat_credit_person
+      entity: Person
+    - name: tax_unit
+      entity: TaxUnit
+- name: refundable_flat_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 63-3024A(1), 63-3024A(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if taxpayer_may_claim_flat_credit: sum_where(flat_credit_persons, flat_credit_for_person,
+      person_credit_not_claimed_by_another_taxpayer_or_subsection) else: 0'
+- name: actual_food_sales_tax_credit_persons
+  kind: data_relation
+  data_relation:
+    predicate: actual_food_sales_tax_credit_persons
+    arity: 2
+    arguments:
+    - name: actual_food_sales_tax_credit_person
+      entity: Person
+    - name: tax_unit
+      entity: TaxUnit
+- name: refundable_actual_food_sales_tax_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 63-3024A(9)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3024A
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if taxpayer_may_elect_actual_food_sales_tax_credit: sum_where(actual_food_sales_tax_credit_persons,
+      actual_food_sales_tax_credit_for_person, person_credit_not_claimed_by_another_taxpayer_or_subsection)
+      else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-id/statute/63-3024A`
- Module: `us-id/statutes/63-3024A.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3024a/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.