### PR TITLE
Encode us-nc/statute/105/105-153.7 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16376,6 +16376,15 @@
         ]
       }
     ],
+    "us-nc/statute/105/105-153.7": [
+      {
+        "module": "us-nc/statutes/105/105-153/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nh/regulation/he-w-700/He-W 704.04": [
       {
         "module": "us-nh/regulations/he-w-700/He-W 704/04.yaml",

--- a/us-nc/.axiom/encoding-manifests/statutes/105/105-153/7.json
+++ b/us-nc/.axiom/encoding-manifests/statutes/105/105-153/7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/105/105-153/7.yaml",
+      "sha256": "594b191130912c073719a143ffca21ce1814dd1f159b68f2dcdaaa732eac8a30"
+    },
+    {
+      "path": "statutes/105/105-153/7.test.yaml",
+      "sha256": "11f7ad04b021679eb47579f26137941d179b2b041ab80a7f9c2e81680de1bb13"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-nc/statute/105/105-153.7",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-7/encode-out/_eval_workspaces/codex-gpt-5.5/us-nc-statute-105-105-153.7/workspace/context-manifest.json",
+  "context_manifest_sha256": "3b515f918c34d02e1b2f2fea84fc71b0de6e0a30885e7faec03f88cbdba15412",
+  "generated_at": "2026-07-08T15:36:57.769734+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-7/encode-out/codex-gpt-5.5/statutes/105/105-153/7.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-7/encode-out",
+  "generated_output_sha256": "594b191130912c073719a143ffca21ce1814dd1f159b68f2dcdaaa732eac8a30",
+  "generation_prompt_sha256": "5e21b7bdb3bc45e4b099a54654f953551094901608c928e0cdf8bf2aa66039a2",
+  "model": "gpt-5.5",
+  "run_id": "1de35b19",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "488cf027e144b7d8ca7d8c0300a359c87fd8f735e5be5cc5117681cfb98f2664"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-7/encode-out/traces/codex-gpt-5.5/us-nc-statute-105-105-153.7.json",
+  "trace_sha256": "b585dc9054a0f82dfed7dc5079b19b9d0dcdbd787595b2ef47f3ac3e81243e89"
+}

--- a/us-nc/statutes/105/105-153/7.test.yaml
+++ b/us-nc/statutes/105/105-153/7.test.yaml
@@ -1,0 +1,41 @@
+- name: tax year 2024 rate applies to north carolina taxable income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nc:statutes/105/105-153/7#input.north_carolina_taxable_income: 100000
+  output:
+    us-nc:statutes/105/105-153/7#individual_income_tax: 4600
+- name: tax year 2027 after 2026 rate applies
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-nc:statutes/105/105-153/7#input.north_carolina_taxable_income: 100000
+  output:
+    us-nc:statutes/105/105-153/7#individual_income_tax: 3990
+- name: withholding tables apply when provided and no short period exception
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nc:statutes/105/105-153/7#input.secretary_has_provided_withholding_tables: true
+    us-nc:statutes/105/105-153/7#input.files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period: false
+    us-nc:statutes/105/105-153/7#input.taxable_period_months: 12
+  output:
+    us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: holds
+- name: withholding tables do not apply to short period section 443 accounting change
+    return
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nc:statutes/105/105-153/7#input.secretary_has_provided_withholding_tables: true
+    us-nc:statutes/105/105-153/7#input.files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period: true
+    us-nc:statutes/105/105-153/7#input.taxable_period_months: 11
+  output:
+    us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: not_holds

--- a/us-nc/statutes/105/105-153/7.yaml
+++ b/us-nc/statutes/105/105-153/7.yaml
@@ -1,0 +1,177 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nc/statute/105/105-153.7
+  summary: |-
+    A tax is imposed for each taxable year on the North Carolina taxable income of every individual. The tax is 5.499% for taxable years beginning before January 1, 2019; 5.25% for taxable years beginning on or after January 1, 2019 and before January 1, 2022; and for taxable years beginning on or after January 1, 2022: 4.99% in 2022, 4.75% in 2023, 4.6% in 2024, 4.5% in 2025, 4.25% in 2026, and 3.99% after 2026. The Secretary may provide withholding tables; the tables do not apply to an individual filing a return under Code section 443(a)(1) for a period of less than 12 months due to an annual accounting period change or to an estate or trust.
+rules:
+  - name: individual_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: N.C. Gen. Stat. § 105-153.7(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "before January 1, 2019 ... five and four hundred ninety-nine thousandths percent (5.499%)"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "on or after January 1, 2019 and before January 1, 2022 ... five and one-quarter percent (5.25%)"
+          - path: versions[2].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "In 2022"
+                column: "Tax"
+              excerpt: "In 2022 4.99%"
+          - path: versions[3].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "In 2023"
+                column: "Tax"
+              excerpt: "In 2023 4.75%"
+          - path: versions[4].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "In 2024"
+                column: "Tax"
+              excerpt: "In 2024 4.6%"
+          - path: versions[5].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "In 2025"
+                column: "Tax"
+              excerpt: "In 2025 4.5%"
+          - path: versions[6].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "In 2026"
+                column: "Tax"
+              excerpt: "In 2026 4.25%"
+          - path: versions[7].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              table:
+                header: "Taxable Years Beginning Tax"
+                row: "After 2026"
+                column: "Tax"
+              excerpt: "After 2026 3.99%"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          0.05499
+      - effective_from: '2019-01-01'
+        formula: |-
+          0.0525
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.0499
+      - effective_from: '2023-01-01'
+        formula: |-
+          0.0475
+      - effective_from: '2024-01-01'
+        formula: |-
+          0.046
+      - effective_from: '2025-01-01'
+        formula: |-
+          0.045
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.0425
+      - effective_from: '2027-01-01'
+        formula: |-
+          0.0399
+
+  - name: short_period_return_month_threshold
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: N.C. Gen. Stat. § 105-153.7(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "for a period of less than 12 months"
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          12
+
+  - name: individual_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. § 105-153.7(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "A tax is imposed ... on the North Carolina taxable income of every individual"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
+              output: individual_income_tax_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          max(0, north_carolina_taxable_income) * individual_income_tax_rate
+
+  - name: withholding_tables_apply_to_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: N.C. Gen. Stat. § 105-153.7(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "The Secretary may provide tables ... The tables do not apply to an individual who files a return under section 443(a)(1) ... for a period of less than 12 months"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nc:statutes/105/105-153/7#short_period_return_month_threshold
+              output: short_period_return_month_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          secretary_has_provided_withholding_tables
+          and not files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period
+          and taxable_period_months >= short_period_return_month_threshold


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-nc/statute/105/105-153.7`
- Module: `us-nc/statutes/105/105-153/7.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-7/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.