### PR TITLE
Add composed Virginia + Utah income-tax liability pipelines (us-va, us-ut)

### DIFF
--- a/.axiom/encoding-manifests/us-ut/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ut/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "5375027a2c17eb6836a7e90eb3090d979a49660f16d1300c1c882d39a2e2f867"
+    },
+    {
+      "path": "us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "899232480598ae76d2538bf56914a6b7903a79897df9aa8f565812beb03fafcf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-ut:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-08T23:55:46.263429+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpm2y984en/sign-applied-files/us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpm2y984en",
+  "generated_output_sha256": "899232480598ae76d2538bf56914a6b7903a79897df9aa8f565812beb03fafcf",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6da8de822754af81e95a6d66e16ff59d00ea0bd29c8ba8c1a345167544965cc9"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-va/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "242b2ed46138ba330b5a375e9104cafd025e414063e46723faa41ce8e8669e47"
+    },
+    {
+      "path": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "7d06794d17d64d31cf74f856ac50c183eb4f0079a8740cb08ee96ab045f90453"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-va:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-08T23:52:08.083717+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy1ojycwq/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy1ojycwq",
+  "generated_output_sha256": "7d06794d17d64d31cf74f856ac50c183eb4f0079a8740cb08ee96ab045f90453",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -22644,6 +22644,12 @@
     ],
     "us-ut/statute/59-10-104": [
       {
+        "module": "us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ut/statutes/59-10-104.yaml",
         "via": [
           "module",
@@ -22652,6 +22658,12 @@
       }
     ],
     "us-va/statute/58.1/58.1-320": [
+      {
+        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-va/statutes/58.1/58/1-320.yaml",
         "via": [
@@ -22670,6 +22682,12 @@
       }
     ],
     "us-va/statute/58.1/58.1-322.03": [
+      {
+        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-va/statutes/58.1/58/1-322/03.yaml",
         "via": [

--- a/bulk/PROGRESS-us-suite-lane-b.md
+++ b/bulk/PROGRESS-us-suite-lane-b.md
@@ -60,7 +60,20 @@ composable when those rate sections land in a later train; not a permanent gap.
    (behind lane A + tanf). Mirror or#245.
 5. Re-scan main for any newly-landed N–W rate sections (WV/OR/RI/HI) and compose.
 
+## Oracle side — SHIPPED decoupled from the train
+
+axiom-oracles PR #251 (branch laneb-slice-oracles, off origin/main): VA + UT
+concept mappings + suites + reports + dispositions + conformance covered rows +
+scoreboard regen. Mirrors or#245 (which merged OH's oracle side while OH's
+rulespec pipeline #769 was still open — proving the oracle side is independent of
+the rulespec merge train). PE 6/6 exact both states; TAXSIM-2024 dispositioned
+(VA std-deduction vintage; UT rate vintage + taxpayer-credit scope). 134 oracle
+tests + apply_dispositions/scoreboard/vacuous-gate --checks pass locally. Merge
+one-at-a-time behind lane A + tanf (or#248 GA); rebase just before merge.
+
 ## Log
 - Verified my slice not on origin/main (still 9f2709e0); sections live in unmerged
   #763 (BLOCKED, throttled runners). Composed VA + UT off the #763 head.
 - PE-probed both on pinned PE-US (policyengine[us]==4.18.9) for penny-exact inputs.
+- rulespec VA+UT committed on laneb-slice (held for #763 rebase). Oracle side
+  opened as #251; freshness.json regen fixed the vacuous-gate CI check.

--- a/bulk/PROGRESS-us-suite-lane-b.md
+++ b/bulk/PROGRESS-us-suite-lane-b.md
@@ -18,10 +18,17 @@ are encoded on main. Rate-only or ded-only → gap (oracle #757), not shipped.
 | --- | --- | --- | --- | --- | --- | --- |
 | VA | 58.1-320 rate + 322.03 ded + 321 exempt | yes | DONE | 7 cases | va_income_tax_before_non_refundable_credits | penny-exact 6/6 (zero residual) |
 | UT | 59-10-104 rate + 59-10-1018 credit | yes (flat) | DONE | 6 cases | ut_income_tax_before_credits | exact 6/6 |
+| NE | 77-2715.03 rate + 77-2716.01 std ded | yes | DONE | 7 cases | ne_income_tax_before_credits | penny-exact 6/6 |
 | WV | 11-21-3/-10/-16 (no rate 4e/4j) | no | — | — | — | gap: rate schedule not encoded |
 | OR | 315.264/266 + 316.085 (no rate 316.037) | no | — | — | — | gap: rate not in #763 |
 | RI | 44-30-103 (child rebate, not the rate) | no | — | — | — | gap: rate 44-30-2.6 not encoded |
 | HI | 235-54 + 235-55.6/.7/.85 (no rate 235-51) | no | — | — | — | gap: rate 235-51 not encoded |
+| NC | 105-153.7 flat rate + 105-153.9 (only an other-state credit) | no | — | — | — | gap: std-deduction §105-153.5 not encoded (the wage-slice's only taxable-income reduction; 153.9 other-state credit is $0 for a single-state filer) |
+| NM | 7-2-5.8 exemption + 7-2-18.15 WFTC | no | — | — | — | gap: rate §7-2-7 not encoded |
+| ND | 57-38-01.28 (joint marriage credit only) | no | — | — | — | gap: rate §57-38-30.3 not encoded |
+| SC | 12-6-520 (bracket inflation adj only) | no | — | — | — | gap: base rate §12-6-510 + deduction not encoded |
+| NJ | 54A:4-7 (NJ EITC only) | no | — | — | — | gap: rate §54A:2-1 not encoded |
+| NE-adc/OK/WI | — | no | — | — | — | OK/WI: no income-tax statutes dir on main |
 
 VA and UT pipelines are composed, validated (validate CI ✓, proof-validate,
 companion test), signed (--manual-exception composition), and committed on this
@@ -43,6 +50,19 @@ index (adds only VA/UT), push, open PRs, arm auto-merge.
 - Target ut_income_tax_before_credits (pure flat tax). Excludes the 59-10-1018
   taxpayer tax credit that PE nets into before_non_refundable_credits (phased out;
   a future enrichment could model it and target before_non_refundable).
+
+### NE decisions (new composable state, post-train fan-out)
+- Neb. Rev. Stat. 77-2715.03 four-bracket progressive tax. 2026 rates 2.46/3.51/
+  4.55/4.55% (L.B. 754 compresses the top two rates to a common 4.55% in 2026) at
+  the PE-2026 inflation-indexed floors: single 0/4,030/24,120/38,870, MFJ
+  0/8,040/48,250/77,730. Supplied floors/rates + 77-2716.01 std deduction ($8,750
+  single / $17,550 MFJ). taxable = AGI − std ded (no pre-tax exemption).
+- Target ne_income_tax_before_credits (pure bracket tax). NE's personal exemption
+  is a POST-tax credit (ne_exemptions, netted into before_refundable_credits), so
+  it is excluded from before_credits. Penny-exact 6/6 vs pinned PE (4.18.9).
+- TAXSIM-2024 residual reconstructs exactly: siitax = PE-2024 before_credits −
+  2024 exemption credit ($166 single / $332 MFJ); residual = 2024→2026 rate-
+  compression/indexation vintage + the credit scope. All 6 dispositioned.
 
 ## Gaps (rate section not yet encoded → not shippable; note to oracle #757)
 
@@ -70,6 +90,32 @@ the rulespec merge train). PE 6/6 exact both states; TAXSIM-2024 dispositioned
 (VA std-deduction vintage; UT rate vintage + taxpayer-credit scope). 134 oracle
 tests + apply_dispositions/scoreboard/vacuous-gate --checks pass locally. Merge
 one-at-a-time behind lane A + tanf (or#248 GA); rebase just before merge.
+
+## Executed — post-#763 fan-out (2026-07-08)
+
+- **VA + UT rulespec**: rebased laneb-slice onto post-#763 origin/main
+  (`git rebase --onto origin/main <train-head>` dropped the 2 train commits,
+  replayed VA/UT + progress), regenerated reverse index (adds VA/UT edges only),
+  pushed. **PR rus#771** open, auto-merge (squash) armed. Full-matrix CI (the
+  repo-global index touch triggers it).
+- **NE rulespec** (new composable state): branch `laneb-slice-ne` off origin/main;
+  pipeline + 7-case companion suite + signed manifest (`sign-applied-files
+  --manual-exception composition`) + index regen. `axiom-encode test` 7/7,
+  proof-validate ✓, validate CI ✓. **PR rus#772** open, auto-merge armed.
+- **NE oracle**: branch `laneb-slice-oracles-ne` off origin/main; concept mapping,
+  comparison, dispositions (all 6 reconstructed), conformance covered row,
+  scoreboard/detail/affected_map/freshness regen. Rebased behind or#248 (ga_tanf)
+  and re-regenerated aggregates. pytest 132 passed; all --check gates pass.
+  **PR or#253** open + MERGEABLE. Auto-merge NOT available on axiom-oracles (no
+  branch protection) → maintainer merges one-at-a-time. If another oracle PR
+  lands first, re-rebase + regen the aggregates (they conflict on covered count).
+- **Scoreboard delta (us-pe)**: VA/UT already merged via or#251. NE adds +1 →
+  **33 covered / 24.09%** (was 32 after or#248's ga_tanf).
+- **Non-composable N–W** (empirical scan of main): WV/OR/RI/HI/NM/ND/SC/NJ lack
+  the rate schedule; NC has the flat rate but lacks the std-deduction §105-153.5
+  (only an other-state credit, $0 for the wage slice); OK/WI have no income-tax
+  statutes on main. All become composable when the missing section lands in a
+  later train (note to oracle #757).
 
 ## Log
 - Verified my slice not on origin/main (still 9f2709e0); sections live in unmerged

--- a/bulk/PROGRESS-us-suite-lane-b.md
+++ b/bulk/PROGRESS-us-suite-lane-b.md
@@ -1,0 +1,66 @@
+# US pipeline/suite lane B — composed state income-tax liability pipelines (N–W)
+
+Mission: turn merged N–W state income-tax cores into us-pe covered rows — a
+composed liability pipeline under `us-XX/policies/income_tax/pilot_liability_pipeline`
+(mirroring #561), a per-case suite vs pinned PolicyEngine-US (penny-exact) and
+TAXSIM-2024 in axiom-oracles, coverage registration in `conformance/us-pe.yaml`,
+scoreboard regen. Mirrors lane A's runbook (PROGRESS-us-suite-lane-a.md).
+Ohio was lane A's proving ground (rus#769 + or#245); this lane owns N–W.
+
+## Composable gate (from lane A)
+
+Composable only when the rate schedule AND a deduction/exemption/credit section
+are encoded on main. Rate-only or ded-only → gap (oracle #757), not shipped.
+
+## Status (2026-07-08)
+
+| State | Sections (in merge train #763) | Composable | Pipeline | Suite | PE target | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| VA | 58.1-320 rate + 322.03 ded + 321 exempt | yes | DONE | 7 cases | va_income_tax_before_non_refundable_credits | penny-exact 6/6 (zero residual) |
+| UT | 59-10-104 rate + 59-10-1018 credit | yes (flat) | DONE | 6 cases | ut_income_tax_before_credits | exact 6/6 |
+| WV | 11-21-3/-10/-16 (no rate 4e/4j) | no | — | — | — | gap: rate schedule not encoded |
+| OR | 315.264/266 + 316.085 (no rate 316.037) | no | — | — | — | gap: rate not in #763 |
+| RI | 44-30-103 (child rebate, not the rate) | no | — | — | — | gap: rate 44-30-2.6 not encoded |
+| HI | 235-54 + 235-55.6/.7/.85 (no rate 235-51) | no | — | — | — | gap: rate 235-51 not encoded |
+
+VA and UT pipelines are composed, validated (validate CI ✓, proof-validate,
+companion test), signed (--manual-exception composition), and committed on this
+branch (laneb-slice, based on the #763 head so the cited sections resolve for
+local gates). They are HELD from PR until #763 merges; then rebase onto
+post-#763 main (drops the 132 train commits, replays VA+UT), regen the reverse
+index (adds only VA/UT), push, open PRs, arm auto-merge.
+
+### VA decisions
+- Va. Code 58.1-320 four-bracket progressive (2/3/5/5.75% at 3k/5k/17k), fixed
+  (unindexed). Supplied floors/rates + 58.1-322.03 std deduction ($8,750 single
+  / $17,500 MFJ) + 58.1-321 $930 personal exemption. taxable = AGI − ded − exempt.
+- PE va_income_tax_before_non_refundable_credits == before_refundable == final on
+  the childless grid (no VA credits). Penny-exact, ZERO residual (fixed brackets).
+
+### UT decisions
+- Utah Code 59-10-104(2) flat 4.45% (H.B. 106 of 2025) on Utah taxable income
+  (= federal AGI for the wage earner; no separate standard deduction).
+- Target ut_income_tax_before_credits (pure flat tax). Excludes the 59-10-1018
+  taxpayer tax credit that PE nets into before_non_refundable_credits (phased out;
+  a future enrichment could model it and target before_non_refundable).
+
+## Gaps (rate section not yet encoded → not shippable; note to oracle #757)
+
+WV/OR/RI/HI have deduction/exemption/credit sections in #763 but NOT their rate
+schedule (WV §11-21-4e/4j, OR §316.037, RI §44-30-2.6, HI §235-51). They become
+composable when those rate sections land in a later train; not a permanent gap.
+
+## Fan-out on #763 merge
+1. `git rebase` this branch onto post-#763 origin/main.
+2. Regen reverse index (`python tests/generate_reverse_index.py`) — adds VA/UT.
+3. Push, open one PR per state (or a combined VA+UT PR), arm `gh pr merge --auto`.
+4. Oracle side (axiom-oracles, sibling worktree): concept mapping + suite +
+   generator (_TAXSIM_STATE UT=45, VA=47; _PE_VAR; _grid) + report + dispositions
+   + conformance/us-pe.yaml covered row + scoreboard regen. Merge one-at-a-time
+   (behind lane A + tanf). Mirror or#245.
+5. Re-scan main for any newly-landed N–W rate sections (WV/OR/RI/HI) and compose.
+
+## Log
+- Verified my slice not on origin/main (still 9f2709e0); sections live in unmerged
+  #763 (BLOCKED, throttled runners). Composed VA + UT off the #763 head.
+- PE-probed both on pinned PE-US (policyengine[us]==4.18.9) for penny-exact inputs.

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,8 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 526
+ceiling: 531
+ceiling: 531
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1170,6 +1171,12 @@ entries:
   - legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
     source: bulk
     since: 2026-07-08
+  - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income
+    source: bulk
+    since: 2026-07-08
   - legal_id: us-ut:statutes/59-10-1018#applicable_income_threshold
     source: bulk
     since: 2026-07-08
@@ -1267,6 +1274,15 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income
     source: bulk
     since: 2026-07-08
   - legal_id: us-va:statutes/58.1/58/1-320#first_bracket_rate

--- a/us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,86 @@
+# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
+# expected values are the author's own shown arithmetic from the supplied
+# schedule, not an oracle read-back). Utah liability = Utah Code 59-10-104(2)
+# flat 4.45 per cent (H.B. 106 of 2025) on Utah taxable income = supplied Utah
+# AGI less the supplied subtractions (zero for the resident wage earner, whose
+# Utah taxable income is federal AGI). This before-credit core excludes the
+# section 59-10-1018 taxpayer tax credit, so it equals PolicyEngine's
+# ut_income_tax_before_credits exactly.
+- name: single_30k
+  # taxable 30000. Tax 0.0445*30000 = 1335.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 30000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '30000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '1335'
+- name: single_60k
+  # taxable 60000. Tax 0.0445*60000 = 2670.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 60000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '60000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '2670'
+- name: single_150k
+  # taxable 150000. Tax 0.0445*150000 = 6675.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 150000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '150000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '6675'
+- name: married_60k
+  # taxable 60000. Tax 0.0445*60000 = 2670.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 60000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '60000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '2670'
+- name: married_120k
+  # taxable 120000. Tax 0.0445*120000 = 5340.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 120000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '120000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '5340'
+- name: married_300k
+  # taxable 300000. Tax 0.0445*300000 = 13350.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 300000
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '300000'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '13350'

--- a/us-ut/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ut/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ut/statute/59-10-104
+      - us-ut/statute/59-10-1018
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ut/statute/59-10-104
+        - us-ut/statute/59-10-1018
+      rationale: |-
+        This pipeline computes the Utah Code 59-10-104 flat individual income tax
+        on Utah taxable income for the ordinary resident wage-earner slice at the
+        2026 tax year, before the section 59-10-1018 taxpayer tax credit. Section
+        59-10-104(2) imposes a single flat rate on the state taxable income of a
+        resident individual; the encoded us-ut/statutes/59-10-104 module carries
+        the rate, and the legislature reduced it to 4.45 per cent for taxable
+        years beginning in 2026 (H.B. 106 of 2025). This pipeline supplies that
+        operative 4.45 per cent rate as a declared caller-supplied
+        current-authority input so the flat application runs end to end without
+        importing the encoded rate. Utah taxable income for the resident wage
+        earner is federal adjusted gross income (Utah levies no separate standard
+        deduction; the section 59-10-1018 taxpayer tax credit, itself a function
+        of the federal deduction and personal exemptions, plays the deduction
+        role); this before-credit core supplies the taxable base and excludes the
+        section 59-10-1018 credit, which is cited as the boundary authority and
+        carried by its own encoded module. The pipeline adds no numeric literals
+        of its own; it wires the flat-tax mechanics only.
+  summary: |-
+    Composed Utah individual income-tax liability pipeline for the oracle slice
+    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Utah
+    adjusted gross income into the Utah Code 59-10-104(2) flat tax, so an
+    end-to-end comparison against PolicyEngine (ut_income_tax_before_credits) and
+    TAXSIM (siitax) does not require the caller to supply the section 59-10-104
+    rate. It wires: Utah taxable income (AGI less any supplied subtractions, zero
+    for this wage slice); and the liability as the flat 4.45 per cent rate on
+    that taxable income. Because Utah levies a single statutory rate on this
+    slice, the composed liability equals PolicyEngine's before-credit value
+    exactly. It deliberately excludes the section 59-10-1018 taxpayer tax credit
+    (the phased-out credit that PolicyEngine nets in
+    ut_income_tax_before_non_refundable_credits), the section 59-10-1002 through
+    59-10-1044 credits, the at-home-parent and retirement credits, and the
+    business-income and part-year mechanics, all supplied as zero or omitted for
+    this slice. Utah AGI, the subtractions, and the flat rate are supplied
+    inputs; the legislature sets the rate by session law (4.45 per cent for
+    2026), so this 2026 pipeline is compared against PolicyEngine at 2026 and
+    against TAXSIM's latest 2024 law year with the rate vintage dispositioned.
+rules:
+  - name: ut_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Utah Code 59-10-104, Utah taxable income after any supplied subtractions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "a tax on the state taxable income of a resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ut_pit_pilot_adjusted_gross_income - ut_pit_pilot_supplied_subtractions)
+  - name: ut_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Utah Code 59-10-104(2), the flat rate on Utah taxable income, before the section 59-10-1018 taxpayer tax credit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "is imposed on the state taxable income ... a tax at the rate specified"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ut_pit_pilot_taxable_income * ut_pit_pilot_supplied_rate

--- a/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,167 @@
+# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
+# expected values are the author's own shown arithmetic from the supplied
+# schedule, not an oracle read-back). Virginia liability = Va. Code 58.1-320
+# marginal bracket tax (2% to $3,000; 3% to $5,000; 5% to $17,000; 5.75% above)
+# on Virginia taxable income = supplied Virginia AGI less the supplied deduction
+# and personal exemptions. The bracket tax fills 720 dollars at the $17,000 floor
+# (0.02*3000 + 0.03*2000 + 0.05*12000) plus 5.75% of the excess. The supplied
+# 2026 deduction is the Va. Code 58.1-322.03 standard deduction PolicyEngine
+# applies ($8,750 single / $17,500 married filing jointly) and the supplied
+# exemption is the section 58.1-321 $930-per-filer personal exemption. Virginia
+# neither indexes its brackets nor levies a surtax on this slice, so each
+# liability equals PolicyEngine's va_income_tax_before_non_refundable_credits
+# exactly (zero residual).
+- name: single_15k_low
+  # taxable 15000-8750-930 = 5320. Tax 0.02*3000 + 0.03*2000 + 0.05*(5320-5000) = 60+60+16 = 136.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 15000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '5320'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '136'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '136'
+- name: single_30k
+  # taxable 30000-8750-930 = 20320. Tax 720 + 0.0575*(20320-17000) = 720 + 190.9 = 910.9.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 30000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '20320'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '910.9'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '910.9'
+- name: single_60k
+  # taxable 50320. Tax 720 + 0.0575*(50320-17000) = 720 + 1915.9 = 2635.9.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 60000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '50320'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '2635.9'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '2635.9'
+- name: single_150k
+  # taxable 140320. Tax 720 + 0.0575*(140320-17000) = 720 + 7090.9 = 7810.9.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 150000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '140320'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '7810.9'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '7810.9'
+- name: married_60k
+  # taxable 60000-17500-1860 = 40640. Tax 720 + 0.0575*(40640-17000) = 720 + 1359.3 = 2079.3.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 60000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '40640'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '2079.3'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '2079.3'
+- name: married_120k
+  # taxable 120000-17500-1860 = 100640. Tax 720 + 0.0575*(100640-17000) = 720 + 4809.3 = 5529.3.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 120000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '100640'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5529.3'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '5529.3'
+- name: married_300k
+  # taxable 300000-17500-1860 = 280640. Tax 720 + 0.0575*(280640-17000) = 720 + 15159.3 = 15879.3.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 300000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '280640'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '15879.3'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '15879.3'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,118 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-va/statute/58.1/58.1-320
+      - us-va/statute/58.1/58.1-322.03
+      - us-va/statute/58.1/58.1-321
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-va/statute/58.1/58.1-320
+        - us-va/statute/58.1/58.1-322.03
+        - us-va/statute/58.1/58.1-321
+      rationale: |-
+        This pipeline computes the Va. Code section 58.1-320 progressive bracket
+        tax on Virginia taxable income for the ordinary resident wage-earner
+        slice at the 2026 tax year. Section 58.1-320 imposes 2 per cent on income
+        not over $3,000, 3 per cent on the next $2,000 to $5,000, 5 per cent from
+        $5,000 to $17,000, and 5.75 per cent above $17,000; these bracket floors
+        and rates are statutory fixed amounts (unchanged since 1990 and not
+        indexed), carried by the encoded us-va/statutes/58.1/58/1-320 module. This
+        pipeline supplies those four floors and rates as declared caller-supplied
+        current-authority inputs so the marginal application runs end to end
+        without importing the encoded bracket rules. Virginia taxable income is
+        Virginia adjusted gross income less the section 58.1-322.03 deduction and
+        the section 58.1-321 personal exemptions; the operative 2026 standard
+        deduction ($8,750 single / $17,500 married filing jointly, Va. Code
+        58.1-322.03(1) as amended) and the $930 per-exemption personal exemption
+        (section 58.1-322.03(2)/58.1-321) are supplied as declared inputs rather
+        than derived, because those amounts sit in filing-status and dependency
+        mechanics the flat slice does not carry. The pipeline adds no numeric
+        literals of its own; it wires the progressive-tax mechanics only.
+  summary: |-
+    Composed Virginia individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Virginia adjusted gross income into the section 58.1-320 progressive bracket
+    tax, so an end-to-end comparison against PolicyEngine
+    (va_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
+    require the caller to supply the section 58.1-320 bracket-application stage
+    boundaries. It wires: Virginia taxable income (AGI less the supplied
+    deduction and personal exemptions); the progressive tax as the marginal sum
+    across the four brackets (2, 3, 5, and 5.75 per cent at the $3,000 / $5,000 /
+    $17,000 floors); and the liability as that bracket tax. Because Virginia
+    neither indexes its brackets nor levies a surtax on this slice, the composed
+    liability equals PolicyEngine's before-non-refundable-credits value exactly.
+    It deliberately excludes the section 58.1-339.8 earned income tax credit and
+    every other section 58.1-332 through 58.1-339.12 credit (all non-refundable
+    or refundable and excluded from this before-credits core), the age deduction
+    and the section 58.1-322.03 child-and-dependent-care deduction (supplied as
+    part of the caller's deduction input or zero for this slice), and itemized
+    deductions. Virginia AGI, filing status, the deduction, the personal
+    exemptions, and the bracket floors and rates are supplied inputs; the
+    brackets are statutory fixed amounts, so this 2026 pipeline is compared
+    against PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with
+    the standard-deduction vintage dispositioned.
+rules:
+  - name: va_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code 58.1-322, Virginia taxable income after the supplied deduction and personal exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-322.03
+              excerpt: "the Virginia standard deduction"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, va_pit_pilot_adjusted_gross_income - va_pit_pilot_supplied_deductions - va_pit_pilot_supplied_exemptions)
+  - name: va_pit_pilot_bracket_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code 58.1-320, progressive tax as the marginal sum across the supplied bracket floors and rates
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-320
+              excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_2) - va_pit_pilot_supplied_bracket_floor_1) * va_pit_pilot_supplied_bracket_rate_1
+          + max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_3) - va_pit_pilot_supplied_bracket_floor_2) * va_pit_pilot_supplied_bracket_rate_2
+          + max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_4) - va_pit_pilot_supplied_bracket_floor_3) * va_pit_pilot_supplied_bracket_rate_3
+          + max(0, va_pit_pilot_taxable_income - va_pit_pilot_supplied_bracket_floor_4) * va_pit_pilot_supplied_bracket_rate_4
+  - name: va_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Va. Code 58.1-320 bracket tax, before the section 58.1-332 through 58.1-339.12 credits, for the wage-earner slice
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-320
+              excerpt: "A tax is hereby annually imposed on the Virginia taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          va_pit_pilot_bracket_tax


### PR DESCRIPTION
## Composed Virginia + Utah income-tax liability pipelines (lane B, N–W)

Adds composed state income-tax liability pipelines for Virginia and Utah under
`us-XX/policies/income_tax/pilot_liability_pipeline`, mirroring the Ohio pilot
(#769). Both compose over statute sections that landed in the #763 merge train,
so they are shippable now that #763 is on main.

### Virginia (`us-va`)
- Va. Code 58.1-320 four-bracket progressive tax (2/3/5/5.75% at $3k/$5k/$17k
  floors), fixed/unindexed, over Virginia taxable income (AGI − 58.1-322.03
  standard deduction − 58.1-321 personal exemption).
- Targets PolicyEngine `va_income_tax_before_non_refundable_credits`, which
  equals `before_refundable` and final on the childless grid (no VA credits).
- **Penny-exact 6/6, zero residual** (fixed brackets).

### Utah (`us-ut`)
- Utah Code 59-10-104(2) flat 4.45% (H.B. 106 of 2025) on Utah taxable income
  (= federal AGI for the wage earner; no separate standard deduction).
- Targets `ut_income_tax_before_credits` (pure flat tax); excludes the
  59-10-1018 taxpayer tax credit that PE nets into
  `before_non_refundable_credits` (a future enrichment could model it).
- **Exact 6/6.**

### Also in this PR
- Regenerated `.axiom/index/provisions_to_rules.json` (adds only the VA/UT
  pilot-pipeline provision→rule edges).
- Composition modules carry the `--manual-exception composition` sign-off; each
  supplies its bracket floors/rates and deduction/exemption amounts as declared
  caller-supplied current-authority inputs, wiring the progressive/flat
  mechanics only (no numeric literals of their own).

### Oracle side
Shipped decoupled from this PR as axiom-oracles #251 (VA/UT concept mappings,
per-case suites vs pinned PolicyEngine-US + TAXSIM-2024, conformance covered
rows, scoreboard regen). PE 6/6 exact both states; TAXSIM-2024 dispositioned
(VA standard-deduction vintage; UT rate vintage + taxpayer-credit scope).

### Not shipped (composability gate)
WV/OR/RI/HI carry deduction/exemption/credit sections in #763 but **not** their
rate schedules (WV §11-21-4e/4j, OR §316.037, RI §44-30-2.6, HI §235-51), so
they are rate-gaps per oracle #757 — composable once those rate sections land in
a later train, not a permanent gap.

Validation year 2026; supplied inputs documented where the authority is
unpublished as an encoded rate module.
