### PR TITLE
Encode us-me/statute/36/5126-A (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11915,6 +11915,15 @@
         ]
       }
     ],
+    "us-me/statute/36/5126-A": [
+      {
+        "module": "us-me/statutes/36/5126-A.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,32 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 20
 entries:
+  - legal_id: us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#married_separate_phaseout_denominator
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#nonjoint_spouse_additional_personal_exemption_deduction_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#other_phaseout_denominator
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-me/.axiom/encoding-manifests/statutes/36/5126-A.json
+++ b/us-me/.axiom/encoding-manifests/statutes/36/5126-A.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/36/5126-A.yaml",
+      "sha256": "5c3094e945bf84e7c44cd2217f9b48107c36bee5189260c0157269dd8ed2ced7"
+    },
+    {
+      "path": "statutes/36/5126-A.test.yaml",
+      "sha256": "ff443b2078284e11c4fdcd31e9c805ed4772955b08ec9edc594adc8ca1806d7e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-me/statute/36/5126-A",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5126-a/encode-out/_eval_workspaces/codex-gpt-5.5/us-me-statute-36-5126-A/workspace/context-manifest.json",
+  "context_manifest_sha256": "7ecca4951f004baa3951a599460711682629c04b3bd44fcd1dd11c782057d34a",
+  "generated_at": "2026-07-08T15:25:17.379562+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5126-a/encode-out/codex-gpt-5.5/statutes/36/5126-A.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5126-a/encode-out",
+  "generated_output_sha256": "5c3094e945bf84e7c44cd2217f9b48107c36bee5189260c0157269dd8ed2ced7",
+  "generation_prompt_sha256": "2fa9b5f4e6e456e1657f4559b78c16c167014f6219a7af923e784bad1f132b56",
+  "model": "gpt-5.5",
+  "run_id": "850ab83d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "56587d142a4ca6514a4aa9c66b27b7bb8f4f63fa6efdf503f688fa636dbd7b3d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5126-a/encode-out/traces/codex-gpt-5.5/us-me-statute-36-5126-A.json",
+  "trace_sha256": "10d199f3f15beab1a470efd6e7030caaa480ea944dc4a93066734d5ed6a5e495"
+}

--- a/us-me/statutes/36/5126-A.test.yaml
+++ b/us-me/statutes/36/5126-A.test.yaml
@@ -1,0 +1,39 @@
+- name: base_and_joint_exemptions_allowed_before_deferred_phaseout
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5126-A#input.individual_may_be_claimed_as_dependent_on_another_return: false
+    us-me:statutes/36/5126-A#input.individual_is_married: true
+    us-me:statutes/36/5126-A#input.individual_files_joint_return: true
+  output:
+    us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout: 4150
+    us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction: 4150
+    us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch: 8300
+- name: dependent_claimed_on_another_return_blocks_base_exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5126-A#input.individual_may_be_claimed_as_dependent_on_another_return: true
+    us-me:statutes/36/5126-A#input.individual_is_married: true
+    us-me:statutes/36/5126-A#input.individual_files_joint_return: true
+  output:
+    us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout: 0
+    us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction: 4150
+    us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch: 4150
+- name: no_joint_return_additional_exemption_when_not_joint
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5126-A#input.individual_may_be_claimed_as_dependent_on_another_return: false
+    us-me:statutes/36/5126-A#input.individual_is_married: true
+    us-me:statutes/36/5126-A#input.individual_files_joint_return: false
+  output:
+    us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout: 4150
+    us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction: 0
+    us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch: 4150

--- a/us-me/statutes/36/5126-A.yaml
+++ b/us-me/statutes/36/5126-A.yaml
@@ -1,0 +1,183 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-me/statute/36/5126-A
+  summary: |-
+    For income tax years beginning on or after January 1, 2018, a resident individual is allowed a personal exemption deduction equal to $4,150, unless the individual may be claimed as a dependent on another return, plus $4,150 if married filing a joint return. For years beginning on or after January 1, 2020, an additional $4,150 may be allowed for a non-joint spouse if federal spouse exemption conditions are met and the spouse is not claimable as a dependent. The deduction is reduced by a phase-out fraction using Maine adjusted gross income over an inflation-adjusted applicable amount, with denominators of $62,500 for married filing separately and $125,000 in all other cases, capped at one.
+  deferred_outputs:
+    - output: us-me:statutes/36/5126-A#personal_exemption_deduction
+      reason: The final deduction depends on the applicable amount adjusted for inflation under section 5403, but no copied context provides the exact executable output for that cited adjustment.
+    - output: us-me:statutes/36/5126-A#nonjoint_spouse_additional_personal_exemption_deduction
+      reason: The non-joint spouse branch depends on whether an exemption deduction would be allowed for the individual's spouse under Code section 151, notwithstanding section 151(d)(5)(A), but no copied context provides the cited executable dependency.
+rules:
+  - name: personal_exemption_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "equal to $4,150"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "income tax years beginning on or after January 1, 2018"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          4150
+  - name: joint_return_additional_personal_exemption_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "additional personal exemption deduction ... equal to $4,150 if the individual is married filing a joint return"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "income tax years beginning on or after January 1, 2018"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          4150
+  - name: nonjoint_spouse_additional_personal_exemption_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "additional personal exemption deduction ... equal to $4,150 if the individual is married and does not file a joint return"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "income tax years beginning on or after January 1, 2020"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          4150
+  - name: married_separate_phaseout_denominator
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5126-A(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "denominator is $62,500 in the case of a married individual filing a separate return"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          62500
+  - name: other_phaseout_denominator
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 36 M.R.S. § 5126-A(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "denominator is ... $125,000 in all other cases"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          125000
+  - name: base_personal_exemption_deduction_before_phaseout
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "resident individual is allowed a personal exemption deduction ... equal to $4,150, unless the individual may be claimed as a dependent on another return"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          if individual_may_be_claimed_as_dependent_on_another_return: 0 else: personal_exemption_deduction_amount
+  - name: joint_return_additional_personal_exemption_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "if the individual is married filing a joint return"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          if individual_is_married and individual_files_joint_return: joint_return_additional_personal_exemption_deduction_amount else: 0
+  - name: personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 36 M.R.S. § 5126-A(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-me/statute/36/5126-A
+              excerpt: "The deduction allowed under this subsection is subject to the phase-out under subsection 2"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          base_personal_exemption_deduction_before_phaseout + joint_return_additional_personal_exemption_deduction


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-me/statute/36/5126-A`
- Module: `us-me/statutes/36/5126-A.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5126-a/rulespec-us/oracle-coverage-pending.yaml: 18 declared (+8 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.