### PR TITLE
Encode us-mn/statute/290.067 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11951,6 +11951,15 @@
         ]
       }
     ],
+    "us-mn/statute/290.067": [
+      {
+        "module": "us-mn/statutes/290/067.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,41 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 23
 entries:
+  - legal_id: us-mn:statutes/290/067#dependent_care_credit_after_income_limit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#dependent_care_credit_income_limit_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#income_reduction_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#infant_deemed_expense_age_limit_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#licensed_parent_family_day_care_child_age_limit_years
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#one_qualifying_individual_income_limit_base_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#statutory_income_reduction_threshold
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_count
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_income_limit_base_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-mn:statutes/290/067#younger_child_deemed_expense_age_limit_months
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-mn/.axiom/encoding-manifests/statutes/290/067.json
+++ b/us-mn/.axiom/encoding-manifests/statutes/290/067.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/290/067.yaml",
+      "sha256": "f4d28f9d4b30ac8e04dd968f3bdada17e3ae4e02ebf57672c52b872c34030576"
+    },
+    {
+      "path": "statutes/290/067.test.yaml",
+      "sha256": "22720c79427926075b319948bb87b1f09636c732923593350ef024d6d0f71488"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-mn/statute/290.067",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-067/encode-out/_eval_workspaces/codex-gpt-5.5/us-mn-statute-290.067/workspace/context-manifest.json",
+  "context_manifest_sha256": "9975d50a128886b5ae1802baebcfe080d86f13bef9f0c77147e13dc6fdbcb892",
+  "generated_at": "2026-07-08T15:31:12.406466+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-067/encode-out/codex-gpt-5.5/statutes/290/067.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-067/encode-out",
+  "generated_output_sha256": "f4d28f9d4b30ac8e04dd968f3bdada17e3ae4e02ebf57672c52b872c34030576",
+  "generation_prompt_sha256": "7be7934a0bb0f70b6b3f054b381e681de1846d18b9f55fa5a276b231666c0058",
+  "model": "gpt-5.5",
+  "run_id": "8e6c535b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "69a259fe02893657b753ac7cf1d3b691c0e28bad160324c7ed7d48350fdf14f6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-067/encode-out/traces/codex-gpt-5.5/us-mn-statute-290.067.json",
+  "trace_sha256": "abe0552d35e57abf26e116dd347c99856e3d59c63d3c70ed77ead47b3696a189"
+}

--- a/us-mn/statutes/290/067.test.yaml
+++ b/us-mn/statutes/290/067.test.yaml
@@ -1,0 +1,45 @@
+- name: one_qualifying_individual_above_threshold_limited
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/067#input.qualifying_individual_count: 1
+    us-mn:statutes/290/067#input.federal_adjusted_gross_income: 54230
+    us-mn:statutes/290/067#input.dependent_care_credit_otherwise_calculated_under_this_subdivision: 550
+    us-mn:statutes/290/067#input.minnesota_source_earned_income_of_claimant_and_spouse: 40000
+    us-mn:statutes/290/067#input.total_earned_income_of_claimant_and_spouse: 80000
+  output:
+    us-mn:statutes/290/067#dependent_care_credit_income_limit_amount: 500
+    us-mn:statutes/290/067#dependent_care_credit_after_income_limit: 500
+    us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio: 0.5
+- name: two_qualifying_individuals_credit_below_income_limit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/067#input.qualifying_individual_count: 2
+    us-mn:statutes/290/067#input.federal_adjusted_gross_income: 56230
+    us-mn:statutes/290/067#input.dependent_care_credit_otherwise_calculated_under_this_subdivision: 900
+    us-mn:statutes/290/067#input.minnesota_source_earned_income_of_claimant_and_spouse: 30000
+    us-mn:statutes/290/067#input.total_earned_income_of_claimant_and_spouse: 60000
+  output:
+    us-mn:statutes/290/067#dependent_care_credit_income_limit_amount: 1000
+    us-mn:statutes/290/067#dependent_care_credit_after_income_limit: 900
+    us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio: 0.5
+- name: high_income_credit_floored_at_zero
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-mn:statutes/290/067#input.qualifying_individual_count: 1
+    us-mn:statutes/290/067#input.federal_adjusted_gross_income: 65230
+    us-mn:statutes/290/067#input.dependent_care_credit_otherwise_calculated_under_this_subdivision: 100
+    us-mn:statutes/290/067#input.minnesota_source_earned_income_of_claimant_and_spouse: 0
+    us-mn:statutes/290/067#input.total_earned_income_of_claimant_and_spouse: 0
+  output:
+    us-mn:statutes/290/067#dependent_care_credit_income_limit_amount: 0
+    us-mn:statutes/290/067#dependent_care_credit_after_income_limit: 0
+    us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio: 0

--- a/us-mn/statutes/290/067.yaml
+++ b/us-mn/statutes/290/067.yaml
@@ -1,0 +1,206 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mn/statute/290.067
+  summary: |-
+    Subdivision 1 allows a dependent care credit by reference to IRC section 21, with special deemed-expense rules for young children, nonresident and part-year resident allocation, and an income limitation. For taxpayers with federal adjusted gross income in excess of $52,230, the credit is the lesser of the otherwise calculated credit or $600/$1,200 minus five percent of the excess, but not below zero. Subdivision 2b requires annual adjustment of the income threshold. Subdivision 3 makes the credit refundable.
+  deferred_outputs:
+    - output: us-mn:statutes/290/067#dependent_care_credit
+      reason: The base credit, qualifying individual rules, earned income limitation mechanics, dependent care assistance program definition, organization categories, and inflation adjustment are determined by cited sources not supplied in context, including IRC sections 21, 21(c), 21(d), 129, 501(c)(3), 501(a), 112, Minnesota section 290.0132, and section 270C.22. This file retains independent source-stated scalars and encodes the income limitation from subdivision 1(h) using a completed otherwise-calculated credit boundary input.
+rules:
+  - name: statutory_income_reduction_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "federal adjusted gross income in excess of $52,230"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          52230
+
+  - name: one_qualifying_individual_income_limit_base_credit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "$600 minus five percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          600
+
+  - name: two_or_more_qualifying_individuals_income_limit_base_credit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "$1,200 minus five percent"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1200
+
+  - name: income_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "five percent of federal adjusted gross income in excess of $52,230"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.05
+
+  - name: two_or_more_qualifying_individuals_count
+    kind: parameter
+    dtype: Count
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "two or more qualifying individuals"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+
+  - name: licensed_parent_family_day_care_child_age_limit_years
+    kind: parameter
+    dtype: Decimal
+    source: Minn. Stat. section 290.067, subd. 1(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "has not attained the age of six years"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          6
+
+  - name: younger_child_deemed_expense_age_limit_months
+    kind: parameter
+    dtype: Decimal
+    source: Minn. Stat. section 290.067, subd. 1(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "16 months old or younger"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          16
+
+  - name: infant_deemed_expense_age_limit_years
+    kind: parameter
+    dtype: Decimal
+    source: Minn. Stat. section 290.067, subd. 1(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+              excerpt: "has not attained the age of one year"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1
+
+  - name: nonresident_or_part_year_resident_earned_income_allocation_ratio
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: Minn. Stat. section 290.067, subd. 1(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if total_earned_income_of_claimant_and_spouse > 0: min(1, max(0, minnesota_source_earned_income_of_claimant_and_spouse / total_earned_income_of_claimant_and_spouse)) else: 0
+
+  - name: dependent_care_credit_income_limit_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if qualifying_individual_count >= two_or_more_qualifying_individuals_count: max(0, two_or_more_qualifying_individuals_income_limit_base_credit - (income_reduction_rate * max(0, federal_adjusted_gross_income - statutory_income_reduction_threshold))) else: max(0, one_qualifying_individual_income_limit_base_credit - (income_reduction_rate * max(0, federal_adjusted_gross_income - statutory_income_reduction_threshold)))
+
+  - name: dependent_care_credit_after_income_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minn. Stat. section 290.067, subd. 1(h)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.067
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          min(max(0, dependent_care_credit_otherwise_calculated_under_this_subdivision), dependent_care_credit_income_limit_amount)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-mn/statute/290.067`
- Module: `us-mn/statutes/290/067.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-mn-statute-290-067/rulespec-us/oracle-coverage-pending.yaml: 23 declared (+11 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.