### PR TITLE
Encode us-mt/statute/15-30-2318 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11960,6 +11960,15 @@
         ]
       }
     ],
+    "us-mt/statute/15-30-2318": [
+      {
+        "module": "us-mt/statutes/15-30-2318.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nc/manual/dhhs/fns/appendix-3100-social-security-district-offices/page-1": [
       {
         "module": "us-nc/policies/dhhs/fns/appendix-3100-social-security-district-offices/page-1.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,20 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 16
 entries:
+  - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mt:statutes/15-30-2318#reduction_percentage
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mt:statutes/15-30-2318#state_earned_income_tax_credit_percentage
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mt/.axiom/encoding-manifests/statutes/15-30-2318.json
+++ b/us-mt/.axiom/encoding-manifests/statutes/15-30-2318.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/15-30-2318.yaml",
+      "sha256": "0e9ce55be17dcd39970d0fe8498536bb409e8c21c7bd1047459d96302a4c9102"
+    },
+    {
+      "path": "statutes/15-30-2318.test.yaml",
+      "sha256": "76e213ad3245bc0817d4392a9bfb7ed7e4efe4c18f28dfd6f6faa8888fe9986b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mt/statute/15-30-2318",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mt-statute-15-30-2318/encode-out/_eval_workspaces/codex-gpt-5.5/us-mt-statute-15-30-2318/workspace/context-manifest.json",
+  "context_manifest_sha256": "a1195cdf1618ee056faef37500cd7a902578757b618cad1d87657c47711a1760",
+  "generated_at": "2026-07-08T15:31:01.426580+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mt-statute-15-30-2318/encode-out/codex-gpt-5.5/statutes/15-30-2318.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mt-statute-15-30-2318/encode-out",
+  "generated_output_sha256": "0e9ce55be17dcd39970d0fe8498536bb409e8c21c7bd1047459d96302a4c9102",
+  "generation_prompt_sha256": "65c585653c62ae605e7e235b64e6e973ee4c5827b446d921e1d06d39a038fa65",
+  "model": "gpt-5.5",
+  "run_id": "a3098a8e",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a7c302fe782300aa2a029271030efc0bb6855c8ca79bd8d4378132b6acd9c43c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mt-statute-15-30-2318/encode-out/traces/codex-gpt-5.5/us-mt-statute-15-30-2318.json",
+  "trace_sha256": "73d94850f0d929aac54dc59d34e4feca33238c0eb28ea33fc708f12242d4988d"
+}

--- a/us-mt/statutes/15-30-2318.test.yaml
+++ b/us-mt/statutes/15-30-2318.test.yaml
@@ -1,0 +1,45 @@
+- name: resident_credit_without_501d_reduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mt:statutes/15-30-2318#input.taxpayer_is_resident: true
+    us-mt:statutes/15-30-2318#input.federal_earned_income_credit: 1000
+    us-mt:statutes/15-30-2318#input.earned_income: 10000
+    us-mt:statutes/15-30-2318#input.earned_income_disallowed_under_subsection_3: 0
+    us-mt:statutes/15-30-2318#input.tax_liability_under_this_chapter: 150
+  output:
+    us-mt:statutes/15-30-2318#reduction_percentage: 0
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit: 200
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund: 50
+- name: resident_credit_reduced_for_501d_dividend_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mt:statutes/15-30-2318#input.taxpayer_is_resident: true
+    us-mt:statutes/15-30-2318#input.federal_earned_income_credit: 1000
+    us-mt:statutes/15-30-2318#input.earned_income: 10000
+    us-mt:statutes/15-30-2318#input.earned_income_disallowed_under_subsection_3: 2500
+    us-mt:statutes/15-30-2318#input.tax_liability_under_this_chapter: 0
+  output:
+    us-mt:statutes/15-30-2318#reduction_percentage: 0.25
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit: 150
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund: 150
+- name: nonresident_not_allowed_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mt:statutes/15-30-2318#input.taxpayer_is_resident: false
+    us-mt:statutes/15-30-2318#input.federal_earned_income_credit: 1000
+    us-mt:statutes/15-30-2318#input.earned_income: 10000
+    us-mt:statutes/15-30-2318#input.earned_income_disallowed_under_subsection_3: 0
+    us-mt:statutes/15-30-2318#input.tax_liability_under_this_chapter: 0
+  output:
+    us-mt:statutes/15-30-2318#reduction_percentage: 0
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit: 0
+    us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund: 0

--- a/us-mt/statutes/15-30-2318.yaml
+++ b/us-mt/statutes/15-30-2318.yaml
@@ -1,0 +1,102 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mt/statute/15-30-2318
+  summary: |-
+    Resident taxpayer credit equals 20% of the federal earned income credit; credit is reduced for earned income treated as a dividend received by a member of an IRC 501(d) agricultural organization. The excess over tax liability is refundable.
+  deferred_outputs:
+    - output: us-mt:statutes/15-30-2318/a#earned_income
+      reason: Earned income is defined by cross-reference to section 32 of the Internal Revenue Code, and that federal definition is not supplied in this source unit.
+rules:
+  - name: state_earned_income_tax_credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: 15-30-2318(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mt/statute/15-30-2318
+              excerpt: "20% of the amount of the credit"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.20
+
+  - name: reduction_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 15-30-2318(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-mt/statute/15-30-2318
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if earned_income == 0: 0 else: earned_income_disallowed_under_subsection_3 / earned_income
+
+  - name: montana_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 15-30-2318(1)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mt/statute/15-30-2318
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mt:statutes/15-30-2318#state_earned_income_tax_credit_percentage
+              output: state_earned_income_tax_credit_percentage
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mt:statutes/15-30-2318#reduction_percentage
+              output: reduction_percentage
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if taxpayer_is_resident: max(0, federal_earned_income_credit * state_earned_income_tax_credit_percentage * max(0, 1 - reduction_percentage)) else: 0
+
+  - name: montana_earned_income_tax_credit_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 15-30-2318(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mt/statute/15-30-2318
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
+              output: montana_earned_income_tax_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          max(0, montana_earned_income_tax_credit - tax_liability_under_this_chapter)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mt/statute/15-30-2318`
- Module: `us-mt/statutes/15-30-2318.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mt-statute-15-30-2318/rulespec-us/oracle-coverage-pending.yaml: 16 declared (+4 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.