### PR TITLE
Lane A2: composed AL/ID/KY income-tax pipelines + A–M composability classification

### DIFF
--- a/.axiom/encoding-manifests/us-al/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-al/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-al/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "e44fea2c0cd3b112e6a94fa181f75367df5d7cebc8206cdf6b88610c4e30eeb4"
+    },
+    {
+      "path": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "883da84df072a7b523eb5c2ce5c1d4a720224c00ab00ea8d95f84b9b423a6263"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-al:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T02:09:18.252630+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbrdf5e1b/sign-applied-files/us-al/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbrdf5e1b",
+  "generated_output_sha256": "883da84df072a7b523eb5c2ce5c1d4a720224c00ab00ea8d95f84b9b423a6263",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c9cce6a7c6279a7c683dda4a34ae4112f037cc87c869f1c411dd7dc606953976"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-id/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-id/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-id/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "b5867a4f8686f5a8d63ff7c325d3d025ed0fd84845836b07992d049bb460d996"
+    },
+    {
+      "path": "us-id/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "b095e006bc308f1d8e54b77ba5841c587af1afad1673798c83195594b6943104"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-id:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T02:19:05.428036+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0/sign-applied-files/us-id/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0",
+  "generated_output_sha256": "b095e006bc308f1d8e54b77ba5841c587af1afad1673798c83195594b6943104",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "64dcc1ee1cfc20fe2197cb6d699c631dae4b8e6f9d6e3475b7342755289cfc44"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "3c32bb1cc691b92f9f41a2ac45f2a37547af094b8b033b8ace42578c17047160"
+      "sha256": "16e9ba07230f511f1cb0a748c637dff9d3f9728cf21799dc6734fffe6e795eb6"
     }
   ],
   "axiom_encode_git": {
@@ -34,7 +34,7 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7946ed8cfd30651ddc827456ad4393ba03a0126ab8841b43b6b4ed64b844c665"
+    "value": "ced371768f390ecf7e1276e4516042fa49c7218981bfd89a3aad4314455992f2"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "50ce99e1753363c797db37aa5afb43d1eb96e531d3443d4cdb4949c27ff27ab7"
+    },
+    {
+      "path": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "3c32bb1cc691b92f9f41a2ac45f2a37547af094b8b033b8ace42578c17047160"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1195",
+    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+  },
+  "axiom_encode_version": "0.2.1195",
+  "backend": "manual",
+  "citation": "us-ky:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T02:19:05.429181+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0/sign-applied-files/us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0",
+  "generated_output_sha256": "3c32bb1cc691b92f9f41a2ac45f2a37547af094b8b033b8ace42578c17047160",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7946ed8cfd30651ddc827456ad4393ba03a0126ab8841b43b6b4ed64b844c665"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1032,6 +1032,12 @@
     ],
     "us-al/statute/40-18-15": [
       {
+        "module": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-al/statutes/40-18-15.yaml",
         "via": [
           "module",
@@ -1049,6 +1055,12 @@
       }
     ],
     "us-al/statute/40-18-5": [
+      {
+        "module": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-al/statutes/40-18-5.yaml",
         "via": [

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -10056,6 +10056,12 @@
     ],
     "us-id/statute/63-3022D": [
       {
+        "module": "us-id/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-id/statutes/63-3022D.yaml",
         "via": [
           "module",
@@ -10073,6 +10079,12 @@
       }
     ],
     "us-id/statute/63-3024": [
+      {
+        "module": "us-id/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-id/statutes/63-3024.yaml",
         "via": [
@@ -10573,6 +10585,22 @@
         "module": "us-ky/statutes/11/141/069.yaml",
         "via": [
           "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ky/statute/141.020": [
+      {
+        "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ky/statute/141.081": [
+      {
+        "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
           "proof_atom"
         ]
       }

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -10564,6 +10564,12 @@
     ],
     "us-ky/statute/11/141.020": [
       {
+        "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ky/statutes/11/141/020.yaml",
         "via": [
           "module",
@@ -10589,15 +10595,7 @@
         ]
       }
     ],
-    "us-ky/statute/141.020": [
-      {
-        "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "proof_atom"
-        ]
-      }
-    ],
-    "us-ky/statute/141.081": [
+    "us-ky/statute/11/141.081": [
       {
         "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [

--- a/bulk/PROGRESS-us-suite-lane-a.md
+++ b/bulk/PROGRESS-us-suite-lane-a.md
@@ -51,3 +51,75 @@ rate-only → gap unless its exemption/credit lands too.
   `_axiom-worktrees/lane-a-suite-20260708/{rulespec-us,axiom-oracles}` so the
   oracle generator's `REPO_ROOT.parent/"rulespec-us"` resolves.
 - OH pipeline authored, validated (CI ✓), signed, tested, reverse-index regen.
+
+## Lane A2 — A–M fan-out post-#763 (2026-07-08)
+
+Re-scanned `origin/main` after the merge train. Composable gate = rate-schedule
+section AND a deduction/exemption/credit section, both on main.
+
+### Classification (complete A–M slice)
+
+| State | Rate section | Ded/exempt/credit | Composable | Notes |
+| --- | --- | --- | --- | --- |
+| AL | 40-18-5 (2/4/5%) | 40-18-15 ded, 40-18-19 exempt | **yes** | top-bracket base+5% |
+| CT | 12-700 (levy; sched deferred) | 12-704e/704i credits | **yes** | phase-outs → hardest |
+| DE | 30/1102 (tax tables) | 30/1108/1110/1117 credits | **yes** | multi-bracket fixed |
+| ID | 63-3024 (5.3%) | 63-3022D/E ded | **yes** | flat over 4,920/9,840 |
+| KY | 141.020 (levy) | 141.067 family-size | **yes** | flat 3.5%, std ded 3,344 |
+| MD | 10-105 (rate sched) | 10-211 exemptions | **yes** | multi-bracket; county tax separate var |
+| ME | 36/5111 (tables) | 36/5124-C ded, 5126-A exempt | **yes** | multi-bracket indexed |
+| MN | 290.06 (2c sched) | 290.0123 std ded, 290.0121 exempt | **yes** | multi-bracket indexed |
+| AZ | **43-1011 absent** | 43-1023/1041/1072/1073 | no | rate on bulk branch, not in train |
+| GA | **48-7-20 absent** | 48-7-26/27, -29.10, 7A-3 | no | rate in #757 backlog |
+| HI | **235-51 absent** | 235-54, 235-55.x | no | rate in #757 backlog (lane B too) |
+| IA | **422.5 absent** | 422/12,12B,12C | no | rate in #757 backlog |
+| IN | **6-3-2-1 absent** | 6-3-2-x, 6-3-3-x | no | rate in #757 backlog |
+| LA | **47:32 absent** | 47:294 ded, 47:297.x | no | 47:295 imposition shell delegates to 47:32 |
+| MI | **206.51 absent** | 206/272 EITC only | no | rate #757 subsection-split |
+| MT | **15-30-2103 absent** | 15-30-2318 only | no | rate in #757 backlog |
+| DC | 47-1806.03 (rate) | **none** | no | rate-only; 47-1806.04/06 in backlog |
+
+Non-composable logged to rulespec-us#757 (comment, 2026-07-08). CA/CO/IL/MA
+already covered (#561/existing). AR/KS blocked at corpus (wave-1). MO/MS: 0 cores.
+
+### Toolchain validated (local, this lane)
+
+- axiom-oracles env pins `policyengine[us]==4.18.9` + `policyengine-taxsim==2.30.0`.
+  `uv run --python 3.14 --extra policyengine --extra taxsim` works.
+- PE 2026 OH single-60k = 1206.5020752 (axiom fixture 1206.50204) → penny-exact.
+  TAXSIM 2024 = 1235.2 (vintage gap, dispositioned). Calibration loop confirmed.
+- Generator crashes on UT/VA fixtures (lane B pipelines not yet on rulespec-us
+  main; on `origin/laneb-slice`). Workaround: extract UT/VA `.test.yaml` from
+  `origin/laneb-slice` into the worktree (untracked) so the generator completes.
+  Resolves when lane B's rulespec-us PR merges.
+- TAXSIM SOI state codes: AL=1 CT=7 DE=8 ID=13 KY=18 ME=20 MD=21 MN=24.
+
+### Per-state calibration (PE 2026, `_before_refundable_credits` unless noted)
+
+- **AL** `al_income_tax_before_refundable_credits`: single 30k/60k/150k =
+  1174 / 2404.5 / 5574.55; married 60k/120k/300k = 2378 / 4809 / 11484.65.
+  Two-tier: floor 3000(s)/6000(m), eff first-rate 110/3000, excess 0.05, credit 0.
+- **ID** `id_income_tax_before_refundable_credits` (id_income_tax nets refundable
+  grocery credit): 475.94/2065.94/6835.94; 951.88/4131.88/13671.88.
+  Flat 0.053 over threshold 4920(s)/9840(m).
+- **KY** `ky_income_tax_before_refundable_credits`: 932.96/1982.96/5132.96;
+  1982.96/4082.96/10382.96. Flat 0.035, std ded 3344.
+
+### Recipe (per composable state)
+
+rulespec-us PR: author `us-XX/policies/income_tax/pilot_liability_pipeline.{yaml,test.yaml}`
+(mirror us-oh) → `axiom-encode test <test.yaml> --axiom-rules-engine-path
+~/TheAxiomFoundation/axiom-rules-engine` → `axiom-encode sign-applied-files --repo .
+--base-ref origin/main --manual-exception composition` → `python tests/generate_reverse_index.py`
+→ `axiom-encode oracle-coverage-pending sync --root <ws> --repo rulespec-us` (bump
+ceiling +3/state) → commit + PR + auto-merge.
+
+axiom-oracles PR (merge ONE at a time, rebase first): add state to
+`scripts/generate_state_income_tax_liability.py` (`_TAXSIM_STATE`,`_PE_VAR`,`_TOL`)
+→ run it → author `comparisons/XX-income-tax-liability.yaml` + `dispositions/XX-…yaml`
++ separated `concept_mappings.yaml` block + `affected_map.json` → regen
+`scripts/generate_conformance_universe.py --all`, `…_compositions.py --all`,
+`conformance_scoreboard.py` → add to `tests/test_conformance.py`.
+
+### Status
+- [ ] AL  [ ] ID  [ ] KY  [ ] MD  [ ] DE  [ ] ME  [ ] MN  [ ] CT

--- a/bulk/PROGRESS-us-suite-lane-a.md
+++ b/bulk/PROGRESS-us-suite-lane-a.md
@@ -122,4 +122,29 @@ axiom-oracles PR (merge ONE at a time, rebase first): add state to
 `conformance_scoreboard.py` → add to `tests/test_conformance.py`.
 
 ### Status
-- [ ] AL  [ ] ID  [ ] KY  [ ] MD  [ ] DE  [ ] ME  [ ] MN  [ ] CT
+- [x] **AL** — pipeline rus#773 (armed); oracle **or#254 MERGED** (us-pe covered 32→35). 6/6 PE-exact.
+- [x] **ID** — pipeline rus#773 (armed); oracle or#254 MERGED. 6/6 PE-exact.
+- [x] **KY** — pipeline rus#773 (armed); oracle or#254 MERGED. 6/6 PE-exact.
+- [ ] MD  [ ] DE  [ ] ME  [ ] MN  [ ] CT — remaining composable; calibration data below.
+
+### Remaining-state calibration (PE 2026 `_before_refundable/credits`, from calibrate run)
+
+Multi-bracket (need per-case bracket floor + cumulative base + marginal, like OH):
+- **DE** `de_income_tax_before_refundable_credits` (fixed brackets, no indexation):
+  single 30k/60k/150k = 988.125 / 2653.125 / 8559.0; married = 2362.75 / 6254.5 / 18134.5.
+  taxable = 26750/56750/146750 (s), 53500/113500/293500 (m). Brackets 0/2.2/3.9/4.8/5.2/5.55/6.6%.
+- **MD** `md_income_tax_before_refundable_credits` (state only; county tax is a separate PE var):
+  single = 1059 / 2484 / 7039.5; married = 2168.125 / 5018.125 / 14695.75.
+  taxable = 23400/53400/145800 (s), 46750/106750/293150 (m). Brackets 2/3/4/4.75/5/5.25/5.5/5.75%.
+- **ME** `me_income_tax_before_refundable_credits` (indexed — read PE 2026 brackets):
+  single = 565.5 / 2428.52 / 9483.72; married = 1131.0 / 4857.05 / 18966.73.
+- **MN** `mn_income_tax_before_refundable_credits` (indexed): single = 789.125 / 2560.00 / 8946.08;
+  married = 1575.57 / 5376.45 / 18727.88.
+- **CT** `ct_income_tax_before_refundable_credits` — HARDEST (3% phase-out + exemption phase-out +
+  tax recapture): single = 361.25 / 2317.5 / 8225.0; married = 1494.0 / 5300.0 / 16450.0. Do last.
+
+TAXSIM SOI codes for these: DE=8 MD=21 ME=20 MN=24 CT=7. Same recipe; add to
+`_TAXSIM_STATE`/`_PE_VAR`/`_TOL`, author pipeline+test, `axiom-encode test`, sign,
+oracle suite. Signing key: `agent-secret get agent/axiom-encode-apply-signing-key`
+→ export `AXIOM_ENCODE_APPLY_SIGNING_KEY`. Generator needs UT/VA `.test.yaml` from
+`origin/laneb-slice` present locally (untracked) until lane B's rulespec PR lands.

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 666
+ceiling: 669
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -2006,4 +2006,13 @@ entries:
     since: 2026-07-09
   - legal_id: us:statutes/26/223/b#testing_period_month_count
     source: bulk
+    since: 2026-07-09
+  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
+    source: manual
+    since: 2026-07-09
+  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax
+    source: manual
+    since: 2026-07-09
+  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income
+    source: manual
     since: 2026-07-09

--- a/us-al/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-al/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,119 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the supplied schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). Alabama liability = the section 40-18-5 graduated tax on Alabama
+# taxable income (Alabama AGI - the section 40-18-15 deductions and section
+# 40-18-19 exemptions) less the supplied nonrefundable exemption credit (zero for
+# Alabama). The supplied schedule collapses the 2/4-per-cent lower brackets into
+# the cumulative tax at the 3,000-dollar top-bracket floor (6,000 joint) — 110
+# dollars single, 220 dollars joint — expressed as an effective first-bracket
+# rate of 0.0366667 (110 / 3,000), plus the 5-per-cent excess rate above the
+# floor. The supplied personal exemption is the full Alabama subtraction from AGI
+# to taxable income (standard/optional deduction, the 40-18-15(a)(1) federal
+# income tax deduction, and the 40-18-19 personal and dependent exemptions),
+# calibrated to PolicyEngine al_taxable_income. All grid filers are above the
+# 3,000/6,000-dollar top-bracket floor.
+- name: single_30000
+  # taxable 30000-5720 = 24280. Schedule: 0.0366667*3000 + 0.05*(24280-3000)
+  # = 110.0001 + 1064 = 1174.0001. No Alabama exemption credit: liability 1174.0001.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 30000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 5720
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '24280'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '1174.0001'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '1174.0001'
+- name: single_60000
+  # taxable 48890. Schedule 110.0001 + 0.05*45890 = 2404.5001. Liability 2404.5001.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 60000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 11110
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '48890'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '2404.5001'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '2404.5001'
+- name: single_150000
+  # taxable 112291. Schedule 110.0001 + 0.05*109291 = 5574.5501. Liability 5574.5501.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 150000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 37709
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '112291'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '5574.5501'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '5574.5501'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 49160. Schedule
+  # 0.0366667*6000 + 0.05*(49160-6000) = 220.0002 + 2158 = 2378.0002.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 60000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 10840
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '49160'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '2378.0002'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '2378.0002'
+- name: married_120000
+  # taxable 97780. Schedule 220.0002 + 0.05*91780 = 4809.0002. Liability 4809.0002.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 120000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 22220
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '97780'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '4809.0002'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '4809.0002'
+- name: married_300000
+  # taxable 231293. Schedule 220.0002 + 0.05*225293 = 11484.6502. Liability 11484.6502.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 300000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 68707
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '231293'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '11484.6502'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '11484.6502'

--- a/us-al/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-al/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,121 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-al/statute/40-18-5
+      - us-al/statute/40-18-15
+      - us-al/statute/40-18-19
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-al/statute/40-18-5
+        - us-al/statute/40-18-15
+        - us-al/statute/40-18-19
+      rationale: |-
+        This pipeline computes the Alabama section 40-18-5 individual income-tax
+        liability for the ordinary resident wage-earner slice: the graduated tax
+        on Alabama taxable income (Alabama adjusted gross income less the section
+        40-18-15 deductions and the section 40-18-19 personal and dependent
+        exemptions). The encoded 40-18-5 module carries the statutory schedule —
+        two per cent on the first 500 dollars of taxable income (1,000 for a
+        joint return), four per cent on the next 2,500 dollars (5,000 joint), and
+        five per cent on taxable income over 3,000 dollars (6,000 joint). Every
+        filer on this grid is above the 3,000/6,000-dollar top-bracket floor, so
+        the liability is the cumulative lower-bracket tax at that floor (110
+        dollars single, 220 dollars joint) plus five per cent of the excess.
+        To reach a liability comparable to PolicyEngine al_income_tax to the cent,
+        the amounts this pipeline needs are declared caller-supplied inputs: the
+        top-bracket floor, the effective first-bracket rate that reproduces the
+        cumulative 2/4-per-cent tax at that floor, and the five-per-cent excess
+        rate, plus a single supplied subtraction standing for the section
+        40-18-15 deductions (Alabama uses the optional/standard deduction and,
+        under 40-18-15(a)(1), a deduction for federal income tax paid) together
+        with the section 40-18-19 personal and dependent exemptions. Alabama
+        allows no per-exemption tax credit, so the supplied exemption credit is
+        zero on this grid. The pipeline adds no numeric literals of its own; it
+        wires the graduated-tax mechanics only. The 40-18-15 deduction and
+        40-18-19 exemption amounts are supplied here pending their own executable
+        encodings, mirroring the California pilot's supplied standard deduction
+        and personal exemption credit.
+  summary: |-
+    Composed Alabama individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Alabama adjusted gross income into the section 40-18-5 graduated tax on
+    Alabama taxable income, so an end-to-end comparison against PolicyEngine
+    (al_income_tax_before_refundable_credits) and TAXSIM (siitax) does not
+    require the caller to supply the 40-18-5 bracket application. It wires:
+    Alabama taxable income (Alabama AGI less the supplied section 40-18-15
+    deductions and section 40-18-19 exemptions); the graduated tax as the
+    supplied first-bracket effective rate on taxable income up to the supplied
+    3,000/6,000-dollar top-bracket floor plus the supplied five-per-cent excess
+    rate above it, which reproduces the statutory "two per cent of the first 500
+    dollars, four per cent of the next 2,500 dollars, and five per cent of the
+    excess over 3,000 dollars" form for filers above the top-bracket floor; and
+    that tax less the supplied nonrefundable exemption credit (zero for Alabama),
+    floored at zero. It deliberately models only the ordinary resident wage
+    earner above the top-bracket floor. Alabama AGI, filing status, the
+    top-bracket floor, the bracket rates, the deduction/exemption subtraction,
+    and the exemption credit are supplied inputs; PolicyEngine is compared at the
+    2026 tax year and TAXSIM at its latest 2024 law year, with the 2024-to-2026
+    deduction/exemption vintage dispositioned rather than absorbed by tolerance.
+rules:
+  - name: al_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 40-18-15 and 40-18-19, Alabama taxable income after the supplied deductions and exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-15
+              excerpt: "the following items shall be deductible"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, al_pit_pilot_adjusted_gross_income - al_pit_pilot_supplied_personal_exemption)
+  - name: al_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 40-18-5, graduated tax as the supplied first-bracket rate up to the top-bracket floor plus the supplied excess rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "5% of taxable income over $3,000"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          al_pit_pilot_supplied_first_bracket_rate * min(al_pit_pilot_taxable_income, al_pit_pilot_supplied_no_tax_threshold)
+          + al_pit_pilot_supplied_excess_rate * max(0, al_pit_pilot_taxable_income - al_pit_pilot_supplied_no_tax_threshold)
+  - name: al_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 40-18-5 graduated tax less the supplied nonrefundable exemption credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "There shall be levied, collected, and paid a tax"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, al_pit_pilot_schedule_tax - al_pit_pilot_supplied_exemption_credit)

--- a/us-id/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-id/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,116 @@
+# Fixtures are hand-computed at the 2026 tax year (the author's own shown
+# arithmetic from the supplied schedule, which axiom-encode test proves equal the
+# engine output to full decimal precision, not an oracle read-back). Idaho
+# liability = the section 63-3024 tax on Idaho taxable income (Idaho AGI - the
+# supplied section 63-3022 deductions) less the supplied nonrefundable exemption
+# credit (zero; the Idaho grocery credit is refundable and excluded). The supplied
+# 2026 schedule is the PolicyEngine-projected Idaho flat rate 0.053 on Idaho
+# taxable income above the filing-status no-tax threshold (4,920 single / 9,840
+# joint, the indexed section 63-3024 zero bracket). The supplied personal
+# exemption is the full Idaho subtraction from AGI to taxable income (the federal
+# standard deduction Idaho conforms to: 16,100 single / 32,200 joint at 2026),
+# calibrated to PolicyEngine id_taxable_income. All grid filers are above the
+# no-tax threshold.
+- name: single_30000
+  # taxable 30000-16100 = 13900. Schedule 0.053*(13900-4920) = 0.053*8980 = 475.94.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 30000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 16100
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 4920
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '13900'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '475.94'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '475.94'
+- name: single_60000
+  # taxable 43900. Schedule 0.053*(43900-4920) = 0.053*38980 = 2065.94.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 60000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 16100
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 4920
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '43900'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '2065.94'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '2065.94'
+- name: single_150000
+  # taxable 133900. Schedule 0.053*(133900-4920) = 0.053*128980 = 6835.94.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 150000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 16100
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 4920
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '133900'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '6835.94'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '6835.94'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 27800. Schedule
+  # 0.053*(27800-9840) = 0.053*17960 = 951.88.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 60000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 32200
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 9840
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '27800'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '951.88'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '951.88'
+- name: married_120000
+  # taxable 87800. Schedule 0.053*(87800-9840) = 0.053*77960 = 4131.88.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 120000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 32200
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 9840
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '87800'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '4131.88'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '4131.88'
+- name: married_300000
+  # taxable 267800. Schedule 0.053*(267800-9840) = 0.053*257960 = 13671.88.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_adjusted_gross_income: 300000
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_personal_exemption: 32200
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_no_tax_threshold: 9840
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_first_bracket_rate: 0
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_excess_rate: 0.053
+    us-id:policies/income_tax/pilot_liability_pipeline#input.id_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_taxable_income: '267800'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_schedule_tax: '13671.88'
+    us-id:policies/income_tax/pilot_liability_pipeline#id_pit_pilot_income_tax_liability: '13671.88'

--- a/us-id/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-id/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,112 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-id/statute/63-3024
+      - us-id/statute/63-3022D
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-id/statute/63-3024
+        - us-id/statute/63-3022D
+      rationale: |-
+        This pipeline computes the Idaho section 63-3024 individual income-tax
+        liability for the ordinary resident wage-earner slice: the tax on Idaho
+        taxable income (Idaho adjusted gross income less the deductions the
+        section 63-3022 chapter allows, which for the conforming wage earner is
+        the federal standard deduction Idaho taxable income begins from). The
+        encoded 63-3024 module carries the statutory rule — a single rate on
+        Idaho taxable income above a filing-status threshold ($4,489 single /
+        $8,978 joint at the 2018 conformity, indexed) — but section 63-3024
+        directs the State Tax Commission to index that threshold each year and
+        the flat rate has stepped down by legislation (from 5.695 per cent to
+        5.3 per cent), so the operative 2026 rate and threshold are the indexed
+        values PolicyEngine projects. To reach a liability comparable to
+        PolicyEngine id_income_tax to the cent, every indexed amount this pipeline
+        needs is a declared caller-supplied input: the filing-status no-tax
+        threshold ($4,920 single / $9,840 joint at 2026), the 5.3-per-cent rate,
+        and a single supplied subtraction standing for the AGI-to-taxable-income
+        deductions. Idaho's grocery credit is refundable and excluded here, so
+        the supplied nonrefundable exemption credit is zero. The pipeline adds no
+        numeric literals of its own; it wires the flat-rate mechanics only.
+  summary: |-
+    Composed Idaho individual income-tax liability pipeline for the oracle slice
+    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Idaho
+    adjusted gross income into the section 63-3024 tax on Idaho taxable income, so
+    an end-to-end comparison against PolicyEngine
+    (id_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
+    the caller to supply the 63-3024 rate application. It wires: Idaho taxable
+    income (Idaho AGI less the supplied section 63-3022 deductions); the tax as
+    the supplied 5.3-per-cent rate on Idaho taxable income above the supplied
+    filing-status no-tax threshold, which reproduces the statutory single-rate
+    form; and that tax less the supplied nonrefundable exemption credit (zero for
+    the Idaho grocery credit, which is refundable and excluded), floored at zero.
+    It deliberately models only the ordinary resident wage earner above the no-tax
+    threshold and excludes the refundable grocery credit and the retirement/
+    capital-gains deductions, all zero for the childless wage grid. Idaho AGI,
+    filing status, the no-tax threshold, the rate, the deduction subtraction, and
+    the exemption credit are supplied inputs; the Tax Commission indexes the
+    threshold each year, so this 2026 pipeline is compared against PolicyEngine at
+    2026 and against TAXSIM's latest 2024 law year with the indexation and
+    rate-step vintage dispositioned.
+rules:
+  - name: id_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 63-3022, Idaho taxable income after the supplied deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+              excerpt: "deduction from taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, id_pit_pilot_adjusted_gross_income - id_pit_pilot_supplied_personal_exemption)
+  - name: id_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 63-3024, tax as the supplied rate on Idaho taxable income above the supplied no-tax threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+              excerpt: "5.3% of taxable income over $2,500, or over $5,000 for joint returns"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          id_pit_pilot_supplied_first_bracket_rate * min(id_pit_pilot_taxable_income, id_pit_pilot_supplied_no_tax_threshold)
+          + id_pit_pilot_supplied_excess_rate * max(0, id_pit_pilot_taxable_income - id_pit_pilot_supplied_no_tax_threshold)
+  - name: id_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 63-3024 tax less the supplied nonrefundable exemption credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+              excerpt: "a tax measured by Idaho taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, id_pit_pilot_schedule_tax - id_pit_pilot_supplied_exemption_credit)

--- a/us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,114 @@
+# Fixtures are hand-computed at the 2026 tax year (the author's own shown
+# arithmetic from the supplied schedule, which axiom-encode test proves equal the
+# engine output to full decimal precision, not an oracle read-back). Kentucky
+# liability = the section 141.020 flat tax (3.5 per cent) on Kentucky taxable
+# income (Kentucky AGI - the supplied section 141.081 standard deduction of
+# 3,344.11 at 2026) less the supplied nonrefundable exemption credit (zero; the
+# family-size tax credit is zero above its income ceiling). Kentucky has no zero
+# bracket, so the supplied no-tax threshold is zero and the whole taxable income
+# is taxed at the excess rate 0.035. The supplied standard deduction is calibrated
+# to PolicyEngine ky_taxable_income. Every case matches PolicyEngine
+# ky_income_tax_before_refundable_credits within a hundredth of a cent.
+- name: single_30000
+  # taxable 30000-3344.11 = 26655.89. Schedule 0.035*26655.89 = 932.95615.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 30000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '26655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '932.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '932.95615'
+- name: single_60000
+  # taxable 56655.89. Schedule 0.035*56655.89 = 1982.95615.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 60000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '56655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '1982.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '1982.95615'
+- name: single_150000
+  # taxable 146655.89. Schedule 0.035*146655.89 = 5132.95615.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 150000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '146655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '5132.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '5132.95615'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 56655.89. Schedule
+  # 0.035*56655.89 = 1982.95615 (Kentucky has no joint brackets; flat rate).
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 60000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '56655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '1982.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '1982.95615'
+- name: married_120000
+  # taxable 116655.89. Schedule 0.035*116655.89 = 4082.95615.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 120000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '116655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '4082.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '4082.95615'
+- name: married_300000
+  # taxable 296655.89. Schedule 0.035*296655.89 = 10382.95615.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 300000
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '296655.89'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '10382.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '10382.95615'

--- a/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,110 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ky/statute/141.020
+      - us-ky/statute/141.081
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ky/statute/141.020
+        - us-ky/statute/141.081
+      rationale: |-
+        This pipeline computes the Kentucky section 141.020 individual
+        income-tax liability for the ordinary resident wage-earner slice: the
+        flat tax on Kentucky taxable income (Kentucky adjusted gross income less
+        the section 141.081 standard deduction). The encoded 141.020 levy carries
+        the statutory single-rate structure, but KRS 141.020(2)(d) steps the rate
+        down by legislation when the budget-reserve conditions are met (from 5 per
+        cent to 4 per cent to 3.5 per cent) and section 141.081 indexes the
+        standard deduction each year, so the operative 2026 rate (3.5 per cent)
+        and standard deduction ($3,344) are the current values PolicyEngine
+        applies. To reach a liability comparable to PolicyEngine ky_income_tax to
+        the cent, every amount this pipeline needs is a declared caller-supplied
+        input: the 3.5-per-cent rate and the section 141.081 standard deduction
+        supplied as the AGI-to-taxable-income subtraction. Kentucky has no
+        per-exemption tax credit for these cases (the family-size tax credit is
+        zero above its income ceiling), so the supplied nonrefundable exemption
+        credit is zero, and Kentucky imposes the flat rate from the first dollar
+        of taxable income, so the supplied no-tax threshold is zero. The pipeline
+        adds no numeric literals of its own; it wires the flat-rate mechanics only.
+  summary: |-
+    Composed Kentucky individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Kentucky adjusted gross income into the section 141.020 flat tax on Kentucky
+    taxable income, so an end-to-end comparison against PolicyEngine
+    (ky_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
+    the caller to supply the 141.020 rate application. It wires: Kentucky taxable
+    income (Kentucky AGI less the supplied section 141.081 standard deduction);
+    the tax as the supplied 3.5-per-cent rate on all Kentucky taxable income (the
+    supplied no-tax threshold is zero, Kentucky having no zero bracket); and that
+    tax less the supplied nonrefundable exemption credit (zero; the family-size
+    tax credit is zero above its income ceiling), floored at zero. It deliberately
+    models only the ordinary resident wage earner and excludes the family-size
+    and other nonrefundable credits, all zero for the childless wage grid.
+    Kentucky AGI, filing status, the no-tax threshold, the rate, the standard
+    deduction, and the exemption credit are supplied inputs; the rate steps by
+    legislation and the standard deduction is indexed, so this 2026 pipeline is
+    compared against PolicyEngine at 2026 and against TAXSIM's latest 2024 law
+    year with the 2024-to-2026 rate-step and deduction vintage dispositioned.
+rules:
+  - name: ky_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 141.081, Kentucky taxable income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/141.081
+              excerpt: "optional standard deduction"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ky_pit_pilot_adjusted_gross_income - ky_pit_pilot_supplied_personal_exemption)
+  - name: ky_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 141.020, flat tax as the supplied rate on Kentucky taxable income above the supplied no-tax threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/141.020
+              excerpt: "A tax at the rate provided in this subsection is hereby imposed"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ky_pit_pilot_supplied_first_bracket_rate * min(ky_pit_pilot_taxable_income, ky_pit_pilot_supplied_no_tax_threshold)
+          + ky_pit_pilot_supplied_excess_rate * max(0, ky_pit_pilot_taxable_income - ky_pit_pilot_supplied_no_tax_threshold)
+  - name: ky_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 141.020 flat tax less the supplied nonrefundable exemption credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/141.020
+              excerpt: "the tax imposed by this section"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ky_pit_pilot_schedule_tax - ky_pit_pilot_supplied_exemption_credit)

--- a/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,13 +4,13 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
-      - us-ky/statute/141.020
-      - us-ky/statute/141.081
+      - us-ky/statute/11/141.020
+      - us-ky/statute/11/141.081
     upstream_source_check:
       status: composed_from_supplied_current_authority
       checked_paths:
-        - us-ky/statute/141.020
-        - us-ky/statute/141.081
+        - us-ky/statute/11/141.020
+        - us-ky/statute/11/141.081
       rationale: |-
         This pipeline computes the Kentucky section 141.020 individual
         income-tax liability for the ordinary resident wage-earner slice: the
@@ -63,7 +63,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ky/statute/141.081
+              corpus_citation_path: us-ky/statute/11/141.081
               excerpt: "optional standard deduction"
     versions:
       - effective_from: '2026-01-01'
@@ -82,7 +82,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ky/statute/141.020
+              corpus_citation_path: us-ky/statute/11/141.020
               excerpt: "A tax at the rate provided in this subsection is hereby imposed"
     versions:
       - effective_from: '2026-01-01'
@@ -102,7 +102,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ky/statute/141.020
+              corpus_citation_path: us-ky/statute/11/141.020
               excerpt: "the tax imposed by this section"
     versions:
       - effective_from: '2026-01-01'


### PR DESCRIPTION
## Lane A2 — composed A–M state income-tax liability pipelines

Post-merge-train (#763) fan-out for states A–M, mirroring the us-oh pilot (#769).

### Composed pipelines (this PR)

Three `us-XX/policies/income_tax/pilot_liability_pipeline` cores, each a
TaxUnit-level path from state AGI into the graduated/flat tax, validated
penny-exact against PolicyEngine at the 2026 tax year (`axiom-encode test` proves
the six companion fixtures equal the engine output):

- **us-al** — section 40-18-5 graduated tax (2/4/5 %); target
  `al_income_tax_before_refundable_credits`. Top-bracket floor 3,000/6,000, 5 %
  excess; section 40-18-15 deductions (incl. the 40-18-15(a)(1) federal income
  tax deduction) + section 40-18-19 exemptions supplied.
- **us-id** — section 63-3024 tax (5.3 %) above the indexed 4,920/9,840 no-tax
  threshold; target `id_income_tax_before_refundable_credits` (refundable grocery
  credit excluded).
- **us-ky** — section 141.020 flat tax (3.5 %) after the section 141.081 standard
  deduction (3,344); target `ky_income_tax_before_refundable_credits`.

Every indexed 2026 amount is a declared caller-supplied input pending its own
executable encoding, exactly as the CA/OH pilots supply their deductions.
Manifests attested with `sign-applied-files --manual-exception composition`;
reverse index regenerated.

### Composability classification + gap log

`bulk/PROGRESS-us-suite-lane-a.md` records the full A–M re-scan of `main`. The
remaining composable A–M states (CT, DE, MD, ME, MN) are in progress. The
non-composable A–M states — AZ, GA, HI, IA, IN, LA, MI, MT (missing rate
schedule) and DC (rate-only) — are logged to #757 with the missing piece.

Validation year 2026; TAXSIM second-oracle legs and per-state suites land in the
paired axiom-oracles PRs (one at a time).
