### PR TITLE
Encode us-md/statute/gtg/10-211 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11906,6 +11906,15 @@
         ]
       }
     ],
+    "us-md/statute/gtg/10-211": [
+      {
+        "module": "us-md/statutes/gtg/10-211.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-me/regulation/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need": [
       {
         "module": "us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.yaml",

--- a/us-md/.axiom/encoding-manifests/statutes/gtg/10-211.json
+++ b/us-md/.axiom/encoding-manifests/statutes/gtg/10-211.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/gtg/10-211.yaml",
+      "sha256": "fa4d8ef467b7a2f186a3f7ce60591c936d0345227257fed45ab5e791561dfa0f"
+    },
+    {
+      "path": "statutes/gtg/10-211.test.yaml",
+      "sha256": "3a7216c1909b3b4bf822423e23d72019e1e4d93df3a5d0f0ddf43a2e00494d80"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-md/statute/gtg/10-211",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-211/encode-out/_eval_workspaces/codex-gpt-5.5/us-md-statute-gtg-10-211/workspace/context-manifest.json",
+  "context_manifest_sha256": "a90767a1707b033dd8c6f101ba98bc16aa4c208bc1d2eb52018de2f52bceb294",
+  "generated_at": "2026-07-08T15:27:41.997375+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-211/encode-out/codex-gpt-5.5/statutes/gtg/10-211.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-211/encode-out",
+  "generated_output_sha256": "fa4d8ef467b7a2f186a3f7ce60591c936d0345227257fed45ab5e791561dfa0f",
+  "generation_prompt_sha256": "84ec45f33fc50672d7acf259bc81ec2b4d01e26a2e5a7a6096a21b55e67e1021",
+  "model": "gpt-5.5",
+  "run_id": "dcf4f71f",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b10193301c4110fab984200baf4b6983f435d73a168ca98a0b2377a43eeaf11d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-211/encode-out/traces/codex-gpt-5.5/us-md-statute-gtg-10-211.json",
+  "trace_sha256": "fb8494f7acd0f5d9b90d9cc34ad2b7824e4f623df7384f8d9fc30aa584ef7e0c"
+}

--- a/us-md/statutes/gtg/10-211.test.yaml
+++ b/us-md/statutes/gtg/10-211.test.yaml
@@ -1,0 +1,88 @@
+- name: ordinary_taxpayer_full_exemption_with_spouse_and_dependents
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-211#input.taxpayer_has_spouse: true
+    us-md:statutes/gtg/10-211#input.joint_return_made_by_taxpayer_and_spouse: false
+    us-md:statutes/gtg/10-211#input.spouse_has_no_gross_income: true
+    us-md:statutes/gtg/10-211#input.spouse_is_dependent_of_another_taxpayer: false
+    us-md:statutes/gtg/10-211#input.dependent_count_under_section_152: 2
+    us-md:statutes/gtg/10-211#input.aged_dependent_count_under_section_152: 1
+    us-md:statutes/gtg/10-211#input.federal_adjusted_gross_income: 90000
+    us-md:statutes/gtg/10-211#input.joint_head_or_surviving_spouse_phaseout_thresholds_apply: false
+    us-md:statutes/gtg/10-211#input.individual_is_fiduciary: false
+    us-md:statutes/gtg/10-211#input.individual_at_least_65_on_last_day_of_taxable_year: true
+    us-md:statutes/gtg/10-211#input.individual_is_blind_under_section_10_208_c_on_last_day_of_taxable_year: false
+  output:
+    us-md:statutes/gtg/10-211#qualifying_spouse_exemption_available: holds
+    us-md:statutes/gtg/10-211#exemption_count: 4
+    us-md:statutes/gtg/10-211#exemption_amount_for_subsection_b_1_or_b_2: 3200
+    us-md:statutes/gtg/10-211#maryland_exemption_deduction: 17000
+- name: ordinary_taxpayer_middle_phaseout_no_spouse_exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-211#input.taxpayer_has_spouse: true
+    us-md:statutes/gtg/10-211#input.joint_return_made_by_taxpayer_and_spouse: true
+    us-md:statutes/gtg/10-211#input.spouse_has_no_gross_income: true
+    us-md:statutes/gtg/10-211#input.spouse_is_dependent_of_another_taxpayer: false
+    us-md:statutes/gtg/10-211#input.dependent_count_under_section_152: 1
+    us-md:statutes/gtg/10-211#input.aged_dependent_count_under_section_152: 0
+    us-md:statutes/gtg/10-211#input.federal_adjusted_gross_income: 140000
+    us-md:statutes/gtg/10-211#input.joint_head_or_surviving_spouse_phaseout_thresholds_apply: false
+    us-md:statutes/gtg/10-211#input.individual_is_fiduciary: false
+    us-md:statutes/gtg/10-211#input.individual_at_least_65_on_last_day_of_taxable_year: false
+    us-md:statutes/gtg/10-211#input.individual_is_blind_under_section_10_208_c_on_last_day_of_taxable_year: true
+  output:
+    us-md:statutes/gtg/10-211#qualifying_spouse_exemption_available: not_holds
+    us-md:statutes/gtg/10-211#exemption_count: 2
+    us-md:statutes/gtg/10-211#exemption_amount_for_subsection_b_1_or_b_2: 800
+    us-md:statutes/gtg/10-211#maryland_exemption_deduction: 2600
+- name: favored_status_phaseout_reduced_amount
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-211#input.taxpayer_has_spouse: false
+    us-md:statutes/gtg/10-211#input.joint_return_made_by_taxpayer_and_spouse: false
+    us-md:statutes/gtg/10-211#input.spouse_has_no_gross_income: false
+    us-md:statutes/gtg/10-211#input.spouse_is_dependent_of_another_taxpayer: false
+    us-md:statutes/gtg/10-211#input.dependent_count_under_section_152: 2
+    us-md:statutes/gtg/10-211#input.aged_dependent_count_under_section_152: 1
+    us-md:statutes/gtg/10-211#input.federal_adjusted_gross_income: 160000
+    us-md:statutes/gtg/10-211#input.joint_head_or_surviving_spouse_phaseout_thresholds_apply: true
+    us-md:statutes/gtg/10-211#input.individual_is_fiduciary: false
+    us-md:statutes/gtg/10-211#input.individual_at_least_65_on_last_day_of_taxable_year: false
+    us-md:statutes/gtg/10-211#input.individual_is_blind_under_section_10_208_c_on_last_day_of_taxable_year: false
+  output:
+    us-md:statutes/gtg/10-211#qualifying_spouse_exemption_available: not_holds
+    us-md:statutes/gtg/10-211#exemption_count: 3
+    us-md:statutes/gtg/10-211#exemption_amount_for_subsection_b_1_or_b_2: 1600
+    us-md:statutes/gtg/10-211#maryland_exemption_deduction: 6400
+- name: fiduciary_cannot_deduct_individual_exemption
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-md:statutes/gtg/10-211#input.taxpayer_has_spouse: false
+    us-md:statutes/gtg/10-211#input.joint_return_made_by_taxpayer_and_spouse: false
+    us-md:statutes/gtg/10-211#input.spouse_has_no_gross_income: false
+    us-md:statutes/gtg/10-211#input.spouse_is_dependent_of_another_taxpayer: false
+    us-md:statutes/gtg/10-211#input.dependent_count_under_section_152: 0
+    us-md:statutes/gtg/10-211#input.aged_dependent_count_under_section_152: 0
+    us-md:statutes/gtg/10-211#input.federal_adjusted_gross_income: 50000
+    us-md:statutes/gtg/10-211#input.joint_head_or_surviving_spouse_phaseout_thresholds_apply: false
+    us-md:statutes/gtg/10-211#input.individual_is_fiduciary: true
+    us-md:statutes/gtg/10-211#input.individual_at_least_65_on_last_day_of_taxable_year: true
+    us-md:statutes/gtg/10-211#input.individual_is_blind_under_section_10_208_c_on_last_day_of_taxable_year: true
+  output:
+    us-md:statutes/gtg/10-211#qualifying_spouse_exemption_available: not_holds
+    us-md:statutes/gtg/10-211#exemption_count: 1
+    us-md:statutes/gtg/10-211#exemption_amount_for_subsection_b_1_or_b_2: 3200
+    us-md:statutes/gtg/10-211#maryland_exemption_deduction: 0

--- a/us-md/statutes/gtg/10-211.yaml
+++ b/us-md/statutes/gtg/10-211.yaml
@@ -1,0 +1,321 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-md/statute/gtg/10-211
+  summary: "An individual may deduct exemptions for the taxpayer, a qualifying spouse,\
+    \ and dependents as defined in IRC \xA7 152. An individual other than a fiduciary\
+    \ may deduct $3,200 for each exemption, an additional $3,200 for each dependent\
+    \ age 65 or older, $1,000 if the individual is at least 65, and $1,000 if blind.\
+    \ Subsection (c) limits each subsection (b)(1) or (2) exemption amount by federal\
+    \ adjusted gross income thresholds."
+rules:
+- name: base_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(b)(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: $3,200 for each exemption
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3200'
+- name: aged_dependent_additional_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(b)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: an additional $3,200 for each dependent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3200'
+- name: individual_age_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(b)(3)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: an additional $1,000 if the individual ... is at least 65 years
+            old
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1000'
+- name: blind_individual_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(b)(4)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: an additional $1,000 if the individual ... is a blind individual
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1000'
+- name: ordinary_phaseout_first_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: federal adjusted gross income ... greater than $100,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '100000'
+- name: ordinary_phaseout_second_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)(i)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: does not exceed $125,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '125000'
+- name: ordinary_phaseout_third_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)(ii)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: not greater than $150,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '150000'
+- name: favored_status_phaseout_first_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: federal adjusted gross income ... greater than $150,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '150000'
+- name: favored_status_phaseout_second_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(2)(i)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: does not exceed $175,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '175000'
+- name: favored_status_phaseout_third_agi_threshold
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(2)(ii)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: not greater than $200,000
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '200000'
+- name: phaseout_reduced_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)(i), (c)(2)(i)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: $1,600 if federal adjusted gross income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1600'
+- name: phaseout_minimum_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)(ii), (c)(2)(ii)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: $800 if federal adjusted gross income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '800'
+- name: phased_out_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)(1)(iii), (c)(2)(iii)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+          excerpt: $0 if federal adjusted gross income
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0'
+- name: qualifying_spouse_exemption_available
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(a)(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'taxpayer_has_spouse
+
+      and not joint_return_made_by_taxpayer_and_spouse
+
+      and spouse_has_no_gross_income
+
+      and not spouse_is_dependent_of_another_taxpayer'
+- name: exemption_count
+  kind: derived
+  entity: TaxUnit
+  dtype: Count
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(a)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1 + (if qualifying_spouse_exemption_available: 1 else: 0) + dependent_count_under_section_152'
+- name: exemption_amount_for_subsection_b_1_or_b_2
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(c)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if joint_head_or_surviving_spouse_phaseout_thresholds_apply:\n  if federal_adjusted_gross_income\
+      \ <= favored_status_phaseout_first_agi_threshold:\n    base_exemption_amount\n\
+      \  else:\n    if federal_adjusted_gross_income <= favored_status_phaseout_second_agi_threshold:\n\
+      \      phaseout_reduced_exemption_amount\n    else:\n      if federal_adjusted_gross_income\
+      \ <= favored_status_phaseout_third_agi_threshold:\n        phaseout_minimum_exemption_amount\n\
+      \      else:\n        phased_out_exemption_amount\nelse:\n  if federal_adjusted_gross_income\
+      \ <= ordinary_phaseout_first_agi_threshold:\n    base_exemption_amount\n  else:\n\
+      \    if federal_adjusted_gross_income <= ordinary_phaseout_second_agi_threshold:\n\
+      \      phaseout_reduced_exemption_amount\n    else:\n      if federal_adjusted_gross_income\
+      \ <= ordinary_phaseout_third_agi_threshold:\n        phaseout_minimum_exemption_amount\n\
+      \      else:\n        phased_out_exemption_amount"
+- name: maryland_exemption_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: "Md. Code, Tax-General \xA7 10-211(b), (c)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-md/statute/gtg/10-211
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if individual_is_fiduciary: 0 else: max(0, (exemption_count * exemption_amount_for_subsection_b_1_or_b_2)
+      + (aged_dependent_count_under_section_152 * exemption_amount_for_subsection_b_1_or_b_2)
+      + (if individual_at_least_65_on_last_day_of_taxable_year: individual_age_exemption_amount
+      else: 0) + (if individual_is_blind_under_section_10_208_c_on_last_day_of_taxable_year:
+      blind_individual_exemption_amount else: 0))'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-md/statute/gtg/10-211`
- Module: `us-md/statutes/gtg/10-211.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-md-statute-gtg-10-211/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.