### PR TITLE
Point Alaska CMS eligibility sources at body block

### DIFF
--- a/.axiom/encoding-manifests/us-ak/policies/cms/alaska-chip-eligibility.json
+++ b/.axiom/encoding-manifests/us-ak/policies/cms/alaska-chip-eligibility.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "us-ak/policies/cms/alaska-chip-eligibility.yaml",
-      "sha256": "cadb5094415603972f16fdfb1e3e39269c3073a8852605eaad21804ca17f4a90"
+      "sha256": "c8feeb95fa975591e64c7b0623d8bf96598950e5185ab0acc3321cd3d3bf86a7"
     },
     {
       "path": "us-ak/policies/cms/alaska-chip-eligibility.test.yaml",
@@ -10,32 +10,41 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "d38939e03029442e88414de9896e96c8dea847a2",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-chip-eligibility-composition-infra-20260705",
-    "version": "0.2.1138",
-    "version_commit": "d38939e03029442e88414de9896e96c8dea847a2"
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1138",
-  "backend": "deterministic",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
   "citation": "us-ak:policies/cms/alaska-chip-eligibility",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-05T08:13:55.394440+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpanqzbp84/deterministic-cms-chip-eligibility-composition/us-ak/policies/cms/alaska-chip-eligibility.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpanqzbp84",
-  "generated_output_sha256": "cadb5094415603972f16fdfb1e3e39269c3073a8852605eaad21804ca17f4a90",
+  "generated_at": "2026-07-09T15:04:42.547764+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpo6438djw/sign-applied-files/us-ak/policies/cms/alaska-chip-eligibility.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpo6438djw",
+  "generated_output_sha256": "c8feeb95fa975591e64c7b0623d8bf96598950e5185ab0acc3321cd3d3bf86a7",
   "generation_prompt_sha256": null,
-  "model": "cms-chip-eligibility-composition-v1",
-  "run_id": "deterministic-cms-chip-eligibility-composition",
-  "runner": "deterministic-generator",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "7d2728fd522fa751658f1a4edc1c39c8fae8d7ebeb9beb1a92c95e742f9bbbfc"
+    "value": "2731074418a6eee745258e9f815fd1b8f9e07e58039d01d425be47e1c39eb7fb"
   },
-  "tool": "axiom-encode generate-cms-chip-eligibility-composition",
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-07-05T08:13:55.394440+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "7315dfe90fb7d980b168174977bd7aa1a8fd09cb2f13b888f7a1b90afe30d165",
+    "prior_signature": "7d2728fd522fa751658f1a4edc1c39c8fae8d7ebeb9beb1a92c95e742f9bbbfc",
+    "run_id": "deterministic-cms-chip-eligibility-composition",
+    "tool": "axiom-encode generate-cms-chip-eligibility-composition"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.json
+++ b/.axiom/encoding-manifests/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml",
-      "sha256": "c816d6493f0315f485c06bb09907ab9292bcad217b55df5ed28f2f8c6de66dfd"
+      "sha256": "4ef3ad21b68080c84f8231588280abeba0cde12fa2fc58fcd1487741e60c91e5"
     },
     {
       "path": "us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.test.yaml",
@@ -10,32 +10,41 @@
     }
   ],
   "axiom_encode_git": {
-    "commit": "52ea0fe67d178d9dcbad744a4cd05664a27224cf",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1136",
-    "version_commit": "8fbbcf0410b6ed712af403e38b4ecca6ed3e78fd"
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1136",
-  "backend": "deterministic",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
   "citation": "us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-05T06:04:52.410825+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj51set98/deterministic-cms-eligibility-levels/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj51set98",
-  "generated_output_sha256": "c816d6493f0315f485c06bb09907ab9292bcad217b55df5ed28f2f8c6de66dfd",
+  "generated_at": "2026-07-09T15:04:42.549522+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpo6438djw/sign-applied-files/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpo6438djw",
+  "generated_output_sha256": "4ef3ad21b68080c84f8231588280abeba0cde12fa2fc58fcd1487741e60c91e5",
   "generation_prompt_sha256": null,
-  "model": "cms-medicaid-chip-eligibility-levels-v1",
-  "run_id": "deterministic-cms-eligibility-levels",
-  "runner": "deterministic-generator",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "907201280b276b9b301d6c73f6b6fe6daf147eaa3132df804cf3cbf87e99666d"
+    "value": "29c462a187b58177bc49463a3e742c05393eb2917123cda4843d5b9c13c9b745"
   },
-  "tool": "axiom-encode generate-cms-medicaid-chip-eligibility-levels",
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-07-05T06:04:52.410825+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "8b44bf956d11bcd6324c80987c9aa7a48aa4e77add46ecd0ed6cb47d4352b119",
+    "prior_signature": "907201280b276b9b301d6c73f6b6fe6daf147eaa3132df804cf3cbf87e99666d",
+    "run_id": "deterministic-cms-eligibility-levels",
+    "tool": "axiom-encode generate-cms-medicaid-chip-eligibility-levels"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -22949,19 +22949,6 @@
     ],
     "us/form/cms/medicaid-chip-bhp-eligibility-levels": [
       {
-        "module": "us-ak/policies/cms/alaska-chip-eligibility.yaml",
-        "via": [
-          "proof_atom"
-        ]
-      },
-      {
-        "module": "us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-al/policies/cms/alabama-chip-eligibility.yaml",
         "via": [
           "proof_atom"
@@ -23606,6 +23593,21 @@
       },
       {
         "module": "us-wy/policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1": [
+      {
+        "module": "us-ak/policies/cms/alaska-chip-eligibility.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us-ak/policies/cms/alaska-chip-eligibility.yaml
+++ b/us-ak/policies/cms/alaska-chip-eligibility.yaml
@@ -7,7 +7,7 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
-      - us/form/cms/medicaid-chip-bhp-eligibility-levels
+      - us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
       - us/statute/42/1397jj/b/1
       - us/statute/42/1397ll/d/2
     upstream_source_check:
@@ -44,7 +44,7 @@ rules:
             import:
               target: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_separate_chip_available
               output: alaska_children_separate_chip_available
-              hash: sha256:c816d6493f0315f485c06bb09907ab9292bcad217b55df5ed28f2f8c6de66dfd
+              hash: sha256:4ef3ad21b68080c84f8231588280abeba0cde12fa2fc58fcd1487741e60c91e5
     versions:
       - effective_from: '2023-12-01'
         formula: |-
@@ -61,7 +61,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "Children Separate CHIP"
     versions:
       - effective_from: '2023-12-01'
@@ -80,7 +80,7 @@ rules:
             import:
               target: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_pregnant_women_chip_available
               output: alaska_pregnant_women_chip_available
-              hash: sha256:c816d6493f0315f485c06bb09907ab9292bcad217b55df5ed28f2f8c6de66dfd
+              hash: sha256:4ef3ad21b68080c84f8231588280abeba0cde12fa2fc58fcd1487741e60c91e5
     versions:
       - effective_from: '2023-12-01'
         formula: |-
@@ -97,7 +97,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "Pregnant Women CHIP"
     versions:
       - effective_from: '2023-12-01'

--- a/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml
+++ b/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml
@@ -5,7 +5,7 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
     upstream_source_check:
       status: official_parameter_source
       checked_paths:
@@ -37,7 +37,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "203%"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -57,7 +57,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "203%"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -77,7 +77,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "203%"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -97,7 +97,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "N/A"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -117,7 +117,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "200%"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -137,7 +137,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "N/A"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -157,7 +157,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "130%($)"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -177,7 +177,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "130%($)"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -197,7 +197,7 @@ rules:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "133%"
               table:
                 header: "State Medicaid, CHIP and BHP Income Eligibility Standards"
@@ -223,7 +223,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "5% FPL disregard"
     versions:
       - effective_from: '2023-12-01'
@@ -245,7 +245,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "5% FPL disregard"
     versions:
       - effective_from: '2023-12-01'
@@ -267,7 +267,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "5% FPL disregard"
     versions:
       - effective_from: '2023-12-01'
@@ -289,7 +289,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels/block-1
               excerpt: "5% FPL disregard"
     versions:
       - effective_from: '2023-12-01'


### PR DESCRIPTION
## Summary
- updates Alaska CMS eligibility modules to cite the body-bearing CMS eligibility-levels block path
- refreshes the Alaska CMS import hashes, manifests, and reverse index

## Checks
- `find /tmp/rulespec-us-work/us-ak -name "*.yaml" -not -name "*.test.yaml" -print | sort | xargs uv run axiom-encode validate --skip-reviewers`
- `uv run axiom-encode proof-validate --require-money-atoms --ratchet-file /tmp/rulespec-us-work/known-missing-money-atoms.yaml --money-atom-root /tmp/rulespec-us-work /tmp/rulespec-us-work/us-ak/policies/cms/alaska-chip-eligibility.yaml /tmp/rulespec-us-work/us-ak/policies/cms/alaska-medicaid-chip-bhp-eligibility-levels.yaml`
- `python tests/generate_reverse_index.py --check`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py`

## Cycle
- ready for /cycle review after focused local checks passed