### PR TITLE
Encode us-la/statute/47:297.4 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -9889,6 +9889,15 @@
         ]
       }
     ],
+    "us-la/statute/47:297.4": [
+      {
+        "module": "us-la/statutes/47:297/4.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/regulation/106-cmr/360/010/block-1": [
       {
         "module": "us-ma/regulations/106-cmr/360/010/block-1.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,44 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 24
 entries:
+  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit_carryforward
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#excess_credit_carryforward_year_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#high_income_credit_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#initial_low_income_unreduced_federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#low_income_federal_adjusted_gross_income_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#middle_income_claimed_federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#middle_income_federal_adjusted_gross_income_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#upper_income_claimed_federal_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-la:statutes/47:297/4#upper_middle_income_federal_adjusted_gross_income_limit
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-la/.axiom/encoding-manifests/statutes/47:297/4.json
+++ b/us-la/.axiom/encoding-manifests/statutes/47:297/4.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/47:297/4.yaml",
+      "sha256": "fbb722050bd38639b942bfdf8a3cf5823b0128e64561a93aeb5e261b82cbb88a"
+    },
+    {
+      "path": "statutes/47:297/4.test.yaml",
+      "sha256": "c2070d1e163c28f6c2b474b15bf7f4eacf95d42632703394ef38c1a8e816a7d0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-la/statute/47:297.4",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-4/encode-out/_eval_workspaces/codex-gpt-5.5/us-la-statute-47-297.4/workspace/context-manifest.json",
+  "context_manifest_sha256": "fc07c33e4235bee61cec48ee3c7114b37081f92492bfccf50d64a051c7dfd248",
+  "generated_at": "2026-07-08T15:24:13.025572+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-4/encode-out/codex-gpt-5.5/statutes/47:297/4.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-4/encode-out",
+  "generated_output_sha256": "fbb722050bd38639b942bfdf8a3cf5823b0128e64561a93aeb5e261b82cbb88a",
+  "generation_prompt_sha256": "49dff61bfcc6a9a22656ad7d46e3a0e4352e4a4673ce2a470dcb987be040288e",
+  "model": "gpt-5.5",
+  "run_id": "578309e9",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d0744551d5fa6c95170f88e7052fcf29cad390523e7924b49f3a91f1753f7e2e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-4/encode-out/traces/codex-gpt-5.5/us-la-statute-47-297.4.json",
+  "trace_sha256": "9eabe547f5305aca8b88696982795f391b9d5f588bb3dd9324131cf633234dad"
+}

--- a/us-la/statutes/47:297/4.test.yaml
+++ b/us-la/statutes/47:297/4.test.yaml
@@ -1,0 +1,83 @@
+- name: low_income_refundable_credit_uses_unreduced_federal_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/4#input.individual_is_resident: true
+    us-la:statutes/47:297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47:297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47:297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47:297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
+    us-la:statutes/47:297/4#input.taxable_year_is_in_initial_low_income_credit_period: false
+    us-la:statutes/47:297/4#input.louisiana_income_tax_liability: 300
+  output:
+    us-la:statutes/47:297/4#child_care_expense_credit: 500
+    us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment: 200
+    us-la:statutes/47:297/4#child_care_expense_credit_carryforward: 0
+- name: middle_income_nonrefundable_excess_carries_forward
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/4#input.individual_is_resident: true
+    us-la:statutes/47:297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47:297/4#input.federal_adjusted_gross_income: 30000
+    us-la:statutes/47:297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47:297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47:297/4#input.taxable_year_is_in_initial_low_income_credit_period: false
+    us-la:statutes/47:297/4#input.louisiana_income_tax_liability: 100
+  output:
+    us-la:statutes/47:297/4#child_care_expense_credit: 180
+    us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47:297/4#child_care_expense_credit_carryforward: 80
+- name: upper_middle_income_credit_is_ten_percent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/4#input.individual_is_resident: true
+    us-la:statutes/47:297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47:297/4#input.federal_adjusted_gross_income: 50000
+    us-la:statutes/47:297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47:297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47:297/4#input.taxable_year_is_in_initial_low_income_credit_period: false
+    us-la:statutes/47:297/4#input.louisiana_income_tax_liability: 100
+  output:
+    us-la:statutes/47:297/4#child_care_expense_credit: 60
+    us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47:297/4#child_care_expense_credit_carryforward: 0
+- name: high_income_credit_is_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47:297/4#input.individual_is_resident: true
+    us-la:statutes/47:297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47:297/4#input.federal_adjusted_gross_income: 70000
+    us-la:statutes/47:297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47:297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47:297/4#input.taxable_year_is_in_initial_low_income_credit_period: false
+    us-la:statutes/47:297/4#input.louisiana_income_tax_liability: 10
+  output:
+    us-la:statutes/47:297/4#child_care_expense_credit: 25
+    us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47:297/4#child_care_expense_credit_carryforward: 15
+- name: auto_zero_child_care_expense_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47:297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
+    us-la:statutes/47:297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47:297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
+    us-la:statutes/47:297/4#input.individual_is_resident: false
+    us-la:statutes/47:297/4#input.louisiana_income_tax_liability: 0
+    us-la:statutes/47:297/4#input.taxable_year_is_in_initial_low_income_credit_period: false
+    us-la:statutes/47:297/4#input.unreduced_federal_child_care_credit: 0
+  output:
+    us-la:statutes/47:297/4#child_care_expense_credit: 0

--- a/us-la/statutes/47:297/4.yaml
+++ b/us-la/statutes/47:297/4.yaml
@@ -1,0 +1,238 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-la/statute/47:297.4
+  summary: Credit from Louisiana income tax for child care expenses for which a resident
+    individual is eligible pursuant to IRC Section 21; percentage varies by federal
+    adjusted gross income, with refundability for individuals at or below $25,000
+    and five-year carryforward for individuals above $25,000.
+rules:
+- name: low_income_federal_adjusted_gross_income_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(A)(1), (B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: federal adjusted gross income is equal to or less than twenty-five
+            thousand dollars
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25000'
+- name: middle_income_federal_adjusted_gross_income_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: greater than twenty-five thousand dollars and less than or equal
+            to thirty-five thousand dollars
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '35000'
+- name: upper_middle_income_federal_adjusted_gross_income_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(A)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: greater than thirty-five thousand and less than or equal to sixty
+            thousand dollars
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '60000'
+- name: initial_low_income_unreduced_federal_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: R.S. 47:297.4(A)(1)(a)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: twenty-five percent of the unreduced federal credit
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.25'
+- name: later_low_income_unreduced_federal_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: R.S. 47:297.4(A)(1)(a)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: For tax years beginning after December 31, 2006 fifty percent of
+            the unreduced federal credit
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.50'
+- name: middle_income_claimed_federal_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: R.S. 47:297.4(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: thirty percent of the federal credit for child care expenses claimed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.30'
+- name: upper_income_claimed_federal_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: R.S. 47:297.4(A)(3), (A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: ten percent of the federal credit for child care expenses claimed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.10'
+- name: high_income_credit_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: lesser of twenty-five dollars or ten percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '25'
+- name: excess_credit_carryforward_year_limit
+  kind: parameter
+  dtype: Count
+  period: Year
+  source: R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: for a period not exceeding five years
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '5'
+- name: child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: resident individual is eligible pursuant to the federal income
+            tax credit provided by Internal Revenue Code Section 21
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: The credit shall be calculated using the following percentages
+  versions:
+  - effective_from: '0001-01-01'
+    formula: |-
+      if individual_is_resident and eligible_for_federal_child_care_credit_under_section_21:
+        if federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:
+          unreduced_federal_child_care_credit * (if taxable_year_is_in_initial_low_income_credit_period: initial_low_income_unreduced_federal_credit_percentage else: later_low_income_unreduced_federal_credit_percentage)
+        else:
+          if federal_adjusted_gross_income <= middle_income_federal_adjusted_gross_income_limit:
+            federal_child_care_credit_claimed_on_federal_return * middle_income_claimed_federal_credit_percentage
+          else:
+            if federal_adjusted_gross_income <= upper_middle_income_federal_adjusted_gross_income_limit:
+              federal_child_care_credit_claimed_on_federal_return * upper_income_claimed_federal_credit_percentage
+            else:
+              min(max(0, high_income_credit_cap), max(0, federal_child_care_credit_claimed_on_federal_return * upper_income_claimed_federal_credit_percentage))
+      else:
+        0
+- name: child_care_expense_credit_refundable_overpayment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: If the credit ... for resident individuals whose federal adjusted
+            gross income is equal to or less than twenty-five thousand dollars exceeds
+            the amount of such individual's tax liability
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if individual_is_resident and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:
+      max(0, child_care_expense_credit - louisiana_income_tax_liability) else: 0'
+- name: child_care_expense_credit_carryforward
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: If the credit ... for resident individuals whose federal adjusted
+            gross income is greater than twenty-five thousand dollars exceeds the
+            amount of such individual's tax liability
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if individual_is_resident and federal_adjusted_gross_income > low_income_federal_adjusted_gross_income_limit:
+      max(0, child_care_expense_credit - louisiana_income_tax_liability) else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-la/statute/47:297.4`
- Module: `us-la/statutes/47:297/4.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-la-statute-47-297-4/rulespec-us/oracle-coverage-pending.yaml: 22 declared (+12 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.