### PR TITLE
Encode us-mn/statute/290.0671 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11951,6 +11951,15 @@
         ]
       }
     ],
+    "us-mn/statute/290.0671": [
+      {
+        "module": "us-mn/statutes/290/0671.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,44 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 24
 entries:
+  - legal_id: us-mn:statutes/290/0671#earned_income_credit_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#earned_income_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#no_qualifying_child_maximum_age_exclusive
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#no_qualifying_child_minimum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#older_child_no_section_290_0661_phaseout_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#one_qualifying_older_child_increase
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#qualifying_older_child_minimum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#three_or_more_qualifying_older_children_increase
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#two_qualifying_older_children_increase
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mn/.axiom/encoding-manifests/statutes/290/0671.json
+++ b/us-mn/.axiom/encoding-manifests/statutes/290/0671.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/290/0671.yaml",
+      "sha256": "06a41b222f4bbfe65bfc7f8ba78c3f390b1e394722565681f56c14f47f066479"
+    },
+    {
+      "path": "statutes/290/0671.test.yaml",
+      "sha256": "c8efd7a4d736f23e38eecf8e034bff2418f5603435b0fc24e9341d41291aa13f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mn/statute/290.0671",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0671/encode-out/_eval_workspaces/codex-gpt-5.5/us-mn-statute-290.0671/workspace/context-manifest.json",
+  "context_manifest_sha256": "db331cb1f0d544d89341a0e591515c4f9d10c66a2df69f2207fc6dc0e16184c2",
+  "generated_at": "2026-07-08T15:30:34.190714+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0671/encode-out/codex-gpt-5.5/statutes/290/0671.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0671/encode-out",
+  "generated_output_sha256": "06a41b222f4bbfe65bfc7f8ba78c3f390b1e394722565681f56c14f47f066479",
+  "generation_prompt_sha256": "81a8b2132d1671e734fe357cbc736f5964208177af4c164d444b0efa59b7c613",
+  "model": "gpt-5.5",
+  "run_id": "1d3d613d",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5cdc4949150b6857c89c92212e1061609e7871411aebe0a44f5a698e055594af"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0671/encode-out/traces/codex-gpt-5.5/us-mn-statute-290.0671.json",
+  "trace_sha256": "8ad29ec8acdb0b109ec1f5071f5ec8416b6d16d401ae635b691a8b976e3553da"
+}

--- a/us-mn/statutes/290/0671.test.yaml
+++ b/us-mn/statutes/290/0671.test.yaml
@@ -1,0 +1,45 @@
+- name: one older child preliminary credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/0671#input.earned_income: 5000
+    us-mn:statutes/290/0671#input.qualifying_older_child_count: 1
+    us-mn:statutes/290/0671#input.resident_for_entire_tax_year: false
+    us-mn:statutes/290/0671#input.federal_adjusted_gross_income: 0
+    us-mn:statutes/290/0671#input.earned_income_not_subject_to_tax_under_this_chapter_for_allocation: 0
+  output:
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout: 1125
+    us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio: 1
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation: 1125
+- name: earned income cap and three older children
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/0671#input.earned_income: 10000
+    us-mn:statutes/290/0671#input.qualifying_older_child_count: 3
+    us-mn:statutes/290/0671#input.resident_for_entire_tax_year: false
+    us-mn:statutes/290/0671#input.federal_adjusted_gross_income: 0
+    us-mn:statutes/290/0671#input.earned_income_not_subject_to_tax_under_this_chapter_for_allocation: 0
+  output:
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout: 2850
+    us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio: 1
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation: 2850
+- name: allocation for untaxed earned income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/0671#input.earned_income: 8750
+    us-mn:statutes/290/0671#input.qualifying_older_child_count: 0
+    us-mn:statutes/290/0671#input.resident_for_entire_tax_year: true
+    us-mn:statutes/290/0671#input.federal_adjusted_gross_income: 10000
+    us-mn:statutes/290/0671#input.earned_income_not_subject_to_tax_under_this_chapter_for_allocation: 2000
+  output:
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout: 350
+    us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio: 0.8
+    us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation: 280

--- a/us-mn/statutes/290/0671.yaml
+++ b/us-mn/statutes/290/0671.yaml
@@ -1,0 +1,229 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/statute/290.0671
+  summary: |-
+    Subdivision 1 allows the Minnesota working family credit. The credit equals four percent of the first $8,750 of earned income and is increased by $925, $2,100, or $2,500 for one, two, or three or more qualifying older children. The credit is phased out jointly with section 290.0661; if the taxpayer has one or more qualifying older children and did not qualify under section 290.0661, the phaseout rate equals nine percent. The credit is refundable. Earned income amounts and qualifying older child amounts are annually adjusted under section 270C.22; the statutory year is taxable year 2023.
+  deferred_outputs:
+    - output: us-mn:statutes/290/0671#working_family_credit
+      reason: The final credit depends on eligibility and phaseout mechanics under Internal Revenue Code section 32 and Minnesota section 290.0661, which are not available in copied RuleSpec context.
+      source_values:
+        - us-mn:statutes/290/0671#earned_income_credit_rate
+        - us-mn:statutes/290/0671#earned_income_credit_cap
+        - us-mn:statutes/290/0671#one_qualifying_older_child_increase
+        - us-mn:statutes/290/0671#two_qualifying_older_children_increase
+        - us-mn:statutes/290/0671#three_or_more_qualifying_older_children_increase
+        - us-mn:statutes/290/0671#older_child_no_section_290_0661_phaseout_rate
+rules:
+  - name: earned_income_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: Minn. Stat. 290.0671, subd. 1(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "equals four percent of the first $8,750 of earned income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.04
+  - name: earned_income_credit_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "first $8,750 of earned income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          8750
+  - name: one_qualifying_older_child_increase
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "$925 for a taxpayer with one qualifying older child"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          925
+  - name: two_qualifying_older_children_increase
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(c)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "$2,100 for a taxpayer with two qualifying older children"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2100
+  - name: three_or_more_qualifying_older_children_increase
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(c)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "$2,500 for a taxpayer with three or more qualifying older children"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2500
+  - name: older_child_no_section_290_0661_phaseout_rate
+    kind: parameter
+    dtype: Rate
+    source: Minn. Stat. 290.0671, subd. 1(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "the phaseout rate equals nine percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.09
+  - name: qualifying_older_child_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: Minn. Stat. 290.0671, subd. 1a
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "attained at least the age of 18 in the taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          18
+  - name: no_qualifying_child_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: Minn. Stat. 290.0671, subd. 1(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "has attained the age of 19"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          19
+  - name: no_qualifying_child_maximum_age_exclusive
+    kind: parameter
+    dtype: Integer
+    source: Minn. Stat. 290.0671, subd. 1(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "but not attained age 65 before the close of the taxable year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          65
+  - name: working_family_credit_before_phaseout
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(b)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "equals four percent of the first $8,750 of earned income"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "increased by: (1) $925 ... (2) $2,100 ... (3) $2,500"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_credit_rate * min(max(0, earned_income), max(0, earned_income_credit_cap))
+          + (if qualifying_older_child_count == 1: one_qualifying_older_child_increase else: if qualifying_older_child_count == 2: two_qualifying_older_children_increase else: if qualifying_older_child_count >= 3: three_or_more_qualifying_older_children_increase else: 0)
+  - name: earned_income_taxable_allocation_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    source: Minn. Stat. 290.0671, subd. 1(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "allocated based on the ratio of federal adjusted gross income reduced by the earned income not subject to tax under this chapter over federal adjusted gross income"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if resident_for_entire_tax_year and federal_adjusted_gross_income > 0: (federal_adjusted_gross_income - earned_income_not_subject_to_tax_under_this_chapter_for_allocation) / federal_adjusted_gross_income else: 1
+  - name: working_family_credit_before_phaseout_after_allocation
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minn. Stat. 290.0671, subd. 1(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.0671
+              excerpt: "the credit must be allocated based on the ratio"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, working_family_credit_before_phaseout * earned_income_taxable_allocation_ratio)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mn/statute/290.0671`
- Module: `us-mn/statutes/290/0671.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-0671/rulespec-us/oracle-coverage-pending.yaml: 24 declared (+12 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.