### PR TITLE
Encode us-mn/statute/290.06 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11951,6 +11951,15 @@
         ]
       }
     ],
+    "us-mn/statute/290.06": [
+      {
+        "module": "us-mn/statutes/290/06.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,89 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 39
 entries:
+  - legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit_carryover_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit_carryover_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#bovine_testing_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#corporate_bovine_testing_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#corporation_franchise_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#corporation_franchise_tax_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#film_production_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#film_production_credit_carryover_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#head_of_household_bracket_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#head_of_household_bracket_selector
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#joint_return_bracket_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#joint_return_bracket_selector
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#noncorporate_bovine_testing_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#pass_through_entity_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#section_529_credit_recapture_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#section_529_plan_recapture_additional_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#section_529_subtraction_recapture_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_cap
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_carryover_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#transit_pass_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#transit_pass_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#unmarried_bracket_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/06#unmarried_bracket_selector
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mn/.axiom/encoding-manifests/statutes/290/06.json
+++ b/us-mn/.axiom/encoding-manifests/statutes/290/06.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/290/06.yaml",
+      "sha256": "d48bfdc7f4630a9782f1333e3740b13f6411d0d9ab27f63875a0679a47617482"
+    },
+    {
+      "path": "statutes/290/06.test.yaml",
+      "sha256": "21d90ea158d632fcc83c091cef8675944301a70bd287f937a3a0a7779e341ff2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mn/statute/290.06",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-06/encode-out/_eval_workspaces/codex-gpt-5.5/us-mn-statute-290.06/workspace/context-manifest.json",
+  "context_manifest_sha256": "dcab9af00eed15f72d93fdd78f1cfd570da1a00864d3369530780dae24486fa7",
+  "generated_at": "2026-07-08T15:30:53.308063+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-06/encode-out/codex-gpt-5.5/statutes/290/06.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-06/encode-out",
+  "generated_output_sha256": "d48bfdc7f4630a9782f1333e3740b13f6411d0d9ab27f63875a0679a47617482",
+  "generation_prompt_sha256": "3af028c8966e562fd0e77fd9cd1b48b3837a986aac30e3fc4bf82aad36200781",
+  "model": "gpt-5.5",
+  "run_id": "e662aeb3",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3a5f642b0f6f07c2c8420c0b70261bbb1fa871dc6cfe43dee33299606d6b8cf8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-06/encode-out/traces/codex-gpt-5.5/us-mn-statute-290.06.json",
+  "trace_sha256": "8e1628b380ffa90c01144602644783dee43ad31d0eed7a4a47c32a25e51bd59c"
+}

--- a/us-mn/statutes/290/06.test.yaml
+++ b/us-mn/statutes/290/06.test.yaml
@@ -1,0 +1,351 @@
+- name: corporation franchise tax applies rate to nonnegative taxable income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/06#input.corporate_taxable_income: 100000
+  output:
+    us-mn:statutes/290/06#corporation_franchise_tax: 9800
+- name: section 529 recapture excludes federally taxed distribution portion
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: true
+    us-mn:statutes/290/06#input.credit_ratio: 0.2
+    us-mn:statutes/290/06#input.subtraction_ratio: 0.1
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 1000
+  output:
+    us-mn:statutes/290/06#section_529_plan_recapture_additional_tax: 110
+- name: transit pass credit applies to Minnesota employee-use expense
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 2000
+  output:
+    us-mn:statutes/290/06#transit_pass_credit: 600
+- name: seed capital credit applies cap and disqualification
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: true
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 300000
+  output:
+    us-mn:statutes/290/06#seed_capital_investment_credit: 112500
+- name: auto_output_joint_return_bracket_selector
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#joint_return_bracket_selector: 0
+- name: auto_output_unmarried_bracket_selector
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#unmarried_bracket_selector: 0
+- name: auto_output_head_of_household_bracket_selector
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#head_of_household_bracket_selector: 0
+- name: auto_output_bovine_testing_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#bovine_testing_credit: 0
+- name: auto_output_beginning_farmer_incentive_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#beginning_farmer_incentive_credit: 0
+- name: auto_output_beginning_farmer_management_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#beginning_farmer_management_credit: 0
+- name: auto_output_film_production_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#film_production_credit: 0
+- name: auto_output_pass_through_entity_tax_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#pass_through_entity_tax_credit: 0
+- name: auto_zero_section_529_plan_recapture_additional_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#section_529_plan_recapture_additional_tax: 0
+- name: auto_zero_seed_capital_investment_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.beginning_farmer_incentive_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_amount: 0
+    us-mn:statutes/290/06#input.beginning_farmer_management_credit_approved_and_certified: false
+    us-mn:statutes/290/06#input.cattle_tuberculosis_testing_expenses: 0
+    us-mn:statutes/290/06#input.corporate_filer_for_bovine_testing_credit: false
+    us-mn:statutes/290/06#input.corporate_taxable_income: 0
+    us-mn:statutes/290/06#input.credit_ratio: 0
+    us-mn:statutes/290/06#input.distribution_amount_not_subject_to_federal_529_c_6_tax: 0
+    us-mn:statutes/290/06#input.film_production_credit_certificate_amount: 0
+    us-mn:statutes/290/06#input.owner_tax_liability_calculated_for_pass_through_entity_tax: 0
+    us-mn:statutes/290/06#input.qualified_account_distribution_used_for_nonqualified_purpose: false
+    us-mn:statutes/290/06#input.qualified_seed_capital_investment_amount: 0
+    us-mn:statutes/290/06#input.qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax: false
+    us-mn:statutes/290/06#input.seed_capital_investment_is_eligible: false
+    us-mn:statutes/290/06#input.subtraction_ratio: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_incentive_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_beginning_farmer_management_credit: 0
+    us-mn:statutes/290/06#input.tax_liability_before_film_production_credit: 0
+    us-mn:statutes/290/06#input.taxable_net_income: 0
+    us-mn:statutes/290/06#input.taxpayer_disqualified_from_seed_capital_credit: false
+    us-mn:statutes/290/06#input.transit_pass_expense_for_minnesota_employee_use: 0
+    us-mn:statutes/290/06#input.tuberculosis_testing_of_cattle_in_minnesota_is_federally_required: false
+  output:
+    us-mn:statutes/290/06#seed_capital_investment_credit: 0

--- a/us-mn/statutes/290/06.yaml
+++ b/us-mn/statutes/290/06.yaml
@@ -1,0 +1,696 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/statute/290.06
+  summary: 'Subdivision 1: corporation franchise tax is computed by applying 9.8 percent
+    to taxable income. Subdivision 2c states income tax rate schedules for individuals,
+    estates, and trusts, subject to inflation adjustment under subdivision 2d. Subdivisions
+    2g, 2h, 22, 23, 23a, 27, 28, 33, 35, 37, 38, 39, and 40 state additional taxes,
+    credits, refunds, limits, carryovers, and refundability rules.'
+  deferred_outputs:
+  - output: us-mn:statutes/290/06#individual_income_tax
+    reason: Filing-status classifications for married filing jointly, surviving spouse,
+      unmarried individual, head of household, married filing separately, estates,
+      and trusts depend on cited definitions and upstream filing-status sources not
+      provided in context; subdivision 2d also requires annual inflation-adjusted
+      brackets under section 270C.22.
+    source_values:
+    - us-mn:statutes/290/06#joint_return_bracket_lower_bound
+    - us-mn:statutes/290/06#joint_return_bracket_upper_bound
+    - us-mn:statutes/290/06#joint_return_bracket_rate
+    - us-mn:statutes/290/06#unmarried_bracket_lower_bound
+    - us-mn:statutes/290/06#unmarried_bracket_upper_bound
+    - us-mn:statutes/290/06#unmarried_bracket_rate
+    - us-mn:statutes/290/06#head_of_household_bracket_lower_bound
+    - us-mn:statutes/290/06#head_of_household_bracket_upper_bound
+    - us-mn:statutes/290/06#head_of_household_bracket_rate
+rules:
+- name: corporation_franchise_tax_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: rate of 9.8 percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.098'
+- name: corporation_franchise_tax
+  kind: derived
+  entity: Corporation
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: computed by applying to their taxable income the rate of 9.8 percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, corporate_taxable_income) * corporation_franchise_tax_rate
+- name: joint_return_bracket_selector
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: Minn. Stat. 290.06, subd. 2c(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: On the first $38,770 ... over $38,770, but not over $154,020 ...
+            over $154,020, but not over $269,010 ... over $269,010
+  versions:
+  - effective_from: '2019-01-01'
+    formula: 'if taxable_net_income <= joint_return_bracket_upper_bound[0]: 0 else:
+      if taxable_net_income <= joint_return_bracket_upper_bound[1]: 1 else: if taxable_net_income
+      <= joint_return_bracket_upper_bound[2]: 2 else: 3'
+- name: joint_return_bracket_lower_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: joint_return_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: married individuals filing joint returns and surviving spouses
+              rate schedule
+            row_key: bracket
+            column_key: lower_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0
+      1: 38770
+      2: 154020
+      3: 269010
+- name: joint_return_bracket_upper_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: joint_return_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: married individuals filing joint returns and surviving spouses
+              rate schedule
+            row_key: bracket
+            column_key: upper_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 38770
+      1: 154020
+      2: 269010
+      3: 0
+- name: joint_return_bracket_rate
+  kind: parameter
+  dtype: Rate
+  indexed_by: joint_return_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: married individuals filing joint returns and surviving spouses
+              rate schedule
+            row_key: bracket
+            column_key: rate
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0.0535
+      1: 0.068
+      2: 0.0785
+      3: 0.0985
+- name: unmarried_bracket_selector
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: Minn. Stat. 290.06, subd. 2c(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: On the first $26,520 ... over $26,520, but not over $87,110 ...
+            over $87,110, but not over $161,720 ... over $161,720
+  versions:
+  - effective_from: '2019-01-01'
+    formula: 'if taxable_net_income <= unmarried_bracket_upper_bound[0]: 0 else: if
+      taxable_net_income <= unmarried_bracket_upper_bound[1]: 1 else: if taxable_net_income
+      <= unmarried_bracket_upper_bound[2]: 2 else: 3'
+- name: unmarried_bracket_lower_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: unmarried_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: unmarried individuals rate schedule
+            row_key: bracket
+            column_key: lower_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0
+      1: 26520
+      2: 87110
+      3: 161720
+- name: unmarried_bracket_upper_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: unmarried_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: unmarried individuals rate schedule
+            row_key: bracket
+            column_key: upper_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 26520
+      1: 87110
+      2: 161720
+      3: 0
+- name: unmarried_bracket_rate
+  kind: parameter
+  dtype: Rate
+  indexed_by: unmarried_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: unmarried individuals rate schedule
+            row_key: bracket
+            column_key: rate
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0.0535
+      1: 0.068
+      2: 0.0785
+      3: 0.0985
+- name: head_of_household_bracket_selector
+  kind: derived
+  entity: TaxUnit
+  dtype: Integer
+  period: Year
+  source: Minn. Stat. 290.06, subd. 2c(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: On the first $32,650 ... over $32,650, but not over $131,190 ...
+            over $131,190, but not over $214,980 ... over $214,980
+  versions:
+  - effective_from: '2019-01-01'
+    formula: 'if taxable_net_income <= head_of_household_bracket_upper_bound[0]: 0
+      else: if taxable_net_income <= head_of_household_bracket_upper_bound[1]: 1 else:
+      if taxable_net_income <= head_of_household_bracket_upper_bound[2]: 2 else: 3'
+- name: head_of_household_bracket_lower_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: head_of_household_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: head of household rate schedule
+            row_key: bracket
+            column_key: lower_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0
+      1: 32650
+      2: 131190
+      3: 214980
+- name: head_of_household_bracket_upper_bound
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: head_of_household_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: head of household rate schedule
+            row_key: bracket
+            column_key: upper_bound
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 32650
+      1: 131190
+      2: 214980
+      3: 0
+- name: head_of_household_bracket_rate
+  kind: parameter
+  dtype: Rate
+  indexed_by: head_of_household_bracket_selector
+  source: Minn. Stat. 290.06, subd. 2c(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          table:
+            header: head of household rate schedule
+            row_key: bracket
+            column_key: rate
+  versions:
+  - effective_from: '2019-01-01'
+    values:
+      0: 0.0535
+      1: 0.068
+      2: 0.0785
+      3: 0.0985
+- name: section_529_credit_recapture_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 2h(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: 50 percent of the product of the credit ratio and the amount of
+            the distribution
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.50'
+- name: section_529_subtraction_recapture_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 2h(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: ten percent of the product of the subtraction ratio and the amount
+            of the distribution
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.10'
+- name: section_529_plan_recapture_additional_tax
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 2h(b)-(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: If a distribution from a qualified account is used for a purpose
+            other than to pay for qualified higher education expenses
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: does not apply to any portion of a distribution that is subject
+            to the additional tax under section 529(c)(6)
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if qualified_account_distribution_used_for_nonqualified_purpose: (section_529_credit_recapture_rate
+      * credit_ratio * max(0, distribution_amount_not_subject_to_federal_529_c_6_tax))
+      + (section_529_subtraction_recapture_rate * subtraction_ratio * max(0, distribution_amount_not_subject_to_federal_529_c_6_tax))
+      else: 0'
+- name: transit_pass_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 28
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: equal to 30 percent of the expense incurred
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.30'
+- name: transit_pass_credit
+  kind: derived
+  entity: Employer
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 28
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: If the taxpayer purchases the transit passes from the transit system
+            operator, and resells them to the employees, the credit is based on the
+            amount of the difference
+  versions:
+  - effective_from: '0001-01-01'
+    formula: transit_pass_credit_rate * max(0, transit_pass_expense_for_minnesota_employee_use)
+- name: corporate_bovine_testing_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 33(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: for corporate filers ... 25 percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.25'
+- name: noncorporate_bovine_testing_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 33(a)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: for all other filers, one-half
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.50'
+- name: bovine_testing_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 33(a), (d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: Expenses incurred in a calendar year in which tuberculosis testing
+            of cattle in Minnesota is not federally required are not allowed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if tuberculosis_testing_of_cattle_in_minnesota_is_federally_required:
+      (if corporate_filer_for_bovine_testing_credit: corporate_bovine_testing_credit_rate
+      * max(0, cattle_tuberculosis_testing_expenses) else: noncorporate_bovine_testing_credit_rate
+      * max(0, cattle_tuberculosis_testing_expenses)) else: 0'
+- name: seed_capital_investment_credit_rate
+  kind: parameter
+  dtype: Rate
+  source: Minn. Stat. 290.06, subd. 35(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: The credit equals 45 percent
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '0.45'
+- name: seed_capital_investment_credit_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 35(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: must not exceed $112,500
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '112500'
+- name: seed_capital_investment_credit_carryover_years
+  kind: parameter
+  dtype: Count
+  source: Minn. Stat. 290.06, subd. 35(h)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: four succeeding taxable years
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '4'
+- name: seed_capital_investment_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 35(a), (d), (f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: An individual, estate, or trust is allowed a credit ... for investments
+            in a qualifying business
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: A taxpayer who owns a controlling interest ... is not entitled
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if seed_capital_investment_is_eligible and not taxpayer_disqualified_from_seed_capital_credit:
+      min(seed_capital_investment_credit_cap, seed_capital_investment_credit_rate
+      * max(0, qualified_seed_capital_investment_amount)) else: 0'
+- name: beginning_farmer_incentive_credit_carryover_years
+  kind: parameter
+  dtype: Count
+  source: Minn. Stat. 290.06, subd. 37(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: 15 succeeding taxable years
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '15'
+- name: beginning_farmer_incentive_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 37(a)-(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: limited to the amount stated on the certificate
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: limited to the liability for tax
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if beginning_farmer_incentive_credit_approved_and_certified: min(max(0,
+      beginning_farmer_incentive_credit_certificate_amount), max(0, tax_liability_before_beginning_farmer_incentive_credit))
+      else: 0'
+- name: beginning_farmer_management_credit_carryover_years
+  kind: parameter
+  dtype: Count
+  source: Minn. Stat. 290.06, subd. 38(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: three succeeding taxable years
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3'
+- name: beginning_farmer_management_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 38(a)-(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: may take a credit ... for participation in a financial management
+            program
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: limited to the liability for tax
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if beginning_farmer_management_credit_approved_and_certified: min(max(0,
+      beginning_farmer_management_credit_amount), max(0, tax_liability_before_beginning_farmer_management_credit))
+      else: 0'
+- name: film_production_credit_carryover_years
+  kind: parameter
+  dtype: Count
+  source: Minn. Stat. 290.06, subd. 39(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: five succeeding taxable years
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '5'
+- name: film_production_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 39(a)-(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: equal to the amount certified on a credit certificate
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: limited to the liability for tax
+  versions:
+  - effective_from: '0001-01-01'
+    formula: min(max(0, film_production_credit_certificate_amount), max(0, tax_liability_before_film_production_credit))
+- name: pass_through_entity_tax_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Minn. Stat. 290.06, subd. 40(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-mn/statute/290.06
+          excerpt: equal to the amount of the owner's tax liability as calculated
+            under section 289A.08
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if qualifying_owner_of_qualifying_entity_electing_pass_through_entity_tax:
+      max(0, owner_tax_liability_calculated_for_pass_through_entity_tax) else: 0'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mn/statute/290.06`
- Module: `us-mn/statutes/290/06.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-06/rulespec-us/oracle-coverage-pending.yaml: 39 declared (+27 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.