### PR TITLE
Encode us-in/statute/6-3-2-28 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-2-28": [
+      {
+        "module": "us-in/statutes/6-3-2-28.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-2-28.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-2-28.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-2-28.yaml",
+      "sha256": "d076205e9f614e33ffbc8c599996b81f3d171a9878a4dced801620887e9a5674"
+    },
+    {
+      "path": "statutes/6-3-2-28.test.yaml",
+      "sha256": "4eed19f4220fc0cebacab525004c5e43d0245c79638d34001583970c105c0d8e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-2-28",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-28/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-2-28/workspace/context-manifest.json",
+  "context_manifest_sha256": "ca20ebef5c18e9461b8269b6b909cac13860e80d382f749637199a16a63cc296",
+  "generated_at": "2026-07-08T15:20:20.229324+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-28/encode-out/codex-gpt-5.5/statutes/6-3-2-28.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-28/encode-out",
+  "generated_output_sha256": "d076205e9f614e33ffbc8c599996b81f3d171a9878a4dced801620887e9a5674",
+  "generation_prompt_sha256": "ca0a9b192147ab77bc386b636e75ac322115645f7c67d61bbc3bbf7deeaff040",
+  "model": "gpt-5.5",
+  "run_id": "9645861b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6930e5e275a56f7bbb0b7963ba9150529ff1fc0faedde5da85e29f9f748e64ab"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-28/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-2-28.json",
+  "trace_sha256": "a20aa6e49cf60c576a18c15e5aad42574d0e53c9eeaaf700c9513ae9091065c6"
+}

--- a/us-in/statutes/6-3-2-28.test.yaml
+++ b/us-in/statutes/6-3-2-28.test.yaml
@@ -1,0 +1,75 @@
+- name: qualified_individual_receives_health_care_sharing_expense_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-28#input.resident_of_indiana: true
+    us-in:statutes/6-3-2-28#input.member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year: true
+    us-in:statutes/6-3-2-28#input.amount_paid_for_membership_in_health_care_sharing_ministry: 1200
+    us-in:statutes/6-3-2-28#input.deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner: true
+    us-in:statutes/6-3-2-28#input.submitted_department_information_necessary_to_calculate_deduction: true
+  output:
+    us-in:statutes/6-3-2-28#qualified_individual: holds
+    us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses: 1200
+    us-in:statutes/6-3-2-28#health_care_sharing_expense_deduction: 1200
+- name: nonresident_is_not_qualified_individual
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-28#input.resident_of_indiana: false
+    us-in:statutes/6-3-2-28#input.member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year: true
+    us-in:statutes/6-3-2-28#input.amount_paid_for_membership_in_health_care_sharing_ministry: 1200
+    us-in:statutes/6-3-2-28#input.deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner: true
+    us-in:statutes/6-3-2-28#input.submitted_department_information_necessary_to_calculate_deduction: true
+  output:
+    us-in:statutes/6-3-2-28#qualified_individual: not_holds
+    us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses: 0
+    us-in:statutes/6-3-2-28#health_care_sharing_expense_deduction: 0
+- name: no_month_of_membership_is_not_qualified_individual
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-28#input.resident_of_indiana: true
+    us-in:statutes/6-3-2-28#input.member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year: false
+    us-in:statutes/6-3-2-28#input.amount_paid_for_membership_in_health_care_sharing_ministry: 1200
+    us-in:statutes/6-3-2-28#input.deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner: true
+    us-in:statutes/6-3-2-28#input.submitted_department_information_necessary_to_calculate_deduction: true
+  output:
+    us-in:statutes/6-3-2-28#qualified_individual: not_holds
+    us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses: 0
+    us-in:statutes/6-3-2-28#health_care_sharing_expense_deduction: 0
+- name: deduction_not_claimed_on_return_is_not_received
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-28#input.resident_of_indiana: true
+    us-in:statutes/6-3-2-28#input.member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year: true
+    us-in:statutes/6-3-2-28#input.amount_paid_for_membership_in_health_care_sharing_ministry: 1200
+    us-in:statutes/6-3-2-28#input.deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner: false
+    us-in:statutes/6-3-2-28#input.submitted_department_information_necessary_to_calculate_deduction: true
+  output:
+    us-in:statutes/6-3-2-28#qualified_individual: holds
+    us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses: 1200
+    us-in:statutes/6-3-2-28#health_care_sharing_expense_deduction: 0
+- name: required_department_information_not_submitted_is_not_received
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-28#input.resident_of_indiana: true
+    us-in:statutes/6-3-2-28#input.member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year: true
+    us-in:statutes/6-3-2-28#input.amount_paid_for_membership_in_health_care_sharing_ministry: 1200
+    us-in:statutes/6-3-2-28#input.deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner: true
+    us-in:statutes/6-3-2-28#input.submitted_department_information_necessary_to_calculate_deduction: false
+  output:
+    us-in:statutes/6-3-2-28#qualified_individual: holds
+    us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses: 1200
+    us-in:statutes/6-3-2-28#health_care_sharing_expense_deduction: 0

--- a/us-in/statutes/6-3-2-28.yaml
+++ b/us-in/statutes/6-3-2-28.yaml
@@ -1,0 +1,96 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-2-28
+  summary: |-
+    "Qualified individual" means an Indiana resident who is a member of a health care sharing ministry for at least one month during a taxable year. Each taxable year, a qualified individual is entitled to a deduction equal to the total amount of qualified health care sharing expenses paid during the taxable year, and must claim the deduction on the annual state tax return and submit information required by the department.
+rules:
+  - name: qualified_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Indiana Code § 6-3-2-28(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-28
+              excerpt: qualified individual means an individual who is a resident of Indiana and a member of a health care sharing ministry for at least one month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          resident_of_indiana
+          and member_of_health_care_sharing_ministry_for_at_least_one_month_during_taxable_year
+
+  - name: qualified_health_care_sharing_expenses
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Indiana Code § 6-3-2-28(a)(2), (b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-28
+              excerpt: qualified health care sharing expenses means the amount paid by a qualified individual for membership in a health care sharing ministry
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-28#qualified_individual
+              output: qualified_individual
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if qualified_individual: amount_paid_for_membership_in_health_care_sharing_ministry else: 0
+
+  - name: health_care_sharing_expense_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Indiana Code § 6-3-2-28(b), (c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-28
+              excerpt: deduction ... equal to the total amount of qualified health care sharing expenses paid
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-28
+              excerpt: must claim the deduction on the qualified individual's annual state tax return
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-in/statute/6-3-2-28
+              excerpt: submit to the department any information that the department determines is necessary to calculate the amount
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-28#qualified_individual
+              output: qualified_individual
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-in:statutes/6-3-2-28#qualified_health_care_sharing_expenses
+              output: qualified_health_care_sharing_expenses
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if qualified_individual and deduction_claimed_on_annual_state_tax_return_in_department_prescribed_manner and submitted_department_information_necessary_to_calculate_deduction: qualified_health_care_sharing_expenses else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-2-28`
- Module: `us-in/statutes/6-3-2-28.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-28/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.