### PR TITLE
Encode us-in/statute/6-3-2-10 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-2-10": [
+      {
+        "module": "us-in/statutes/6-3-2-10.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-2-10.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-2-10.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-2-10.yaml",
+      "sha256": "4e726c896fbf999b80f2b3cc9976e1977fff9f28e1e5fce022f5b0932a848bf6"
+    },
+    {
+      "path": "statutes/6-3-2-10.test.yaml",
+      "sha256": "801a8f2ba9b26f0652f06e95d13062e6b363f19555b0c63ad654499f3cd57317"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-2-10",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-10/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-2-10/workspace/context-manifest.json",
+  "context_manifest_sha256": "d48d825c3e3c1d8f09f974a5230ca1ce1305f753b84af7a6e3909e35442bee4c",
+  "generated_at": "2026-07-08T15:17:00.060569+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-10/encode-out/codex-gpt-5.5/statutes/6-3-2-10.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-10/encode-out",
+  "generated_output_sha256": "4e726c896fbf999b80f2b3cc9976e1977fff9f28e1e5fce022f5b0932a848bf6",
+  "generation_prompt_sha256": "9e55de41b76b1417590eeb6a30e128b4a6774040c85e9f1e0556c44fba8e6982",
+  "model": "gpt-5.5",
+  "run_id": "2644738e",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0566da1e3992500ad7b718cbb194ae44b4ee3778b6161fed2cdd7f2c33a1b0ac"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-10/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-2-10.json",
+  "trace_sha256": "5cda95d70e90a26d54853202af2ef892d39db5e864cfaefbb807d432b47530ca"
+}

--- a/us-in/statutes/6-3-2-10.test.yaml
+++ b/us-in/statutes/6-3-2-10.test.yaml
@@ -1,0 +1,65 @@
+- name: individual unemployment deduction uses eligible compensation minus excess
+    agi
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_included_in_federal_gross_income: 10000
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_excluded_from_federal_gross_income_under_section_85_c: 2000
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_not_taxable_under_45_usc_352: 1000
+    us-in:statutes/6-3-2-10#input.individual_files_joint_return_with_spouse: false
+    us-in:statutes/6-3-2-10#input.individual_is_married_at_close_of_taxable_year: false
+    us-in:statutes/6-3-2-10#input.individual_lived_apart_from_spouse_at_all_times_during_taxable_year: false
+    us-in:statutes/6-3-2-10#input.adjusted_gross_income_or_combined_adjusted_gross_income_if_joint: 20000
+  output:
+    us-in:statutes/6-3-2-10#eligible_unemployment_compensation: 11000
+    us-in:statutes/6-3-2-10#excess_adjusted_gross_income_threshold: 12000
+    us-in:statutes/6-3-2-10#excess_adjusted_gross_income: 5000
+    us-in:statutes/6-3-2-10#unemployment_compensation_deduction: 6000
+- name: married separate nonapart threshold is zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_included_in_federal_gross_income: 3000
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_excluded_from_federal_gross_income_under_section_85_c: 0
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_not_taxable_under_45_usc_352: 0
+    us-in:statutes/6-3-2-10#input.individual_files_joint_return_with_spouse: false
+    us-in:statutes/6-3-2-10#input.individual_is_married_at_close_of_taxable_year: true
+    us-in:statutes/6-3-2-10#input.individual_lived_apart_from_spouse_at_all_times_during_taxable_year: false
+    us-in:statutes/6-3-2-10#input.adjusted_gross_income_or_combined_adjusted_gross_income_if_joint: 8000
+  output:
+    us-in:statutes/6-3-2-10#excess_adjusted_gross_income_threshold: 0
+    us-in:statutes/6-3-2-10#excess_adjusted_gross_income: 4000
+    us-in:statutes/6-3-2-10#unemployment_compensation_deduction: 0
+- name: joint return computes one combined deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-10#input.individual_and_spouse_are_described_in_subsection_a_3_A: true
+    us-in:statutes/6-3-2-10#input.combined_eligible_unemployment_compensation_of_individual_and_spouse: 20000
+    us-in:statutes/6-3-2-10#input.joint_return_excess_adjusted_gross_income: 3000
+  output:
+    us-in:statutes/6-3-2-10#joint_return_unemployment_compensation_deduction: 17000
+- name: auto_zero_joint_return_unemployment_compensation_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-10#input.adjusted_gross_income_or_combined_adjusted_gross_income_if_joint: 0
+    us-in:statutes/6-3-2-10#input.combined_eligible_unemployment_compensation_of_individual_and_spouse: 0
+    us-in:statutes/6-3-2-10#input.individual_and_spouse_are_described_in_subsection_a_3_A: false
+    us-in:statutes/6-3-2-10#input.individual_files_joint_return_with_spouse: false
+    us-in:statutes/6-3-2-10#input.individual_is_married_at_close_of_taxable_year: false
+    us-in:statutes/6-3-2-10#input.individual_lived_apart_from_spouse_at_all_times_during_taxable_year: false
+    us-in:statutes/6-3-2-10#input.joint_return_excess_adjusted_gross_income: 0
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_excluded_from_federal_gross_income_under_section_85_c: 0
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_included_in_federal_gross_income: 0
+    us-in:statutes/6-3-2-10#input.unemployment_compensation_not_taxable_under_45_usc_352: 0
+  output:
+    us-in:statutes/6-3-2-10#joint_return_unemployment_compensation_deduction: 0

--- a/us-in/statutes/6-3-2-10.yaml
+++ b/us-in/statutes/6-3-2-10.yaml
@@ -1,0 +1,229 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-2-10
+  summary: |-
+    "Eligible unemployment compensation" means unemployment compensation included in federal gross income plus unemployment compensation excluded under IRC 85(c), excluding amounts not taxable under 45 U.S.C. 352. An individual is entitled to a deduction equal to the greater of zero or eligible unemployment compensation minus excess adjusted gross income. For joint-return spouses, the deduction is computed on combined eligible unemployment compensation and no more than one deduction is permitted.
+rules:
+  - name: excess_adjusted_gross_income_fraction
+    kind: parameter
+    dtype: Rate
+    source: 6-3-2-10(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "one-half (1/2)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1 / 2
+
+  - name: joint_return_excess_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(a)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "Eighteen thousand dollars ($18,000)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          18000
+
+  - name: married_separate_nonapart_excess_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(a)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "Zero dollars ($0)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0
+
+  - name: other_individual_excess_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(a)(3)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "Twelve thousand dollars ($12,000)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          12000
+
+  - name: one_joint_deduction_limit
+    kind: parameter
+    dtype: Count
+    source: 6-3-2-10(d)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "more than one (1) deduction"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1
+
+  - name: eligible_unemployment_compensation
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+              excerpt: "does not include amounts not taxable under this article as a result of 45 U.S.C. 352"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, unemployment_compensation_included_in_federal_gross_income + unemployment_compensation_excluded_from_federal_gross_income_under_section_85_c - unemployment_compensation_not_taxable_under_45_usc_352)
+
+  - name: excess_adjusted_gross_income_threshold
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_files_joint_return_with_spouse: joint_return_excess_adjusted_gross_income_threshold else: if individual_is_married_at_close_of_taxable_year and not individual_lived_apart_from_spouse_at_all_times_during_taxable_year: married_separate_nonapart_excess_adjusted_gross_income_threshold else: other_individual_excess_adjusted_gross_income_threshold
+
+  - name: excess_adjusted_gross_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-10#excess_adjusted_gross_income_fraction
+              output: excess_adjusted_gross_income_fraction
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-10#excess_adjusted_gross_income_threshold
+              output: excess_adjusted_gross_income_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, excess_adjusted_gross_income_fraction * (adjusted_gross_income_or_combined_adjusted_gross_income_if_joint + unemployment_compensation_excluded_from_federal_gross_income_under_section_85_c - excess_adjusted_gross_income_threshold))
+
+  - name: unemployment_compensation_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-10#eligible_unemployment_compensation
+              output: eligible_unemployment_compensation
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-10#excess_adjusted_gross_income
+              output: excess_adjusted_gross_income
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, eligible_unemployment_compensation - excess_adjusted_gross_income)
+
+  - name: joint_return_unemployment_compensation_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 6-3-2-10(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-10
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-10#one_joint_deduction_limit
+              output: one_joint_deduction_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_and_spouse_are_described_in_subsection_a_3_A and one_joint_deduction_limit == 1: max(0, combined_eligible_unemployment_compensation_of_individual_and_spouse - joint_return_excess_adjusted_gross_income) else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-2-10`
- Module: `us-in/statutes/6-3-2-10.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-10/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.