### PR TITLE
Lane A3: composed DE/MD/ME/MN/CT income-tax liability pipelines

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ct/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "edca3a53e6fcd74e34abdb0cb518658ec7122dabcb08c68a4bd8d7c7d2cf4d56"
+    },
+    {
+      "path": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "3658325574ce05445cfba036d092bba5bd777af591fed342a1f48fd9f4a96481"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1196",
+    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+  },
+  "axiom_encode_version": "0.2.1196",
+  "backend": "manual",
+  "citation": "us-ct:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T06:33:47.689322+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
+  "generated_output_sha256": "3658325574ce05445cfba036d092bba5bd777af591fed342a1f48fd9f4a96481",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1c6c64fb596c390afbad198b4b589a16dbc0213f8202bc3ecb204aa5a0286b50"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-de/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-de/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-de/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "4413c690c058f2458cc9d60207c9b237233b44ff6208d5c1547a0bbf1e97277d"
+    },
+    {
+      "path": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "3dd2a5ff7e506870d91723d46675c5e903f8fb5a2f9f35722b201673cd204156"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1196",
+    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+  },
+  "axiom_encode_version": "0.2.1196",
+  "backend": "manual",
+  "citation": "us-de:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T06:33:47.690165+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
+  "generated_output_sha256": "3dd2a5ff7e506870d91723d46675c5e903f8fb5a2f9f35722b201673cd204156",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ebd844448788e57266ebb5d0a8dc678c07fad2ea1567d445092aec065722d8b2"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-md/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-md/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-md/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "95723c883ecc6c2e147fdcce9a4bc62c1d0622adbc9a1e3c44dfa9fb1721df90"
+    },
+    {
+      "path": "us-md/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "235db8b137605756252b2bce718b962c182ad95609840fe314b34d9ac12d8d8f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1196",
+    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+  },
+  "axiom_encode_version": "0.2.1196",
+  "backend": "manual",
+  "citation": "us-md:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T06:33:47.690615+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-md/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
+  "generated_output_sha256": "235db8b137605756252b2bce718b962c182ad95609840fe314b34d9ac12d8d8f",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f7e04076789e38b54cdd7187f9daf31d98e940b8866fad050a559e24c1271e29"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-me/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-me/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-me/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "ce1e1856891ea831d06b11c5b9b9e7112ffab4aeccc668c855b43393442f2bab"
+    },
+    {
+      "path": "us-me/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "30ffb72137918aa65f2b4abf5581bdbba97439cc7b4f39426fb8c373895085b9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1196",
+    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+  },
+  "axiom_encode_version": "0.2.1196",
+  "backend": "manual",
+  "citation": "us-me:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T06:33:47.691057+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-me/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
+  "generated_output_sha256": "30ffb72137918aa65f2b4abf5581bdbba97439cc7b4f39426fb8c373895085b9",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "919d40cc2fffac9768769adbca0f70b8ab5252abd84979dc0690496e0e5ff2f5"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-mn/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-mn/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "8df6dfe0d5bce1db166bf9bbdefc4fa5de3b9962283413c99c2529d90ea22a2c"
+    },
+    {
+      "path": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "e83bd457ca4dc2831f679f22bf707d6dcd8724795dd7529e62a24321937a0507"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1196",
+    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+  },
+  "axiom_encode_version": "0.2.1196",
+  "backend": "manual",
+  "citation": "us-mn:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T06:33:47.691474+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
+  "generated_output_sha256": "e83bd457ca4dc2831f679f22bf707d6dcd8724795dd7529e62a24321937a0507",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "311be8d8bafacdb9c258451eae5b9c2a6846936cc1d0216d564a8891d2dfdd96"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8244,6 +8244,12 @@
     ],
     "us-ct/statute/12-700": [
       {
+        "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ct/statutes/12-700.yaml",
         "via": [
           "module"
@@ -8251,6 +8257,12 @@
       }
     ],
     "us-ct/statute/12-704e": [
+      {
+        "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ct/statutes/12-704e.yaml",
         "via": [
@@ -8360,6 +8372,12 @@
     ],
     "us-de/statute/30/1102": [
       {
+        "module": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-de/statutes/30/1102.yaml",
         "via": [
           "module",
@@ -8368,6 +8386,12 @@
       }
     ],
     "us-de/statute/30/1108": [
+      {
+        "module": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-de/statutes/30/1108.yaml",
         "via": [
@@ -8386,6 +8410,12 @@
       }
     ],
     "us-de/statute/30/1110": [
+      {
+        "module": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-de/statutes/30/1110.yaml",
         "via": [
@@ -12633,6 +12663,12 @@
     ],
     "us-md/statute/gtg/10-105": [
       {
+        "module": "us-md/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-md/statutes/gtg/10-105.yaml",
         "via": [
           "module",
@@ -12641,6 +12677,12 @@
       }
     ],
     "us-md/statute/gtg/10-211": [
+      {
+        "module": "us-md/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-md/statutes/gtg/10-211.yaml",
         "via": [
@@ -12660,6 +12702,12 @@
     ],
     "us-me/statute/36/5111": [
       {
+        "module": "us-me/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-me/statutes/36/5111.yaml",
         "via": [
           "module",
@@ -12668,6 +12716,12 @@
       }
     ],
     "us-me/statute/36/5124-C": [
+      {
+        "module": "us-me/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-me/statutes/36/5124-C.yaml",
         "via": [
@@ -12768,6 +12822,12 @@
     ],
     "us-mn/statute/290.0123": [
       {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-mn/statutes/290/0123.yaml",
         "via": [
           "module",
@@ -12776,6 +12836,12 @@
       }
     ],
     "us-mn/statute/290.06": [
+      {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-mn/statutes/290/06.yaml",
         "via": [

--- a/bulk/PROGRESS-us-suite-lane-a3.md
+++ b/bulk/PROGRESS-us-suite-lane-a3.md
@@ -1,0 +1,56 @@
+# US suite lane A3 — composed DE/MD/ME/MN/CT income-tax liability pipelines
+
+Continues lane A/A2 (OH pilot; AL/ID/KY shipped). Composes the five teed-up
+states into `us-XX/policies/income_tax/pilot_liability_pipeline` + per-case suite
+vs pinned PolicyEngine-US (penny-exact) and TAXSIM-2024 in axiom-oracles.
+
+Branches (from origin/main): rulespec-us `lane-a3-suite-20260709`,
+axiom-oracles `lane-a3-oracles-20260709`. Sibling worktree layout under
+`_axiom-worktrees/lane-a-suite-20260708/{rulespec-us,axiom-oracles}` so the oracle
+generator's `REPO_ROOT.parent/"rulespec-us"` resolves.
+
+## Pipeline shape (all five)
+
+Multi-bracket generalization of the OH/AL two-tier form — per case supply the
+cumulative base tax at the bracket floor, the floor, and the bracket marginal
+rate (progress-note "cumulative base + marginal, like OH"):
+- `xx_pit_pilot_taxable_income = max(0, AGI - supplied_standard_deduction)`
+- `xx_pit_pilot_schedule_tax = supplied_bracket_base + supplied_marginal_rate * max(0, taxable - supplied_bracket_floor)`
+- `xx_pit_pilot_income_tax_liability = max(0, schedule_tax - supplied_nonrefundable_credit)`
+
+Inputs: AGI, standard_deduction, bracket_floor, bracket_base, marginal_rate,
+nonrefundable_credit (all per-case supplied indexed/current authority).
+
+## Per-state (PE 2026 `_before_refundable_credits`, all penny-exact)
+
+- **DE** §1102 (fixed brackets); credit = §1110 personal credit 110/220.
+  single 988.125/2653.125/8559; married 2362.75/6254.5/18134.5.
+- **MD** §10-105 STATE only (county tax = separate PE var, excluded); credit 0.
+  single 1059/2484/7039.5; married 2168.125/5018.125/14695.75.
+- **ME** §5111 (indexed); credit 0. single 565.5/2428.52/9483.72;
+  married 1131/4857.05/18966.73. Rate §5111 + std-ded §5124-C landed via the L–N
+  batch (composability re-verified post-train; ME note resolved, no #757 ledger).
+- **MN** §290.06 subd. 2c (indexed); credit 0 except married-300k, where the
+  supplied credit is the negative §290.091 AMT (mn_amt=182.58, binds above the
+  regular tax). single 789.125/2560.00/8946.08; married 1575.57/5376.45/18727.88.
+- **CT** §12-700 (resident schedule deferred on main → supplied); credit = net
+  §12-703 personal credit / §12-700(b) 3% phase-out recapture (negative where
+  recapture dominates: -475 / -200 / -950). single 361.25/2317.5/8225;
+  married 1494/5300/16450.
+
+## Status
+
+- [x] Phase 1 rulespec-us: 5 pipelines authored, `axiom-encode test` 30/30 cent-
+  exact, signed (`--manual-exception composition`), reverse index + pending sync
+  (ceiling 531→537, dup key fixed). Commit f4d4b25b. PR: pending.
+- [ ] Phase 2 axiom-oracles: generator (`_TAXSIM_STATE`/`_PE_VAR`/`_TOL` DE=8 MD=21
+  ME=20 MN=24 CT=7), comparisons+dispositions (TAXSIM-2024 vintage; MD also the
+  siitax county-tax scope gap), concept_mappings append-only, us-pe.yaml suite
+  rows, test_conformance live_pe_suites +5, scoreboard/affected/vacuous regen.
+
+## Notes
+
+- AL/ID/KY oracle registration merged (or#254) but rulespec pilots unmerged
+  (rus#773 BLOCKED); for the phase-2 generator run, AL/ID/KY `.test.yaml` are
+  copied UNTRACKED into the rulespec-us worktree (documented UT/VA workaround
+  pattern) so `_axiom_liabilities()` completes. UT/VA now on rulespec-us main.

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 531
-ceiling: 531
+ceiling: 537
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -412,6 +411,15 @@ entries:
   - legal_id: us-la:statutes/47:297/8#louisiana_earned_income_tax_credit
     source: bulk
     since: 2026-07-08
+  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income
+    source: bulk
+    since: 2026-07-09
   - legal_id: us-me:statutes/36/5111#head_of_household_band_0_upper
     source: bulk
     since: 2026-07-08
@@ -550,6 +558,15 @@ entries:
   - legal_id: us-mi:statutes/206/272#total_earned_income_tax_credit_allowed
     source: bulk
     since: 2026-07-08
+  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income
+    source: bulk
+    since: 2026-07-09
   - legal_id: us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
     source: bulk
     since: 2026-07-08

--- a/us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,106 @@
+# Fixtures are hand-computed at the 2026 tax year (expected values are the
+# author's shown arithmetic from the supplied schedule, which axiom-encode test
+# proves equal the engine output to full decimal precision, not an oracle
+# read-back). Connecticut section 12-700 graduated tax less the net section 12-704c personal credit / section 12-700(b) 3-percent phase-out recapture (negative credit = recapture exceeds the personal credit).
+- name: single_30000
+  # taxable 15000; schedule 200 + 0.045*max(0,15000-10000) = 425; less credit 63.75 -> liability 361.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 30000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 15000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 10000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 200
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.045
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 63.75
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '15000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '425'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '361.25'
+- name: single_60000
+  # taxable 60000; schedule 2000 + 0.055*max(0,60000-50000) = 2550; less credit 232.5 -> liability 2317.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 60000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 50000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 2000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.055
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 232.5
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '60000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '2550'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '2317.5'
+- name: single_150000
+  # taxable 150000; schedule 4750 + 0.06*max(0,150000-100000) = 7750; less credit -475 -> liability 8225.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 150000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 100000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 4750
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.06
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -475
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '150000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '7750'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '8225'
+- name: married_60000
+  # taxable 48000; schedule 400 + 0.045*max(0,48000-20000) = 1660; less credit 166 -> liability 1494.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 60000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 12000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 20000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 400
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.045
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 166
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '48000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '1660'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '1494'
+- name: married_120000
+  # taxable 120000; schedule 4000 + 0.055*max(0,120000-100000) = 5100; less credit -200 -> liability 5300.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 120000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 100000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 4000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.055
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -200
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '120000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '5100'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '5300'
+- name: married_300000
+  # taxable 300000; schedule 9500 + 0.06*max(0,300000-200000) = 15500; less credit -950 -> liability 16450.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 300000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 200000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 9500
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.06
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -950
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '300000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '15500'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '16450'

--- a/us-ct/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ct/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,128 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ct/statute/12-700
+      - us-ct/statute/12-704e
+      - us-ct/statute/12-704i
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ct/statute/12-700
+        - us-ct/statute/12-704e
+        - us-ct/statute/12-704i
+      rationale: |-
+        This pipeline computes the Connecticut section 12-700 individual
+        income-tax liability for the ordinary resident wage-earner slice: the
+        graduated tax on Connecticut taxable income (Connecticut adjusted gross
+        income less the section 12-702 personal exemption) less the net of the
+        section 12-703 personal credit and the section 12-700(b) three-per-cent
+        phase-out (benefit recapture). The section 12-700 resident tax SCHEDULE is
+        carried on main as a deferred output (its bracket table depends on upstream
+        filing-status sources not yet imported), so this pipeline supplies the
+        operative 2026 schedule directly — the 3, 5, 5.5, 6, 6.5, 6.9, and 6.99 per
+        cent brackets — exactly as the Ohio pilot supplies its indexed schedule.
+        Because the six-case grid crosses several brackets, each case supplies the
+        cumulative tax at its bracket floor, that floor, and the bracket marginal
+        rate, so the schedule reproduces the graduated tax as the supplied
+        cumulative base plus the supplied marginal rate on taxable income above the
+        floor. To reach a liability comparable to PolicyEngine ct_income_tax to the
+        cent, the amounts this pipeline needs are declared caller-supplied inputs:
+        the section 12-702 personal exemption (15,000 single / 24,000 joint,
+        phased out one dollar per dollar over the threshold, so the supplied
+        subtraction is zero in the higher-income cases), the per-case bracket
+        floor, the cumulative base tax at that floor, the bracket marginal rate,
+        and a single supplied credit standing for the NET of the section 12-703
+        personal credit (which reduces the tax at lower income) and the section
+        12-700(b) three-per-cent phase-out and tax recapture (which ADD to the tax
+        at higher income) — so the supplied credit is positive where the personal
+        credit dominates and negative where the recapture dominates. The pipeline
+        adds no numeric literals of its own; it wires the graduated-tax mechanics
+        only. The section 12-702 exemption and the section 12-703 credit / section
+        12-700(b) recapture are supplied here pending their own executable
+        encodings, mirroring the California pilot's supplied standard deduction and
+        personal exemption credit.
+  summary: |-
+    Composed Connecticut individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Connecticut adjusted gross income into the section 12-700 graduated tax on
+    Connecticut taxable income, so an end-to-end comparison against PolicyEngine
+    (ct_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
+    the caller to supply the 12-700 bracket application, the section 12-703
+    personal credit, or the section 12-700(b) recapture. It wires: Connecticut
+    taxable income (Connecticut AGI less the supplied section 12-702 personal
+    exemption); the graduated tax as the supplied cumulative base tax at the
+    case's bracket floor plus the supplied marginal rate on taxable income above
+    that floor, which reproduces the statutory 3/5/5.5/6/6.5/6.9/6.99-per-cent
+    schedule for filers above the floor; and that tax less the supplied credit —
+    the net of the section 12-703 personal credit and the section 12-700(b)
+    three-per-cent phase-out / tax recapture, hence positive at lower income and
+    negative (a net addition) at higher income — floored at zero. It deliberately
+    models only the ordinary resident wage earner and excludes the property-tax
+    and earned-income credits, all zero for the childless wage-earner grid.
+    Connecticut AGI, filing status, the personal exemption, the bracket floor,
+    base, and marginal rate, and the net credit are supplied inputs; the exemption
+    and credit thresholds are indexed, so this 2026 pipeline is compared against
+    PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with the
+    indexation vintage dispositioned.
+rules:
+  - name: ct_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-700 and 12-702, Connecticut taxable income after the supplied personal exemption
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-700
+              excerpt: "Connecticut taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_supplied_standard_deduction)
+  - name: ct_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-700, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-700
+              excerpt: "the tax shall be"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ct_pit_pilot_supplied_bracket_base
+          + ct_pit_pilot_supplied_marginal_rate * max(0, ct_pit_pilot_taxable_income - ct_pit_pilot_supplied_bracket_floor)
+  - name: ct_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-700 graduated tax less the supplied net 12-703 credit / 12-700(b) recapture, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/statute/12-704e
+              excerpt: "credit against the tax"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ct_pit_pilot_schedule_tax - ct_pit_pilot_supplied_nonrefundable_credit)

--- a/us-de/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-de/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,120 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the section 1102 schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). Delaware liability = the section 1102 graduated tax on Delaware
+# taxable income (Delaware AGI - the section 1108 standard deduction: 3,250 single
+# / 6,500 joint) less the section 1110 personal credit (110 per exemption). Each
+# case supplies the cumulative tax at its bracket floor, the floor, and the
+# bracket marginal rate: floor 25,000 / base 1,001 / 5.55 per cent for the
+# 5.55-per-cent bracket (cumulative 0 + .022*3000 + .039*5000 + .048*10000 +
+# .052*5000 = 1,001 at 25,000), and floor 60,000 / base 2,943.5 / 6.6 per cent for
+# the top bracket (1,001 + .0555*35000 = 2,943.5 at 60,000). PolicyEngine
+# de_income_tax_before_refundable_credits matches to the cent.
+- name: single_30000
+  # taxable 30000-3250 = 26750. Schedule 1001 + 0.0555*(26750-25000) = 1001 + 97.125
+  # = 1098.125. Less 110 personal credit: liability 988.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 30000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '26750'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '1098.125'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '988.125'
+- name: single_60000
+  # taxable 56750. Schedule 1001 + 0.0555*(56750-25000) = 1001 + 1762.125 = 2763.125.
+  # Less 110: liability 2653.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 60000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '56750'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '2763.125'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '2653.125'
+- name: single_150000
+  # taxable 146750. Top bracket: 2943.5 + 0.066*(146750-60000) = 2943.5 + 5725.5
+  # = 8669.0. Less 110: liability 8559.0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 150000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '146750'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '8669'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '8559'
+- name: married_60000
+  # MFJ, spouse income 0. taxable 60000-6500 = 53500. Schedule 1001 + 0.0555*(53500-25000)
+  # = 1001 + 1581.75 = 2582.75. Less 220 (two exemptions): liability 2362.75.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 60000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '53500'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '2582.75'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '2362.75'
+- name: married_120000
+  # taxable 113500. Top bracket: 2943.5 + 0.066*(113500-60000) = 2943.5 + 3531 = 6474.5.
+  # Less 220: liability 6254.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 120000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '113500'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '6474.5'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '6254.5'
+- name: married_300000
+  # taxable 293500. Top bracket: 2943.5 + 0.066*(293500-60000) = 2943.5 + 15411 = 18354.5.
+  # Less 220: liability 18134.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 300000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '293500'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '18354.5'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '18134.5'

--- a/us-de/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-de/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,121 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-de/statute/30/1102
+      - us-de/statute/30/1108
+      - us-de/statute/30/1110
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-de/statute/30/1102
+        - us-de/statute/30/1108
+        - us-de/statute/30/1110
+      rationale: |-
+        This pipeline computes the Delaware section 1102 individual income-tax
+        liability for the ordinary resident wage-earner slice: the graduated tax
+        on Delaware taxable income (Delaware adjusted gross income less the
+        section 1108 standard deduction) less the section 1110 personal credits.
+        The encoded 1102 module carries the statutory rate schedule — zero on the
+        first 2,000 dollars, 2.2 per cent to 5,000, 3.9 per cent to 10,000, 4.8
+        per cent to 20,000, 5.2 per cent to 25,000, 5.55 per cent to 60,000, and
+        6.6 per cent above 60,000 — and those bracket boundaries are fixed in
+        statute (Delaware does not index them). Because the six-case grid crosses
+        the 5.55-per-cent and 6.6-per-cent brackets, each case supplies the
+        cumulative tax at its bracket floor, that floor, and the bracket's
+        marginal rate, so the schedule reproduces the graduated tax as the
+        supplied cumulative base plus the supplied marginal rate on taxable income
+        above the floor. To reach a liability comparable to PolicyEngine
+        de_income_tax to the cent, the amounts this pipeline needs are declared
+        caller-supplied inputs: the section 1108 standard deduction (3,250 dollars
+        single, 6,500 dollars joint), the per-case bracket floor, the cumulative
+        base tax at that floor, the bracket marginal rate, and the section 1110
+        personal credit (110 dollars per exemption — 110 single, 220 for the
+        two-exemption joint filer). The pipeline adds no numeric literals of its
+        own; it wires the graduated-tax mechanics only. The section 1108 standard
+        deduction and section 1110 personal-credit provisions are supplied here
+        pending their own executable encodings, mirroring the California pilot's
+        supplied standard deduction and personal exemption credit.
+  summary: |-
+    Composed Delaware individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Delaware adjusted gross income into the section 1102 graduated tax on Delaware
+    taxable income less the section 1110 personal credits, so an end-to-end
+    comparison against PolicyEngine (de_income_tax_before_refundable_credits) and
+    TAXSIM (siitax) does not require the caller to supply the 1102 bracket
+    application or the 1110 credit. It wires: Delaware taxable income (Delaware
+    AGI less the supplied section 1108 standard deduction); the graduated tax as
+    the supplied cumulative base tax at the case's bracket floor plus the supplied
+    marginal rate on taxable income above that floor, which reproduces the
+    statutory 0/2.2/3.9/4.8/5.2/5.55/6.6-per-cent schedule for filers above the
+    floor; and that tax less the supplied section 1110 personal credit, floored at
+    zero. It deliberately models only the ordinary resident wage earner and
+    excludes the section 1109 itemized-deduction election, the lump-sum and
+    business schedules, and the refundable/earned-income credits, all of which are
+    zero for the childless wage-earner grid. Delaware AGI, filing status, the
+    standard deduction, the bracket floor, base, and marginal rate, and the
+    personal credit are supplied inputs; Delaware's brackets are fixed in statute,
+    so this pipeline is compared against PolicyEngine at 2026 and against TAXSIM's
+    latest 2024 law year with the 2024-to-2026 vintage dispositioned rather than
+    absorbed by tolerance.
+rules:
+  - name: de_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 1102 and 1108, Delaware taxable income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1108
+              excerpt: "the standard deduction of a resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, de_pit_pilot_adjusted_gross_income - de_pit_pilot_supplied_standard_deduction)
+  - name: de_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 1102, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1102
+              excerpt: "tax table income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          de_pit_pilot_supplied_bracket_base
+          + de_pit_pilot_supplied_marginal_rate * max(0, de_pit_pilot_taxable_income - de_pit_pilot_supplied_bracket_floor)
+  - name: de_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 1102 graduated tax less the 1110 personal credits, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/statute/30/1110
+              excerpt: "personal credits"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, de_pit_pilot_schedule_tax - de_pit_pilot_supplied_nonrefundable_credit)

--- a/us-md/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-md/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,106 @@
+# Fixtures are hand-computed at the 2026 tax year (expected values are the
+# author's shown arithmetic from the supplied schedule, which axiom-encode test
+# proves equal the engine output to full decimal precision, not an oracle
+# read-back). Maryland section 10-105 state graduated tax (county tax is a separate PE variable, not modeled) on Maryland taxable income.
+- name: single_30000
+  # taxable 23400; schedule 90 + 0.0475*max(0,23400-3000) = 1059; less credit 0 -> liability 1059.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 30000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 6600
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 3000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 90
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.0475
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '23400'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '1059'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '1059'
+- name: single_60000
+  # taxable 53400; schedule 90 + 0.0475*max(0,53400-3000) = 2484; less credit 0 -> liability 2484.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 60000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 6600
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 3000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 90
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.0475
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '53400'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '2484'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '2484'
+- name: single_150000
+  # taxable 145800; schedule 5947.5 + 0.0525*max(0,145800-125000) = 7039.5; less credit 0 -> liability 7039.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 150000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 4200
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 125000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 5947.5
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.0525
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '145800'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '7039.5'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '7039.5'
+- name: married_60000
+  # taxable 46750; schedule 90 + 0.0475*max(0,46750-3000) = 2168.125; less credit 0 -> liability 2168.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 60000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 13250
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 3000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 90
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.0475
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '46750'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '2168.125'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '2168.125'
+- name: married_120000
+  # taxable 106750; schedule 90 + 0.0475*max(0,106750-3000) = 5018.125; less credit 0 -> liability 5018.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 120000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 13250
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 3000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 90
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.0475
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '106750'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '5018.125'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '5018.125'
+- name: married_300000
+  # taxable 293150; schedule 10947.5 + 0.055*max(0,293150-225000) = 14695.75; less credit 0 -> liability 14695.75.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_adjusted_gross_income: 300000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_standard_deduction: 6850
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_floor: 225000
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_bracket_base: 10947.5
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_marginal_rate: 0.055
+    us-md:policies/income_tax/pilot_liability_pipeline#input.md_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_taxable_income: '293150'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_schedule_tax: '14695.75'
+    us-md:policies/income_tax/pilot_liability_pipeline#md_pit_pilot_income_tax_liability: '14695.75'

--- a/us-md/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-md/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,120 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-md/statute/gtg/10-105
+      - us-md/statute/gtg/10-211
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-md/statute/gtg/10-105
+        - us-md/statute/gtg/10-211
+      rationale: |-
+        This pipeline computes the Maryland Tax-General section 10-105 STATE
+        individual income-tax liability for the ordinary resident wage-earner
+        slice: the graduated state tax on Maryland taxable income (Maryland
+        adjusted gross income less the standard deduction and the section 10-211
+        personal exemptions). The encoded 10-105 module carries the statutory
+        state rate schedule — 2 per cent on the first 1,000 dollars, 3 per cent to
+        2,000, 4 per cent to 3,000, 4.75 per cent to 100,000 (single) / 150,000
+        (joint), then 5, 5.25, 5.5, and 5.75 per cent bands above. Because the
+        six-case grid crosses several brackets, each case supplies the cumulative
+        state tax at its bracket floor, that floor, and the bracket marginal rate,
+        so the schedule reproduces the graduated state tax as the supplied
+        cumulative base plus the supplied marginal rate on taxable income above the
+        floor. This pipeline models the STATE tax only: the county income tax
+        (Tax-General section 10-103, a separate PolicyEngine variable md_county_tax)
+        is out of scope, so the target is PolicyEngine
+        md_income_tax_before_refundable_credits (the state analog) and no county
+        rate is supplied. To reach a liability comparable to that variable to the
+        cent, the amounts this pipeline needs are declared caller-supplied inputs:
+        the standard-deduction-plus-section-10-211-exemption subtraction (which
+        the section 10-211 exemption phase-out reduces at higher income), the
+        per-case bracket floor, the cumulative base tax at that floor, and the
+        bracket marginal rate. Maryland allows no per-exemption state tax credit on
+        this grid, so the supplied credit is zero. The pipeline adds no numeric
+        literals of its own; it wires the graduated-tax mechanics only. The
+        standard deduction and section 10-211 exemption amounts are supplied here
+        pending their own executable encodings, mirroring the California pilot's
+        supplied standard deduction.
+  summary: |-
+    Composed Maryland STATE individual income-tax liability pipeline for the
+    oracle slice at the 2026 tax year. It exposes a TaxUnit-level path from a
+    supplied Maryland adjusted gross income into the section 10-105 graduated
+    state tax on Maryland taxable income, so an end-to-end comparison against
+    PolicyEngine (md_income_tax_before_refundable_credits) and TAXSIM (siitax)
+    does not require the caller to supply the 10-105 bracket application. It
+    wires: Maryland taxable income (Maryland AGI less the supplied standard
+    deduction and section 10-211 exemptions); the graduated state tax as the
+    supplied cumulative base tax at the case's bracket floor plus the supplied
+    marginal rate on taxable income above that floor, which reproduces the
+    statutory 2/3/4/4.75/5/5.25/5.5/5.75-per-cent state schedule for filers above
+    the floor; and that tax less the supplied credit (zero for Maryland), floored
+    at zero. It deliberately models only the resident wage earner and the STATE
+    tax; the county income tax (section 10-103) and refundable credits are
+    excluded. Maryland AGI, filing status, the deduction/exemption subtraction,
+    the bracket floor, base, and marginal rate, and the credit are supplied
+    inputs; PolicyEngine is compared at the 2026 tax year and TAXSIM at its latest
+    2024 law year, with the 2024-to-2026 vintage and TAXSIM's inclusion of the
+    Maryland local tax dispositioned rather than absorbed by tolerance.
+rules:
+  - name: md_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 10-105 and 10-211, Maryland taxable income after the supplied deduction and exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+              excerpt: "An individual may deduct exemptions for the taxpayer"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, md_pit_pilot_adjusted_gross_income - md_pit_pilot_supplied_standard_deduction)
+  - name: md_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 10-105, graduated state tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+              excerpt: "State income tax rate schedules for individuals"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          md_pit_pilot_supplied_bracket_base
+          + md_pit_pilot_supplied_marginal_rate * max(0, md_pit_pilot_taxable_income - md_pit_pilot_supplied_bracket_floor)
+  - name: md_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 10-105 graduated state tax less the supplied credit (zero for Maryland), floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+              excerpt: "the State income tax is the sum of"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, md_pit_pilot_schedule_tax - md_pit_pilot_supplied_nonrefundable_credit)

--- a/us-me/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-me/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,106 @@
+# Fixtures are hand-computed at the 2026 tax year (expected values are the
+# author's shown arithmetic from the supplied schedule, which axiom-encode test
+# proves equal the engine output to full decimal precision, not an oracle
+# read-back). Maine section 5111 graduated tax on Maine taxable income (no credit).
+- name: single_30000
+  # taxable 9750; schedule 0 + 0.058*max(0,9750-0) = 565.5; less credit 0 -> liability 565.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 30000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 20250
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 0
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 0
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.058
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '9750'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '565.5'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '565.5'
+- name: single_60000
+  # taxable 39750; schedule 1554.4 + 0.0675*max(0,39750-26800) = 2428.525; less credit 0 -> liability 2428.525.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 60000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 20250
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 26800
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 1554.4
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.0675
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '39750'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '2428.525'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '2428.525'
+- name: single_150000
+  # taxable 139750; schedule 4028.275 + 0.0715*max(0,139750-63450) = 9483.725; less credit 0 -> liability 9483.725.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 150000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 10250
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 63450
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 4028.275
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.0715
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '139750'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '9483.725'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '9483.725'
+- name: married_60000
+  # taxable 19500; schedule 0 + 0.058*max(0,19500-0) = 1131; less credit 0 -> liability 1131.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 60000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 40500
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 0
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 0
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.058
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '19500'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '1131'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '1131'
+- name: married_120000
+  # taxable 79500; schedule 3108.8 + 0.0675*max(0,79500-53600) = 4857.05; less credit 0 -> liability 4857.05.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 120000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 40500
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 53600
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 3108.8
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.0675
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '79500'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '4857.05'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '4857.05'
+- name: married_300000
+  # taxable 279490; schedule 8056.55 + 0.0715*max(0,279490-126900) = 18966.735; less credit 0 -> liability 18966.735.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_adjusted_gross_income: 300000
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_standard_deduction: 20510
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_floor: 126900
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_bracket_base: 8056.55
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_marginal_rate: 0.0715
+    us-me:policies/income_tax/pilot_liability_pipeline#input.me_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income: '279490'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax: '18966.735'
+    us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability: '18966.735'

--- a/us-me/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-me/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,121 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-me/statute/36/5111
+      - us-me/statute/36/5124-C
+      - us-me/statute/36/5126-A
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-me/statute/36/5111
+        - us-me/statute/36/5124-C
+        - us-me/statute/36/5126-A
+      rationale: |-
+        This pipeline computes the Maine section 5111 individual income-tax
+        liability for the ordinary resident wage-earner slice: the graduated tax
+        on Maine taxable income (Maine adjusted gross income less the section
+        5124-C standard deduction and the section 5126-A personal exemption). The
+        encoded 5111 module carries the statutory rate tables — for tax years
+        beginning on or after January 1, 2017 a three-bracket schedule of 5.8,
+        6.75, and 7.15 per cent — but section 5111 subsection 1-F requires the
+        Assessor to adjust the bracket dollar amounts each year for inflation, so
+        the operative 2026 bracket boundaries are indexed values PolicyEngine
+        projects (26,800 / 63,450 single; 53,600 / 126,900 joint). Because the
+        six-case grid crosses all three brackets, each case supplies the
+        cumulative tax at its bracket floor, that floor, and the bracket marginal
+        rate, so the schedule reproduces the graduated tax as the supplied
+        cumulative base plus the supplied marginal rate on taxable income above the
+        floor. To reach a liability comparable to PolicyEngine me_income_tax to the
+        cent, the amounts this pipeline needs are declared caller-supplied inputs:
+        the section 5124-C standard deduction plus the section 5126-A personal
+        exemption (both indexed and both phased out at higher income, so the
+        supplied subtraction shrinks in the top cases), the per-case bracket floor,
+        the cumulative base tax at that floor, and the bracket marginal rate. Maine
+        applies no per-exemption tax credit on this childless grid, so the supplied
+        credit is zero. The pipeline adds no numeric literals of its own; it wires
+        the graduated-tax mechanics only. The section 5124-C deduction and section
+        5126-A exemption amounts are supplied here pending their own executable
+        encodings, mirroring the California pilot's supplied standard deduction.
+  summary: |-
+    Composed Maine individual income-tax liability pipeline for the oracle slice
+    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Maine
+    adjusted gross income into the section 5111 graduated tax on Maine taxable
+    income, so an end-to-end comparison against PolicyEngine
+    (me_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
+    the caller to supply the 5111 bracket application. It wires: Maine taxable
+    income (Maine AGI less the supplied section 5124-C standard deduction and
+    section 5126-A personal exemption); the graduated tax as the supplied
+    cumulative base tax at the case's bracket floor plus the supplied marginal
+    rate on taxable income above that floor, which reproduces the statutory
+    5.8/6.75/7.15-per-cent schedule for filers above the floor; and that tax less
+    the supplied credit (zero for Maine on this grid), floored at zero. It
+    deliberately models only the ordinary resident wage earner and excludes the
+    property-tax-fairness and other refundable credits, all zero for the childless
+    wage-earner grid. Maine AGI, filing status, the deduction/exemption
+    subtraction, the bracket floor, base, and marginal rate, and the credit are
+    supplied inputs; the Assessor indexes the brackets and the deduction/exemption
+    each year, so this 2026 pipeline is compared against PolicyEngine at 2026 and
+    against TAXSIM's latest 2024 law year with the indexation vintage
+    dispositioned.
+rules:
+  - name: me_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 5111 and 5124-C/5126-A, Maine taxable income after the supplied standard deduction and personal exemption
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5124-C
+              excerpt: "the standard deduction of a resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, me_pit_pilot_adjusted_gross_income - me_pit_pilot_supplied_standard_deduction)
+  - name: me_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 5111, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "imposes individual income tax tables"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          me_pit_pilot_supplied_bracket_base
+          + me_pit_pilot_supplied_marginal_rate * max(0, me_pit_pilot_taxable_income - me_pit_pilot_supplied_bracket_floor)
+  - name: me_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 5111 graduated tax less the supplied credit (zero for Maine on this grid), floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-me/statute/36/5111
+              excerpt: "the tax imposed by this section"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, me_pit_pilot_schedule_tax - me_pit_pilot_supplied_nonrefundable_credit)

--- a/us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,106 @@
+# Fixtures are hand-computed at the 2026 tax year (expected values are the
+# author's shown arithmetic from the supplied schedule, which axiom-encode test
+# proves equal the engine output to full decimal precision, not an oracle
+# read-back). Minnesota section 290.06 subd. 2c graduated tax; the top married case adds the section 290.091 alternative minimum tax as a negative supplied credit.
+- name: single_30000
+  # taxable 14750; schedule 0 + 0.0535*max(0,14750-0) = 789.125; less credit 0 -> liability 789.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 30000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0535
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '14750'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '789.125'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '789.125'
+- name: single_60000
+  # taxable 44750; schedule 1782.085 + 0.068*max(0,44750-33310) = 2560.005; less credit 0 -> liability 2560.005.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 60000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 33310
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 1782.085
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.068
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '44750'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2560.005'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '2560.005'
+- name: single_150000
+  # taxable 134750; schedule 6956.885 + 0.0785*max(0,134750-109410) = 8946.075; less credit 0 -> liability 8946.075.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 150000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 109410
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 6956.885
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0785
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '134750'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '8946.075'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '8946.075'
+- name: married_60000
+  # taxable 29450; schedule 0 + 0.0535*max(0,29450-0) = 1575.575; less credit 0 -> liability 1575.575.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 60000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 30550
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0535
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '29450'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1575.575'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '1575.575'
+- name: married_120000
+  # taxable 89450; schedule 2605.45 + 0.068*max(0,89450-48700) = 5376.45; less credit 0 -> liability 5376.45.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 120000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 30550
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 48700
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 2605.45
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.068
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '89450'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '5376.45'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '5376.45'
+- name: married_300000
+  # taxable 271119.5; schedule 12449.81 + 0.0785*max(0,271119.5-193470) = 18545.29575; less credit -182.58 -> liability 18727.87575.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 300000
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 28880.5
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 193470
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 12449.81
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0785
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: -182.58
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '271119.5'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '18545.29575'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '18727.87575'

--- a/us-mn/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-mn/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,127 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-mn/statute/290.06
+      - us-mn/statute/290.0123
+      - us-mn/statute/290.0121
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-mn/statute/290.06
+        - us-mn/statute/290.0123
+        - us-mn/statute/290.0121
+      rationale: |-
+        This pipeline computes the Minnesota section 290.06 subdivision 2c
+        individual income-tax liability for the ordinary resident wage-earner
+        slice: the graduated tax on Minnesota taxable income (Minnesota adjusted
+        gross income less the section 290.0123 standard deduction and the section
+        290.0121 exemptions). The encoded 290.06 module carries the statutory
+        subdivision 2c schedule — 5.35, 6.8, 7.85, and 9.85 per cent — but
+        subdivision 2d requires the Commissioner to adjust the bracket dollar
+        amounts each year for inflation under section 270C.22, so the operative
+        2026 bracket boundaries are indexed values PolicyEngine projects (33,310 /
+        109,410 / 203,130 single; 48,700 / 193,470 / 337,900 joint). Because the
+        six-case grid crosses several brackets, each case supplies the cumulative
+        tax at its bracket floor, that floor, and the bracket marginal rate, so the
+        schedule reproduces the graduated tax as the supplied cumulative base plus
+        the supplied marginal rate on taxable income above the floor. To reach a
+        liability comparable to PolicyEngine mn_income_tax to the cent, the amounts
+        this pipeline needs are declared caller-supplied inputs: the section
+        290.0123 standard deduction plus the section 290.0121 exemptions (indexed,
+        and phased out at higher income so the supplied subtraction shrinks in the
+        top married case), the per-case bracket floor, the cumulative base tax at
+        that floor, and the bracket marginal rate. The supplied credit carries the
+        section 290.091 alternative minimum tax as a NEGATIVE credit in the one
+        case where it binds (the 300,000-dollar married filer, whose 6.75-per-cent
+        alternative minimum tax exceeds the regular subdivision-2c tax by 182.58
+        dollars); every other case has a zero supplied credit. The pipeline adds no
+        numeric literals of its own; it wires the graduated-tax mechanics only. The
+        section 290.0123 deduction, section 290.0121 exemption, and section 290.091
+        alternative-minimum-tax provisions are supplied here pending their own
+        executable encodings, mirroring the California pilot's supplied standard
+        deduction.
+  summary: |-
+    Composed Minnesota individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Minnesota adjusted gross income into the section 290.06 subdivision 2c
+    graduated tax on Minnesota taxable income, so an end-to-end comparison against
+    PolicyEngine (mn_income_tax_before_refundable_credits) and TAXSIM (siitax)
+    does not require the caller to supply the subdivision-2c bracket application.
+    It wires: Minnesota taxable income (Minnesota AGI less the supplied section
+    290.0123 standard deduction and section 290.0121 exemptions); the graduated
+    tax as the supplied cumulative base tax at the case's bracket floor plus the
+    supplied marginal rate on taxable income above that floor, which reproduces the
+    statutory 5.35/6.8/7.85/9.85-per-cent schedule for filers above the floor; and
+    that tax less the supplied credit — zero except for the top married filer,
+    where the supplied credit is the negative section 290.091 alternative minimum
+    tax addition that binds above the regular tax — floored at zero. It
+    deliberately models only the ordinary resident wage earner and excludes the
+    working-family and other refundable credits, all zero for the childless
+    wage-earner grid. Minnesota AGI, filing status, the deduction/exemption
+    subtraction, the bracket floor, base, and marginal rate, and the credit are
+    supplied inputs; the Commissioner indexes the brackets and the
+    deduction/exemption each year, so this 2026 pipeline is compared against
+    PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with the
+    indexation vintage dispositioned.
+rules:
+  - name: mn_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 290.06 and 290.0123/290.0121, Minnesota taxable income after the supplied standard deduction and exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.0123
+              excerpt: "standard deduction"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, mn_pit_pilot_adjusted_gross_income - mn_pit_pilot_supplied_standard_deduction)
+  - name: mn_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 290.06 subd. 2c, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.06
+              excerpt: "income tax rate schedules for individuals"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          mn_pit_pilot_supplied_bracket_base
+          + mn_pit_pilot_supplied_marginal_rate * max(0, mn_pit_pilot_taxable_income - mn_pit_pilot_supplied_bracket_floor)
+  - name: mn_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 290.06 subd. 2c graduated tax less the supplied credit (negative = the 290.091 alternative minimum tax addition), floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.06
+              excerpt: "the tax imposed by this section"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, mn_pit_pilot_schedule_tax - mn_pit_pilot_supplied_nonrefundable_credit)


### PR DESCRIPTION
Composes the five remaining lane-A composable states into
`us-XX/policies/income_tax/pilot_liability_pipeline`, mirroring the us-oh pilot
(#769) and the AL/ID/KY pipelines (#773). Extends the two-tier form to a
multi-bracket per-case supplied cumulative base + marginal rate above the bracket
floor.

Each state is a TaxUnit-level path from state AGI into the graduated tax on state
taxable income for the ordinary resident wage earner; six companion cases (single
+ married, 30k–300k) reproduce PolicyEngine `<state>_income_tax_before_refundable_credits`
at the 2026 tax year to the cent. `axiom-encode test` proves the fixtures equal
the engine output — **30/30**.

| State | Section | Notes |
| --- | --- | --- |
| DE | §1102 | fixed brackets; §1110 personal credit 110/220 |
| MD | §10-105 | STATE tax only (county tax is a separate PE variable, excluded) |
| ME | §5111 | indexed 5.8/6.75/7.15% tables |
| MN | §290.06 subd. 2c | indexed; top married case supplies the §290.091 AMT as a negative credit |
| CT | §12-700 | resident schedule deferred on main → supplied; net §12-703 credit / §12-700(b) 3% recapture |

Manifests attested with `sign-applied-files --manual-exception composition`;
reverse index regenerated; `oracle-coverage-pending` synced (ceiling 531→537,
duplicate ceiling key collapsed, pending `check` passes).

Oracle-side registration (comparisons, dispositions, us-pe covered rows) lands in
the companion axiom-oracles PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
