### PR TITLE
Encode us-mn/statute/290.0121 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11951,6 +11951,15 @@
         ]
       }
     ],
+    "us-mn/statute/290.0121": [
+      {
+        "module": "us-mn/statutes/290/0121.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,41 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 23
 entries:
+  - legal_id: us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#dependent_exemption_before_disallowance
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#inflation_rounding_multiple
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#married_filing_separately_phaseout_step_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#married_filing_separately_threshold_fraction_of_joint
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#maximum_applicable_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#phaseout_percentage_points_per_step
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#statutory_dependent_exemption_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#statutory_head_of_household_threshold_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#statutory_joint_return_or_surviving_spouse_threshold_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0121#statutory_single_threshold_amount
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mn/.axiom/encoding-manifests/statutes/290/0121.json
+++ b/us-mn/.axiom/encoding-manifests/statutes/290/0121.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/290/0121.yaml",
+      "sha256": "79cc0793f21a73ca8711790ccd38090e0d495cd5b46f4193194f001ec3cab625"
+    },
+    {
+      "path": "statutes/290/0121.test.yaml",
+      "sha256": "e40fe1d4222fbf825d258bb63df5e00065256e3f0557eb1f50d084f515afe483"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mn/statute/290.0121",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0121/encode-out/_eval_workspaces/codex-gpt-5.5/us-mn-statute-290.0121/workspace/context-manifest.json",
+  "context_manifest_sha256": "1a5872743a7fbfb5f35e6f13cca241215f62382a81a04b75e1a4f5e1675ecb4a",
+  "generated_at": "2026-07-08T15:29:26.671076+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0121/encode-out/codex-gpt-5.5/statutes/290/0121.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0121/encode-out",
+  "generated_output_sha256": "79cc0793f21a73ca8711790ccd38090e0d495cd5b46f4193194f001ec3cab625",
+  "generation_prompt_sha256": "d6e5e1f213caac39caa35461f4cffdf586e7084fe5747d88a9d267c554d25513",
+  "model": "gpt-5.5",
+  "run_id": "95bad22a",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cb4c5e98001a93c29cd1373f5e73a4c0f89ca1246ebbc485a4036ef4d2eaa58b"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0121/encode-out/traces/codex-gpt-5.5/us-mn-statute-290.0121.json",
+  "trace_sha256": "dfd66c33b7ab8cf6e68b0b8620c1a8bbb2b66b9b3dab66b874c815862cf80817"
+}

--- a/us-mn/statutes/290/0121.test.yaml
+++ b/us-mn/statutes/290/0121.test.yaml
@@ -1,0 +1,10 @@
+- name: dependent exemption before disallowance multiplies statutory amount by dependent
+    count
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/0121#input.dependent_count_under_sections_151_and_152: 3
+  output:
+    us-mn:statutes/290/0121#dependent_exemption_before_disallowance: 12750

--- a/us-mn/statutes/290/0121.yaml
+++ b/us-mn/statutes/290/0121.yaml
@@ -1,0 +1,231 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/statute/290.0121
+  summary: A taxpayer's dependent exemption equals the exemption amount multiplied
+    by dependents under IRC sections 151 and 152, minus the disallowed exemption amount,
+    not below zero. The exemption amount is $4,250. The disallowed amount is the pre-disallowance
+    dependent exemption multiplied by an applicable percentage. The applicable percentage
+    is two percentage points per $1,250 of excess federal adjusted gross income for
+    married separate filers, and per $2,500 for all other filers, capped at 100 percent.
+    Threshold amounts are $291,950 for joint return or surviving spouse, $243,300
+    for head of household, $194,650 for unmarried non-surviving-spouse non-head-of-household
+    individuals, and half the joint amount for married separate returns. Amounts are
+    inflation-adjusted after 2019 under section 270C.22 and rounded down to the nearest
+    $50.
+  deferred_outputs:
+  - output: us-mn:statutes/290/0121#applicable_percentage
+    reason: Requires upstream US tax filing-status classification and the section
+      270C.22 inflation adjustment mechanics; this source states the threshold categories
+      and phaseout formula but does not define filing status or the inflation factor.
+    source_values:
+    - us-mn:statutes/290/0121#statutory_joint_return_or_surviving_spouse_threshold_amount
+    - us-mn:statutes/290/0121#statutory_head_of_household_threshold_amount
+    - us-mn:statutes/290/0121#statutory_single_threshold_amount
+    - us-mn:statutes/290/0121#married_filing_separately_phaseout_step_amount
+    - us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
+    - us-mn:statutes/290/0121#phaseout_percentage_points_per_step
+    - us-mn:statutes/290/0121#maximum_applicable_percentage
+    - us-mn:statutes/290/0121#inflation_rounding_multiple
+  - output: us-mn:statutes/290/0121#dependent_exemption
+    reason: Final exemption depends on the deferred applicable percentage and inflation-adjusted
+      exemption amount.
+    source_values:
+    - us-mn:statutes/290/0121#statutory_dependent_exemption_amount
+rules:
+- name: statutory_dependent_exemption_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 1(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: The exemption amount equals $4,250.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '4250'
+- name: statutory_joint_return_or_surviving_spouse_threshold_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(c)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: $291,950 for a joint return or a surviving spouse
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '291950'
+- name: statutory_head_of_household_threshold_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(c)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: $243,300 for a head of a household
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '243300'
+- name: statutory_single_threshold_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(c)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: $194,650 for an individual who is not married and who is not a
+            surviving spouse or head of a household
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '194650'
+- name: married_filing_separately_threshold_fraction_of_joint
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(c)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: half the amount for a joint return for a married individual filing
+            a separate return
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1 / 2
+- name: married_filing_separately_phaseout_step_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: two percentage points for each $1,250, or fraction of that amount
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1250'
+- name: all_other_filers_phaseout_step_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: two percentage points for each $2,500, or fraction of that amount
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '2500'
+- name: phaseout_percentage_points_per_step
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: two percentage points
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.02'
+- name: maximum_applicable_percentage
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 2(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: The applicable percentage must not exceed 100 percent.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '1'
+- name: inflation_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 3
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: rounded down to the nearest $50 amount
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '50'
+- name: dependent_exemption_before_disallowance
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: Minn. Stat. 290.0121, subd. 1(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.0121
+          excerpt: the exemption amount multiplied by the number of individuals who
+            are dependents
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-mn:statutes/290/0121#statutory_dependent_exemption_amount
+          output: statutory_dependent_exemption_amount
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: statutory_dependent_exemption_amount * dependent_count_under_sections_151_and_152


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mn/statute/290.0121`
- Module: `us-mn/statutes/290/0121.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0121/rulespec-us/oracle-coverage-pending.yaml: 23 declared (+11 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.