### PR TITLE
Encode us-id/statute/63-3022E (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9645,6 +9645,15 @@
         ]
       }
     ],
+    "us-id/statute/63-3022E": [
+      {
+        "module": "us-id/statutes/63-3022E.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-il/manual/dhs/csmm/15232/block-1": [
       {
         "module": "us-il/policies/dhs/csmm/15232/block-1.yaml",

--- a/us-id/.axiom/encoding-manifests/statutes/63-3022E.json
+++ b/us-id/.axiom/encoding-manifests/statutes/63-3022E.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/63-3022E.yaml",
+      "sha256": "c897ab4f367ba3a131dd94967ccc5452aa6d2abbd0aad6829e5c3ae241681ad8"
+    },
+    {
+      "path": "statutes/63-3022E.test.yaml",
+      "sha256": "b66d055b556969a6c1df664d2bd1ea59292c25c2fcc6fd4c8663ebda057c1568"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-id/statute/63-3022E",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022e/encode-out/_eval_workspaces/codex-gpt-5.5/us-id-statute-63-3022E/workspace/context-manifest.json",
+  "context_manifest_sha256": "9a231cb10821d7d7f8e3ffda97d8145bd8ecbc6f2c5f75229033928534af3758",
+  "generated_at": "2026-07-08T15:15:04.866713+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022e/encode-out/codex-gpt-5.5/statutes/63-3022E.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022e/encode-out",
+  "generated_output_sha256": "c897ab4f367ba3a131dd94967ccc5452aa6d2abbd0aad6829e5c3ae241681ad8",
+  "generation_prompt_sha256": "6098b717cd9741d9b21f2e62b9f08ea49390784e4b2455ef3bc58c5b201dd44d",
+  "model": "gpt-5.5",
+  "run_id": "2fb56bbb",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "338577c1bdf3919846b6ed2ab8475e151dbf71b7cf7b867c70ffdb4daf44aca9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022e/encode-out/traces/codex-gpt-5.5/us-id-statute-63-3022E.json",
+  "trace_sha256": "6d1ae3ef554422f10eb5bf3153035549a4e506183fc29d8bb9508ebd4f08ec73"
+}

--- a/us-id/statutes/63-3022E.test.yaml
+++ b/us-id/statutes/63-3022E.test.yaml
@@ -1,0 +1,46 @@
+- name: person household member qualifies
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022E#input.individual_maintains_household: true
+    us-id:statutes/63-3022E#input.person_is_immediate_family_member_residing_in_that_household: true
+    us-id:statutes/63-3022E#input.person_age: 65
+    us-id:statutes/63-3022E#input.person_has_developmental_disability: false
+    us-id:statutes/63-3022E#input.support_fraction_received_from_household_maintainer: 0.75
+    us-id:statutes/63-3022E#input.person_is_return_filer: false
+    us-id:statutes/63-3022E#input.person_is_filing_own_return: false
+  output:
+    us-id:statutes/63-3022E#household_member_qualifies_for_additional_deduction: holds
+    us-id:statutes/63-3022E#disabled_filer_qualifies_for_own_return_deduction: not_holds
+- name: return filer blocked unless disabled own return
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022E#input.individual_maintains_household: true
+    us-id:statutes/63-3022E#input.person_is_immediate_family_member_residing_in_that_household: true
+    us-id:statutes/63-3022E#input.person_age: 70
+    us-id:statutes/63-3022E#input.person_has_developmental_disability: true
+    us-id:statutes/63-3022E#input.support_fraction_received_from_household_maintainer: 0.75
+    us-id:statutes/63-3022E#input.person_is_return_filer: true
+    us-id:statutes/63-3022E#input.person_is_filing_own_return: true
+  output:
+    us-id:statutes/63-3022E#household_member_qualifies_for_additional_deduction: not_holds
+    us-id:statutes/63-3022E#disabled_filer_qualifies_for_own_return_deduction: holds
+- name: deduction capped at three qualifying persons
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-id:statutes/63-3022E#relation.additional_deduction_person:
+    - us-id:statutes/63-3022E#input.person_qualifies_for_deduction: true
+    - us-id:statutes/63-3022E#input.person_qualifies_for_deduction: true
+    - us-id:statutes/63-3022E#input.person_qualifies_for_deduction: true
+    - us-id:statutes/63-3022E#input.person_qualifies_for_deduction: true
+  output:
+    us-id:statutes/63-3022E#qualifying_individual_deduction_count: 3
+    us-id:statutes/63-3022E#additional_deduction_from_taxable_income: 3000

--- a/us-id/statutes/63-3022E.yaml
+++ b/us-id/statutes/63-3022E.yaml
@@ -1,0 +1,155 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-id/statute/63-3022E
+  summary: 'Additional deduction from taxable income: $1,000 for each qualifying individual
+    age 65 or older or with developmental disabilities in a maintained household,
+    limited to three deductions per return; no deduction for return filers except
+    a person with a developmental disability filing his own return.'
+rules:
+- name: per_qualifying_individual_deduction_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Idaho Code section 63-3022E(1), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+          excerpt: one thousand dollars ($1,000) for each individual
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1000'
+- name: maximum_deductions_per_return
+  kind: parameter
+  dtype: Count
+  source: Idaho Code section 63-3022E(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+          excerpt: not be allowed more than three (3) deductions
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3'
+- name: qualifying_age_threshold
+  kind: parameter
+  dtype: Integer
+  source: Idaho Code section 63-3022E(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+          excerpt: sixty-five (65) years of age or older
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '65'
+- name: support_fraction_threshold
+  kind: parameter
+  dtype: Rate
+  source: Idaho Code section 63-3022E(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+          excerpt: more than one-half (1/2) of his or her support
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1 / 2
+- name: household_member_qualifies_for_additional_deduction
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: Idaho Code section 63-3022E(1), (3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'individual_maintains_household
+
+      and person_is_immediate_family_member_residing_in_that_household
+
+      and (person_age >= qualifying_age_threshold or person_has_developmental_disability)
+
+      and support_fraction_received_from_household_maintainer > support_fraction_threshold
+
+      and not person_is_return_filer'
+- name: disabled_filer_qualifies_for_own_return_deduction
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: Idaho Code section 63-3022E(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'person_is_return_filer
+
+      and person_has_developmental_disability
+
+      and person_is_filing_own_return'
+- name: additional_deduction_person
+  kind: data_relation
+  data_relation:
+    predicate: additional_deduction_person
+    arity: 2
+- name: qualifying_individual_deduction_count
+  kind: derived
+  entity: TaxUnit
+  dtype: Count
+  period: Year
+  source: Idaho Code section 63-3022E(1), (2), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+  versions:
+  - effective_from: '0001-01-01'
+    formula: min(count_where(additional_deduction_person, person_qualifies_for_deduction),
+      maximum_deductions_per_return)
+- name: additional_deduction_from_taxable_income
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Idaho Code section 63-3022E(1), (2), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-id/statute/63-3022E
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, qualifying_individual_deduction_count * per_qualifying_individual_deduction_amount)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-id/statute/63-3022E`
- Module: `us-id/statutes/63-3022E.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-id-statute-63-3022e/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.