### PR TITLE
Encode us-in/statute/6-3-2-6 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-2-6": [
+      {
+        "module": "us-in/statutes/6-3-2-6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-2-6.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-2-6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-2-6.yaml",
+      "sha256": "ff70788a15c6444c43c79a548f72f3997ee5b5997955953a9b065be4b3e1d7b1"
+    },
+    {
+      "path": "statutes/6-3-2-6.test.yaml",
+      "sha256": "c38c14516255c79fd3bd3e95df9dbd077ccc413d04d2cdd81d4aa63154b52fa0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-2-6",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-6/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-2-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "2fe9e69a5378bb9589fc21d87d1cb23f04d29b064d3c5e0316a60971b8256c33",
+  "generated_at": "2026-07-08T15:16:02.555083+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-6/encode-out/codex-gpt-5.5/statutes/6-3-2-6.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-6/encode-out",
+  "generated_output_sha256": "ff70788a15c6444c43c79a548f72f3997ee5b5997955953a9b065be4b3e1d7b1",
+  "generation_prompt_sha256": "fd3329b30b2865b295d2dc7e83b1041f39350dfc26cf101134cfad59ed6d5b54",
+  "model": "gpt-5.5",
+  "run_id": "897a4851",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a946d3baa1e46af4a7a623c2851b24fcbca09fdbf7162f9f7955467029da59f8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-6/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-2-6.json",
+  "trace_sha256": "69e4c514deb89642d1d6840d5c861371acb4e7de3b648fd682eb7ee4e8f02945"
+}

--- a/us-in/statutes/6-3-2-6.test.yaml
+++ b/us-in/statutes/6-3-2-6.test.yaml
@@ -1,0 +1,54 @@
+- name: caps qualifying rent at general limit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-6#input.individual_rents_dwelling_for_principal_place_of_residence: true
+    us-in:statutes/6-3-2-6#input.dwelling_is_exempt_from_indiana_property_tax: false
+    us-in:statutes/6-3-2-6#input.married_individual_filing_separate_return_for_taxable_year: false
+    us-in:statutes/6-3-2-6#input.rent_paid_with_respect_to_dwelling_during_taxable_year: 5000
+  output:
+    us-in:statutes/6-3-2-6#dwelling_for_renter_deduction: holds
+    us-in:statutes/6-3-2-6#renter_deduction_cap: 3000
+    us-in:statutes/6-3-2-6#renter_deduction: 3000
+- name: married separate cap applies
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-6#input.individual_rents_dwelling_for_principal_place_of_residence: true
+    us-in:statutes/6-3-2-6#input.dwelling_is_exempt_from_indiana_property_tax: false
+    us-in:statutes/6-3-2-6#input.married_individual_filing_separate_return_for_taxable_year: true
+    us-in:statutes/6-3-2-6#input.rent_paid_with_respect_to_dwelling_during_taxable_year: 2000
+  output:
+    us-in:statutes/6-3-2-6#dwelling_for_renter_deduction: holds
+    us-in:statutes/6-3-2-6#renter_deduction_cap: 1500
+    us-in:statutes/6-3-2-6#renter_deduction: 1500
+- name: exempt property tax dwelling blocks deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-6#input.individual_rents_dwelling_for_principal_place_of_residence: true
+    us-in:statutes/6-3-2-6#input.dwelling_is_exempt_from_indiana_property_tax: true
+    us-in:statutes/6-3-2-6#input.married_individual_filing_separate_return_for_taxable_year: false
+    us-in:statutes/6-3-2-6#input.rent_paid_with_respect_to_dwelling_during_taxable_year: 2400
+  output:
+    us-in:statutes/6-3-2-6#dwelling_for_renter_deduction: not_holds
+    us-in:statutes/6-3-2-6#renter_deduction: 0
+- name: principal residence rental required
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-6#input.individual_rents_dwelling_for_principal_place_of_residence: false
+    us-in:statutes/6-3-2-6#input.dwelling_is_exempt_from_indiana_property_tax: false
+    us-in:statutes/6-3-2-6#input.married_individual_filing_separate_return_for_taxable_year: false
+    us-in:statutes/6-3-2-6#input.rent_paid_with_respect_to_dwelling_during_taxable_year: 2400
+  output:
+    us-in:statutes/6-3-2-6#dwelling_for_renter_deduction: not_holds
+    us-in:statutes/6-3-2-6#renter_deduction: 0

--- a/us-in/statutes/6-3-2-6.yaml
+++ b/us-in/statutes/6-3-2-6.yaml
@@ -1,0 +1,139 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-2-6
+  summary: |-
+    Each taxable year, an individual who rents a dwelling for use as the individual's principal place of residence may deduct the lesser of rent paid or $3,000. A married couple filing jointly may not claim more than $3,000, a married individual filing separately may not claim more than $1,500, and the deduction does not apply to a dwelling exempt from Indiana property tax.
+rules:
+  - name: renter_deduction_general_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IC 6-3-2-6(a), (b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+              excerpt: "three thousand dollars ($3,000)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+
+  - name: renter_deduction_married_separate_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IC 6-3-2-6(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+              excerpt: "one thousand five hundred dollars ($1,500)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1500
+
+  - name: dwelling_for_renter_deduction
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: IC 6-3-2-6(a), (c), (d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_rents_dwelling_for_principal_place_of_residence
+          and not dwelling_is_exempt_from_indiana_property_tax
+
+  - name: renter_deduction_cap
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IC 6-3-2-6(a), (b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+              excerpt: "may not claim a deduction under this section of more than three thousand dollars ($3,000)"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+              excerpt: "more than one thousand five hundred dollars ($1,500)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-6#renter_deduction_general_cap
+              output: renter_deduction_general_cap
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-6#renter_deduction_married_separate_cap
+              output: renter_deduction_married_separate_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if married_individual_filing_separate_return_for_taxable_year: renter_deduction_married_separate_cap else: renter_deduction_general_cap
+
+  - name: renter_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IC 6-3-2-6(a), (b), (c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-6
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-6#dwelling_for_renter_deduction
+              output: dwelling_for_renter_deduction
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-6#renter_deduction_cap
+              output: renter_deduction_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if dwelling_for_renter_deduction: min(max(0, rent_paid_with_respect_to_dwelling_during_taxable_year), renter_deduction_cap) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-2-6`
- Module: `us-in/statutes/6-3-2-6.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-6/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.