### PR TITLE
Encode us-in/statute/6-3-3-12 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-3-12": [
+      {
+        "module": "us-in/statutes/6-3-3-12.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-3-12.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-3-12.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-3-12.yaml",
+      "sha256": "95ce7557f77920cf0f470efaad5fa0d0407d4f2241a7a365da9208d04e08a464"
+    },
+    {
+      "path": "statutes/6-3-3-12.test.yaml",
+      "sha256": "cff2eac4dd7fc4641cc3df9ed58b3867f67337f8e6babe2feb70053e658d7dd4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-3-12",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-12/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-3-12/workspace/context-manifest.json",
+  "context_manifest_sha256": "0e4f4a15e8e30370a3cefad78a01cae2e24fed5b51ade373eed78e993293e751",
+  "generated_at": "2026-07-08T15:19:47.851826+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-12/encode-out/codex-gpt-5.5/statutes/6-3-3-12.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-12/encode-out",
+  "generated_output_sha256": "95ce7557f77920cf0f470efaad5fa0d0407d4f2241a7a365da9208d04e08a464",
+  "generation_prompt_sha256": "499158f57833040165726cde03b7f703a3d0cfa5605676793e776b53ccc1a028",
+  "model": "gpt-5.5",
+  "run_id": "a7685ffd",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "444ec13234f94c16046e472976eccccde914ed9af2364505d891e2cb2a32c2c4"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-12/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-3-12.json",
+  "trace_sha256": "07a8c10236d5d722a2dd244ab6d471a71e1591e2662507e592ca80f25f5f40c2"
+}

--- a/us-in/statutes/6-3-3-12.test.yaml
+++ b/us-in/statutes/6-3-3-12.test.yaml
@@ -1,0 +1,86 @@
+- name: contribution_direct_money_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-12#input.money_directly_provided_to_college_choice_529_account_by_taxpayer: true
+    us-in:statutes/6-3-3-12#input.money_credited_to_account_from_bonus_points_or_other_consideration: false
+    us-in:statutes/6-3-3-12#input.money_transferred_from_other_qualified_tuition_program_or_similar_plan: false
+    us-in:statutes/6-3-3-12#input.money_transferred_from_qualified_able_program_or_similar_plan: false
+  output:
+    us-in:statutes/6-3-3-12#college_choice_529_contribution: holds
+- name: payment_and_expense_definitions_blocked_by_exclusions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-12#input.money_directly_provided_to_college_choice_529_account_by_taxpayer: true
+    us-in:statutes/6-3-3-12#input.money_credited_to_account_from_bonus_points_or_other_consideration: true
+    us-in:statutes/6-3-3-12#input.money_transferred_from_other_qualified_tuition_program_or_similar_plan: false
+    us-in:statutes/6-3-3-12#input.money_transferred_from_qualified_able_program_or_similar_plan: false
+    us-in:statutes/6-3-3-12#input.withdrawal_or_distribution_from_college_choice_529_plan: true
+    us-in:statutes/6-3-3-12#input.college_choice_529_qualified_withdrawal: true
+    ? us-in:statutes/6-3-3-12#input.expense_is_for_tuition_connected_with_elementary_or_secondary_school_enrollment_or_attendance
+    : true
+    us-in:statutes/6-3-3-12#input.school_is_located_in_indiana: false
+    us-in:statutes/6-3-3-12#input.expense_is_permitted_under_section_529: true
+  output:
+    us-in:statutes/6-3-3-12#college_choice_529_contribution: not_holds
+    us-in:statutes/6-3-3-12#college_choice_529_nonqualified_withdrawal: not_holds
+    us-in:statutes/6-3-3-12#qualified_k12_education_expense: not_holds
+- name: taxpayer_and_reporting_requirements_hold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-12#input.return_is_single_return_filed_by_individual: false
+    us-in:statutes/6-3-3-12#input.return_is_joint_return_filed_by_married_couple: false
+    us-in:statutes/6-3-3-12#input.return_is_separate_return_filed_by_married_individual: true
+    us-in:statutes/6-3-3-12#input.taxable_year_begins_after_separate_return_effective_date: true
+    ? us-in:statutes/6-3-3-12#input.account_owner_has_required_repayment_under_subsection_q_for_taxable_year_with_nonqualified_withdrawal
+    : true
+    us-in:statutes/6-3-3-12#input.required_repayment_reported_on_annual_state_income_tax_return: true
+  output:
+    us-in:statutes/6-3-3-12#taxpayer_for_college_choice_529_credit: holds
+    us-in:statutes/6-3-3-12#account_owner_required_repayment_reported: holds
+- name: taxpayer_and_reporting_requirements_do_not_hold
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-12#input.return_is_single_return_filed_by_individual: false
+    us-in:statutes/6-3-3-12#input.return_is_joint_return_filed_by_married_couple: false
+    us-in:statutes/6-3-3-12#input.return_is_separate_return_filed_by_married_individual: true
+    us-in:statutes/6-3-3-12#input.taxable_year_begins_after_separate_return_effective_date: false
+    ? us-in:statutes/6-3-3-12#input.account_owner_has_required_repayment_under_subsection_q_for_taxable_year_with_nonqualified_withdrawal
+    : true
+    us-in:statutes/6-3-3-12#input.required_repayment_reported_on_annual_state_income_tax_return: false
+  output:
+    us-in:statutes/6-3-3-12#taxpayer_for_college_choice_529_credit: not_holds
+    us-in:statutes/6-3-3-12#account_owner_required_repayment_reported: not_holds
+- name: auto_positive_college_choice_529_nonqualified_withdrawal
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-3-12#input.college_choice_529_qualified_withdrawal: false
+    us-in:statutes/6-3-3-12#input.withdrawal_or_distribution_from_college_choice_529_plan: true
+  output:
+    us-in:statutes/6-3-3-12#college_choice_529_nonqualified_withdrawal: holds
+- name: auto_positive_qualified_k12_education_expense
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-in:statutes/6-3-3-12#input.expense_is_for_tuition_connected_with_elementary_or_secondary_school_enrollment_or_attendance
+    : true
+    us-in:statutes/6-3-3-12#input.expense_is_permitted_under_section_529: true
+    us-in:statutes/6-3-3-12#input.school_is_located_in_indiana: true
+  output:
+    us-in:statutes/6-3-3-12#qualified_k12_education_expense: holds

--- a/us-in/statutes/6-3-3-12.yaml
+++ b/us-in/statutes/6-3-3-12.yaml
@@ -1,0 +1,103 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-3-12
+  summary: |-
+    IC 6-3-3-12 defines contribution, nonqualified withdrawal, qualified K-12 education expenses, and taxpayer for the College Choice 529 credit. The section also requires account owners to report any repayment required under subsection (q) on the annual state income tax return for the taxable year in which a nonqualified withdrawal is made.
+rules:
+  - name: college_choice_529_contribution
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-12(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-12
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          money_directly_provided_to_college_choice_529_account_by_taxpayer
+          and not money_credited_to_account_from_bonus_points_or_other_consideration
+          and not money_transferred_from_other_qualified_tuition_program_or_similar_plan
+          and not money_transferred_from_qualified_able_program_or_similar_plan
+  - name: college_choice_529_nonqualified_withdrawal
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-12(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-12
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          withdrawal_or_distribution_from_college_choice_529_plan
+          and not college_choice_529_qualified_withdrawal
+  - name: qualified_k12_education_expense
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-12(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-12
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          expense_is_for_tuition_connected_with_elementary_or_secondary_school_enrollment_or_attendance
+          and school_is_located_in_indiana
+          and expense_is_permitted_under_section_529
+  - name: taxpayer_for_college_choice_529_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-12(j)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-12
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          return_is_single_return_filed_by_individual
+          or return_is_joint_return_filed_by_married_couple
+          or (return_is_separate_return_filed_by_married_individual and taxable_year_begins_after_separate_return_effective_date)
+  - name: account_owner_required_repayment_reported
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-12(r)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-12
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          account_owner_has_required_repayment_under_subsection_q_for_taxable_year_with_nonqualified_withdrawal
+          and required_repayment_reported_on_annual_state_income_tax_return


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-3-12`
- Module: `us-in/statutes/6-3-3-12.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-12/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.