### PR TITLE
Encode us-me/statute/36/5219-S (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11915,6 +11915,15 @@
         ]
       }
     ],
+    "us-me/statute/36/5219-S": [
+      {
+        "module": "us-me/statutes/36/5219-S.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,20 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 16
 entries:
+  - legal_id: us-me:statutes/36/5219-S#eligible_without_qualifying_child_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-me:statutes/36/5219-S#other_eligible_individual_credit_rate
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-me/.axiom/encoding-manifests/statutes/36/5219-S.json
+++ b/us-me/.axiom/encoding-manifests/statutes/36/5219-S.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/36/5219-S.yaml",
+      "sha256": "29564f79d2bd6bf8bc866925c31a0fcc88946c74d85eb9b1617d3cf68c5e1d11"
+    },
+    {
+      "path": "statutes/36/5219-S.test.yaml",
+      "sha256": "f136389ed5020aa2a228bfc5329989e3c21842541fad44f5960c4fe20986a6eb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-me/statute/36/5219-S",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5219-s/encode-out/_eval_workspaces/codex-gpt-5.5/us-me-statute-36-5219-S/workspace/context-manifest.json",
+  "context_manifest_sha256": "7cce673f7060edf5314953712428abf69009511d303278fb32033f4a300a4812",
+  "generated_at": "2026-07-08T15:25:48.220229+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5219-s/encode-out/codex-gpt-5.5/statutes/36/5219-S.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5219-s/encode-out",
+  "generated_output_sha256": "29564f79d2bd6bf8bc866925c31a0fcc88946c74d85eb9b1617d3cf68c5e1d11",
+  "generation_prompt_sha256": "a0e48c1a829e086aa996141aa316c57c0130b55ae65b8219b2e7908b5abb4e93",
+  "model": "gpt-5.5",
+  "run_id": "e98ccaca",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3398595e71a574437cf2377f492b16621c736443b0675e402733932ba98cb2c1"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5219-s/encode-out/traces/codex-gpt-5.5/us-me-statute-36-5219-S.json",
+  "trace_sha256": "3be01ee2d448b8afed1baf5c4ea8e3f4480284f729c72890e6f780caa593e456"
+}

--- a/us-me/statutes/36/5219-S.test.yaml
+++ b/us-me/statutes/36/5219-S.test.yaml
@@ -1,0 +1,84 @@
+- name: resident_without_qualifying_child_refundable_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5219-S#input.individual_is_eligible_individual: true
+    us-me:statutes/36/5219-S#input.individual_does_not_have_qualifying_child: true
+    us-me:statutes/36/5219-S#input.individual_files_as_nonresident: false
+    us-me:statutes/36/5219-S#input.individual_files_as_part_year_resident: false
+    us-me:statutes/36/5219-S#input.federal_earned_income_credit: 1000
+    us-me:statutes/36/5219-S#input.maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.part_year_maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.maine_income_tax_otherwise_due: 100
+  output:
+    us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation: 500
+    us-me:statutes/36/5219-S#maine_earned_income_credit: 500
+- name: resident_with_qualifying_child_uses_other_rate
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5219-S#input.individual_is_eligible_individual: true
+    us-me:statutes/36/5219-S#input.individual_does_not_have_qualifying_child: false
+    us-me:statutes/36/5219-S#input.individual_files_as_nonresident: false
+    us-me:statutes/36/5219-S#input.individual_files_as_part_year_resident: false
+    us-me:statutes/36/5219-S#input.federal_earned_income_credit: 1000
+    us-me:statutes/36/5219-S#input.maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.part_year_maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.maine_income_tax_otherwise_due: 100
+  output:
+    us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation: 250
+    us-me:statutes/36/5219-S#maine_earned_income_credit: 250
+- name: nonresident_credit_is_prorated_and_nonrefundable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5219-S#input.individual_is_eligible_individual: true
+    us-me:statutes/36/5219-S#input.individual_does_not_have_qualifying_child: true
+    us-me:statutes/36/5219-S#input.individual_files_as_nonresident: true
+    us-me:statutes/36/5219-S#input.individual_files_as_part_year_resident: false
+    us-me:statutes/36/5219-S#input.federal_earned_income_credit: 1000
+    us-me:statutes/36/5219-S#input.maine_adjusted_gross_income_ratio: 0.5
+    us-me:statutes/36/5219-S#input.part_year_maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.maine_income_tax_otherwise_due: 200
+  output:
+    us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation: 250
+    us-me:statutes/36/5219-S#maine_earned_income_credit: 200
+- name: part_year_resident_credit_is_prorated_and_refundable
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-me:statutes/36/5219-S#input.individual_is_eligible_individual: true
+    us-me:statutes/36/5219-S#input.individual_does_not_have_qualifying_child: false
+    us-me:statutes/36/5219-S#input.individual_files_as_nonresident: false
+    us-me:statutes/36/5219-S#input.individual_files_as_part_year_resident: true
+    us-me:statutes/36/5219-S#input.federal_earned_income_credit: 1000
+    us-me:statutes/36/5219-S#input.maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.part_year_maine_adjusted_gross_income_ratio: 0.5
+    us-me:statutes/36/5219-S#input.maine_income_tax_otherwise_due: 50
+  output:
+    us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation: 125
+    us-me:statutes/36/5219-S#maine_earned_income_credit: 125
+- name: auto_zero_maine_earned_income_credit_before_limitation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:statutes/36/5219-S#input.federal_earned_income_credit: 0
+    us-me:statutes/36/5219-S#input.individual_does_not_have_qualifying_child: false
+    us-me:statutes/36/5219-S#input.individual_files_as_nonresident: false
+    us-me:statutes/36/5219-S#input.individual_files_as_part_year_resident: false
+    us-me:statutes/36/5219-S#input.individual_is_eligible_individual: false
+    us-me:statutes/36/5219-S#input.maine_adjusted_gross_income_ratio: 0
+    us-me:statutes/36/5219-S#input.maine_income_tax_otherwise_due: 0
+    us-me:statutes/36/5219-S#input.part_year_maine_adjusted_gross_income_ratio: 0
+  output:
+    us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation: 0

--- a/us-me/statutes/36/5219-S.yaml
+++ b/us-me/statutes/36/5219-S.yaml
@@ -1,0 +1,94 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-me/statute/36/5219-S
+  summary: Resident, nonresident, and part-year resident eligible individuals are
+    allowed Maine earned income tax credits based on percentages of the federal earned
+    income credit. For tax years beginning 2022 or after, the percentage is 50% for
+    eligible individuals without a qualifying child and 25% for all other eligible
+    individuals; nonresident and part-year resident credits are multiplied by Maine-to-federal
+    adjusted gross income ratios. The credit may not reduce Maine income tax below
+    zero, except credits under subsections 1, 1-A, 3 and 3-A are refundable for tax
+    years beginning on or after January 1, 2016.
+rules:
+- name: eligible_without_qualifying_child_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: "36 M.R.S. \xA7 5219-S(1-A), (2-A), (3-A)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-me/statute/36/5219-S
+          excerpt: 50% of the federal earned income credit
+  versions:
+  - effective_from: '2022-01-01'
+    formula: '0.50'
+- name: other_eligible_individual_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: "36 M.R.S. \xA7 5219-S(1-A), (2-A), (3-A)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-me/statute/36/5219-S
+          excerpt: 25% of the federal earned income credit
+  versions:
+  - effective_from: '2022-01-01'
+    formula: '0.25'
+- name: maine_earned_income_credit_before_limitation
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "36 M.R.S. \xA7 5219-S(1-A), (2-A), (3-A)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-me/statute/36/5219-S
+          excerpt: multiplied by the ratio of the individual's Maine adjusted gross
+            income ... to the individual's entire federal adjusted gross income
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-me/statute/36/5219-S
+          excerpt: resident individual ... 50% ... without a qualifying child and
+            25% ... all other
+  versions:
+  - effective_from: '2022-01-01'
+    formula: 'if individual_is_eligible_individual: federal_earned_income_credit *
+      (if individual_does_not_have_qualifying_child: eligible_without_qualifying_child_credit_rate
+      else: other_eligible_individual_credit_rate) * (if individual_files_as_nonresident:
+      maine_adjusted_gross_income_ratio else: if individual_files_as_part_year_resident:
+      part_year_maine_adjusted_gross_income_ratio else: 1) else: 0'
+- name: maine_earned_income_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "36 M.R.S. \xA7 5219-S(4)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-me/statute/36/5219-S
+          excerpt: may not reduce the Maine income tax to less than zero, except that
+            ... subsections 1, 1-A, 3 and 3-A is refundable
+  versions:
+  - effective_from: '2022-01-01'
+    formula: |-
+      if individual_files_as_nonresident: min(max(0, maine_earned_income_credit_before_limitation), max(0, maine_income_tax_otherwise_due)) else: maine_earned_income_credit_before_limitation


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-me/statute/36/5219-S`
- Module: `us-me/statutes/36/5219-S.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-me-statute-36-5219-s/rulespec-us/oracle-coverage-pending.yaml: 16 declared (+4 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.