### PR TITLE
Encode us-md/statute/gtg/10-105 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11906,6 +11906,15 @@
         ]
       }
     ],
+    "us-md/statute/gtg/10-105": [
+      {
+        "module": "us-md/statutes/gtg/10-105.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-me/regulation/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need": [
       {
         "module": "us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.yaml",

--- a/us-md/.axiom/encoding-manifests/statutes/gtg/10-105.json
+++ b/us-md/.axiom/encoding-manifests/statutes/gtg/10-105.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/gtg/10-105.yaml",
+      "sha256": "715794ef8b789530b5ee9e906a0114d3ad0b848fb733b4915ba1aab6c953172e"
+    },
+    {
+      "path": "statutes/gtg/10-105.test.yaml",
+      "sha256": "0a42d43df375ef0b2b5e03f5d86fd75bfc474562a88bf5d9532d237a988d9baf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-md/statute/gtg/10-105",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-105/encode-out/_eval_workspaces/codex-gpt-5.5/us-md-statute-gtg-10-105/workspace/context-manifest.json",
+  "context_manifest_sha256": "e09fd11622a19e343ab4db050ede150142bd43c61a44c4c5a56cde207f64db38",
+  "generated_at": "2026-07-08T15:26:08.647896+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-105/encode-out/codex-gpt-5.5/statutes/gtg/10-105.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-105/encode-out",
+  "generated_output_sha256": "715794ef8b789530b5ee9e906a0114d3ad0b848fb733b4915ba1aab6c953172e",
+  "generation_prompt_sha256": "f121e717f42a8fba743924949ace6fd99f19cf14b8337420158a97da0d54bab0",
+  "model": "gpt-5.5",
+  "run_id": "758de86b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b39f4a7e301b9f291b73eb82175689cd0f5e70d7d1393bb129d6f8ec2123b3a5"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-105/encode-out/traces/codex-gpt-5.5/us-md-statute-gtg-10-105.json",
+  "trace_sha256": "219c64c8a06a7f2b29b0a8fd4f943f7ae1c01cf6e9af23455acac7b21ccfcaec"
+}

--- a/us-md/statutes/gtg/10-105.test.yaml
+++ b/us-md/statutes/gtg/10-105.test.yaml
@@ -1,0 +1,41 @@
+- name: corporation_tax_applies_rate_to_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-105#input.maryland_taxable_income: 100000
+  output:
+    us-md:statutes/gtg/10-105#corporation_state_income_tax: 8250
+- name: corporation_tax_floors_negative_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-105#input.maryland_taxable_income: -5000
+  output:
+    us-md:statutes/gtg/10-105#corporation_state_income_tax: 0
+- name: nonresident_tax_apportioned_by_statutory_fraction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-105#input.state_income_tax_on_nonresident_income_without_specified_subtractions: 1000
+    us-md:statutes/gtg/10-105#input.nonresident_maryland_taxable_income_with_specified_subtractions: 30000
+    us-md:statutes/gtg/10-105#input.nonresident_maryland_taxable_income_without_specified_subtractions: 50000
+  output:
+    us-md:statutes/gtg/10-105#nonresident_state_income_tax: 600
+- name: auto_zero_nonresident_state_income_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:statutes/gtg/10-105#input.maryland_taxable_income: 0
+    us-md:statutes/gtg/10-105#input.nonresident_maryland_taxable_income_with_specified_subtractions: 0
+    us-md:statutes/gtg/10-105#input.nonresident_maryland_taxable_income_without_specified_subtractions: 0
+    us-md:statutes/gtg/10-105#input.state_income_tax_on_nonresident_income_without_specified_subtractions: 0
+  output:
+    us-md:statutes/gtg/10-105#nonresident_state_income_tax: 0

--- a/us-md/statutes/gtg/10-105.yaml
+++ b/us-md/statutes/gtg/10-105.yaml
@@ -1,0 +1,155 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-md/statute/gtg/10-105
+  summary: (a) State income tax rate schedules for individuals, including spouses
+    filing jointly, surviving spouses, and heads of household; an additional 2% tax
+    on net capital gain for individuals with federal adjusted gross income in excess
+    of $350,000, subject to listed exceptions. (b) Corporation rate is 8.25%. (d)
+    Nonresident tax is apportioned by a fraction using Maryland taxable income with
+    and without specified subtractions.
+  deferred_outputs:
+  - output: us-md:statutes/gtg/10-105#individual_state_income_tax
+    reason: The source requires selecting between filing-status groups and cross-referenced
+      federal classifications; no executable upstream filing-status RuleSpec output
+      is supplied in context, and local filing-status inputs are prohibited.
+  - output: us-md:statutes/gtg/10-105#additional_capital_gain_tax
+    reason: The source depends on federally determined net capital gain and enumerated
+      exempt capital-gain categories, including cross-referenced retirement arrangements
+      and federal adjusted gross income. This mixed surface is not encoded as a final
+      individual tax without the required upstream classifications.
+rules:
+- name: corporation_income_tax_rate
+  kind: parameter
+  dtype: Rate
+  source: "Md. Code, Tax-General \xA7 10-105(b)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: The State income tax rate for a corporation is 8.25% of Maryland
+            taxable income.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.0825'
+- name: corporation_state_income_tax
+  kind: derived
+  entity: Corporation
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Md. Code, Tax-General \xA7 10-105(b)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: 8.25% of Maryland taxable income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, maryland_taxable_income) * corporation_income_tax_rate
+- name: additional_capital_gain_tax_rate
+  kind: parameter
+  dtype: Rate
+  source: "Md. Code, Tax-General \xA7 10-105(a)(3)(i)2"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: an additional 2% of the amount of net capital gain
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.02'
+- name: additional_capital_gain_tax_federal_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "Md. Code, Tax-General \xA7 10-105(a)(4)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: federal adjusted gross income in excess of $350,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '350000'
+- name: primary_residence_sale_price_limit_for_capital_gain_exception
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "Md. Code, Tax-General \xA7 10-105(a)(3)(ii)1"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: any residential dwelling sold for less than $1,500,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1500000'
+- name: livestock_holding_period_for_capital_gain_exception
+  kind: parameter
+  dtype: Count
+  source: "Md. Code, Tax-General \xA7 10-105(a)(3)(ii)3"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: held for more than 12 months
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '12'
+- name: farming_or_ranching_gross_income_share_threshold
+  kind: parameter
+  dtype: Rate
+  source: "Md. Code, Tax-General \xA7 10-105(a)(3)(ii)3"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: more than 50% of the individual's gross income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.50'
+- name: nonresident_state_income_tax
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "Md. Code, Tax-General \xA7 10-105(d)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-105
+          excerpt: multiplied times a fraction
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if nonresident_maryland_taxable_income_without_specified_subtractions
+      > 0: state_income_tax_on_nonresident_income_without_specified_subtractions *
+      nonresident_maryland_taxable_income_with_specified_subtractions / nonresident_maryland_taxable_income_without_specified_subtractions
+      else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-md/statute/gtg/10-105`
- Module: `us-md/statutes/gtg/10-105.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-105/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.