### PR TITLE
Encode us-ne/statute/77/77-2715.07 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16376,6 +16376,15 @@
         ]
       }
     ],
+    "us-ne/statute/77/77-2715.07": [
+      {
+        "module": "us-ne/statutes/77/77-2715/07.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nh/regulation/he-w-700/He-W 704.04": [
       {
         "module": "us-nh/regulations/he-w-700/He-W 704/04.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,32 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 20
 entries:
+  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#family_member_for_extremely_blighted_area_residence_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_allowed
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_amount
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_minimum_gestation_weeks
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-ne/.axiom/encoding-manifests/statutes/77/77-2715/07.json
+++ b/us-ne/.axiom/encoding-manifests/statutes/77/77-2715/07.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/77/77-2715/07.yaml",
+      "sha256": "f21713bd28cafd43403ddf48b404c92ff8ba3c2043546853031f26975d326438"
+    },
+    {
+      "path": "statutes/77/77-2715/07.test.yaml",
+      "sha256": "d37779f9764c5d0d506083962d226eb0dbbe9eeeebb8bc17d4355972e785c326"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-ne/statute/77/77-2715.07",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ne-statute-77-77-2715-07/encode-out/_eval_workspaces/codex-gpt-5.5/us-ne-statute-77-77-2715.07/workspace/context-manifest.json",
+  "context_manifest_sha256": "43687cf8d4bf9eb8812db9137191b03073cab26254620d31eae3eca23233406a",
+  "generated_at": "2026-07-08T15:33:14.648733+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ne-statute-77-77-2715-07/encode-out/codex-gpt-5.5/statutes/77/77-2715/07.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ne-statute-77-77-2715-07/encode-out",
+  "generated_output_sha256": "f21713bd28cafd43403ddf48b404c92ff8ba3c2043546853031f26975d326438",
+  "generation_prompt_sha256": "cf4c5b3a0eccaf93723c2791a1bcdfa19cf1d8bf74588d0e5d8e4423c389c071",
+  "model": "gpt-5.5",
+  "run_id": "b84dcb38",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7fbbb07d661c2ed20245d83b5537b251203e073603ed1fed60753bccc28091ed"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ne-statute-77-77-2715-07/encode-out/traces/codex-gpt-5.5/us-ne-statute-77-77-2715.07.json",
+  "trace_sha256": "69c5ee5dcb44bc06942242b338b6273177d9624ddacf94a17a74edb2cda381e8"
+}

--- a/us-ne/statutes/77/77-2715/07.test.yaml
+++ b/us-ne/statutes/77/77-2715/07.test.yaml
@@ -1,0 +1,85 @@
+- name: extremely blighted area residence credit allowed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ne:statutes/77/77-2715/07#input.individual_purchased_residence_during_taxable_year: true
+    us-ne:statutes/77/77-2715/07#input.residence_is_located_within_extremely_blighted_area: true
+    us-ne:statutes/77/77-2715/07#input.residence_is_individuals_primary_residence: true
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individual: false
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individuals_spouse: false
+    us-ne:statutes/77/77-2715/07#input.no_more_than_one_credit_claimed_with_respect_to_single_residence: true
+  output:
+    us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_allowed: holds
+    us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit: 5000
+- name: residence purchased from family member blocks credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ne:statutes/77/77-2715/07#input.individual_purchased_residence_during_taxable_year: true
+    us-ne:statutes/77/77-2715/07#input.residence_is_located_within_extremely_blighted_area: true
+    us-ne:statutes/77/77-2715/07#input.residence_is_individuals_primary_residence: true
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individual: true
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individuals_spouse: false
+    us-ne:statutes/77/77-2715/07#input.no_more_than_one_credit_claimed_with_respect_to_single_residence: true
+  output:
+    us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_allowed: not_holds
+    us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit: 0
+- name: family member definition includes grandparent
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_spouse: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_child: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_parent: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_brother: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_sister: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_grandchild: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_grandparent: true
+  output:
+    us-ne:statutes/77/77-2715/07#family_member_for_extremely_blighted_area_residence_credit: holds
+- name: stillborn child credit allowed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-ne:statutes/77/77-2715/07#input.claimant_is_parent_of_stillborn_child: true
+    us-ne:statutes/77/77-2715/07#input.fetal_death_certificate_filed_for_child: true
+    us-ne:statutes/77/77-2715/07#input.child_gestation_weeks: 20
+    us-ne:statutes/77/77-2715/07#input.child_would_have_been_dependent_of_claimant: true
+    us-ne:statutes/77/77-2715/07#input.stillbirth_occurred_in_taxable_year: true
+  output:
+    us-ne:statutes/77/77-2715/07#stillborn_child_credit_allowed: holds
+    us-ne:statutes/77/77-2715/07#stillborn_child_credit: 2000
+- name: auto_zero_stillborn_child_credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_brother: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_child: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_grandchild: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_grandparent: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_parent: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_sister: false
+    us-ne:statutes/77/77-2715/07#input.candidate_is_individuals_spouse: false
+    us-ne:statutes/77/77-2715/07#input.child_gestation_weeks: 0
+    us-ne:statutes/77/77-2715/07#input.child_would_have_been_dependent_of_claimant: false
+    us-ne:statutes/77/77-2715/07#input.claimant_is_parent_of_stillborn_child: false
+    us-ne:statutes/77/77-2715/07#input.fetal_death_certificate_filed_for_child: false
+    us-ne:statutes/77/77-2715/07#input.individual_purchased_residence_during_taxable_year: false
+    us-ne:statutes/77/77-2715/07#input.no_more_than_one_credit_claimed_with_respect_to_single_residence: false
+    us-ne:statutes/77/77-2715/07#input.residence_is_individuals_primary_residence: false
+    us-ne:statutes/77/77-2715/07#input.residence_is_located_within_extremely_blighted_area: false
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individual: false
+    us-ne:statutes/77/77-2715/07#input.residence_was_purchased_from_family_member_of_individuals_spouse: false
+    us-ne:statutes/77/77-2715/07#input.stillbirth_occurred_in_taxable_year: false
+  output:
+    us-ne:statutes/77/77-2715/07#stillborn_child_credit: 0

--- a/us-ne/statutes/77/77-2715/07.yaml
+++ b/us-ne/statutes/77/77-2715/07.yaml
@@ -1,0 +1,203 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ne/statute/77/77-2715.07
+  summary: |-
+    Subsection (7) allows a $5,000 nonrefundable income tax credit for taxable years beginning or deemed to begin on or after January 1, 2020, and before January 1, 2032, for an individual who purchases a primary residence in an extremely blighted area, not from a family member of the individual or spouse. Subsection (7)(e) defines family member as an individual's spouse, child, parent, brother, sister, grandchild, or grandparent, whether by blood, marriage, or adoption. Subsection (9) allows a $2,000 refundable credit for the parent of a stillborn child if specified conditions are met.
+  deferred_outputs:
+    - output: us-ne:statutes/77/77-2715/07/1#resident_individual_credits
+      reason: Depends on federal credits under Internal Revenue Code sections 22 and 21 and Nebraska section 77-2730, which are not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/2#a_referenced_federal_child_care_credit
+      reason: Depends on the federal credit allowed under Internal Revenue Code section 21 and net operating loss carryforward eligibility mechanics not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/2#b_referenced_federal_child_care_credit
+      reason: Depends on the federal credit allowable under Internal Revenue Code section 21 and net operating loss carryforward eligibility mechanics not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/2#referenced_refundable_credits
+      reason: Cross-referenced credits under sections 77-5209.01, 77-7203, section 32 of the Internal Revenue Code, and named Nebraska credit acts are not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/3#individual_nonrefundable_cross_referenced_credits
+      reason: Cross-referenced credits under section 77-2716.01 and multiple named Nebraska credit acts are not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/4#estate_trust_cross_referenced_credits
+      reason: Depends on section 77-2730 and Beginning Farmer Tax Credit Act mechanics not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/5#financial_institution_franchise_tax_credit
+      reason: Depends on franchise tax paid under sections 77-3801 to 77-3807 and pass-through ownership allocation facts not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/6#credits_provided_in_sections_77_3604_and_77_3605
+      reason: Cross-referenced sections 77-3604 and 77-3605 are not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/7#extremely_blighted_area_residence_credit_recapture
+      reason: Recapture administration by the Department of Revenue after transfer or ceasing primary-residence use is not represented as a taxpayer credit computation in the supported schema.
+    - output: us-ne:statutes/77/77-2715/07/8#named_act_refundable_credits
+      reason: Cross-referenced named Nebraska credit acts are not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/10#credits_provided_in_section_77_7204
+      reason: Cross-referenced section 77-7204 is not provided in copied RuleSpec context.
+    - output: us-ne:statutes/77/77-2715/07/11#credits_provided_in_sections_77_3156_to_77_3159
+      reason: Cross-referenced sections 77-3156, 77-3157, 77-3158, and 77-3159 are not provided in copied RuleSpec context.
+rules:
+  - name: extremely_blighted_area_residence_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 77-2715.07(7)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+              excerpt: "in the amount of five thousand dollars"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          5000
+
+  - name: family_member_for_extremely_blighted_area_residence_credit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 77-2715.07(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          candidate_is_individuals_spouse
+          or candidate_is_individuals_child
+          or candidate_is_individuals_parent
+          or candidate_is_individuals_brother
+          or candidate_is_individuals_sister
+          or candidate_is_individuals_grandchild
+          or candidate_is_individuals_grandparent
+
+  - name: extremely_blighted_area_residence_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 77-2715.07(7)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          individual_purchased_residence_during_taxable_year
+          and residence_is_located_within_extremely_blighted_area
+          and residence_is_individuals_primary_residence
+          and not residence_was_purchased_from_family_member_of_individual
+          and not residence_was_purchased_from_family_member_of_individuals_spouse
+          and no_more_than_one_credit_claimed_with_respect_to_single_residence
+
+  - name: extremely_blighted_area_residence_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 77-2715.07(7)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+              excerpt: "in the amount of five thousand dollars"
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          if extremely_blighted_area_residence_credit_allowed: extremely_blighted_area_residence_credit_amount else: 0
+
+  - name: stillborn_child_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 77-2715.07(9)(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+              excerpt: "The amount of the credit shall be two thousand dollars."
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          2000
+
+  - name: stillborn_child_minimum_gestation_weeks
+    kind: parameter
+    dtype: Count
+    source: 77-2715.07(9)(a)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+              excerpt: "advanced to at least the twentieth week of gestation"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          20
+
+  - name: stillborn_child_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 77-2715.07(9)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          claimant_is_parent_of_stillborn_child
+          and fetal_death_certificate_filed_for_child
+          and child_gestation_weeks >= stillborn_child_minimum_gestation_weeks
+          and child_would_have_been_dependent_of_claimant
+          and stillbirth_occurred_in_taxable_year
+
+  - name: stillborn_child_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 77-2715.07(9)(b)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.07
+              excerpt: "The amount of the credit shall be two thousand dollars."
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          if stillborn_child_credit_allowed: stillborn_child_credit_amount else: 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-ne/statute/77/77-2715.07`
- Module: `us-ne/statutes/77/77-2715/07.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-ne-statute-77-77-2715-07/rulespec-us/oracle-coverage-pending.yaml: 20 declared (+8 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.