### PR TITLE
Encode us-id/statute/63-3022D (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9645,6 +9645,15 @@
         ]
       }
     ],
+    "us-id/statute/63-3022D": [
+      {
+        "module": "us-id/statutes/63-3022D.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/manual/dhs/csmm/15232/block-1": [
       {
         "module": "us-il/policies/dhs/csmm/15232/block-1.yaml",

--- a/us-id/.axiom/encoding-manifests/statutes/63-3022D.json
+++ b/us-id/.axiom/encoding-manifests/statutes/63-3022D.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/63-3022D.yaml",
+      "sha256": "a5a42e078d82ed98e1f8dc412c14861171af6c11f42dfd66302c4932ae395646"
+    },
+    {
+      "path": "statutes/63-3022D.test.yaml",
+      "sha256": "326970b8c8ba2cc49370ee9062878d83ab845887ff788fcf0bdf48c2c4f5875f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-id/statute/63-3022D",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022d/encode-out/_eval_workspaces/codex-gpt-5.5/us-id-statute-63-3022D/workspace/context-manifest.json",
+  "context_manifest_sha256": "56007d524153a7217433453e597cdc01a12635c592ac564a18d505fdb7a32f03",
+  "generated_at": "2026-07-08T15:14:16.571149+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022d/encode-out/codex-gpt-5.5/statutes/63-3022D.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022d/encode-out",
+  "generated_output_sha256": "a5a42e078d82ed98e1f8dc412c14861171af6c11f42dfd66302c4932ae395646",
+  "generation_prompt_sha256": "8595bee4426206b61dce2d5117178d213a763aab631e3ff245abf3bc62502c1e",
+  "model": "gpt-5.5",
+  "run_id": "e6c39f1d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ec4b24da87fad2eb137ffb537759cdd025318dc92a851e5c34582e028d89aeab"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022d/encode-out/traces/codex-gpt-5.5/us-id-statute-63-3022D.json",
+  "trace_sha256": "54c8f6d81e18539fa15d0320f685b0cf1b86ad0e2d01510c82494538cec6c14a"
+}

--- a/us-id/statutes/63-3022D.test.yaml
+++ b/us-id/statutes/63-3022D.test.yaml
@@ -1,0 +1,44 @@
+- name: qualifying_individual_with_expenses_below_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022D#input.individual_maintains_household: true
+    us-id:statutes/63-3022D#input.household_includes_one_or_more_qualifying_individuals_under_section_21_b_1: true
+    us-id:statutes/63-3022D#input.employment_related_expenses_paid_during_taxable_year_as_defined_and_limited_under_section_21: 8000
+  output:
+    us-id:statutes/63-3022D#household_employment_related_expense_deduction: 8000
+- name: qualifying_individual_with_expenses_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022D#input.individual_maintains_household: true
+    us-id:statutes/63-3022D#input.household_includes_one_or_more_qualifying_individuals_under_section_21_b_1: true
+    us-id:statutes/63-3022D#input.employment_related_expenses_paid_during_taxable_year_as_defined_and_limited_under_section_21: 15000
+  output:
+    us-id:statutes/63-3022D#household_employment_related_expense_deduction: 12000
+- name: no_maintained_household
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022D#input.individual_maintains_household: false
+    us-id:statutes/63-3022D#input.household_includes_one_or_more_qualifying_individuals_under_section_21_b_1: true
+    us-id:statutes/63-3022D#input.employment_related_expenses_paid_during_taxable_year_as_defined_and_limited_under_section_21: 8000
+  output:
+    us-id:statutes/63-3022D#household_employment_related_expense_deduction: 0
+- name: no_qualifying_individual_in_household
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022D#input.individual_maintains_household: true
+    us-id:statutes/63-3022D#input.household_includes_one_or_more_qualifying_individuals_under_section_21_b_1: false
+    us-id:statutes/63-3022D#input.employment_related_expenses_paid_during_taxable_year_as_defined_and_limited_under_section_21: 8000
+  output:
+    us-id:statutes/63-3022D#household_employment_related_expense_deduction: 0

--- a/us-id/statutes/63-3022D.yaml
+++ b/us-id/statutes/63-3022D.yaml
@@ -1,0 +1,51 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-id/statute/63-3022D
+  summary: |-
+    Deduction allowed for an individual maintaining a household with one or more qualifying individuals, for employment-related expenses paid during the taxable year, not to exceed $12,000.
+rules:
+  - name: employment_related_expense_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Idaho Code section 63-3022D
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+              excerpt: "not to exceed twelve thousand dollars ($12,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12000
+
+  - name: household_employment_related_expense_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Idaho Code section 63-3022D
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+              excerpt: "not to exceed twelve thousand dollars ($12,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_maintains_household and household_includes_one_or_more_qualifying_individuals_under_section_21_b_1: min(max(0, employment_related_expenses_paid_during_taxable_year_as_defined_and_limited_under_section_21), employment_related_expense_deduction_cap) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-id/statute/63-3022D`
- Module: `us-id/statutes/63-3022D.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022d/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.