### PR TITLE
Encode us-in/statute/6-3.1-21-6 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3.1-21-6": [
+      {
+        "module": "us-in/statutes/6-3/1-21-6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3/1-21-6.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3/1-21-6.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3/1-21-6.yaml",
+      "sha256": "823c783cbb3e5c126c9ddd95c9471d10034ccef2815ea67e42f128001e3872a5"
+    },
+    {
+      "path": "statutes/6-3/1-21-6.test.yaml",
+      "sha256": "da65fdf7d4e8002f1d76d761d1616a7a4dece534b427fe974f0be3821c914e81"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3.1-21-6",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-1-21-6/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3.1-21-6/workspace/context-manifest.json",
+  "context_manifest_sha256": "2964eab7cbc43be65c1f3fc30c390e9a133fecd4ba20a991e86afeeb6a363aa4",
+  "generated_at": "2026-07-08T15:19:39.088974+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-1-21-6/encode-out/codex-gpt-5.5/statutes/6-3/1-21-6.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-1-21-6/encode-out",
+  "generated_output_sha256": "823c783cbb3e5c126c9ddd95c9471d10034ccef2815ea67e42f128001e3872a5",
+  "generation_prompt_sha256": "345db6e6747b6d7899ed40b7f1ff4fae0eaf6371e91c3b5768a4dbefab60800f",
+  "model": "gpt-5.5",
+  "run_id": "cb384184",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c5fefef1bf4c1d03620b3434676213967c6fb109020cef3ba195ad1c9a03599d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-1-21-6/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3.1-21-6.json",
+  "trace_sha256": "d8affdaaafa24a616741baa0937f960783b50c308e112da9c0cf3717f6a65e01"
+}

--- a/us-in/statutes/6-3/1-21-6.test.yaml
+++ b/us-in/statutes/6-3/1-21-6.test.yaml
@@ -1,0 +1,48 @@
+- name: resident credit and refund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3/1-21-6#input.taxpayer_is_nonresident_or_part_year_resident: false
+    us-in:statutes/6-3/1-21-6#input.federal_earned_income_tax_credit_claimed_for_taxable_year: 1000
+    us-in:statutes/6-3/1-21-6#input.income_taxable_in_indiana: 0
+    us-in:statutes/6-3/1-21-6#input.total_income: 1
+    us-in:statutes/6-3/1-21-6#input.adjusted_gross_income_tax_liability: 40
+  output:
+    us-in:statutes/6-3/1-21-6#indiana_earned_income_credit_before_refund: 100
+    us-in:statutes/6-3/1-21-6#indiana_earned_income_credit_refund: 60
+- name: part year resident prorated credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3/1-21-6#input.taxpayer_is_nonresident_or_part_year_resident: true
+    us-in:statutes/6-3/1-21-6#input.federal_earned_income_tax_credit_claimed_for_taxable_year: 1000
+    us-in:statutes/6-3/1-21-6#input.income_taxable_in_indiana: 30000
+    us-in:statutes/6-3/1-21-6#input.total_income: 60000
+    us-in:statutes/6-3/1-21-6#input.adjusted_gross_income_tax_liability: 100
+  output:
+    us-in:statutes/6-3/1-21-6#indiana_earned_income_credit_before_refund: 50
+    us-in:statutes/6-3/1-21-6#indiana_earned_income_credit_refund: 0
+- name: federal election treated as state election
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3/1-21-6#input.taxpayer_properly_elects_bipartisan_budget_act_earned_income_treatment_for_federal_credit: true
+    us-in:statutes/6-3/1-21-6#input.taxable_year_begins_after_federal_bipartisan_budget_act_election_start: true
+  output:
+    us-in:statutes/6-3/1-21-6#bipartisan_budget_act_election_treated_as_made_for_indiana_credit: holds
+- name: federal election not treated when taxable year condition fails
+  period:
+    period_kind: tax_year
+    start: '2016-01-01'
+    end: '2016-12-31'
+  input:
+    us-in:statutes/6-3/1-21-6#input.taxpayer_properly_elects_bipartisan_budget_act_earned_income_treatment_for_federal_credit: true
+    us-in:statutes/6-3/1-21-6#input.taxable_year_begins_after_federal_bipartisan_budget_act_election_start: false
+  output:
+    us-in:statutes/6-3/1-21-6#bipartisan_budget_act_election_treated_as_made_for_indiana_credit: not_holds

--- a/us-in/statutes/6-3/1-21-6.yaml
+++ b/us-in/statutes/6-3/1-21-6.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3.1-21-6
+  summary: |-
+    Sec. 6. (a) Except as provided by subsections (b), (d), and (e), an individual eligible for and claiming the federal earned income tax credit is eligible for an Indiana credit equal to ten percent (10%) of that federal credit. Subsection (b) prorates the credit for nonresidents and part-year residents by Indiana taxable income over total income. Subsection (c) refunds excess credit. Subsection (d) treats a proper federal Bipartisan Budget Act of 2018 election as made for this chapter. Subsection (e) subjects minimum earned income and phaseout thresholds to the same cost of living adjustments provided in the Internal Revenue Code.
+rules:
+  - name: earned_income_credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: Ind. Code § 6-3.1-21-6(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3.1-21-6
+              excerpt: "equal to ten percent (10%)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.10
+
+  - name: indiana_earned_income_credit_before_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ind. Code § 6-3.1-21-6(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3.1-21-6
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3/1-21-6#earned_income_credit_percentage
+              output: earned_income_credit_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_is_nonresident_or_part_year_resident: earned_income_credit_percentage * federal_earned_income_tax_credit_claimed_for_taxable_year * income_taxable_in_indiana / total_income else: earned_income_credit_percentage * federal_earned_income_tax_credit_claimed_for_taxable_year
+
+  - name: indiana_earned_income_credit_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ind. Code § 6-3.1-21-6(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3.1-21-6
+              excerpt: "If the credit amount exceeds the taxpayer's adjusted gross income tax liability"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, indiana_earned_income_credit_before_refund - adjusted_gross_income_tax_liability)
+
+  - name: bipartisan_budget_act_election_treated_as_made_for_indiana_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Ind. Code § 6-3.1-21-6(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/statute/6-3.1-21-6
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          taxpayer_properly_elects_bipartisan_budget_act_earned_income_treatment_for_federal_credit
+          and taxable_year_begins_after_federal_bipartisan_budget_act_election_start


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3.1-21-6`
- Module: `us-in/statutes/6-3/1-21-6.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-1-21-6/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.