### PR TITLE
Encode us-me/statute/36/5213-A (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11915,6 +11915,15 @@
         ]
       }
     ],
+    "us-me/statute/36/5213-A": [
+      {
+        "module": "us-me/statutes/36/5213-A.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,11 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 13
 entries:
+  - legal_id: us-me:statutes/36/5213-A#tax_credit_allowed_under_this_section_is_refundable
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-me/.axiom/encoding-manifests/statutes/36/5213-A.json
+++ b/us-me/.axiom/encoding-manifests/statutes/36/5213-A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/36/5213-A.yaml",
+      "sha256": "05d20648097417c8572c6f56131f916a5b8b8722dd0fb0457b5ca1020ac28af7"
+    },
+    {
+      "path": "statutes/36/5213-A.test.yaml",
+      "sha256": "1a99088ff679a6cea9b3cdb4570a0f2b475bb38973271cc47c4aad7daeb6b3ac"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-me/statute/36/5213-A",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5213-a/encode-out/_eval_workspaces/codex-gpt-5.5/us-me-statute-36-5213-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "e5c0ccbd766e2f1f63c710e06747c7fb32919557d61edb0320a29a38a999ca45",
+  "generated_at": "2026-07-08T15:24:52.365971+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5213-a/encode-out/codex-gpt-5.5/statutes/36/5213-A.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5213-a/encode-out",
+  "generated_output_sha256": "05d20648097417c8572c6f56131f916a5b8b8722dd0fb0457b5ca1020ac28af7",
+  "generation_prompt_sha256": "b5a4aabf46558d5235eb461325d280be8695e7a480518d8afada44a78a9ca4a0",
+  "model": "gpt-5.5",
+  "run_id": "5c00a599",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4b72b91373ea5d210790325b5a95428d16d2f89861311355e8f1907ffcfe91b3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5213-a/encode-out/traces/codex-gpt-5.5/us-me-statute-36-5213-A.json",
+  "trace_sha256": "5d375c91fc4245cabf4a4a79b21f6da399ebf4409a98bb72ef4dbd95507a756e"
+}

--- a/us-me/statutes/36/5213-A.test.yaml
+++ b/us-me/statutes/36/5213-A.test.yaml
@@ -1,0 +1,8 @@
+- name: tax credit under section is refundable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-me:statutes/36/5213-A#tax_credit_allowed_under_this_section_is_refundable: holds

--- a/us-me/statutes/36/5213-A.yaml
+++ b/us-me/statutes/36/5213-A.yaml
@@ -1,0 +1,34 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-me/statute/36/5213-A
+  summary: |-
+    Resident individual credit equals the applicable base credit amount, subject to subsection 4 phase-out. Part-year resident credit is prorated by a resident/nonresident Maine-source income ratio. The credit is refundable. Certain limitations are introduced, but the listed disqualified individuals and phase-out mechanics are not included in this source slice.
+  deferred_outputs:
+    - output: us-me:statutes/36/5213-A#resident_taxpayer_credit
+      reason: The source states the resident credit is the applicable base credit amount subject to subsection 4 phase-out, but this slice does not provide the applicable base credit amount or phase-out mechanics.
+    - output: us-me:statutes/36/5213-A#part_year_resident_taxpayer_credit
+      reason: The source states a prorated part-year resident credit using income as modified by sections 5122 and 5142 and subsection 4 phase-out, but those cited income definitions and the phase-out mechanics are not provided in copied context.
+    - output: us-me:statutes/36/5213-A#taxpayer_qualifies_for_credit
+      reason: The source introduces limitations for individuals who do not qualify, but the disqualifying list is not included in this source slice.
+rules:
+  - name: tax_credit_allowed_under_this_section_is_refundable
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 36 M.R.S. § 5213-A(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-me/statute/36/5213-A
+              excerpt: The tax credit allowed under this section is refundable.
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          true


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-me/statute/36/5213-A`
- Module: `us-me/statutes/36/5213-A.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5213-a/rulespec-us/oracle-coverage-pending.yaml: 11 declared (+1 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.