### PR TITLE
Encode us-nc/statute/105/105-153.9 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16376,6 +16376,15 @@
         ]
       }
     ],
+    "us-nc/statute/105/105-153.9": [
+      {
+        "module": "us-nc/statutes/105/105-153/9.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nh/regulation/he-w-700/He-W 704.04": [
       {
         "module": "us-nh/regulations/he-w-700/He-W 704/04.yaml",

--- a/us-nc/.axiom/encoding-manifests/statutes/105/105-153/9.json
+++ b/us-nc/.axiom/encoding-manifests/statutes/105/105-153/9.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/105/105-153/9.yaml",
+      "sha256": "4a5dcf7d423041a23824d204fc9b442a183ec247188c12abcd23a8163fdcd2ff"
+    },
+    {
+      "path": "statutes/105/105-153/9.test.yaml",
+      "sha256": "c8c388a648295c8ec6caa0dd650f593abc4289c5871e5dbcd8f5957f5328b44a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-nc/statute/105/105-153.9",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-9/encode-out/_eval_workspaces/codex-gpt-5.5/us-nc-statute-105-105-153.9/workspace/context-manifest.json",
+  "context_manifest_sha256": "dadf1b7a61b7d4dc2624c37485bf55cc3ebf9519c79a8c626c2b6e3927f0867c",
+  "generated_at": "2026-07-08T15:37:14.773843+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-9/encode-out/codex-gpt-5.5/statutes/105/105-153/9.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-9/encode-out",
+  "generated_output_sha256": "4a5dcf7d423041a23824d204fc9b442a183ec247188c12abcd23a8163fdcd2ff",
+  "generation_prompt_sha256": "16607fd6183ec4189878c0265f41e31d3a9b8952b41fe5621e91d8abc4ca7905",
+  "model": "gpt-5.5",
+  "run_id": "8918bea2",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0669b2ddfd5eace40d5d6f2dcdfc5456aab3f420a2f1f607a29fbfa51e55c81e"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-9/encode-out/traces/codex-gpt-5.5/us-nc-statute-105-105-153.9.json",
+  "trace_sha256": "a59c778e7883c157fcc1754629969af60f82fe029ac696cbd46bfcff40e7fe85"
+}

--- a/us-nc/statutes/105/105-153/9.test.yaml
+++ b/us-nc/statutes/105/105-153/9.test.yaml
@@ -1,0 +1,8 @@
+- name: no_credit_for_taxes_on_income_eligible_for_subsection_c3_deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-nc:statutes/105/105-153/9#credit_for_taxes_paid_on_income_eligible_for_subsection_c3_deduction: 0

--- a/us-nc/statutes/105/105-153/9.yaml
+++ b/us-nc/statutes/105/105-153/9.yaml
@@ -1,0 +1,33 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nc/statute/105/105-153.9
+  summary: |-
+    105-153.9(f): "No credit is allowed under this section for taxes paid to another state or the District of Columbia on income eligible for the deduction provided in G.S. 105-153.5(c3)." Effect of Amendments states subsection (f) was added effective for taxable years beginning on or after January 1, 2023.
+rules:
+  - name: credit_for_taxes_paid_on_income_eligible_for_subsection_c3_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 105-153.9(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.9
+              excerpt: "No credit is allowed under this section for taxes paid to another state or the District of Columbia on income eligible for the deduction provided in G.S. 105-153.5(c3)."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.9
+              excerpt: "effective for taxable years beginning on or after January 1, 2023"
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-nc/statute/105/105-153.9`
- Module: `us-nc/statutes/105/105-153/9.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nc-statute-105-105-153-9/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.