### PR TITLE
Encode us-in/statute/6-3-3-9 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9846,6 +9846,15 @@
         ]
       }
     ],
+    "us-in/statute/6-3-3-9": [
+      {
+        "module": "us-in/statutes/6-3-3-9.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",

--- a/us-in/.axiom/encoding-manifests/statutes/6-3-3-9.json
+++ b/us-in/.axiom/encoding-manifests/statutes/6-3-3-9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/6-3-3-9.yaml",
+      "sha256": "56794f69fd87a379a89aaaa8ec989fac5374dbf54d424e28999284045eda1d9a"
+    },
+    {
+      "path": "statutes/6-3-3-9.test.yaml",
+      "sha256": "27088d4a4d8775510eced33c00cb3f39434841b23bfb2b5ffd70d08f370b5b97"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-in/statute/6-3-3-9",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-9/encode-out/_eval_workspaces/codex-gpt-5.5/us-in-statute-6-3-3-9/workspace/context-manifest.json",
+  "context_manifest_sha256": "51ccd90b37634fea5b0723e345f80d6807d82a4bbf1c79d20148def2de65bb30",
+  "generated_at": "2026-07-08T15:20:32.709975+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-9/encode-out/codex-gpt-5.5/statutes/6-3-3-9.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-9/encode-out",
+  "generated_output_sha256": "56794f69fd87a379a89aaaa8ec989fac5374dbf54d424e28999284045eda1d9a",
+  "generation_prompt_sha256": "69c43a08dd5f0517baffbfd561276e22ec8dc4248d232cf07566224d0864f16e",
+  "model": "gpt-5.5",
+  "run_id": "4835da88",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1804941079838a16e074eeb39e05cddddb25765382e5f90aff83d47d77de2978"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-9/encode-out/traces/codex-gpt-5.5/us-in-statute-6-3-3-9.json",
+  "trace_sha256": "219882969afa496ff1cfad419bb3482928ae3871600fa980091fa0f5edf4caa7"
+}

--- a/us-in/statutes/6-3-3-9.test.yaml
+++ b/us-in/statutes/6-3-3-9.test.yaml
@@ -1,0 +1,84 @@
+- name: claimant_not_residing_with_spouse_low_income_gets_100
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-9#input.household_federal_adjusted_gross_income: 900
+    us-in:statutes/6-3-3-9#input.days_incarcerated_in_correctional_institution: 0
+    us-in:statutes/6-3-3-9#input.filed_claim_under_this_section: true
+    us-in:statutes/6-3-3-9#input.months_resident_in_indiana_during_taxable_year: 6
+    us-in:statutes/6-3-3-9#input.age_during_some_portion_of_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.spouse_age_during_taxable_year: 0
+    us-in:statutes/6-3-3-9#input.person_is_one_claimant_for_household: true
+    us-in:statutes/6-3-3-9#input.resides_with_spouse_during_taxable_year: false
+    us-in:statutes/6-3-3-9#input.age_at_end_of_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.spouse_age_at_end_of_taxable_year: 0
+  output:
+    us-in:statutes/6-3-3-9#incarcerated_for_disqualifying_period: not_holds
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit_claimant: holds
+    us-in:statutes/6-3-3-9#elderly_credit_income_band: 0
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit: 100
+- name: both_spouses_elderly_middle_income_gets_90
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-9#input.household_federal_adjusted_gross_income: 2000
+    us-in:statutes/6-3-3-9#input.days_incarcerated_in_correctional_institution: 0
+    us-in:statutes/6-3-3-9#input.filed_claim_under_this_section: true
+    us-in:statutes/6-3-3-9#input.months_resident_in_indiana_during_taxable_year: 12
+    us-in:statutes/6-3-3-9#input.age_during_some_portion_of_taxable_year: 66
+    us-in:statutes/6-3-3-9#input.spouse_age_during_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.person_is_one_claimant_for_household: true
+    us-in:statutes/6-3-3-9#input.resides_with_spouse_during_taxable_year: true
+    us-in:statutes/6-3-3-9#input.age_at_end_of_taxable_year: 66
+    us-in:statutes/6-3-3-9#input.spouse_age_at_end_of_taxable_year: 65
+  output:
+    us-in:statutes/6-3-3-9#incarcerated_for_disqualifying_period: not_holds
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit_claimant: holds
+    us-in:statutes/6-3-3-9#elderly_credit_income_band: 1
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit: 90
+- name: incarcerated_for_180_days_blocks_claimant_and_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-9#input.household_federal_adjusted_gross_income: 3500
+    us-in:statutes/6-3-3-9#input.days_incarcerated_in_correctional_institution: 180
+    us-in:statutes/6-3-3-9#input.filed_claim_under_this_section: true
+    us-in:statutes/6-3-3-9#input.months_resident_in_indiana_during_taxable_year: 12
+    us-in:statutes/6-3-3-9#input.age_during_some_portion_of_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.spouse_age_during_taxable_year: 0
+    us-in:statutes/6-3-3-9#input.person_is_one_claimant_for_household: true
+    us-in:statutes/6-3-3-9#input.resides_with_spouse_during_taxable_year: false
+    us-in:statutes/6-3-3-9#input.age_at_end_of_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.spouse_age_at_end_of_taxable_year: 0
+  output:
+    us-in:statutes/6-3-3-9#incarcerated_for_disqualifying_period: holds
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit_claimant: not_holds
+    us-in:statutes/6-3-3-9#elderly_credit_income_band: 2
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit: 0
+- name: income_at_10000_is_outside_credit_schedule
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-in:statutes/6-3-3-9#input.household_federal_adjusted_gross_income: 10000
+    us-in:statutes/6-3-3-9#input.days_incarcerated_in_correctional_institution: 0
+    us-in:statutes/6-3-3-9#input.filed_claim_under_this_section: true
+    us-in:statutes/6-3-3-9#input.months_resident_in_indiana_during_taxable_year: 6
+    us-in:statutes/6-3-3-9#input.age_during_some_portion_of_taxable_year: 64
+    us-in:statutes/6-3-3-9#input.spouse_age_during_taxable_year: 65
+    us-in:statutes/6-3-3-9#input.person_is_one_claimant_for_household: true
+    us-in:statutes/6-3-3-9#input.resides_with_spouse_during_taxable_year: true
+    us-in:statutes/6-3-3-9#input.age_at_end_of_taxable_year: 64
+    us-in:statutes/6-3-3-9#input.spouse_age_at_end_of_taxable_year: 65
+  output:
+    us-in:statutes/6-3-3-9#incarcerated_for_disqualifying_period: not_holds
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit_claimant: holds
+    us-in:statutes/6-3-3-9#elderly_credit_income_band: -1
+    us-in:statutes/6-3-3-9#unified_elderly_tax_credit: 0

--- a/us-in/statutes/6-3-3-9.yaml
+++ b/us-in/statutes/6-3-3-9.yaml
@@ -1,0 +1,294 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-in/statute/6-3-3-9
+  summary: |-
+    "Claimant" means an individual, other than one incarcerated for at least 180 days during the taxable year, who filed a claim, was an Indiana resident for at least six months during the taxable year, and was age 65 during some portion of the taxable year or whose spouse was age 65 or over. One claimant per household may claim the unified tax credit for the elderly. The credit schedules are based on household federal adjusted gross income and whether both spouses living together are age 65 or older at the end of the taxable year.
+  deferred_outputs:
+    - output: us-in:statutes/6-3-3-9/d#surviving_spouse_claim_and_disbursement
+      reason: Administration of claims after death, household-member disbursement, executor or administrator payment, and escheat require estate administration entities and commissioner determinations outside the supported executable tax-credit schema.
+    - output: us-in:statutes/6-3-3-9/f#department_offset_against_outstanding_liabilities
+      reason: Application of claim amounts against department-book liabilities requires liability-account administration not represented by the current RuleSpec computation schema.
+    - output: us-in:statutes/6-3-3-9/k#department_audit_redetermination
+      reason: Audit redetermination and notice finality are administrative procedures rather than computable taxpayer credit formulas.
+    - output: us-in:statutes/6-3-3-9/l#fraudulent_or_negligent_excessive_claim_penalties
+      reason: Fraud, negligence, misdemeanor classification, cancellation, assessment, and statutory interest require enforcement and assessment procedures outside this artifact.
+rules:
+  - name: claimant_residency_months_threshold
+    kind: parameter
+    dtype: Count
+    source: 6-3-3-9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "resident of this state for at least six (6) months"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6
+
+  - name: elderly_age_threshold
+    kind: parameter
+    dtype: Count
+    source: 6-3-3-9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "sixty-five (65) years of age"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+
+  - name: incarceration_disqualification_days_threshold
+    kind: parameter
+    dtype: Count
+    source: 6-3-3-9(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "at least one hundred eighty (180) days"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          180
+
+  - name: elderly_credit_income_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "less than $1,000; at least $1,000, but less than $3,000; at least $3,000, but less than $10,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if household_federal_adjusted_gross_income < elderly_credit_band_0_upper_bound: 0 else: if household_federal_adjusted_gross_income >= elderly_credit_band_1_lower_bound and household_federal_adjusted_gross_income < elderly_credit_band_1_upper_bound: 1 else: if household_federal_adjusted_gross_income >= elderly_credit_band_2_lower_bound and household_federal_adjusted_gross_income < elderly_credit_band_2_upper_bound: 2 else: -1
+
+  - name: elderly_credit_band_0_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "less than $1,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1000
+
+  - name: elderly_credit_band_1_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "at least $1,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1000
+
+  - name: elderly_credit_band_1_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "less than $3,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+
+  - name: elderly_credit_band_2_lower_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "at least $3,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          3000
+
+  - name: elderly_credit_band_2_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "less than $10,000"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10000
+
+  - name: elderly_credit_single_or_one_elderly_spouse_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: elderly_credit_income_band
+    source: 6-3-3-9(g)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              table:
+                header: "HOUSEHOLD FEDERAL ADJUSTED GROSS INCOME FOR TAXABLE YEAR CREDIT"
+                row_key: "income band"
+                column_key: "credit for claimant not residing with spouse or only one spouse age 65 or older"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 100
+          1: 50
+          2: 40
+
+  - name: elderly_credit_both_spouses_elderly_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: elderly_credit_income_band
+    source: 6-3-3-9(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              table:
+                header: "HOUSEHOLD FEDERAL ADJUSTED GROSS INCOME FOR TAXABLE YEAR CREDIT"
+                row_key: "income band"
+                column_key: "credit if both claimant and spouse are age 65 or older"
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          0: 140
+          1: 90
+          2: 80
+
+  - name: incarcerated_for_disqualifying_period
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-9(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "for a period of at least one hundred eighty (180) days during the taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          days_incarcerated_in_correctional_institution >= incarceration_disqualification_days_threshold
+
+  - name: unified_elderly_tax_credit_claimant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 6-3-3-9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "Claimant means an individual, other than an individual described in subsection (c)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          filed_claim_under_this_section
+          and months_resident_in_indiana_during_taxable_year >= claimant_residency_months_threshold
+          and (age_during_some_portion_of_taxable_year >= elderly_age_threshold or spouse_age_during_taxable_year >= elderly_age_threshold)
+          and not incarcerated_for_disqualifying_period
+
+  - name: unified_elderly_tax_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 6-3-3-9(e), 6-3-3-9(g)-(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              excerpt: "one (1) claimant per household may claim, as a credit"
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-in/statute/6-3-3-9
+              table:
+                header: "HOUSEHOLD FEDERAL ADJUSTED GROSS INCOME FOR TAXABLE YEAR CREDIT"
+                row: "less than $1,000; at least $1,000 but less than $3,000; at least $3,000 but less than $10,000"
+                column: "credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if unified_elderly_tax_credit_claimant and person_is_one_claimant_for_household and elderly_credit_income_band >= 0: if resides_with_spouse_during_taxable_year and age_at_end_of_taxable_year >= elderly_age_threshold and spouse_age_at_end_of_taxable_year >= elderly_age_threshold: elderly_credit_both_spouses_elderly_amount[elderly_credit_income_band] else: elderly_credit_single_or_one_elderly_spouse_amount[elderly_credit_income_band] else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-in/statute/6-3-3-9`
- Module: `us-in/statutes/6-3-3-9.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-in-statute-6-3-3-9/rulespec-us/oracle-coverage-pending.yaml: 10 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.