### PR TITLE
Encode us-nj/statute/54a:4-7 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16462,6 +16462,15 @@
         ]
       }
     ],
+    "us-nj/statute/54a:4-7": [
+      {
+        "module": "us-nj/statutes/54a:4-7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nv/manual/dwss/eligibility-payments/a-600/page-38": [
       {
         "module": "us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml",

--- a/us-nj/.axiom/encoding-manifests/statutes/54a:4-7.json
+++ b/us-nj/.axiom/encoding-manifests/statutes/54a:4-7.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/54a:4-7.yaml",
+      "sha256": "bf317f9438648582ecc75380c2def4963055c31d68469d25cdab9e13f6e9a684"
+    },
+    {
+      "path": "statutes/54a:4-7.test.yaml",
+      "sha256": "de789d8ead1f3b6ae3a775939233b4e819a24988eb113852434fcdc0ad5c5baa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us-nj/statute/54a:4-7",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nj-statute-54a-4-7/encode-out/_eval_workspaces/codex-gpt-5.5/us-nj-statute-54a-4-7/workspace/context-manifest.json",
+  "context_manifest_sha256": "664cbe03ac1875b45040745a0172cedb80e69fd8efe7c5bf48382223aafd60a2",
+  "generated_at": "2026-07-08T15:39:50.563580+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nj-statute-54a-4-7/encode-out/codex-gpt-5.5/statutes/54a:4-7.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nj-statute-54a-4-7/encode-out",
+  "generated_output_sha256": "bf317f9438648582ecc75380c2def4963055c31d68469d25cdab9e13f6e9a684",
+  "generation_prompt_sha256": "d43dcab2928823b6853c5b5f51bd68f108eebcb1d9166a3d16a85f23d2ce08ac",
+  "model": "gpt-5.5",
+  "run_id": "3a181eaf",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3a19b1da272544c575b9bd398a71f733b18cd7c8add80a7e044eb7a747bb22ce"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nj-statute-54a-4-7/encode-out/traces/codex-gpt-5.5/us-nj-statute-54a-4-7.json",
+  "trace_sha256": "c9af7c6db2d43644e53ca4afab3057506885ea173b72c1b19b7010614f84fcf2"
+}

--- a/us-nj/statutes/54a:4-7.test.yaml
+++ b/us-nj/statutes/54a:4-7.test.yaml
@@ -1,0 +1,104 @@
+- name: regular resident receives current percentage credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nj:statutes/54a:4-7#input.claimant_is_resident_individual: true
+    us-nj:statutes/54a:4-7#input.eligible_for_federal_earned_income_tax_credit_under_section_32: true
+    us-nj:statutes/54a:4-7#input.married_claimant_joint_return_requirement_satisfied: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_at_least_18_years_old: false
+    us-nj:statutes/54a:4-7#input.resident_individual_can_claim_qualifying_child_for_federal_eitc: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_ineligible_for_federal_eitc_due_to_age_requirements: false
+    us-nj:statutes/54a:4-7#input.resident_individual_meets_all_federal_eitc_qualifications_except_age: false
+    us-nj:statutes/54a:4-7#input.federal_earned_income_tax_credit_that_would_be_allowed: 1000
+    us-nj:statutes/54a:4-7#input.federal_maximum_eitc_for_taxpayers_with_no_qualifying_child: 600
+    us-nj:statutes/54a:4-7#input.claimant_is_part_year_resident: false
+    us-nj:statutes/54a:4-7#input.claimant_residency_months_in_taxable_year: 12
+    us-nj:statutes/54a:4-7#input.tax_otherwise_due_after_all_other_credits_and_payments: 250
+  output:
+    us-nj:statutes/54a:4-7#regular_nj_earned_income_tax_credit_eligible: holds
+    us-nj:statutes/54a:4-7#age_modified_nj_earned_income_tax_credit_eligible: not_holds
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_before_proration: 400
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit: 400
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_against_tax_due: 250
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_overpayment: 150
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_disregarded_for_benefit_income: holds
+- name: part year resident credit is prorated
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nj:statutes/54a:4-7#input.claimant_is_resident_individual: true
+    us-nj:statutes/54a:4-7#input.eligible_for_federal_earned_income_tax_credit_under_section_32: true
+    us-nj:statutes/54a:4-7#input.married_claimant_joint_return_requirement_satisfied: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_at_least_18_years_old: false
+    us-nj:statutes/54a:4-7#input.resident_individual_can_claim_qualifying_child_for_federal_eitc: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_ineligible_for_federal_eitc_due_to_age_requirements: false
+    us-nj:statutes/54a:4-7#input.resident_individual_meets_all_federal_eitc_qualifications_except_age: false
+    us-nj:statutes/54a:4-7#input.federal_earned_income_tax_credit_that_would_be_allowed: 1200
+    us-nj:statutes/54a:4-7#input.federal_maximum_eitc_for_taxpayers_with_no_qualifying_child: 600
+    us-nj:statutes/54a:4-7#input.claimant_is_part_year_resident: true
+    us-nj:statutes/54a:4-7#input.claimant_residency_months_in_taxable_year: 6
+    us-nj:statutes/54a:4-7#input.tax_otherwise_due_after_all_other_credits_and_payments: 500
+  output:
+    us-nj:statutes/54a:4-7#regular_nj_earned_income_tax_credit_eligible: holds
+    us-nj:statutes/54a:4-7#age_modified_nj_earned_income_tax_credit_eligible: not_holds
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_before_proration: 480
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit: 240
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_against_tax_due: 240
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_overpayment: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_disregarded_for_benefit_income: holds
+- name: age modified no qualifying child branch
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nj:statutes/54a:4-7#input.claimant_is_resident_individual: true
+    us-nj:statutes/54a:4-7#input.eligible_for_federal_earned_income_tax_credit_under_section_32: false
+    us-nj:statutes/54a:4-7#input.married_claimant_joint_return_requirement_satisfied: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_at_least_18_years_old: true
+    us-nj:statutes/54a:4-7#input.resident_individual_can_claim_qualifying_child_for_federal_eitc: false
+    us-nj:statutes/54a:4-7#input.resident_individual_is_ineligible_for_federal_eitc_due_to_age_requirements: true
+    us-nj:statutes/54a:4-7#input.resident_individual_meets_all_federal_eitc_qualifications_except_age: true
+    us-nj:statutes/54a:4-7#input.federal_earned_income_tax_credit_that_would_be_allowed: 0
+    us-nj:statutes/54a:4-7#input.federal_maximum_eitc_for_taxpayers_with_no_qualifying_child: 600
+    us-nj:statutes/54a:4-7#input.claimant_is_part_year_resident: false
+    us-nj:statutes/54a:4-7#input.claimant_residency_months_in_taxable_year: 12
+    us-nj:statutes/54a:4-7#input.tax_otherwise_due_after_all_other_credits_and_payments: 0
+  output:
+    us-nj:statutes/54a:4-7#regular_nj_earned_income_tax_credit_eligible: not_holds
+    us-nj:statutes/54a:4-7#age_modified_nj_earned_income_tax_credit_eligible: holds
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_before_proration: 240
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit: 240
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_against_tax_due: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_overpayment: 240
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_disregarded_for_benefit_income: holds
+- name: no eligibility produces no credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nj:statutes/54a:4-7#input.claimant_is_resident_individual: false
+    us-nj:statutes/54a:4-7#input.eligible_for_federal_earned_income_tax_credit_under_section_32: false
+    us-nj:statutes/54a:4-7#input.married_claimant_joint_return_requirement_satisfied: true
+    us-nj:statutes/54a:4-7#input.resident_individual_is_at_least_18_years_old: true
+    us-nj:statutes/54a:4-7#input.resident_individual_can_claim_qualifying_child_for_federal_eitc: false
+    us-nj:statutes/54a:4-7#input.resident_individual_is_ineligible_for_federal_eitc_due_to_age_requirements: true
+    us-nj:statutes/54a:4-7#input.resident_individual_meets_all_federal_eitc_qualifications_except_age: true
+    us-nj:statutes/54a:4-7#input.federal_earned_income_tax_credit_that_would_be_allowed: 1000
+    us-nj:statutes/54a:4-7#input.federal_maximum_eitc_for_taxpayers_with_no_qualifying_child: 600
+    us-nj:statutes/54a:4-7#input.claimant_is_part_year_resident: false
+    us-nj:statutes/54a:4-7#input.claimant_residency_months_in_taxable_year: 12
+    us-nj:statutes/54a:4-7#input.tax_otherwise_due_after_all_other_credits_and_payments: 100
+  output:
+    us-nj:statutes/54a:4-7#regular_nj_earned_income_tax_credit_eligible: not_holds
+    us-nj:statutes/54a:4-7#age_modified_nj_earned_income_tax_credit_eligible: not_holds
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_before_proration: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_against_tax_due: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_overpayment: 0
+    us-nj:statutes/54a:4-7#nj_earned_income_tax_credit_disregarded_for_benefit_income: not_holds

--- a/us-nj/statutes/54a:4-7.yaml
+++ b/us-nj/statutes/54a:4-7.yaml
@@ -1,0 +1,287 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nj/statute/54a:4-7
+  summary: |-
+    A resident individual eligible for the federal earned income tax credit is allowed a New Jersey credit equal to the applicable percentage of the federal credit; the percentage is 40% for taxable years beginning on or after January 1, 2020. A part-year resident claimant's credit is prorated by months of residency over 12, with 15 days or more constituting a month. A resident individual at least 18 years old with no qualifying child may qualify if ineligible for the federal credit due to age requirements, using the federal maximum amount for taxpayers with no qualifying child.
+rules:
+  - name: nj_earned_income_tax_credit_percentage
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: N.J.S.54A:4-7(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "10% for the taxable year beginning on or after January 1, 2000, but before January 1, 2001"
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "15% for the taxable year beginning on or after January 1, 2001, but before January 1, 2002"
+          - path: versions[2].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "17.5% for the taxable year beginning on or after January 1, 2002, but before January 1, 2003"
+          - path: versions[3].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "20% for taxable years beginning on or after January 1, 2003, but before January 1, 2008"
+          - path: versions[4].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "22.5% for taxable years beginning on or after January 1, 2008 but before January 1, 2009"
+          - path: versions[5].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "25% for taxable years beginning on or after January 1, 2009 but before January 1, 2010"
+          - path: versions[6].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "20% for taxable years beginning on or after January 1, 2010, but before January 1, 2015"
+          - path: versions[7].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "30% for taxable years beginning on or after January 1, 2015, but before January 1, 2016"
+          - path: versions[8].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "35% for taxable years beginning on or after January 1, 2016, but before January 1, 2018"
+          - path: versions[9].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "37% for the taxable year beginning on or after January 1, 2018, but before January 1, 2019"
+          - path: versions[10].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "39% for the taxable year beginning on or after January 1, 2019, but before January 1, 2020"
+          - path: versions[11].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "40% for taxable years beginning on or after January 1, 2020"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          0.10
+      - effective_from: '2001-01-01'
+        formula: |-
+          0.15
+      - effective_from: '2002-01-01'
+        formula: |-
+          0.175
+      - effective_from: '2003-01-01'
+        formula: |-
+          0.20
+      - effective_from: '2008-01-01'
+        formula: |-
+          0.225
+      - effective_from: '2009-01-01'
+        formula: |-
+          0.25
+      - effective_from: '2010-01-01'
+        formula: |-
+          0.20
+      - effective_from: '2015-01-01'
+        formula: |-
+          0.30
+      - effective_from: '2016-01-01'
+        formula: |-
+          0.35
+      - effective_from: '2018-01-01'
+        formula: |-
+          0.37
+      - effective_from: '2019-01-01'
+        formula: |-
+          0.39
+      - effective_from: '2020-01-01'
+        formula: |-
+          0.40
+  - name: residency_proration_denominator_months
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: N.J.S.54A:4-7(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "the total number of months of the claimant's residency in the taxable year bears to 12"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          12
+  - name: regular_nj_earned_income_tax_credit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: N.J.S.54A:4-7(a)(1), (a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          claimant_is_resident_individual
+          and eligible_for_federal_earned_income_tax_credit_under_section_32
+          and married_claimant_joint_return_requirement_satisfied
+  - name: age_modified_nj_earned_income_tax_credit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: N.J.S.54A:4-7(a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "at least 18 years of age or older"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          claimant_is_resident_individual
+          and resident_individual_is_at_least_18_years_old
+          and not resident_individual_can_claim_qualifying_child_for_federal_eitc
+          and resident_individual_is_ineligible_for_federal_eitc_due_to_age_requirements
+          and resident_individual_meets_all_federal_eitc_qualifications_except_age
+          and married_claimant_joint_return_requirement_satisfied
+  - name: nj_earned_income_tax_credit_before_proration
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: N.J.S.54A:4-7(a)(1), (a)(2), (a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "percentage of the federal earned income tax credit"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "predicated on the federal maximum amount for taxpayers with no qualifying child"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          if regular_nj_earned_income_tax_credit_eligible: nj_earned_income_tax_credit_percentage * max(0, federal_earned_income_tax_credit_that_would_be_allowed) else: if age_modified_nj_earned_income_tax_credit_eligible: nj_earned_income_tax_credit_percentage * max(0, federal_maximum_eitc_for_taxpayers_with_no_qualifying_child) else: 0
+  - name: nj_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: N.J.S.54A:4-7(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "shall be pro-rated, based upon that proportion which the total number of months of the claimant's residency in the taxable year bears to 12"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          if claimant_is_part_year_resident: nj_earned_income_tax_credit_before_proration * claimant_residency_months_in_taxable_year / residency_proration_denominator_months else: nj_earned_income_tax_credit_before_proration
+  - name: nj_earned_income_tax_credit_overpayment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: N.J.S.54A:4-7(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "If the credit exceeds the amount of tax otherwise due, that amount of excess shall be an overpayment"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          max(0, nj_earned_income_tax_credit - tax_otherwise_due_after_all_other_credits_and_payments)
+  - name: nj_earned_income_tax_credit_against_tax_due
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: N.J.S.54A:4-7(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "shall be applied against the tax otherwise due"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          min(max(0, nj_earned_income_tax_credit), max(0, tax_otherwise_due_after_all_other_credits_and_payments))
+  - name: nj_earned_income_tax_credit_disregarded_for_benefit_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: N.J.S.54A:4-7(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          nj_earned_income_tax_credit > 0


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-nj/statute/54a:4-7`
- Module: `us-nj/statutes/54a:4-7.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- Unchanged /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-nj-statute-54a-4-7/rulespec-us/oracle-coverage-pending.yaml: 12 declared (+0 added, -0 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.