### PR TITLE
Encode us-la/statute/47:297.8 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9889,6 +9889,15 @@
         ]
       }
     ],
+    "us-la/statute/47:297.8": [
+      {
+        "module": "us-la/statutes/47:297/8.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/regulation/106-cmr/360/010/block-1": [
       {
         "module": "us-ma/regulations/106-cmr/360/010/block-1.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,26 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 18
 entries:
+  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_base_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_temporary_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/8#louisiana_earned_income_tax_credit
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-la/.axiom/encoding-manifests/statutes/47:297/8.json
+++ b/us-la/.axiom/encoding-manifests/statutes/47:297/8.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/47:297/8.yaml",
+      "sha256": "f0ff5ef671c53292923302a93ac91784a86783c2f6e5f2c6f5bb166305997812"
+    },
+    {
+      "path": "statutes/47:297/8.test.yaml",
+      "sha256": "1c04893ccfbd803a02b133dd0e1c3520c26bbc20dd93835e85965621a9e01499"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-la/statute/47:297.8",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-8/encode-out/_eval_workspaces/codex-gpt-5.5/us-la-statute-47-297.8/workspace/context-manifest.json",
+  "context_manifest_sha256": "3b6e6012acfd31678334368aa177a1379b91c17363c756377fe899aca4b50114",
+  "generated_at": "2026-07-08T15:23:31.411708+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-8/encode-out/codex-gpt-5.5/statutes/47:297/8.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-8/encode-out",
+  "generated_output_sha256": "f0ff5ef671c53292923302a93ac91784a86783c2f6e5f2c6f5bb166305997812",
+  "generation_prompt_sha256": "050cf56a5dfd940f447cb2c968b524c2d18e5d7991747b97709eea5676119904",
+  "model": "gpt-5.5",
+  "run_id": "43ae22c0",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1a2fe1b81e82a112a6ba22e486431d63fa41dae9e7b42fc27c06af40eb7c3510"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-8/encode-out/traces/codex-gpt-5.5/us-la-statute-47-297.8.json",
+  "trace_sha256": "bd204af7e9207979328ff227cc4e9744955ecda1d05b4938946a643e6b34c711"
+}

--- a/us-la/statutes/47:297/8.test.yaml
+++ b/us-la/statutes/47:297/8.test.yaml
@@ -1,0 +1,39 @@
+- name: temporary_rate_credit_and_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47:297/8#input.individual_is_resident: true
+    us-la:statutes/47:297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47:297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment: 30
+    us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
+- name: post_temporary_rate_no_excess
+  period:
+    period_kind: tax_year
+    start: '2031-01-01'
+    end: '2031-12-31'
+  input:
+    us-la:statutes/47:297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47:297/8#input.individual_is_resident: true
+    us-la:statutes/47:297/8#input.louisiana_income_tax_liability: 40
+  output:
+    us-la:statutes/47:297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: nonresident_has_no_excess_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47:297/8#input.individual_is_resident: false
+    us-la:statutes/47:297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47:297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds

--- a/us-la/statutes/47:297/8.yaml
+++ b/us-la/statutes/47:297/8.yaml
@@ -1,0 +1,137 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-la/statute/47:297.8
+  summary: |-
+    Credit against Louisiana income tax for individuals equals three and one-half percent of the federal earned income tax credit, except tax years beginning on or after January 1, 2019, through December 31, 2030, when it equals five percent. Excess resident-individual credit is an overpayment and its refund is not subject to R.S. 47:1621(B).
+rules:
+  - name: earned_income_tax_credit_base_rate
+    kind: parameter
+    dtype: Rate
+    source: La. R.S. 47:297.8(A)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "three and one-half percent"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "three and one-half percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.035
+      - effective_from: '2031-01-01'
+        formula: |-
+          0.035
+  - name: earned_income_tax_credit_temporary_rate
+    kind: parameter
+    dtype: Rate
+    source: La. R.S. 47:297.8(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "five percent"
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          0.05
+  - name: earned_income_tax_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: La. R.S. 47:297.8(A)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "Except as provided in Paragraph (2)"
+          - path: versions[1].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "For tax years beginning on or after January 1, 2019, through December 31, 2030"
+          - path: versions[2].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "Except as provided in Paragraph (2)"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_tax_credit_base_rate
+      - effective_from: '2019-01-01'
+        formula: |-
+          earned_income_tax_credit_temporary_rate
+      - effective_from: '2031-01-01'
+        formula: |-
+          earned_income_tax_credit_base_rate
+  - name: louisiana_earned_income_tax_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: La. R.S. 47:297.8(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "an amount equal to ... percent of the federal earned income tax credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_tax_credit_rate * max(0, federal_earned_income_tax_credit)
+  - name: earned_income_tax_credit_excess_overpayment
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: La. R.S. 47:297.8(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "If the credit against Louisiana income tax for resident individuals exceeds the amount of such individual's tax liability"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if individual_is_resident: max(0, louisiana_earned_income_tax_credit - louisiana_income_tax_liability) else: 0
+  - name: earned_income_tax_credit_refund_exempt_from_overpayment_requirements
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: La. R.S. 47:297.8(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: "The right to a refund of any such overpayment shall not be subject to the requirements of R.S. 47:1621(B)."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_tax_credit_excess_overpayment > 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-la/statute/47:297.8`
- Module: `us-la/statutes/47:297/8.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-8/rulespec-us/oracle-coverage-pending.yaml: 16 declared (+6 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.