### PR TITLE
Encode us-me/statute/36/5124-C (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11915,6 +11915,15 @@
         ]
       }
     ],
+    "us-me/statute/36/5124-C": [
+      {
+        "module": "us-me/statutes/36/5124-C.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,17 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 15
 entries:
+  - legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction_before_phaseout
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5124-C#standard_deduction_computation_method
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-me/.axiom/encoding-manifests/statutes/36/5124-C.json
+++ b/us-me/.axiom/encoding-manifests/statutes/36/5124-C.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/36/5124-C.yaml",
+      "sha256": "914d616d8c7b7bb72db9d74fb1b73a60b55a847fd0695d0e5ac2edfdee461eba"
+    },
+    {
+      "path": "statutes/36/5124-C.test.yaml",
+      "sha256": "8b0c848afda1bb6312b668f1c15021c3057c809c669ea3f79e66422bbe839e00"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-me/statute/36/5124-C",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5124-c/encode-out/_eval_workspaces/codex-gpt-5.5/us-me-statute-36-5124-C/workspace/context-manifest.json",
+  "context_manifest_sha256": "ee039da3bbce6599ea73ab676f8a179309cf2b4a8dbbbfa1e19585e97c197938",
+  "generated_at": "2026-07-08T15:24:00.732539+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5124-c/encode-out/codex-gpt-5.5/statutes/36/5124-C.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5124-c/encode-out",
+  "generated_output_sha256": "914d616d8c7b7bb72db9d74fb1b73a60b55a847fd0695d0e5ac2edfdee461eba",
+  "generation_prompt_sha256": "e9cfc1668d8a88135404890907d0a370f6c94caa67802b5c49ed2e88b0d6720b",
+  "model": "gpt-5.5",
+  "run_id": "ccf5d741",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e36e1d4e2eb301bd62fdcf742c2f17c6dd75fe78a5b7863b461fab6e694c0495"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5124-c/encode-out/traces/codex-gpt-5.5/us-me-statute-36-5124-C.json",
+  "trace_sha256": "84621281291161ead59f7e2a99d8f90df1a5abee008c8c974c01ea921237a4c1"
+}

--- a/us-me/statutes/36/5124-C.test.yaml
+++ b/us-me/statutes/36/5124-C.test.yaml
@@ -1,0 +1,26 @@
+- name: federal_standard_deduction_period_reduced_by_phaseout
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5124-C#input.federal_standard_deduction: 13850
+    us-me:statutes/36/5124-C#input.basic_standard_deduction: 10000
+    us-me:statutes/36/5124-C#input.additional_standard_deduction: 1500
+    us-me:statutes/36/5124-C#input.standard_deduction_phaseout_reduction_amount: 850
+  output:
+    us-me:statutes/36/5124-C#resident_individual_standard_deduction_before_phaseout: 13850
+    us-me:statutes/36/5124-C#resident_individual_standard_deduction: 13000
+- name: basic_plus_additional_period_reduced_by_phaseout
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:statutes/36/5124-C#input.federal_standard_deduction: 14600
+    us-me:statutes/36/5124-C#input.basic_standard_deduction: 12000
+    us-me:statutes/36/5124-C#input.additional_standard_deduction: 1800
+    us-me:statutes/36/5124-C#input.standard_deduction_phaseout_reduction_amount: 300
+  output:
+    us-me:statutes/36/5124-C#resident_individual_standard_deduction_before_phaseout: 13800
+    us-me:statutes/36/5124-C#resident_individual_standard_deduction: 13500

--- a/us-me/statutes/36/5124-C.yaml
+++ b/us-me/statutes/36/5124-C.yaml
@@ -1,0 +1,81 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-me/statute/36/5124-C
+  summary: |-
+    For tax years beginning on or after January 1, 2020 and before January 1, 2026, the standard deduction of a resident individual is equal to the federal standard deduction, subject to the phase-out under subsection 2. For tax years beginning on or after January 1, 2026, it is equal to the sum of the basic standard deduction and the additional standard deduction, subject to the phase-out under subsection 2.
+rules:
+  - name: standard_deduction_computation_method
+    kind: parameter
+    dtype: Integer
+    source: 36 M.R.S. § 5124-C(1-A), (1-B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "on or after January 1, 2020 and before January 1, 2026"
+          - path: versions[1].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "on or after January 1, 2026"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          1
+      - effective_from: '2026-01-01'
+        formula: |-
+          2
+  - name: resident_individual_standard_deduction_before_phaseout
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5124-C(1-A), (1-B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "equal to the federal standard deduction"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "equal to the sum of the basic standard deduction and the additional standard deduction"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          if standard_deduction_computation_method == 1: federal_standard_deduction else: basic_standard_deduction + additional_standard_deduction
+  - name: resident_individual_standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5124-C(1-A), (1-B), (2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "subject to the phase-out under subsection 2"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "must be reduced by an amount equal to the total standard deduction multiplied by the following fraction"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          max(0, resident_individual_standard_deduction_before_phaseout - standard_deduction_phaseout_reduction_amount)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-me/statute/36/5124-C`
- Module: `us-me/statutes/36/5124-C.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5124-c/rulespec-us/oracle-coverage-pending.yaml: 13 declared (+3 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.