### PR TITLE
Encode us-mi/statute/206.272 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11933,6 +11933,15 @@
         ]
       }
     ],
+    "us-mi/statute/206.272": [
+      {
+        "module": "us-mi/statutes/206/272.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mn/manual/dhs/combined-manual/current/page-944": [
       {
         "module": "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,26 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 18
 entries:
+  - legal_id: us-mi:statutes/206/272#additional_credit_percentage_for_tax_year
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mi:statutes/206/272#additional_earned_income_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit_refund
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mi:statutes/206/272#total_earned_income_tax_credit_allowed
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mi/.axiom/encoding-manifests/statutes/206/272.json
+++ b/us-mi/.axiom/encoding-manifests/statutes/206/272.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/206/272.yaml",
+      "sha256": "5b2256baba0f0a5fe762a4c101f6ac4d5c26dca4943956edfb7124581abd96dd"
+    },
+    {
+      "path": "statutes/206/272.test.yaml",
+      "sha256": "8866686f11b83d818f7f40e104cc574646765d42f00b786b2165c8430c582bb3"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mi/statute/206.272",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mi-statute-206-272/encode-out/_eval_workspaces/codex-gpt-5.5/us-mi-statute-206.272/workspace/context-manifest.json",
+  "context_manifest_sha256": "754aa9058fedd6174b513e67a5d57742bc33eeeeb03e6136c420a6f79cfcbfee",
+  "generated_at": "2026-07-08T15:28:28.069295+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mi-statute-206-272/encode-out/codex-gpt-5.5/statutes/206/272.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mi-statute-206-272/encode-out",
+  "generated_output_sha256": "5b2256baba0f0a5fe762a4c101f6ac4d5c26dca4943956edfb7124581abd96dd",
+  "generation_prompt_sha256": "d6284b559c6b25e8ac498572950e4496004577e290db071cad5f718fb7e9f31c",
+  "model": "gpt-5.5",
+  "run_id": "02251e3c",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cbc6e6a6241d956fa182d441bd055240f44519221214e07d7b118194f6f5a103"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mi-statute-206-272/encode-out/traces/codex-gpt-5.5/us-mi-statute-206.272.json",
+  "trace_sha256": "54b3dc30963e0bc1529b14d073f4a84d0bdd6f5316277717d1535a5eb6ae8a4f"
+}

--- a/us-mi/statutes/206/272.test.yaml
+++ b/us-mi/statutes/206/272.test.yaml
@@ -1,0 +1,56 @@
+- name: tax_year_2021_uses_6_percent
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us-mi:statutes/206/272#input.federal_earned_income_credit_claimed_on_federal_return: 1000
+    us-mi:statutes/206/272#input.taxpayer_claims_credit_under_this_section: true
+    us-mi:statutes/206/272#input.tax_liability: 40
+  output:
+    us-mi:statutes/206/272#earned_income_tax_credit: 60
+    us-mi:statutes/206/272#additional_earned_income_tax_credit: 0
+    us-mi:statutes/206/272#total_earned_income_tax_credit_allowed: 60
+    us-mi:statutes/206/272#earned_income_tax_credit_refund: 20
+- name: tax_year_2022_additional_credit_applies_when_claimed
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-mi:statutes/206/272#input.federal_earned_income_credit_claimed_on_federal_return: 1000
+    us-mi:statutes/206/272#input.taxpayer_claims_credit_under_this_section: true
+    us-mi:statutes/206/272#input.tax_liability: 100
+  output:
+    us-mi:statutes/206/272#earned_income_tax_credit: 60
+    us-mi:statutes/206/272#additional_earned_income_tax_credit: 240
+    us-mi:statutes/206/272#total_earned_income_tax_credit_allowed: 300
+    us-mi:statutes/206/272#earned_income_tax_credit_refund: 200
+- name: tax_year_2022_no_additional_credit_without_claim
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-mi:statutes/206/272#input.federal_earned_income_credit_claimed_on_federal_return: 1000
+    us-mi:statutes/206/272#input.taxpayer_claims_credit_under_this_section: false
+    us-mi:statutes/206/272#input.tax_liability: 100
+  output:
+    us-mi:statutes/206/272#earned_income_tax_credit: 60
+    us-mi:statutes/206/272#additional_earned_income_tax_credit: 0
+    us-mi:statutes/206/272#total_earned_income_tax_credit_allowed: 60
+    us-mi:statutes/206/272#earned_income_tax_credit_refund: 0
+- name: tax_year_2024_uses_30_percent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mi:statutes/206/272#input.federal_earned_income_credit_claimed_on_federal_return: 1000
+    us-mi:statutes/206/272#input.taxpayer_claims_credit_under_this_section: true
+    us-mi:statutes/206/272#input.tax_liability: 50
+  output:
+    us-mi:statutes/206/272#earned_income_tax_credit: 300
+    us-mi:statutes/206/272#additional_earned_income_tax_credit: 0
+    us-mi:statutes/206/272#total_earned_income_tax_credit_allowed: 300
+    us-mi:statutes/206/272#earned_income_tax_credit_refund: 250

--- a/us-mi/statutes/206/272.yaml
+++ b/us-mi/statutes/206/272.yaml
@@ -1,0 +1,169 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mi/statute/206.272
+  summary: |-
+    Sec. 272(1) allows a taxpayer to credit specified percentages of the credit allowed under section 32 of the internal revenue code: 10%, 20%, 6%, and 30% for stated tax-year start periods. Sec. 272(2) gives an additional 24% credit for the 2022 tax year only. Sec. 272(3) refunds any excess credit over tax liability without interest, except as provided in MCL 205.30.
+rules:
+  - name: earned_income_tax_credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: Sec. 272(1)(a)-(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For tax years that begin after December 31, 2007 and before January 1, 2009, 10%."
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For tax years that begin after December 31, 2008 and before January 1, 2012, 20%."
+          - path: versions[2].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For tax years that begin after December 31, 2011 and before January 1, 2023, 6%."
+          - path: versions[3].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For tax years that begin after December 31, 2022, 30%."
+    versions:
+      - effective_from: '2008-01-01'
+        formula: |-
+          0.10
+      - effective_from: '2009-01-01'
+        formula: |-
+          0.20
+      - effective_from: '2012-01-01'
+        formula: |-
+          0.06
+      - effective_from: '2023-01-01'
+        formula: |-
+          0.30
+
+  - name: additional_credit_percentage_for_tax_year
+    kind: parameter
+    dtype: Rate
+    source: Sec. 272(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: default
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For the 2022 tax year only ... an additional credit in an amount equal to 24%"
+          - path: versions[2].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "For the 2022 tax year only"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.24
+      - effective_from: '2023-01-01'
+        formula: |-
+          0
+
+  - name: earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 272(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "A taxpayer may credit ... an amount equal to the specified percentages of the credit the taxpayer is allowed to claim as a credit under section 32"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+    versions:
+      - effective_from: '2008-01-01'
+        formula: |-
+          max(0, federal_earned_income_credit_claimed_on_federal_return * earned_income_tax_credit_percentage)
+
+  - name: additional_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 272(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "a taxpayer that claims a credit under this section ... is entitled to an additional credit in an amount equal to 24%"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_claims_credit_under_this_section: max(0, federal_earned_income_credit_claimed_on_federal_return * additional_credit_percentage_for_tax_year) else: 0
+
+  - name: total_earned_income_tax_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 272(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "may credit ... specified percentages ... additional credit in an amount equal to 24%"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_tax_credit + additional_earned_income_tax_credit
+
+  - name: earned_income_tax_credit_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sec. 272(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: "If the credit allowed by this section exceeds the tax liability of the taxpayer for the tax year, the state treasurer shall refund the excess"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, total_earned_income_tax_credit_allowed - tax_liability)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mi/statute/206.272`
- Module: `us-mi/statutes/206/272.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mi-statute-206-272/rulespec-us/oracle-coverage-pending.yaml: 18 declared (+6 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.