### PR TITLE
Add composed Ohio income-tax liability pipeline (us-oh)

### DIFF
--- a/.axiom/encoding-manifests/us-oh/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-oh/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "34ed226dc87d06b873813eebaba30ac725fcda038eae9a4f3c3b006baedcbe74"
+    },
+    {
+      "path": "us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "81dcc8c54c6be534d164eaf1c9e6a78c25dee03db56937dfc3d7faf27a6ebab2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9759dd348474c15f9fca71253431db76b9273fc7",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1192",
+    "version_commit": "9759dd348474c15f9fca71253431db76b9273fc7"
+  },
+  "axiom_encode_version": "0.2.1192",
+  "backend": "manual",
+  "citation": "us-oh:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-08T21:20:02.842179+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdc8uvnys/sign-applied-files/us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdc8uvnys",
+  "generated_output_sha256": "81dcc8c54c6be534d164eaf1c9e6a78c25dee03db56937dfc3d7faf27a6ebab2",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c39e7a58702e24592264ceda8ca6b8d3818bcd3e434c0990a9ebda87b5a4c459"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16749,6 +16749,12 @@
     ],
     "us-oh/statute/5747.02": [
       {
+        "module": "us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-oh/statutes/5747/02.yaml",
         "via": [
           "module",

--- a/bulk/PROGRESS-us-pipeline-lane-b.md
+++ b/bulk/PROGRESS-us-pipeline-lane-b.md
@@ -1,0 +1,75 @@
+# US composed-pipeline / suite lane B (states N–W)
+
+Mission: build composed state income-tax liability pipelines (rulespec-us#561
+pattern, composition exception) + per-case companion suites vs pinned PE-US
+(penny-exact) with TAXSIM-2024 as second oracle (mirror axiom-oracles#189) +
+coverage registration, for states **N–W**, as their encoder-generated sections
+land on origin/main. Validation year 2026; supplied inputs documented where the
+2026 schedule is unpublished. Worktree leaf must be `rulespec-us` (the validate
+input-resolver keys off it).
+
+## On-main reality (verified via git log at 9f2709e0, 2026-07-08)
+
+The mission's "wv/hi/ut/va/or/ri sections merged pre-train" is **not yet true**:
+those states carry only CHIP/Medicaid/TANF rules on main, no income-tax statute.
+Their income-tax sections are in the in-flight **merge train PR #763**
+("132 bulk-encoded RuleSpec modules") — the individual bulk PRs (#619-636:
+or/ri/va/ut/wv/hi) were closed and folded in. #763 is MERGEABLE, CI pending
+(build + validate shards). WV credit sections #629/#632 are excluded from #763
+(sibling rule-name collision) and stay open.
+
+The only N–W income-tax surface actually on main pre-train: **us-oh** (5747.02
+rate + 5747.71 EITC, merged #614/#615) and us-ny (lane A's already-composed
+pilot). OH is therefore the pre-train composable; the rest wait on #763.
+
+## Status
+
+| State | Section(s) on main | Pipeline | Suite | PE target | Result |
+| --- | --- | --- | --- | --- | --- |
+| us-oh | 5747.02 (rate) | ✅ | ✅ 7 cases | oh_income_tax_before_non_refundable_credits | penny-exact (const 0.00204 float residual) |
+| us-wv | pending #763 | — | — | — | blocked on train |
+| us-hi | pending #763 | — | — | — | blocked on train |
+| us-ut | pending #763 | — | — | — | blocked on train |
+| us-va | pending #763 | — | — | — | blocked on train |
+| us-or | pending #763 | — | — | — | blocked on train |
+| us-ri | pending #763 | — | — | — | blocked on train |
+
+### us-oh (done)
+ORC 5747.02(A)(3)(c) two-tier nonbusiness tax: 0 at/below the $26,050 no-tax
+threshold, else $332.00 + 2.75% of the excess. Supplied inputs = the encoded
+5747.02 parameters (threshold 26050, base 332, rate 0.0275) plus PE's tiered
+personal exemption (2400/2150/1900 per exemption). Compared against PE
+`oh_income_tax_before_non_refundable_credits` at 2026 — PE reproduces the $332
+base via an implied first-bracket rate (0.0127448 x 26050 = 332.00204), so the
+composed liability matches to the cent (constant 0.00204 float residual, sub-cent).
+`oh_income_tax_before_refundable_credits` was rejected as the target because it
+nets a $20 low-income exemption credit (single-30k) the before-credits core
+excludes. Business-income branch 5747.02(A)(4)(b) deferred (no business income).
+Gate battery green: validate, proof-validate (3 atoms), companion test (7 cases),
+guard-generated (manual_exception=composition), oracle-coverage pending ratchet,
+reverse-index.
+
+## Fan-out plan (on #763 merge)
+
+Foreground-poll #763; when it lands, compose in landing order, only where the
+encoded surface covers PE's components (else note gaps to ledger #757). Expected
+supplied-rate slices (rate schedule absent from the encoded surface, supplied as
+current authority, anchored to the imposition section), mirroring the CA pattern:
+- **wv** — 11-21-3 (imposition) + 11-21-10 (taxable income) + 11-21-16
+  (exemptions); rate schedule 11-21-4e not encoded → supplied. Credits 11-21-21/23
+  excluded from #763.
+- **or** 316.037/316.085, **ri** 44-30-2.6, **ut** 59-10-104, **va** 58.1-320/321,
+  **hi** 235-51 — compose as their sections land.
+
+Oracle side (axiom-oracles, mirror #189): per state add the pipeline liability
+concept to scripts/generate_state_income_tax_liability.py (`_PE_VAR`,
+`_TAXSIM_STATE`, grid), a comparison suite yaml, generate the v2 report under
+dashboard/public/data, and a disposition for the TAXSIM-2024 residual. Merge one
+at a time; rebase immediately before merge; verify after; no admin-merge.
+
+## Log
+- Setup: worktree from origin/main (leaf `rulespec-us`); toolchain confirmed by
+  validating lane A's us-ca pipeline (validate/proof/test green).
+- us-oh: authored pipeline + suite, PE-probed the 2026 grid on pinned PE-US
+  (policyengine[us]==4.18.9) for penny-exact inputs, signed manifest, regen index,
+  committed. PR opened.

--- a/us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,127 @@
+# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
+# expected values are the author's own shown arithmetic from the supplied
+# schedule, not an oracle read-back). Ohio nonbusiness liability = ORC
+# 5747.02(A)(3)(c): zero when Ohio taxable nonbusiness income is $26,050 or less,
+# otherwise $332.00 plus 2.75 per cent of the amount in excess of $26,050.
+# Ohio taxable nonbusiness income = supplied Ohio AGI less the supplied personal
+# exemptions. The supplied 2026 personal exemption is the ORC 5747.025 tiered
+# amount PolicyEngine applies (2,400 per exemption at modified AGI at or below
+# 40,000; 2,150 above 40,000 through 80,000; 1,900 above 80,000), stated per
+# case. PolicyEngine reaches the same tax through an implied first-bracket rate
+# (0.0127448 x 26,050 = 332.00204), so each liability equals PolicyEngine's
+# oh_income_tax_before_non_refundable_credits to the cent (a constant 0.00204
+# dollar float residual). The single-30k case additionally carries a 20-dollar
+# non-refundable exemption credit in PolicyEngine's before-refundable value,
+# which this before-credits core excludes.
+- name: single_20k_exempt
+  # taxable 20000-2400 = 17600, at or below the 26050 no-tax threshold, so no tax.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 20000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 2400
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '17600'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '0'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '0'
+- name: single_30k
+  # taxable 30000-2400 = 27600. Tax 332 + 0.0275*(27600-26050) = 332 + 42.625 = 374.625.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 30000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 2400
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '27600'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '374.625'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '374.625'
+- name: single_60k
+  # taxable 60000-2150 = 57850. Tax 332 + 0.0275*(57850-26050) = 332 + 874.5 = 1206.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 60000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 2150
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '57850'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '1206.5'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '1206.5'
+- name: single_150k
+  # taxable 150000-1900 = 148100. Tax 332 + 0.0275*(148100-26050) = 332 + 3356.375 = 3688.375.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 150000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 1900
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '148100'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '3688.375'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '3688.375'
+- name: married_60k
+  # taxable 60000-4300 = 55700. Tax 332 + 0.0275*(55700-26050) = 332 + 815.375 = 1147.375.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 60000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 4300
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '55700'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '1147.375'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '1147.375'
+- name: married_120k
+  # taxable 120000-3800 = 116200. Tax 332 + 0.0275*(116200-26050) = 332 + 2479.125 = 2811.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 120000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 3800
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '116200'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '2811.125'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '2811.125'
+- name: married_300k
+  # taxable 300000-3800 = 296200. Tax 332 + 0.0275*(296200-26050) = 332 + 7429.125 = 7761.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_adjusted_gross_income: 300000
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_personal_exemptions: 3800
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_no_tax_threshold: 26050
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_base_amount: 332
+    us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_supplied_excess_rate: 0.0275
+  output:
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_nonbusiness_income: '296200'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_income_tax: '7761.125'
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '7761.125'

--- a/us-oh/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-oh/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,131 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-oh/statute/5747.02
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-oh/statute/5747.02
+      rationale: |-
+        This pipeline computes the Ohio Revised Code 5747.02 individual
+        nonbusiness income-tax liability for the ordinary resident wage-earner
+        slice at the 2026 tax year. Division (A)(3)(c) provides that, for taxable
+        years beginning in 2026 and thereafter, the tax on Ohio taxable
+        nonbusiness income is "$332.00 plus 2.75% of the amount in excess of
+        $26,050", and division (A)(3) provides that where that income is equal to
+        or less than $26,050 no tax is imposed. The encoded us-oh/statutes/5747/02
+        module carries those operative 2026 values as parameters
+        (individual_nonbusiness_income_tax_base_amount = 332,
+        individual_nonbusiness_income_tax_excess_rate = 0.0275,
+        individual_income_tax_no_tax_threshold = 26050); this pipeline supplies
+        the same three amounts as declared caller-supplied current-authority
+        inputs so the marginal application runs end to end without importing the
+        encoded parameters. Division (A)(5) directs the tax commissioner to index
+        the $26,050 bracket and the base amount to the GDP deflator each year and
+        round to the nearest fifty dollars; the operative 2026 values used here
+        are the statutory 2026-and-thereafter figures in (A)(3)(c), which the
+        commissioner had not yet re-indexed at authoring, so they are supplied
+        rather than derived. The pipeline adds no numeric literals of its own; it
+        wires the two-tier nonbusiness-tax mechanics only.
+  deferred_outputs:
+  - output: us-oh:statutes/5747.02/b#excess_exemptions_deductible_from_taxable_business_income
+    reason: |-
+      Division (A)(4)(b) redirects any personal exemptions that exceed Ohio
+      adjusted gross income less taxable business income against taxable
+      business income before the division (A)(4)(a) three-per-cent
+      business-income tax. This composed slice models the ordinary resident
+      wage earner with no taxable business income, so the division (A)(4)
+      business-income tax and its (b) excess-exemption offset are supplied zero
+      and excluded from this before-credits nonbusiness core; the executable
+      (b) surface is carried by the encoded us-oh/statutes/5747/02 module.
+  summary: |-
+    Composed Ohio individual nonbusiness income-tax liability pipeline for the
+    oracle slice at the 2026 tax year. It exposes a TaxUnit-level path from a
+    supplied Ohio adjusted gross income into the ORC 5747.02(A)(3)(c) two-tier
+    nonbusiness tax, so an end-to-end comparison against PolicyEngine
+    (oh_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
+    require the caller to supply the section 5747.02 bracket-application
+    boundary. It wires: Ohio taxable nonbusiness income (AGI less the supplied
+    personal exemptions); the nonbusiness income tax, which is zero when taxable
+    nonbusiness income does not exceed the $26,050 no-tax threshold and otherwise
+    the $332.00 base plus 2.75 per cent of the amount in excess of $26,050; and
+    the liability as that nonbusiness income tax. PolicyEngine reaches the same
+    value through an implied first-bracket average rate (0.0127448) applied to
+    the first $26,050, which reproduces the $332.00 statutory base to within
+    0.00204 dollars, so the composed liability equals PolicyEngine's
+    before-non-refundable-credits value to the cent. It deliberately excludes the
+    5747.02(A)(4) taxable-business-income tax (supplied zero for the wage-earner
+    slice), the 5747.02(A)(5) annual re-indexation, the estate rates in
+    5747.02(A)(2), the $20 per-exemption credit and joint-filing credit and every
+    other 5747.05 through 5747.98 credit (all non-refundable and excluded from
+    this before-credits core), and the 5747.71 earned income credit. Ohio
+    adjusted gross income, filing status, the personal exemptions, the no-tax
+    threshold, the base amount, and the excess rate are supplied inputs; the tax
+    commissioner indexes the threshold and base each year, so this 2026 pipeline
+    is compared against PolicyEngine at 2026 and against TAXSIM's latest 2024 law
+    year with the indexation vintage dispositioned. PolicyEngine's exemption
+    threshold treats taxable income strictly below $26,050 as exempt, so the two
+    agree at every income except the measure-zero point of exactly $26,050.
+rules:
+  - name: oh_pit_pilot_taxable_nonbusiness_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ORC 5747.02(A)(3), Ohio taxable nonbusiness income after the supplied personal exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "the exemptions allowed to an individual under division (A)(3) of this section ... the taxpayer's Ohio adjusted gross income less taxable business income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, oh_pit_pilot_adjusted_gross_income - oh_pit_pilot_supplied_personal_exemptions)
+  - name: oh_pit_pilot_nonbusiness_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ORC 5747.02(A)(3)(c), the $332.00 base plus 2.75 per cent of taxable nonbusiness income in excess of $26,050, and no tax at or below the threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "For taxable years beginning in 2026 and thereafter, $332.00 plus 2.75% of the amount in excess of $26,050"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if oh_pit_pilot_taxable_nonbusiness_income > oh_pit_pilot_supplied_no_tax_threshold
+          : oh_pit_pilot_supplied_base_amount + oh_pit_pilot_supplied_excess_rate * max(0, oh_pit_pilot_taxable_nonbusiness_income - oh_pit_pilot_supplied_no_tax_threshold)
+          else : 0
+  - name: oh_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ORC 5747.02(A) nonbusiness income tax, before the section 5747.05 through 5747.98 credits, for the wage-earner slice with no taxable business income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "the tax imposed by this section ... on income not otherwise taxed under division (A)(4) of this section"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          oh_pit_pilot_nonbusiness_income_tax


### PR DESCRIPTION
## Summary

Lane B (states N–W) composed-pipeline/suite work. Adds the first N–W pipeline
composable pre-train: **Ohio**. Mirrors the rulespec-us#561 composition
exception and the axiom-oracles#189 oracle pattern.

`us-oh/policies/income_tax/pilot_liability_pipeline` wires the merged ORC
5747.02(A)(3)(c) two-tier individual nonbusiness income tax into a TaxUnit-level
2026 liability: zero at or below the $26,050 no-tax threshold, otherwise $332.00
plus 2.75 per cent of the amount in excess of $26,050.

- **Supplied current authority** — the no-tax threshold (26,050), base amount
  (332), excess rate (0.0275), and personal exemptions are declared caller
  inputs equal to the encoded `us-oh/statutes/5747/02` parameters; the pipeline
  adds no numeric literals.
- **Penny-exact vs PolicyEngine** — compared against
  `oh_income_tax_before_non_refundable_credits` at the 2026 validation year.
  PolicyEngine reproduces the $332 statutory base through an implied
  first-bracket average rate (0.0127448 × 26,050 = 332.00204), so each composed
  liability equals PolicyEngine to the cent (a constant 0.00204-dollar float
  residual). `before_refundable_credits` was rejected as the target because it
  nets a $20 low-income exemption credit (single-30k) this before-credits core
  excludes.
- **Deferred** — 5747.02(A)(4)(b) business-income excess-exemption offset (no
  taxable business income in the wage-earner slice).
- **Fixtures** — hand-computed 2026 arithmetic (encode#1060 convention), 7 cases
  covering single/married at 20k/30k/60k/120k/150k/300k including a
  below-threshold exempt case.

## Verification

- `axiom-encode validate --skip-reviewers` — CI ✓
- `axiom-encode proof-validate` — ✓ (3 atoms)
- `axiom-encode test` — 7 cases pass through the engine
- `axiom-encode guard-generated` — all changed files carry apply manifests
  (manual_exception = composition)
- `axiom-encode oracle-coverage-pending check` — pending ratchet passes
- reverse index regenerated

The companion axiom-oracles suite (mirror #189: `state-income-tax-liability-grid`
+ dispositions for the TAXSIM-2024 vintage residual) follows separately. The
remaining N–W states (wv/hi/ut/va/or/ri) are in the in-flight merge train #763
and will compose as they land on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
