### PR TITLE
Enable axiom-skills plugins (essential + encoding)

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -1,6 +1,7 @@
 version: 1
 allowed_root_directories:
   - .axiom
+  - .claude
   - .github
   - bulk
   - programs
@@ -79,6 +80,10 @@ path_rules:
       - ".txt"
       - ".toml"
       - ".yaml"
+  - patterns:
+      - ".claude/**"
+    allow_extensions:
+      - ".json"
   - patterns:
       - ".github/**"
     allow_extensions:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "axiom-skills": {
+      "source": {
+        "source": "github",
+        "repo": "TheAxiomFoundation/axiom-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "essential@axiom-skills": true,
+    "encoding@axiom-skills": true
+  }
+}


### PR DESCRIPTION
Pilot rollout of the org skill layer ([axiom-skills](https://github.com/TheAxiomFoundation/axiom-skills)).

Fresh clones get prompted to enable the `essential` (ecosystem boundaries, RuleSpec format, engine usage, writing voice + Axiom MCP) and `encoding` (encode gauntlet, corpus, oracles) bundles — every session starts with the same conventions the repo currently relies on reviewers to enforce.

No effect on CI or on contributors who decline the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)