### PR TITLE
Encode us-in/statute/6-3-2-4 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-2-4": [
+      {
+        "module": "us-in/statutes/6-3-2-4.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-2-4.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-2-4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-2-4.yaml",
+      "sha256": "36a799ce5739a7d74c3b1e9a198364dd83bc129f80fb10be8f1ca17094d16659"
+    },
+    {
+      "path": "statutes/6-3-2-4.test.yaml",
+      "sha256": "ab039bfbb78139eeace8195d79d84d3f87aeccac8101dce5d8f5ee07ff0ed2dd"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-2-4",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-4/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-2-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "b51b0225e73925665cf615a29f5453d764ec62bbdc88e52519409e7ef9dcb58b",
+  "generated_at": "2026-07-08T15:16:14.530962+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-4/encode-out/codex-gpt-5.5/statutes/6-3-2-4.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-4/encode-out",
+  "generated_output_sha256": "36a799ce5739a7d74c3b1e9a198364dd83bc129f80fb10be8f1ca17094d16659",
+  "generation_prompt_sha256": "31949288681be6cc7f8b8958103aa816ca944621bfdebf4467257d59f3ffcfcf",
+  "model": "gpt-5.5",
+  "run_id": "93a558d0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "577a6da0c1d2e521b4859a1fe3cbf66bdf46f40040d35c97de8ebbd892063d73"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-4/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-2-4.json",
+  "trace_sha256": "93eb3dc4973f82be1198c281aa782615bb32cb03dd039f8b3fca2102c54300ff"
+}

--- a/us-in/statutes/6-3-2-4.test.yaml
+++ b/us-in/statutes/6-3-2-4.test.yaml
@@ -1,0 +1,42 @@
+- name: covered income after full retirement phase-in
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-in:statutes/6-3-2-4#input.active_or_reserve_component_service_income_for_covered_service_excluding_retirement_or_survivor_benefits
+    : 7000
+    us-in:statutes/6-3-2-4#input.same_active_or_reserve_component_service_income_subtracted_under_ic_6_3_1_3_5_a_18: 0
+    us-in:statutes/6-3-2-4#input.retirement_or_survivor_benefits_in_adjusted_gross_income_for_covered_service: 10000
+    us-in:statutes/6-3-2-4#input.same_retirement_or_survivor_benefits_subtracted_under_ic_6_3_1_3_5_a_18: 0
+  output:
+    us-in:statutes/6-3-2-4#active_or_reserve_component_service_income_deduction: 5000
+    us-in:statutes/6-3-2-4#retirement_or_survivor_benefits_deduction: 10000
+- name: same qualified military income already subtracted is not deducted again
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    ? us-in:statutes/6-3-2-4#input.active_or_reserve_component_service_income_for_covered_service_excluding_retirement_or_survivor_benefits
+    : 7000
+    us-in:statutes/6-3-2-4#input.same_active_or_reserve_component_service_income_subtracted_under_ic_6_3_1_3_5_a_18: 7000
+    us-in:statutes/6-3-2-4#input.retirement_or_survivor_benefits_in_adjusted_gross_income_for_covered_service: 10000
+    us-in:statutes/6-3-2-4#input.same_retirement_or_survivor_benefits_subtracted_under_ic_6_3_1_3_5_a_18: 10000
+  output:
+    us-in:statutes/6-3-2-4#active_or_reserve_component_service_income_deduction: 0
+    us-in:statutes/6-3-2-4#retirement_or_survivor_benefits_deduction: 0
+- name: retirement benefit fifty percent excess phase-in
+  period:
+    period_kind: tax_year
+    start: '2020-01-01'
+    end: '2020-12-31'
+  input:
+    ? us-in:statutes/6-3-2-4#input.active_or_reserve_component_service_income_for_covered_service_excluding_retirement_or_survivor_benefits
+    : 4000
+    us-in:statutes/6-3-2-4#input.same_active_or_reserve_component_service_income_subtracted_under_ic_6_3_1_3_5_a_18: 0
+    us-in:statutes/6-3-2-4#input.retirement_or_survivor_benefits_in_adjusted_gross_income_for_covered_service: 10000
+    us-in:statutes/6-3-2-4#input.same_retirement_or_survivor_benefits_subtracted_under_ic_6_3_1_3_5_a_18: 0
+  output:
+    us-in:statutes/6-3-2-4#active_or_reserve_component_service_income_deduction: 4000
+    us-in:statutes/6-3-2-4#retirement_or_survivor_benefits_deduction: 8125

--- a/us-in/statutes/6-3-2-4.yaml
+++ b/us-in/statutes/6-3-2-4.yaml
@@ -1,0 +1,150 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-2-4
+  summary: |-
+    Effective until 7-1-2025. Each taxable year, an individual or the individual's surviving spouse is entitled to deductions for covered active or reserve service income and covered retirement or survivor's benefits; no deduction is allowed for the same qualified military income subtracted under IC 6-3-1-3.5(a)(18).
+rules:
+  - name: active_service_income_deduction_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IC 6-3-2-4(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "first five thousand dollars ($5,000)"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          5000
+
+  - name: retirement_or_survivor_benefits_base_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IC 6-3-2-4(a)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "six thousand two hundred fifty dollars ($6,250)"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          6250
+
+  - name: retirement_or_survivor_benefits_excess_phase_in_rate
+    kind: parameter
+    dtype: Rate
+    source: IC 6-3-2-4(a)(2)(B)(i)-(iv)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "For taxable years beginning in 2019, twenty-five percent (25%)"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "For taxable years beginning in 2020, fifty percent (50%)"
+          - path: versions[2].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "For taxable years beginning in 2021, seventy-five percent (75%)"
+          - path: versions[3].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "For taxable years beginning after 2021, one hundred percent (100%)"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          0.25
+      - effective_from: '2020-01-01'
+        formula: |-
+          0.50
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.75
+      - effective_from: '2022-01-01'
+        formula: |-
+          1
+
+  - name: active_or_reserve_component_service_income_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IC 6-3-2-4(a)(1), (b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "deduction for the first five thousand dollars ($5,000) of income, excluding adjusted gross income described in subdivision (2)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "not, for that taxable year, entitled to a deduction under this section for the same qualified military income"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          min(max(
+              0,
+              active_or_reserve_component_service_income_for_covered_service_excluding_retirement_or_survivor_benefits - same_active_or_reserve_component_service_income_subtracted_under_ic_6_3_1_3_5_a_18
+            ), max(0, active_service_income_deduction_cap))
+
+  - name: retirement_or_survivor_benefits_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IC 6-3-2-4(a)(2), (b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "The amount of the deduction is the lesser of"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-4
+              excerpt: "not, for that taxable year, entitled to a deduction under this section for the same qualified military income"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          min(
+            max(
+              0,
+              retirement_or_survivor_benefits_in_adjusted_gross_income_for_covered_service - same_retirement_or_survivor_benefits_subtracted_under_ic_6_3_1_3_5_a_18
+            ),
+            retirement_or_survivor_benefits_base_deduction_amount + retirement_or_survivor_benefits_excess_phase_in_rate * max(
+              0,
+              max(
+                0,
+                retirement_or_survivor_benefits_in_adjusted_gross_income_for_covered_service - same_retirement_or_survivor_benefits_subtracted_under_ic_6_3_1_3_5_a_18
+              ) - retirement_or_survivor_benefits_base_deduction_amount
+            )
+          )


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-2-4`
- Module: `us-in/statutes/6-3-2-4.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-4/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.