### PR TITLE
Encode us-nd/statute/57/57-38-01.28 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16376,6 +16376,15 @@
         ]
       }
     ],
+    "us-nd/statute/57/57-38-01.28": [
+      {
+        "module": "us-nd/statutes/57/57-38-01/28.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nh/regulation/he-w-700/He-W 704.04": [
       {
         "module": "us-nh/regulations/he-w-700/He-W 704/04.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,23 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 12
+ceiling: 17
 entries:
+  - legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income_of_lesser_earning_spouse
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-nd:statutes/57/57-38-01/28#statutory_married_couple_credit_maximum
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
     source: bulk
     since: 2026-07-08

--- a/us-nd/.axiom/encoding-manifests/statutes/57/57-38-01/28.json
+++ b/us-nd/.axiom/encoding-manifests/statutes/57/57-38-01/28.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/57/57-38-01/28.yaml",
+      "sha256": "37b80a4f03299d1131327220e6fedb887854790c4ee9d55c5a634536c2c90fd5"
+    },
+    {
+      "path": "statutes/57/57-38-01/28.test.yaml",
+      "sha256": "6fe4340f804ea4d18f53b21d9c53c97caf8219e02b26a83c571e8902f641d1c4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-nd/statute/57/57-38-01.28",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nd-statute-57-57-38-01-28/encode-out/_eval_workspaces/codex-gpt-5.5/us-nd-statute-57-57-38-01.28/workspace/context-manifest.json",
+  "context_manifest_sha256": "36481db7fc6c7fd6333f580416392d9cc50c77810adae1db31e783cc05c24031",
+  "generated_at": "2026-07-08T15:38:58.126477+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nd-statute-57-57-38-01-28/encode-out/codex-gpt-5.5/statutes/57/57-38-01/28.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nd-statute-57-57-38-01-28/encode-out",
+  "generated_output_sha256": "37b80a4f03299d1131327220e6fedb887854790c4ee9d55c5a634536c2c90fd5",
+  "generation_prompt_sha256": "dfc7181c15ee95e4a0b1dbd48957e5e61b1131435f05b9cf725e95792087e6ac",
+  "model": "gpt-5.5",
+  "run_id": "4800edce",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "60a6b7df1a951044d33ca9761f8fd96c774ce1b234c281434a987e39d3545d35"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nd-statute-57-57-38-01-28/encode-out/traces/codex-gpt-5.5/us-nd-statute-57-57-38-01.28.json",
+  "trace_sha256": "bcf3085594cfb0ea166be75bfe46a49545247d1d8db00bbc36ff96f5b90e1a28"
+}

--- a/us-nd/statutes/57/57-38-01/28.test.yaml
+++ b/us-nd/statutes/57/57-38-01/28.test.yaml
@@ -1,0 +1,73 @@
+- name: person qualifying income sums included earned and retirement income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nd:statutes/57/57-38-01/28#input.earned_income_included_in_north_dakota_taxable_income: 40000
+    us-nd:statutes/57/57-38-01/28#input.retirement_plan_income_included_in_north_dakota_taxable_income: 5000
+  output:
+    us-nd:statutes/57/57-38-01/28#qualifying_income: 45000
+- name: lesser spouse qualified income subtracts exemption and half standard deduction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nd:statutes/57/57-38-01/28#input.lesser_spouse_qualifying_income: 20000
+    us-nd:statutes/57/57-38-01/28#input.amount_for_one_exemption_under_section_151_d: 4000
+    us-nd:statutes/57/57-38-01/28#input.standard_deduction_amount_under_section_63_c_2_a_4: 12000
+  output:
+    us-nd:statutes/57/57-38-01/28#qualifying_income_of_lesser_earning_spouse: 10000
+- name: joint resident credit applies formula and cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nd:statutes/57/57-38-01/28#input.married_couple_filing_joint_return_under_section_57_38_30_3: true
+    us-nd:statutes/57/57-38-01/28#input.maximum_credit_adjusted_by_tax_commissioner: 300
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_north_dakota_taxable_income_under_joint_rates: 1000
+    us-nd:statutes/57/57-38-01/28#input.tax_on_qualified_income_of_lesser_earning_spouse_under_single_rates: 300
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_income_minus_qualified_income_of_lesser_earning_spouse_under_single_rates: 500
+    us-nd:statutes/57/57-38-01/28#input.nonresident_or_part_year_resident: false
+    us-nd:statutes/57/57-38-01/28#input.percentage_calculated_under_section_57_38_30_3_1_f: 0.5
+  output:
+    us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment: 200
+    us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit: 200
+- name: part year resident credit is adjusted by section percentage
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nd:statutes/57/57-38-01/28#input.married_couple_filing_joint_return_under_section_57_38_30_3: true
+    us-nd:statutes/57/57-38-01/28#input.maximum_credit_adjusted_by_tax_commissioner: 300
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_north_dakota_taxable_income_under_joint_rates: 1000
+    us-nd:statutes/57/57-38-01/28#input.tax_on_qualified_income_of_lesser_earning_spouse_under_single_rates: 300
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_income_minus_qualified_income_of_lesser_earning_spouse_under_single_rates: 400
+    us-nd:statutes/57/57-38-01/28#input.nonresident_or_part_year_resident: true
+    us-nd:statutes/57/57-38-01/28#input.percentage_calculated_under_section_57_38_30_3_1_f: 0.5
+  output:
+    us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment: 300
+    us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit: 150
+- name: auto_zero_married_couple_joint_return_credit_before_residency_adjustment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nd:statutes/57/57-38-01/28#input.amount_for_one_exemption_under_section_151_d: 0
+    us-nd:statutes/57/57-38-01/28#input.earned_income_included_in_north_dakota_taxable_income: 0
+    us-nd:statutes/57/57-38-01/28#input.lesser_spouse_qualifying_income: 0
+    us-nd:statutes/57/57-38-01/28#input.married_couple_filing_joint_return_under_section_57_38_30_3: false
+    us-nd:statutes/57/57-38-01/28#input.maximum_credit_adjusted_by_tax_commissioner: 0
+    us-nd:statutes/57/57-38-01/28#input.nonresident_or_part_year_resident: false
+    us-nd:statutes/57/57-38-01/28#input.percentage_calculated_under_section_57_38_30_3_1_f: 0
+    us-nd:statutes/57/57-38-01/28#input.retirement_plan_income_included_in_north_dakota_taxable_income: 0
+    us-nd:statutes/57/57-38-01/28#input.standard_deduction_amount_under_section_63_c_2_a_4: 0
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_income_minus_qualified_income_of_lesser_earning_spouse_under_single_rates: 0
+    us-nd:statutes/57/57-38-01/28#input.tax_on_joint_north_dakota_taxable_income_under_joint_rates: 0
+    us-nd:statutes/57/57-38-01/28#input.tax_on_qualified_income_of_lesser_earning_spouse_under_single_rates: 0
+  output:
+    us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment: 0

--- a/us-nd/statutes/57/57-38-01/28.yaml
+++ b/us-nd/statutes/57/57-38-01/28.yaml
@@ -1,0 +1,119 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nd/statute/57/57-38-01.28
+  summary: A married couple filing a joint return under section 57-38-30.3 is allowed
+    a credit not to exceed three hundred dollars per couple. The credit is the difference
+    between the tax on joint North Dakota taxable income under joint rates and the
+    sum of two single-rate tax amounts. For nonresidents or part-year residents, the
+    credit must be adjusted by the percentage calculated under section 57-38-30.3(1)(f).
+    Qualifying income includes earned income and retirement pension, profit-sharing,
+    stock bonus, or annuity plan income to the extent included in North Dakota taxable
+    income.
+rules:
+- name: statutory_married_couple_credit_maximum
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "N.D. Cent. Code \xA7 57-38-01.28(1)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+          excerpt: not to exceed three hundred dollars per couple
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '300'
+- name: qualifying_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "N.D. Cent. Code \xA7 57-38-01.28(4)(a)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'earned_income_included_in_north_dakota_taxable_income
+
+      + retirement_plan_income_included_in_north_dakota_taxable_income'
+- name: qualifying_income_of_lesser_earning_spouse
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "N.D. Cent. Code \xA7 57-38-01.28(4)(b)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+          excerpt: 'minus the sum of: (1) The amount for one exemption ...; and (2)
+            One-half of the amount of the standard deduction'
+  versions:
+  - effective_from: '0001-01-01'
+    formula: max(0, lesser_spouse_qualifying_income - amount_for_one_exemption_under_section_151_d
+      - (standard_deduction_amount_under_section_63_c_2_a_4 / 2))
+- name: married_couple_joint_return_credit_before_residency_adjustment
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "N.D. Cent. Code \xA7 57-38-01.28(1)-(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+          excerpt: not to exceed three hundred dollars per couple
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if married_couple_filing_joint_return_under_section_57_38_30_3: min(
+      maximum_credit_adjusted_by_tax_commissioner, max(0, tax_on_joint_north_dakota_taxable_income_under_joint_rates
+      - (tax_on_qualified_income_of_lesser_earning_spouse_under_single_rates + tax_on_joint_income_minus_qualified_income_of_lesser_earning_spouse_under_single_rates))
+      ) else: 0'
+- name: married_couple_joint_return_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: "N.D. Cent. Code \xA7 57-38-01.28(1)-(3)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-nd/statute/57/57-38-01.28
+          excerpt: For a nonresident or part-year resident, the credit under this
+            section must be adjusted based on the percentage
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if nonresident_or_part_year_resident: married_couple_joint_return_credit_before_residency_adjustment
+      * percentage_calculated_under_section_57_38_30_3_1_f else: married_couple_joint_return_credit_before_residency_adjustment'


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-nd/statute/57/57-38-01.28`
- Module: `us-nd/statutes/57/57-38-01/28.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nd-statute-57-57-38-01-28/rulespec-us/oracle-coverage-pending.yaml: 17 declared (+5 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.