### PR TITLE
Encode us-in/statute/6-3-2-22 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-2-22": [
+      {
+        "module": "us-in/statutes/6-3-2-22.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-2-22.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-2-22.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-2-22.yaml",
+      "sha256": "5b4df398eaf64122e0801550088a6e954e1f611101eb23dcbe4ddd10dbb66de7"
+    },
+    {
+      "path": "statutes/6-3-2-22.test.yaml",
+      "sha256": "3303025dee4f44c8859f8d07ac0e332e3f63dfdb3597282deabe3e5fdb90a0ee"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-2-22",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-22/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-2-22/workspace/context-manifest.json",
+  "context_manifest_sha256": "688f2e7e6c9e3b82af68873180130e0df9d1c1dda94b2daa3732d026cc282f4a",
+  "generated_at": "2026-07-08T15:20:27.591502+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-22/encode-out/codex-gpt-5.5/statutes/6-3-2-22.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-22/encode-out",
+  "generated_output_sha256": "5b4df398eaf64122e0801550088a6e954e1f611101eb23dcbe4ddd10dbb66de7",
+  "generation_prompt_sha256": "396f17f8f727628276531043d257940654d8291617f685cda5e47d094081794e",
+  "model": "gpt-5.5",
+  "run_id": "df636581",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b72b6970cd14120bc4e1ae40baa422b0615a495ec3ecdcb85153c07a8d1ba9f3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-22/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-2-22.json",
+  "trace_sha256": "6a9c20767393485bec6bee7e2d034d32325a7088c7171d2f554b2b5b785987a7"
+}

--- a/us-in/statutes/6-3-2-22.test.yaml
+++ b/us-in/statutes/6-3-2-22.test.yaml
@@ -1,0 +1,180 @@
+- name: one qualifying dependent child receives deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: true
+    us-in:statutes/6-3-2-22#relation.education_expenditure_dependent_children:
+    - us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+      us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+      us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+      us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+      us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+      us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+      ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+      : false
+      us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+  output:
+    us-in:statutes/6-3-2-22#education_expenditure_deduction: 1000
+- name: two qualifying dependent children receive multiplied deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: true
+    us-in:statutes/6-3-2-22#relation.education_expenditure_dependent_children:
+    - us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+      us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+      us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+      us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+      us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+      us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+      ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+      : false
+      us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+    - us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+      us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+      us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: false
+      us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: true
+      us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+      us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+      ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+      : false
+      us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+  output:
+    us-in:statutes/6-3-2-22#education_expenditure_deduction: 2000
+- name: home instructional service exclusion blocks child count
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: true
+    us-in:statutes/6-3-2-22#relation.education_expenditure_dependent_children:
+    - us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+      us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+      us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+      us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+      us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+      us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+      ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+      : true
+      us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+  output:
+    us-in:statutes/6-3-2-22#education_expenditure_deduction: 0
+- name: deduction must be claimed on state return
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: false
+    us-in:statutes/6-3-2-22#relation.education_expenditure_dependent_children:
+    - us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+      us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+      us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+      us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+      us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+      us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+      ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+      : false
+      us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+  output:
+    us-in:statutes/6-3-2-22#education_expenditure_deduction: 0
+- name: auto_output_dependent_child_for_education_expenditure_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: false
+    us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: false
+    us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: false
+    us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: false
+    ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+    : false
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: false
+    us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+    us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: false
+    us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: false
+  output:
+    us-in:statutes/6-3-2-22#dependent_child_for_education_expenditure_deduction: not_holds
+- name: auto_output_private_elementary_or_high_school_education_program
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: false
+    us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: false
+    us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: false
+    us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: false
+    ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+    : false
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: false
+    us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+    us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: false
+    us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: false
+  output:
+    us-in:statutes/6-3-2-22#private_elementary_or_high_school_education_program: not_holds
+- name: auto_output_unreimbursed_education_expenditure_for_dependent_child
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: false
+    us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: false
+    us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: false
+    us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: false
+    ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+    : false
+    us-in:statutes/6-3-2-22#input.taxpayer_claims_deduction_on_annual_state_tax_return: false
+    us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: false
+    us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: false
+    us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: false
+  output:
+    us-in:statutes/6-3-2-22#unreimbursed_education_expenditure_for_dependent_child: not_holds
+- name: auto_positive_dependent_child_for_education_expenditure_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+    us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+    us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+    us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: true
+    us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+  output:
+    us-in:statutes/6-3-2-22#dependent_child_for_education_expenditure_deduction: holds
+- name: auto_positive_private_elementary_or_high_school_education_program
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+    ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+    : false
+  output:
+    us-in:statutes/6-3-2-22#private_elementary_or_high_school_education_program: holds
+- name: auto_positive_unreimbursed_education_expenditure_for_dependent_child
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-in:statutes/6-3-2-22#input.child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance: true
+    us-in:statutes/6-3-2-22#input.child_eligible_for_free_indiana_elementary_or_high_school_education: true
+    us-in:statutes/6-3-2-22#input.child_is_taxpayer_natural_or_adopted_child: true
+    us-in:statutes/6-3-2-22#input.child_qualifies_as_taxpayer_dependent_under_section_152: true
+    ? us-in:statutes/6-3-2-22#input.instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school
+    : false
+    us-in:statutes/6-3-2-22#input.taxpayer_has_court_awarded_guardianship_or_custody_of_child: true
+    us-in:statutes/6-3-2-22#input.taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced: true
+    us-in:statutes/6-3-2-22#input.taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year: true
+  output:
+    us-in:statutes/6-3-2-22#unreimbursed_education_expenditure_for_dependent_child: holds

--- a/us-in/statutes/6-3-2-22.yaml
+++ b/us-in/statutes/6-3-2-22.yaml
@@ -1,0 +1,128 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-2-22
+  summary: Sec. 22. "Dependent child" means an individual who is eligible to receive
+    a free elementary or high school education in an Indiana school corporation, qualifies
+    as a dependent under IRC section 152, and is the taxpayer's natural or adopted
+    child or court appointed guardian/custodian child. A taxpayer who makes an unreimbursed
+    education expenditure during the taxable year is entitled to a deduction against
+    adjusted gross income. The deduction is $1,000 multiplied by the number of dependent
+    children for whom education expenditures were made. A husband and wife are entitled
+    to only one deduction.
+rules:
+- name: education_expenditure_deduction_amount_per_child
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IC 6-3-2-22(d)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-in/statute/6-3-2-22
+          excerpt: one thousand dollars ($1,000)
+  versions:
+  - effective_from: '2011-01-01'
+    formula: '1000'
+- name: dependent_child_for_education_expenditure_deduction
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: IC 6-3-2-22(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-in/statute/6-3-2-22
+  versions:
+  - effective_from: '2011-01-01'
+    formula: 'child_eligible_for_free_indiana_elementary_or_high_school_education
+
+      and child_qualifies_as_taxpayer_dependent_under_section_152
+
+      and (child_is_taxpayer_natural_or_adopted_child or taxpayer_has_court_awarded_guardianship_or_custody_of_child)
+
+      and taxpayer_is_parent_eligible_to_take_exemption_if_parents_divorced'
+- name: private_elementary_or_high_school_education_program
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: IC 6-3-2-22(a)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-in/statute/6-3-2-22
+  versions:
+  - effective_from: '2011-01-01'
+    formula: 'child_attends_indiana_nonpublic_school_satisfying_compulsory_attendance
+
+      and not instructional_service_delivered_in_home_setting_to_child_enrolled_in_school_corporation_or_charter_school'
+- name: unreimbursed_education_expenditure_for_dependent_child
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: IC 6-3-2-22(a)(2), (c), (d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-in/statute/6-3-2-22
+  versions:
+  - effective_from: '2011-01-01'
+    formula: 'dependent_child_for_education_expenditure_deduction
+
+      and private_elementary_or_high_school_education_program
+
+      and taxpayer_made_unreimbursed_education_expenditure_for_child_during_taxable_year'
+- name: education_expenditure_dependent_children
+  kind: data_relation
+  data_relation:
+    predicate: education_expenditure_dependent_children
+    arity: 2
+    arguments:
+    - name: education_expenditure_dependent_child
+      entity: Person
+    - name: tax_unit
+      entity: TaxUnit
+- name: education_expenditure_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: IC 6-3-2-22(c), (d), (e)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-in/statute/6-3-2-22
+          excerpt: $1,000; multiplied by ... the number of the taxpayer's dependent
+            children
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-in:statutes/6-3-2-22#education_expenditure_deduction_amount_per_child
+          output: education_expenditure_deduction_amount_per_child
+          hash: sha256:local
+  versions:
+  - effective_from: '2011-01-01'
+    formula: 'if taxpayer_claims_deduction_on_annual_state_tax_return: education_expenditure_deduction_amount_per_child
+      * count_where(education_expenditure_dependent_children, unreimbursed_education_expenditure_for_dependent_child)
+      else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-2-22`
- Module: `us-in/statutes/6-3-2-22.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-2-22/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.