### PR TITLE
Encode us-nm/statute/7-2-18.15 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16462,6 +16462,15 @@
         ]
       }
     ],
+    "us-nm/statute/7-2-18.15": [
+      {
+        "module": "us-nm/statutes/7-2-18/15.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nv/manual/dwss/eligibility-payments/a-600/page-38": [
       {
         "module": "us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,26 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 18
 entries:
+  - legal_id: us-nm:statutes/7-2-18/15#age_exception_exclusive_maximum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nm:statutes/7-2-18/15#age_exception_minimum_age
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_refund
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-nm/.axiom/encoding-manifests/statutes/7-2-18/15.json
+++ b/us-nm/.axiom/encoding-manifests/statutes/7-2-18/15.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/7-2-18/15.yaml",
+      "sha256": "3bdc7765f8c5c7f23f248a4b9905fc4fb2a111050752e672d5018a0a78f780f7"
+    },
+    {
+      "path": "statutes/7-2-18/15.test.yaml",
+      "sha256": "120b0344bde89fdddc883f1e6a6ed1da859bdd44669fdce37d5dba61654f8584"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-nm/statute/7-2-18.15",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nm-statute-7-2-18-15/encode-out/_eval_workspaces/codex-gpt-5.5/us-nm-statute-7-2-18.15/workspace/context-manifest.json",
+  "context_manifest_sha256": "830747decfee05ed91ab0c01e985fc81c84e5f99cf39a03c374712dad9c8fb6a",
+  "generated_at": "2026-07-08T15:37:01.244588+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nm-statute-7-2-18-15/encode-out/codex-gpt-5.5/statutes/7-2-18/15.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nm-statute-7-2-18-15/encode-out",
+  "generated_output_sha256": "3bdc7765f8c5c7f23f248a4b9905fc4fb2a111050752e672d5018a0a78f780f7",
+  "generation_prompt_sha256": "97cf2ab2af621662b460027cebd3f2825e40bef432670e3e0e9c667078f7ea41",
+  "model": "gpt-5.5",
+  "run_id": "68a24371",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "05548fffbc26d05bfa379a109570464c61dffa918b00768527e3e204a7bf0c13"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nm-statute-7-2-18-15/encode-out/traces/codex-gpt-5.5/us-nm-statute-7-2-18.15.json",
+  "trace_sha256": "e41a57c776f26eec51384046d6a7b223efd4c2dc1fbbca33c27e023c1e5e49bc"
+}

--- a/us-nm/statutes/7-2-18/15.test.yaml
+++ b/us-nm/statutes/7-2-18/15.test.yaml
@@ -1,0 +1,76 @@
+- name: resident filer receives twenty-five percent credit and refund after 2023
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_resident: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_files_individual_new_mexico_income_tax_return: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_eligible_for_federal_earned_income_tax_credit: true
+    ? us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_identification_number_requirement
+    : false
+    us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_age_requirement: false
+    us-nm:statutes/7-2-18/15#input.taxpayer_age: 30
+    us-nm:statutes/7-2-18/15#input.federal_earned_income_tax_credit_amount_for_same_taxable_year: 1000
+    us-nm:statutes/7-2-18/15#input.income_tax_liability: 100
+  output:
+    us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit: holds
+    us-nm:statutes/7-2-18/15#working_families_tax_credit: 250
+    us-nm:statutes/7-2-18/15#working_families_tax_credit_refund: 150
+- name: age exception applies for taxpayer age eighteen
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_resident: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_files_individual_new_mexico_income_tax_return: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_eligible_for_federal_earned_income_tax_credit: false
+    ? us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_identification_number_requirement
+    : false
+    us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_age_requirement: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_age: 18
+    us-nm:statutes/7-2-18/15#input.federal_earned_income_tax_credit_amount_for_same_taxable_year: 800
+    us-nm:statutes/7-2-18/15#input.income_tax_liability: 300
+  output:
+    us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit: holds
+    us-nm:statutes/7-2-18/15#working_families_tax_credit: 200
+    us-nm:statutes/7-2-18/15#working_families_tax_credit_refund: 0
+- name: age exception does not apply once taxpayer reaches twenty-five
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_resident: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_files_individual_new_mexico_income_tax_return: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_eligible_for_federal_earned_income_tax_credit: false
+    ? us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_identification_number_requirement
+    : false
+    us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_age_requirement: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_age: 25
+    us-nm:statutes/7-2-18/15#input.federal_earned_income_tax_credit_amount_for_same_taxable_year: 800
+    us-nm:statutes/7-2-18/15#input.income_tax_liability: 0
+  output:
+    us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit: not_holds
+    us-nm:statutes/7-2-18/15#working_families_tax_credit: 0
+    us-nm:statutes/7-2-18/15#working_families_tax_credit_refund: 0
+- name: twenty percent rate applies for taxable years beginning in 2021
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input:
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_resident: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_files_individual_new_mexico_income_tax_return: true
+    us-nm:statutes/7-2-18/15#input.taxpayer_is_eligible_for_federal_earned_income_tax_credit: false
+    ? us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_identification_number_requirement
+    : true
+    us-nm:statutes/7-2-18/15#input.taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_age_requirement: false
+    us-nm:statutes/7-2-18/15#input.taxpayer_age: 30
+    us-nm:statutes/7-2-18/15#input.federal_earned_income_tax_credit_amount_for_same_taxable_year: 1000
+    us-nm:statutes/7-2-18/15#input.income_tax_liability: 0
+  output:
+    us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit: holds
+    us-nm:statutes/7-2-18/15#working_families_tax_credit: 200
+    us-nm:statutes/7-2-18/15#working_families_tax_credit_refund: 200

--- a/us-nm/statutes/7-2-18/15.yaml
+++ b/us-nm/statutes/7-2-18/15.yaml
@@ -1,0 +1,158 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nm/statute/7-2-18.15
+  summary: |-
+    A resident taxpayer filing an individual New Mexico income tax return may claim the working families tax credit equal to twenty percent for taxable years beginning on or after January 1, 2021, and twenty-five percent for taxable years beginning on or after January 1, 2023, of the federal earned income tax credit for which the taxpayer is eligible or would have been eligible but for specified identification-number or age requirements; the age path applies if the taxpayer is at least eighteen but has not reached twenty-five. Excess credit over income tax liability is refunded.
+rules:
+  - name: working_families_tax_credit_rate
+    kind: parameter
+    dtype: Rate
+    source: Subsections A and B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "twenty percent for taxable years beginning on or after January 1, 2021"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "twenty-five percent for taxable years beginning on or after January 1, 2023"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          0.20
+      - effective_from: '2023-01-01'
+        formula: |-
+          0.25
+
+  - name: age_exception_minimum_age
+    kind: parameter
+    dtype: Integer
+    source: Subsection B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "at least eighteen years of age"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          18
+
+  - name: age_exception_exclusive_maximum_age
+    kind: parameter
+    dtype: Integer
+    source: Subsection B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "has not reached the age of twenty-five"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          25
+
+  - name: taxpayer_qualifies_for_working_families_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Subsections A and B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "at least eighteen years of age but has not reached the age of twenty-five"
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          taxpayer_is_resident
+          and taxpayer_files_individual_new_mexico_income_tax_return
+          and (
+            taxpayer_is_eligible_for_federal_earned_income_tax_credit
+            or taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_identification_number_requirement
+            or (
+              taxpayer_would_be_eligible_for_federal_earned_income_tax_credit_but_for_age_requirement
+              and taxpayer_age >= age_exception_minimum_age
+              and taxpayer_age < age_exception_exclusive_maximum_age
+            )
+          )
+
+  - name: working_families_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Subsections A, B, and E
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "of the federal earned income tax credit for which that taxpayer is eligible for the same taxable year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:statutes/7-2-18/15#working_families_tax_credit_rate
+              output: working_families_tax_credit_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit
+              output: taxpayer_qualifies_for_working_families_tax_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          if taxpayer_qualifies_for_working_families_tax_credit: working_families_tax_credit_rate * max(0, federal_earned_income_tax_credit_amount_for_same_taxable_year) else: 0
+
+  - name: working_families_tax_credit_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: Subsection D
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nm/statute/7-2-18.15
+              excerpt: "If the credit exceeds the individual's income tax liability for the taxable year, the excess shall be refunded"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:statutes/7-2-18/15#working_families_tax_credit
+              output: working_families_tax_credit
+              hash: sha256:local
+    versions:
+      - effective_from: '2021-01-01'
+        formula: |-
+          max(0, working_families_tax_credit - income_tax_liability)


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-nm/statute/7-2-18.15`
- Module: `us-nm/statutes/7-2-18/15.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nm-statute-7-2-18-15/rulespec-us/oracle-coverage-pending.yaml: 18 declared (+6 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.