### PR TITLE
Encode us-me/statute/36/5111 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11915,6 +11915,15 @@
         ]
       }
     ],
+    "us-me/statute/36/5111": [
+      {
+        "module": "us-me/statutes/36/5111.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,74 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 34
 entries:
+  - legal_id: us-me:statutes/36/5111#head_of_household_band_0_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_band_1_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_base_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_excess_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#head_of_household_tax_band
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_0_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_1_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_base_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_excess_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_tax_band
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#nonresident_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_band_0_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_band_1_upper
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_base_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_excess_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_income_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5111#single_separate_tax_band
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-me/.axiom/encoding-manifests/statutes/36/5111.json
+++ b/us-me/.axiom/encoding-manifests/statutes/36/5111.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/36/5111.yaml",
+      "sha256": "acca484401c98c3b4223613d1827aae02a8cedaf9a8e2c4e7ba806eb7110aed8"
+    },
+    {
+      "path": "statutes/36/5111.test.yaml",
+      "sha256": "d375d89771a50882bc4a75d54c87c060bf4173d0069e7e5f6509537f3e26b273"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-me/statute/36/5111",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5111/encode-out/_eval_workspaces/codex-gpt-5.5/us-me-statute-36-5111/workspace/context-manifest.json",
+  "context_manifest_sha256": "cf441b4e1bfec2dd48ec9b10261b39c443e9171d4d533888bff65ee05b46f1c6",
+  "generated_at": "2026-07-08T15:24:28.902102+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5111/encode-out/codex-gpt-5.5/statutes/36/5111.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5111/encode-out",
+  "generated_output_sha256": "acca484401c98c3b4223613d1827aae02a8cedaf9a8e2c4e7ba806eb7110aed8",
+  "generation_prompt_sha256": "728dc03db79763c2cd7a18471bf3249bf8091c50252d4f45b0660cd25115b3fa",
+  "model": "gpt-5.5",
+  "run_id": "0741921f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3c1436568c550ad56994cf57dcc0bd3293540c60d9b8a70c4e102838921f72ad"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5111/encode-out/traces/codex-gpt-5.5/us-me-statute-36-5111.json",
+  "trace_sha256": "be9d19455c53bb990e0e742c868f259dd08046af52024a9232406ea275894599"
+}

--- a/us-me/statutes/36/5111.test.yaml
+++ b/us-me/statutes/36/5111.test.yaml
@@ -1,0 +1,65 @@
+- name: single separate top band tax year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5111#input.maine_taxable_income: 60000
+  output:
+    us-me:statutes/36/5111#single_separate_tax_band: 2
+    us-me:statutes/36/5111#single_separate_income_tax: 3890
+- name: head of household middle band tax year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5111#input.maine_taxable_income: 50000
+  output:
+    us-me:statutes/36/5111#head_of_household_tax_band: 1
+    us-me:statutes/36/5111#head_of_household_income_tax: 3075.375
+- name: joint surviving spouse first band tax year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5111#input.maine_taxable_income: 40000
+  output:
+    us-me:statutes/36/5111#joint_surviving_spouse_tax_band: 0
+    us-me:statutes/36/5111#joint_surviving_spouse_income_tax: 2320
+- name: nonresident ratio tax year
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5111#input.resident_income_tax_computed_under_this_section_and_chapter_805: 2000
+    us-me:statutes/36/5111#input.maine_adjusted_gross_income: 30000
+    us-me:statutes/36/5111#input.entire_federal_adjusted_gross_income: 60000
+  output:
+    us-me:statutes/36/5111#nonresident_income_tax: 1000
+- name: auto_zero_single_separate_tax_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:statutes/36/5111#input.entire_federal_adjusted_gross_income: 0
+    us-me:statutes/36/5111#input.maine_adjusted_gross_income: 0
+    us-me:statutes/36/5111#input.maine_taxable_income: 21049
+    us-me:statutes/36/5111#input.resident_income_tax_computed_under_this_section_and_chapter_805: 0
+  output:
+    us-me:statutes/36/5111#single_separate_tax_band: 0
+- name: auto_zero_head_of_household_tax_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:statutes/36/5111#input.entire_federal_adjusted_gross_income: 0
+    us-me:statutes/36/5111#input.maine_adjusted_gross_income: 0
+    us-me:statutes/36/5111#input.maine_taxable_income: 31549
+    us-me:statutes/36/5111#input.resident_income_tax_computed_under_this_section_and_chapter_805: 0
+  output:
+    us-me:statutes/36/5111#head_of_household_tax_band: 0

--- a/us-me/statutes/36/5111.yaml
+++ b/us-me/statutes/36/5111.yaml
@@ -1,0 +1,466 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-me/statute/36/5111
+  summary: |-
+    Maine section 5111 imposes individual income tax tables for single and married separate filers, heads of households, and married joint filers or surviving spouses, with historical tables for tax years beginning 2000 through 2016 and current tables for tax years beginning on or after January 1, 2017. It also imposes nonresident tax equal to resident tax computed under this section and chapter 805 multiplied by the ratio of Maine adjusted gross income to entire federal adjusted gross income.
+rules:
+  - name: single_separate_tax_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 36 M.R.S. § 5111(1-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $21,050 ... At least $21,050 but less than $50,000 ... $50,000 or more"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          if maine_taxable_income < single_separate_band_0_upper:
+            0
+          else:
+            if maine_taxable_income < single_separate_band_1_upper:
+              1
+            else:
+              2
+  - name: single_separate_band_0_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(1-F), row 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $21,050"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          21050
+  - name: single_separate_band_1_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(1-F), row 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "At least $21,050 but less than $50,000"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          50000
+  - name: single_separate_base_tax
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: single_separate_tax_band
+    source: 36 M.R.S. § 5111(1-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "single individuals and married persons filing separate returns"
+                row_key: "Maine taxable income band"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 1221
+          2: 3175
+  - name: single_separate_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: single_separate_tax_band
+    source: 36 M.R.S. § 5111(1-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "single individuals and married persons filing separate returns"
+                row_key: "Maine taxable income band"
+                column_key: "excess over threshold"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 21050
+          2: 50000
+  - name: single_separate_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: single_separate_tax_band
+    source: 36 M.R.S. § 5111(1-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "single individuals and married persons filing separate returns"
+                row_key: "Maine taxable income band"
+                column_key: "tax rate"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0.058
+          1: 0.0675
+          2: 0.0715
+  - name: single_separate_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5111(1-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "The tax is ... 5.8% ... $1,221 plus 6.75% ... $3,175 plus 7.15%"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          single_separate_base_tax[single_separate_tax_band] + single_separate_rate[single_separate_tax_band] * max(0, maine_taxable_income - single_separate_excess_threshold[single_separate_tax_band])
+
+  - name: head_of_household_tax_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 36 M.R.S. § 5111(2-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $31,550 ... At least $31,550 but less than $75,000 ... $75,000 or more"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          if maine_taxable_income < head_of_household_band_0_upper:
+            0
+          else:
+            if maine_taxable_income < head_of_household_band_1_upper:
+              1
+            else:
+              2
+  - name: head_of_household_band_0_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(2-F), row 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $31,550"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          31550
+  - name: head_of_household_band_1_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(2-F), row 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "At least $31,550 but less than $75,000"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          75000
+  - name: head_of_household_base_tax
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: head_of_household_tax_band
+    source: 36 M.R.S. § 5111(2-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "heads of households"
+                row_key: "Maine taxable income band"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 1830
+          2: 4763
+  - name: head_of_household_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: head_of_household_tax_band
+    source: 36 M.R.S. § 5111(2-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "heads of households"
+                row_key: "Maine taxable income band"
+                column_key: "excess over threshold"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 31550
+          2: 75000
+  - name: head_of_household_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: head_of_household_tax_band
+    source: 36 M.R.S. § 5111(2-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "heads of households"
+                row_key: "Maine taxable income band"
+                column_key: "tax rate"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0.058
+          1: 0.0675
+          2: 0.0715
+  - name: head_of_household_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5111(2-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "The tax is ... 5.8% ... $1,830 plus 6.75% ... $4,763 plus 7.15%"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          head_of_household_base_tax[head_of_household_tax_band] + head_of_household_rate[head_of_household_tax_band] * max(0, maine_taxable_income - head_of_household_excess_threshold[head_of_household_tax_band])
+
+  - name: joint_surviving_spouse_tax_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 36 M.R.S. § 5111(3-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $42,100 ... At least $42,100 but less than $100,000 ... $100,000 or more"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          if maine_taxable_income < joint_surviving_spouse_band_0_upper:
+            0
+          else:
+            if maine_taxable_income < joint_surviving_spouse_band_1_upper:
+              1
+            else:
+              2
+  - name: joint_surviving_spouse_band_0_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(3-F), row 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "Less than $42,100"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          42100
+  - name: joint_surviving_spouse_band_1_upper
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5111(3-F), row 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "At least $42,100 but less than $100,000"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          100000
+  - name: joint_surviving_spouse_base_tax
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: joint_surviving_spouse_tax_band
+    source: 36 M.R.S. § 5111(3-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "married joint returns or surviving spouses"
+                row_key: "Maine taxable income band"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 2442
+          2: 6350
+  - name: joint_surviving_spouse_excess_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: joint_surviving_spouse_tax_band
+    source: 36 M.R.S. § 5111(3-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "married joint returns or surviving spouses"
+                row_key: "Maine taxable income band"
+                column_key: "excess over threshold"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0
+          1: 42100
+          2: 100000
+  - name: joint_surviving_spouse_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: joint_surviving_spouse_tax_band
+    source: 36 M.R.S. § 5111(3-F), tax table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              table:
+                header: "married joint returns or surviving spouses"
+                row_key: "Maine taxable income band"
+                column_key: "tax rate"
+    versions:
+      - effective_from: '2017-01-01'
+        values:
+          0: 0.058
+          1: 0.0675
+          2: 0.0715
+  - name: joint_surviving_spouse_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5111(3-F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "The tax is ... 5.8% ... $2,442 plus 6.75% ... $6,350 plus 7.15%"
+    versions:
+      - effective_from: '2017-01-01'
+        formula: |-
+          joint_surviving_spouse_base_tax[joint_surviving_spouse_tax_band] + joint_surviving_spouse_rate[joint_surviving_spouse_tax_band] * max(0, maine_taxable_income - joint_surviving_spouse_excess_threshold[joint_surviving_spouse_tax_band])
+
+  - name: nonresident_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5111(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "equals the tax computed under this section and chapter 805 as if the nonresident individual were a resident individual, multiplied by the ratio"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          resident_income_tax_computed_under_this_section_and_chapter_805 * maine_adjusted_gross_income / entire_federal_adjusted_gross_income


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-me/statute/36/5111`
- Module: `us-me/statutes/36/5111.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5111/rulespec-us/oracle-coverage-pending.yaml: 32 declared (+22 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.