### PR TITLE
Encode us-la/statute/47:295 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9889,6 +9889,15 @@
         ]
       }
     ],
+    "us-la/statute/47:295": [
+      {
+        "module": "us-la/statutes/47:295.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/regulation/106-cmr/360/010/block-1": [
       {
         "module": "us-ma/regulations/106-cmr/360/010/block-1.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,14 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 10
+ceiling: 12
 entries:
+  - legal_id: us-la:statutes/47:295#penalty_waiver_oversight_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-la/.axiom/encoding-manifests/statutes/47:295.json
+++ b/us-la/.axiom/encoding-manifests/statutes/47:295.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/47:295.yaml",
+      "sha256": "9430e4dc37fc74334d04665cd534f044cc5e5fe5c3cbbfbc25f68e3e4b24a712"
+    },
+    {
+      "path": "statutes/47:295.test.yaml",
+      "sha256": "6bc202481e9d47444067ff6658bd4e4ac81c411b9a3468371ff0ebc50948a232"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-la/statute/47:295",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-295/encode-out/_eval_workspaces/codex-gpt-5.5/us-la-statute-47-295/workspace/context-manifest.json",
+  "context_manifest_sha256": "2a4354167c1012b5716ff50de329233d61eb2ff903c34ba1038070ef1dfca873",
+  "generated_at": "2026-07-08T15:21:57.603410+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-295/encode-out/codex-gpt-5.5/statutes/47:295.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-295/encode-out",
+  "generated_output_sha256": "9430e4dc37fc74334d04665cd534f044cc5e5fe5c3cbbfbc25f68e3e4b24a712",
+  "generation_prompt_sha256": "8c354d35faaf8d4ca09d7ab045645caed0f613368b2f12fda1816b4829ae3e7e",
+  "model": "gpt-5.5",
+  "run_id": "0bf11a85",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "175f3544e88bd8f19459a6ed3001b4791c4cfcba4feeef2e123fa196af8a0c22"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-295/encode-out/traces/codex-gpt-5.5/us-la-statute-47-295.json",
+  "trace_sha256": "3f86b93464f5643eb696501537d6f9b79ef27ddf685c1f07612725cb7c3093a4"
+}

--- a/us-la/statutes/47:295.test.yaml
+++ b/us-la/statutes/47:295.test.yaml
@@ -1,0 +1,33 @@
+- name: penalty waiver above threshold requires oversight
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47:295#input.penalty_amount: 26000
+    us-la:statutes/47:295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
+  output:
+    us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight: holds
+- name: voluntary disclosure waiver exception blocks oversight
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47:295#input.penalty_amount: 26000
+    us-la:statutes/47:295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: true
+  output:
+    us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight: not_holds
+- name: penalty at threshold does not require oversight
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47:295#input.penalty_amount: 25000
+    us-la:statutes/47:295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
+  output:
+    us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight: not_holds

--- a/us-la/statutes/47:295.yaml
+++ b/us-la/statutes/47:295.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  summary: |-
+    "There is imposed an income tax for each taxable year upon the Louisiana income of every individual, whether resident or nonresident." The amount is determined under R.S. 47:32. Beginning January 1, 2016, waivers of all penalties exceeding twenty-five thousand dollars are subject to legislative committee oversight, except penalties waived or remitted under voluntary disclosure program regulations.
+  deferred_outputs:
+    - output: us-la:statutes/47:295#individual_louisiana_income_tax_amount
+      reason: The source imposes the tax but states that the amount is determined in accordance with R.S. 47:32, whose executable computation is not supplied in this prompt.
+rules:
+  - name: penalty_waiver_oversight_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Day
+    source: R.S. 47:295(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-la/statute/47:295
+              excerpt: "penalties exceeding twenty-five thousand dollars"
+    versions:
+      - effective_from: '2016-01-01'
+        formula: |-
+          25000
+
+  - name: penalty_waiver_subject_to_committee_oversight
+    kind: derived
+    entity: PenaltyWaiver
+    dtype: Judgment
+    period: Day
+    source: R.S. 47:295(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-la/statute/47:295
+              excerpt: "waivers of all penalties exceeding twenty-five thousand dollars shall be subject to oversight"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-la/statute/47:295
+              excerpt: "shall not apply to any penalty the secretary remits or waives ... under the department's voluntary disclosure program"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-la:statutes/47:295#penalty_waiver_oversight_threshold
+              output: penalty_waiver_oversight_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2016-01-01'
+        formula: |-
+          penalty_amount > penalty_waiver_oversight_threshold
+          and not penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-la/statute/47:295`
- Module: `us-la/statutes/47:295.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-295/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+2 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.