### PR TITLE
Add composed Nebraska income-tax liability pipeline (us-ne)

### DIFF
--- a/.axiom/encoding-manifests/us-ne/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ne/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "e04ff7e44e7d50a950dd7063eaea3e8103d2637612fd199f9b465a3676780d04"
+    },
+    {
+      "path": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "c49448ecd8f11a5f971ea0c72f69426d41de2250424040cafb8bbc0650c53caa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-ne:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T02:00:24.181315+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp59fr2_7y/sign-applied-files/us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp59fr2_7y",
+  "generated_output_sha256": "c49448ecd8f11a5f971ea0c72f69426d41de2250424040cafb8bbc0650c53caa",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4cf06726f49f8d443a27d5927b7d23820e15836da9ddbaa4461b17e73457d8d2"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17265,6 +17265,12 @@
     ],
     "us-ne/statute/77/77-2715.03": [
       {
+        "module": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ne/statutes/77/77-2715/03.yaml",
         "via": [
           "module",
@@ -17282,6 +17288,12 @@
       }
     ],
     "us-ne/statute/77/77-2716.01": [
+      {
+        "module": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ne/statutes/77/77-2716/01.yaml",
         "via": [

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 523
+ceiling: 526
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -808,6 +808,15 @@ entries:
     source: bulk
     since: 2026-07-08
   - legal_id: us-nd:statutes/57/57-38-01/28#statutory_married_couple_credit_maximum
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-08
+  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income
     source: bulk
     since: 2026-07-08
   - legal_id: us-ne:statutes/77/77-2715/03#bracket_adjustment_rounding_increment

--- a/us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,160 @@
+# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
+# expected values are the author's own shown arithmetic from the supplied
+# schedule, not an oracle read-back). Nebraska liability = Neb. Rev. Stat.
+# 77-2715.03 marginal bracket tax on Nebraska taxable income = supplied Nebraska
+# AGI less the supplied section 77-2716.01 standard deduction. For taxable years
+# beginning in 2026 the four rates are 2.46%, 3.51%, 4.55%, and 4.55% (the top
+# two rates share 4.55% under the L.B. 754 compression) at the inflation-indexed
+# floors PolicyEngine applies for 2026: single 0 / 4,030 / 24,120 / 38,870 and
+# married-filing-jointly 0 / 8,040 / 48,250 / 77,730. The supplied 2026 standard
+# deduction is the section 77-2716.01 amount PolicyEngine applies ($8,750 single
+# / $17,550 married filing jointly). Nebraska's personal exemption is a post-tax
+# credit that this before-credits core excludes, so each liability equals
+# PolicyEngine's ne_income_tax_before_credits exactly.
+- name: single_15k_low
+  # taxable 15000-8750 = 6250. Tax 0.0246*4030 + 0.0351*(6250-4030) = 99.138 + 77.922 = 177.06.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 15000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '6250'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '177.06'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '177.06'
+- name: single_30k
+  # taxable 30000-8750 = 21250. Tax 99.138 + 0.0351*(21250-4030) = 99.138 + 604.422 = 703.56.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 30000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '21250'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '703.56'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '703.56'
+- name: single_60k
+  # taxable 51250. Tax 99.138 + 705.159 + 671.125 + 0.0455*(51250-38870) = 99.138 + 705.159 + 671.125 + 563.29 = 2038.712.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 60000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '51250'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '2038.712'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '2038.712'
+- name: single_150k
+  # taxable 141250. Tax 99.138 + 705.159 + 671.125 + 0.0455*(141250-38870) = 99.138 + 705.159 + 671.125 + 4658.29 = 6133.712.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 150000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '141250'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '6133.712'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '6133.712'
+- name: married_60k
+  # taxable 60000-17550 = 42450. Tax 197.784 + 0.0351*(42450-8040) = 197.784 + 1207.791 = 1405.575.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 60000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '42450'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1405.575'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1405.575'
+- name: married_120k
+  # taxable 102450. Tax 197.784 + 1411.371 + 1341.34 + 0.0455*(102450-77730) = 197.784 + 1411.371 + 1341.34 + 1124.76 = 4075.255.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 120000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '102450'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '4075.255'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '4075.255'
+- name: married_300k
+  # taxable 282450. Tax 197.784 + 1411.371 + 1341.34 + 0.0455*(282450-77730) = 197.784 + 1411.371 + 1341.34 + 9314.76 = 12265.255.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 300000
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '282450'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '12265.255'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '12265.255'

--- a/us-ne/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ne/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,123 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ne/statute/77/77-2715.03
+      - us-ne/statute/77/77-2716.01
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ne/statute/77/77-2715.03
+        - us-ne/statute/77/77-2716.01
+      rationale: |-
+        This pipeline computes the Neb. Rev. Stat. section 77-2715.03 progressive
+        bracket tax on Nebraska taxable income for the ordinary resident
+        wage-earner slice at the 2026 tax year. Section 77-2715.03 imposes a
+        four-rate schedule; for taxable years beginning in 2026 the first two
+        statutory rates are 2.46 per cent and 3.51 per cent and the third and
+        fourth rates are both 4.55 per cent (the L.B. 754 rate compression phases
+        the top two rates down to a common 4.55 per cent in 2026 and to 3.99 per
+        cent thereafter), applied across dollar brackets that section 77-2715.03
+        indexes for inflation each year. These bracket floors and rates are
+        carried by the encoded us-ne/statute/77/77-2715.03 module. This pipeline
+        supplies the four operative 2026 single or married-filing-jointly bracket
+        floors and rates as declared caller-supplied current-authority inputs so
+        the marginal application runs end to end without importing the encoded
+        bracket rules. Nebraska taxable income is Nebraska adjusted gross income
+        (federal adjusted gross income adjusted by the section 77-2716 additions
+        and subtractions, none of which apply to the wage slice) less the section
+        77-2716.01 standard deduction; the operative 2026 standard deduction
+        ($8,750 single / $17,550 married filing jointly) is supplied as a declared
+        input rather than derived, because that amount sits in the filing-status
+        and inflation mechanics the flat slice does not carry. The Nebraska
+        personal exemption is a post-tax credit under section 77-2716.01 (the
+        section 77-2715.03 tax is imposed before it), so it is excluded from this
+        before-credits core. The pipeline adds no numeric literals of its own; it
+        wires the progressive-tax mechanics only.
+  summary: |-
+    Composed Nebraska individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Nebraska adjusted gross income into the section 77-2715.03 progressive
+    bracket tax, so an end-to-end comparison against PolicyEngine
+    (ne_income_tax_before_credits) and TAXSIM (siitax) does not require the
+    caller to supply the section 77-2715.03 bracket-application stage boundaries.
+    It wires: Nebraska taxable income (adjusted gross income less the supplied
+    section 77-2716.01 standard deduction); the progressive tax as the marginal
+    sum across the four supplied brackets (2.46, 3.51, 4.55, and 4.55 per cent at
+    the supplied 2026 floors); and the liability as that bracket tax. Because the
+    2026 third and fourth statutory rates are both 4.55 per cent, the top two
+    brackets form a single effective 4.55 per cent band, but the pipeline retains
+    the four-bracket shape of the statutory schedule. It deliberately excludes the
+    section 77-2716.01 personal exemption credit (a post-tax nonrefundable credit
+    that PolicyEngine nets into ne_income_tax_before_refundable_credits, which
+    this before-credits core excludes), the section 77-2715.07 credits, the
+    section 77-2715.07 refundable credits (Nebraska EITC, child, stillborn), and
+    itemized deductions. Nebraska adjusted gross income, filing status, the
+    standard deduction, and the bracket floors and rates are supplied inputs; the
+    2026 floors are the section 77-2715.03 inflation-indexed amounts, so this 2026
+    pipeline is compared against PolicyEngine at 2026 and against TAXSIM's latest
+    2024 law year with the bracket and standard-deduction indexation vintage
+    dispositioned.
+rules:
+  - name: ne_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Neb. Rev. Stat. 77-2716.01, Nebraska taxable income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2716.01
+              excerpt: "the Nebraska standard deduction"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ne_pit_pilot_adjusted_gross_income - ne_pit_pilot_supplied_deductions)
+  - name: ne_pit_pilot_bracket_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Neb. Rev. Stat. 77-2715.03, progressive tax as the marginal sum across the supplied bracket floors and rates
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.03
+              excerpt: "There is hereby imposed a tax on the Nebraska taxable income of every resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_2) - ne_pit_pilot_supplied_bracket_floor_1) * ne_pit_pilot_supplied_bracket_rate_1
+          + max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_3) - ne_pit_pilot_supplied_bracket_floor_2) * ne_pit_pilot_supplied_bracket_rate_2
+          + max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_4) - ne_pit_pilot_supplied_bracket_floor_3) * ne_pit_pilot_supplied_bracket_rate_3
+          + max(0, ne_pit_pilot_taxable_income - ne_pit_pilot_supplied_bracket_floor_4) * ne_pit_pilot_supplied_bracket_rate_4
+  - name: ne_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Neb. Rev. Stat. 77-2715.03 bracket tax, before the section 77-2716.01 personal exemption credit and the section 77-2715.07 credits, for the wage-earner slice
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/statute/77/77-2715.03
+              excerpt: "There is hereby imposed a tax on the Nebraska taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ne_pit_pilot_bracket_tax


### PR DESCRIPTION
## Composed Nebraska income-tax liability pipeline (lane B, N–W)

Adds a composed Nebraska income-tax liability pipeline under
`us-ne/policies/income_tax/pilot_liability_pipeline`, mirroring the Virginia
pilot (#771) and the Ohio pilot (#769). It composes over statute sections that
landed in the #763 merge train (§77-2715.03 rate schedule, §77-2716.01 standard
deduction), so it is shippable now.

### Nebraska (`us-ne`)
- Neb. Rev. Stat. §77-2715.03 four-bracket progressive tax. For 2026 the four
  rates are 2.46% / 3.51% / 4.55% / 4.55% (L.B. 754 compresses the top two rates
  to a common 4.55% in 2026) at the inflation-indexed floors PolicyEngine applies
  for 2026 — single 0 / 4,030 / 24,120 / 38,870, married-filing-jointly
  0 / 8,040 / 48,250 / 77,730.
- Nebraska taxable income = Nebraska AGI − §77-2716.01 standard deduction
  ($8,750 single / $17,550 MFJ). The Nebraska personal exemption is a **post-tax
  credit** (`ne_exemptions`, netted into `ne_income_tax_before_refundable_credits`),
  so this before-credits core excludes it.
- Targets PolicyEngine `ne_income_tax_before_credits` (the pure §77-2715.03
  bracket tax). **Penny-exact 6/6** on the single/married grid
  (30k/60k/150k single, 60k/120k/300k married), verified against pinned
  policyengine[us]==4.18.9.

### Composition sign-off
The module supplies its four 2026 bracket floors/rates and the standard
deduction as declared caller-supplied current-authority inputs, wiring the
progressive mechanics only (no numeric literals of its own). It carries the
`--manual-exception composition` attestation and cites §77-2715.03 and
§77-2716.01. `axiom-encode test` passes (7 cases), `proof-validate` passes
(3 atoms), local `validate` CI leg passes.

### Also in this PR
- Regenerated `.axiom/index/provisions_to_rules.json` (adds only the us-ne
  pilot-pipeline provision→rule edges).

### Oracle side
Follows as a separate axiom-oracles PR (NE concept mapping, per-case suite vs
pinned PolicyEngine-US + TAXSIM-2024, conformance covered row, scoreboard
regen), mirroring or#245/or#251.

Validation year 2026; the 2026 bracket floors and standard deduction are the
inflation-indexed amounts PolicyEngine applies, supplied as documented current
authority.
