### PR TITLE
Batch-encode 6 us RuleSpec module(s) (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -24852,6 +24852,15 @@
         ]
       }
     ],
+    "us/regulation/7/247/9/b": [
+      {
+        "module": "us/regulations/7-cfr/247/9/b.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/7/273/10": [
       {
         "module": "us/regulations/7-cfr/273/10.yaml",
@@ -25561,6 +25570,13 @@
     ],
     "us/statute/26/164": [
       {
+        "module": "us/statutes/26/164.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us/statutes/26/164/f.yaml",
         "via": [
           "module",
@@ -25627,9 +25643,45 @@
         ]
       }
     ],
+    "us/statute/26/219/b": [
+      {
+        "module": "us/statutes/26/219/b.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/219/g": [
+      {
+        "module": "us/statutes/26/219/g.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/22": [
       {
         "module": "us/statutes/26/22.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/221": [
+      {
+        "module": "us/statutes/26/221.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/223/b": [
+      {
+        "module": "us/statutes/26/223/b.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 578
+ceiling: 648
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1741,5 +1741,215 @@ entries:
     source: bulk
     since: 2026-07-09
   - legal_id: us:policies/usda/snap/fy-2024-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#certified_federal_program_adjunctive_income_eligible
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#maximum_csfp_household_income_limit_fpg_ratio
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#state_administered_program_adjunctive_income_eligible
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#state_agency_csfp_income_limit_complies
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:regulations/7-cfr/247/9/b#subject_to_prior_elderly_pilot_income_criteria
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#applicable_limitation_amount_after_calendar_year_2029
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#applicable_limitation_amount_annual_adjustment_factor
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2025
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2026
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#applicable_limitation_amount_phaseout_floor
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#married_separate_applicable_limitation_fraction
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_phaseout_rate
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_annual_adjustment_factor
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2025
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2026
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#personal_property_tax
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#purchaser_real_property_tax_treated_as_imposed
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/164#seller_real_property_tax_treated_as_imposed
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#catch_up_age_threshold
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#catch_up_applicable_amount_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#catch_up_cost_of_living_rounding_multiple
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#deductible_amount_before_compensation_limit
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#deductible_amount_cost_of_living_rounding_multiple
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#maximum_general_deduction_amount
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#maximum_plan_contribution_deduction_amount
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#plan_contribution_compensation_limit_rate
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#plan_contribution_limit_amount
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#section_applies_to_contribution
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/b#statutory_deductible_amount_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#active_participant
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#active_participant_before_exceptions
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#adjusted_gross_income_for_subsection
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_joint_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_other_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_separate_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#inflation_adjustment_start_year_threshold
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#inflation_rounding_multiple
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#minimum_limitation_before_complete_phaseout
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#phaseout_denominator_joint
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#phaseout_denominator_other
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#reduction_rounding_multiple
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#reserve_component_active_duty_exception_limit_days
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#reserve_component_participation_not_active_participant_solely_for_that_participation
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#spouse_not_active_participant_applicable_dollar_amount_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#spouses_filing_separately_living_apart_not_treated_as_married
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#subsection_applies_to_individual
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#volunteer_firefighter_accrued_benefit_limit
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#volunteer_firefighter_annuity_commencement_age
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#statutory_student_loan_interest_deduction_cap
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_joint_return
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_other_return
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_joint_return
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_other_return
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_age_threshold
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_2
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_3
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_4
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_5
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_6
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#family_coverage_annual_limit
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#individual_attained_additional_contribution_age
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#monthly_proration_denominator
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#self_only_coverage_annual_limit
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#testing_period_additional_tax_rate
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/223/b#testing_period_month_count
     source: bulk
     since: 2026-07-09

--- a/us/.axiom/encoding-manifests/regulations/7-cfr/247/9/b.json
+++ b/us/.axiom/encoding-manifests/regulations/7-cfr/247/9/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/7-cfr/247/9/b.yaml",
+      "sha256": "5429426e80a220064349cbdca97c980ff12be42e3fa2907629b11349150fcbc5"
+    },
+    {
+      "path": "regulations/7-cfr/247/9/b.test.yaml",
+      "sha256": "d218cc97375decc38449d0cf5ab21fbe0eafaf442acd9923623b050696092bdf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/regulation/7/247/9/b",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-regulation-7-247-9-b/encode-out/_eval_workspaces/codex-gpt-5.5/us-regulation-7-247-9-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "a4f29dda0ce3a3c99eb3fb8320f3239f6942c740d3462ffa00a9a0c14e530554",
+  "generated_at": "2026-07-09T15:24:14.271744+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-regulation-7-247-9-b/encode-out/codex-gpt-5.5/regulations/7-cfr/247/9/b.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-regulation-7-247-9-b/encode-out",
+  "generated_output_sha256": "5429426e80a220064349cbdca97c980ff12be42e3fa2907629b11349150fcbc5",
+  "generation_prompt_sha256": "e9ec5e543604856b4de27efb7f29655b031ffb8c8d9302f7a7756f37bbc819aa",
+  "model": "gpt-5.5",
+  "run_id": "128f8d85",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "914c97c6c501724cb43e080082a7bc05f4549bf2336b1c1ed8a0a306fa15884a"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-regulation-7-247-9-b/encode-out/traces/codex-gpt-5.5/us-regulation-7-247-9-b.json",
+  "trace_sha256": "a72f2df01d38901e378433cd4550140f1b890d644d48dfd2c0b0b122166749e1"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/164.json
+++ b/us/.axiom/encoding-manifests/statutes/26/164.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/164.yaml",
+      "sha256": "b2117d82bb081394e0656beecce4ced901a1f3035c9039291da61c599dbd5dc3"
+    },
+    {
+      "path": "statutes/26/164.test.yaml",
+      "sha256": "2495587bf99a1ce5b928a085a0d88363522d189ac195f0ad12ca532ee3c27201"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/statute/26/164",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-164/encode-out/_eval_workspaces/codex-gpt-5.5/us-statute-26-164/workspace/context-manifest.json",
+  "context_manifest_sha256": "94d0b8644d5b50da474c4cc5d9376fc468f84b93a0a87943fb79c147518f9daf",
+  "generated_at": "2026-07-09T15:09:20.476703+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-164/encode-out/codex-gpt-5.5/statutes/26/164.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-164/encode-out",
+  "generated_output_sha256": "b2117d82bb081394e0656beecce4ced901a1f3035c9039291da61c599dbd5dc3",
+  "generation_prompt_sha256": "a4f0b6ce79bfeff4d8cc14a66003c25864a078203386a1ff286fe24c59777024",
+  "model": "gpt-5.5",
+  "run_id": "91148952",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c0b403240bda286b29f139581c6192d98a14fa359f3dfe430c1c2d75a272dd7f"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-164/encode-out/traces/codex-gpt-5.5/us-statute-26-164.json",
+  "trace_sha256": "8696941fa39856923dca243de5b64061e9547bce3831c182149e5d0177b74e02"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/219/b.json
+++ b/us/.axiom/encoding-manifests/statutes/26/219/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/219/b.yaml",
+      "sha256": "0c917160defee34519e1a3b2dd1bf2d4658cddf200908116357a8dd1eb99a8f1"
+    },
+    {
+      "path": "statutes/26/219/b.test.yaml",
+      "sha256": "b807df7eb7d41c08fb05f730c179d2676dcd755ecde28839dfe4475c63bff8b7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/statute/26/219/b",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-b/encode-out/_eval_workspaces/codex-gpt-5.5/us-statute-26-219-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "5a13a6c13181522f69cdca15f30270a4a7e5c7e1a8c3e8dd0573e50827e2ecc8",
+  "generated_at": "2026-07-09T15:23:54.890357+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-b/encode-out/codex-gpt-5.5/statutes/26/219/b.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-b/encode-out",
+  "generated_output_sha256": "0c917160defee34519e1a3b2dd1bf2d4658cddf200908116357a8dd1eb99a8f1",
+  "generation_prompt_sha256": "c9ff67644ea112e2388917d2939e920a4e36bc43644c50db8aae2fe9b4aea2df",
+  "model": "gpt-5.5",
+  "run_id": "60e0c8c1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e27372afbf861fdabc5ccdcc51071f6c7da9be3c08bf9baa2145bc9cbef4ca88"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-b/encode-out/traces/codex-gpt-5.5/us-statute-26-219-b.json",
+  "trace_sha256": "97b11ca3e9202aaff1c2b60165b9ce251e1af6c076b584f0e34aea38b3ec9f74"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/219/g.json
+++ b/us/.axiom/encoding-manifests/statutes/26/219/g.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/219/g.yaml",
+      "sha256": "6c4e54a5eeb420d061f4423d5060253a2b794e58e00dade857d426091f268139"
+    },
+    {
+      "path": "statutes/26/219/g.test.yaml",
+      "sha256": "d0d700c4b28981e2e7c5a11666aaec823e7e9ffdb5bf9a03ebdf39eb7da3ae6a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/statute/26/219/g",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-g/encode-out/_eval_workspaces/codex-gpt-5.5/us-statute-26-219-g/workspace/context-manifest.json",
+  "context_manifest_sha256": "d539aa0668f39fbd644db1e9732435625e0555b9613fb65e041d566163187bf1",
+  "generated_at": "2026-07-09T15:28:58.181303+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-g/encode-out/codex-gpt-5.5/statutes/26/219/g.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-g/encode-out",
+  "generated_output_sha256": "6c4e54a5eeb420d061f4423d5060253a2b794e58e00dade857d426091f268139",
+  "generation_prompt_sha256": "799c23191fef2c36b15200c25882b6bb07a61d22a26829b617b49d5655d69b5c",
+  "model": "gpt-5.5",
+  "run_id": "1fd4aa63",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4ebcd1453734e64a073215aa69f467f32e0a7d7b99e266c00a5e9a6384ee3f59"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-219-g/encode-out/traces/codex-gpt-5.5/us-statute-26-219-g.json",
+  "trace_sha256": "e0efcad80c01b375c2632917288053b4178b1ab7c84a120ea9b7064c3688e1e8"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/221.json
+++ b/us/.axiom/encoding-manifests/statutes/26/221.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/221.yaml",
+      "sha256": "a091ba00e20a801444f7f95c3f3a8e391f7d5e5895125764cae8ee17c3a6a9e5"
+    },
+    {
+      "path": "statutes/26/221.test.yaml",
+      "sha256": "60039121963309aa3ae1ea055125deabf95ef8ae5a66b3a155bea5b57a4e73e7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/statute/26/221",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-221/encode-out/_eval_workspaces/codex-gpt-5.5/us-statute-26-221/workspace/context-manifest.json",
+  "context_manifest_sha256": "05fec4a81ec33962b940c228789932b3c71c33fd98ac0308ea83dfb116fe8612",
+  "generated_at": "2026-07-09T15:08:22.957997+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-221/encode-out/codex-gpt-5.5/statutes/26/221.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-221/encode-out",
+  "generated_output_sha256": "a091ba00e20a801444f7f95c3f3a8e391f7d5e5895125764cae8ee17c3a6a9e5",
+  "generation_prompt_sha256": "abee6d6c7feff983b31f1a31a6839276e82427c108d72c463521cee92abce433",
+  "model": "gpt-5.5",
+  "run_id": "2d470f21",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1fc6638d7c7a3f6af44a271c8cb2a06206555aea3986cba9949918214f218c59"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-221/encode-out/traces/codex-gpt-5.5/us-statute-26-221.json",
+  "trace_sha256": "5db93f0e324ea6c5a09e1460ef51e34f8ef13ce7280b7d521ecb60d6c6eabc04"
+}

--- a/us/.axiom/encoding-manifests/statutes/26/223/b.json
+++ b/us/.axiom/encoding-manifests/statutes/26/223/b.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/223/b.yaml",
+      "sha256": "c7bbff7e7b92731b0f5ffafffd05550440e8a665cd84a9141c54b69737d0d71a"
+    },
+    {
+      "path": "statutes/26/223/b.test.yaml",
+      "sha256": "93d8c6caa0571ee62db6b111e8b18270b7882cac5ecd939cf3bc67d078a4c532"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "db4571c323556c590cd258f21d849b3ce146a341",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1184",
+    "version_commit": "db4571c323556c590cd258f21d849b3ce146a341"
+  },
+  "axiom_encode_version": "0.2.1184",
+  "backend": "codex",
+  "citation": "us/statute/26/223/b",
+  "context_manifest_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-223-b/encode-out/_eval_workspaces/codex-gpt-5.5/us-statute-26-223-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "23bd5820a9675b2ce4c7640970479fecd120b102b6f56fa3963e5321dd3b3f91",
+  "generated_at": "2026-07-09T15:25:01.729858+00:00",
+  "generated_output_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-223-b/encode-out/codex-gpt-5.5/statutes/26/223/b.yaml",
+  "generated_output_root": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-223-b/encode-out",
+  "generated_output_sha256": "c7bbff7e7b92731b0f5ffafffd05550440e8a665cd84a9141c54b69737d0d71a",
+  "generation_prompt_sha256": "6db158de0bcdf7430ab4684c106b4d1d5d2d1dcab699f2b56f8d3e7135b36f68",
+  "model": "gpt-5.5",
+  "run_id": "2c289fa4",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1535b99c977df656124d10cd868f7faf103202c217cfe523a388ab1f620c8f85"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/us-statute-26-223-b/encode-out/traces/codex-gpt-5.5/us-statute-26-223-b.json",
+  "trace_sha256": "553e51fe5c429b087fcf8c57019c2e2a91662a20108fbff03359ca56d43a49f7"
+}

--- a/us/regulations/7-cfr/247/9/b.test.yaml
+++ b/us/regulations/7-cfr/247/9/b.test.yaml
@@ -1,0 +1,93 @@
+- name: household-income-at-or-below-state-limit
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/247/9/b#input.certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects: false
+    us:regulations/7-cfr/247/9/b#input.household_income_at_or_below_state_agency_csfp_income_limit: true
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_snap: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_food_distribution_program_on_indian_reservations: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_ssi: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_low_income_subsidy_program: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_medicare_savings_programs: false
+    us:regulations/7-cfr/247/9/b#input.participates_in_state_administered_program_not_listed_in_paragraph_b: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_routinely_requires_income_documentation: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_income_guidelines_at_or_below_state_csfp_threshold: false
+  output:
+    us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule: holds
+- name: snap-adjunctive-income-eligibility
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/247/9/b#input.certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects: false
+    us:regulations/7-cfr/247/9/b#input.household_income_at_or_below_state_agency_csfp_income_limit: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_snap: true
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_food_distribution_program_on_indian_reservations: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_ssi: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_low_income_subsidy_program: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_medicare_savings_programs: false
+    us:regulations/7-cfr/247/9/b#input.participates_in_state_administered_program_not_listed_in_paragraph_b: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_routinely_requires_income_documentation: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_income_guidelines_at_or_below_state_csfp_threshold: false
+  output:
+    us:regulations/7-cfr/247/9/b#certified_federal_program_adjunctive_income_eligible: holds
+    us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp: holds
+    us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule: holds
+- name: state-administered-program-adjunctive-income-eligibility
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/247/9/b#input.certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects: false
+    us:regulations/7-cfr/247/9/b#input.household_income_at_or_below_state_agency_csfp_income_limit: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_snap: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_food_distribution_program_on_indian_reservations: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_ssi: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_low_income_subsidy_program: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_medicare_savings_programs: false
+    us:regulations/7-cfr/247/9/b#input.participates_in_state_administered_program_not_listed_in_paragraph_b: true
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_routinely_requires_income_documentation: true
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_income_guidelines_at_or_below_state_csfp_threshold: true
+  output:
+    us:regulations/7-cfr/247/9/b#state_administered_program_adjunctive_income_eligible: holds
+    us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp: holds
+    us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule: holds
+- name: prior-elderly-pilot-certification-blocks-current-rule
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/247/9/b#input.certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects: true
+    us:regulations/7-cfr/247/9/b#input.household_income_at_or_below_state_agency_csfp_income_limit: true
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_snap: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_food_distribution_program_on_indian_reservations: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_ssi: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_low_income_subsidy_program: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_medicare_savings_programs: false
+    us:regulations/7-cfr/247/9/b#input.participates_in_state_administered_program_not_listed_in_paragraph_b: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_routinely_requires_income_documentation: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_income_guidelines_at_or_below_state_csfp_threshold: false
+  output:
+    us:regulations/7-cfr/247/9/b#subject_to_prior_elderly_pilot_income_criteria: holds
+    us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule: not_holds
+- name: auto_output_state_agency_csfp_income_limit_complies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/7-cfr/247/9/b#input.certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects: 0
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_food_distribution_program_on_indian_reservations: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_low_income_subsidy_program: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_medicare_savings_programs: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_snap: false
+    us:regulations/7-cfr/247/9/b#input.certified_fully_eligible_for_ssi: false
+    us:regulations/7-cfr/247/9/b#input.household_income_at_or_below_state_agency_csfp_income_limit: false
+    us:regulations/7-cfr/247/9/b#input.participates_in_state_administered_program_not_listed_in_paragraph_b: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_income_guidelines_at_or_below_state_csfp_threshold: false
+    us:regulations/7-cfr/247/9/b#input.state_administered_program_routinely_requires_income_documentation: false
+    us:regulations/7-cfr/247/9/b#input.state_agency_csfp_household_income_limit_fpg_ratio: 0
+  output:
+    us:regulations/7-cfr/247/9/b#state_agency_csfp_income_limit_complies: holds
+- name: auto_positive_state_agency_csfp_income_limit_complies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:regulations/7-cfr/247/9/b#input.state_agency_csfp_household_income_limit_fpg_ratio: 0
+  output:
+    us:regulations/7-cfr/247/9/b#state_agency_csfp_income_limit_complies: holds

--- a/us/regulations/7-cfr/247/9/b.yaml
+++ b/us/regulations/7-cfr/247/9/b.yaml
@@ -1,0 +1,144 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/247/9/b
+  summary: |-
+    The State agency must use a household income limit at or below 150 percent of the Federal Poverty Guidelines. Participants in households at or below this level are income-eligible, except participants certified before September 17, 1986 remain subject to prior criteria. The State agency may accept full eligibility for listed Federal programs, or certain State-administered program participation, as adjunctive income eligibility.
+rules:
+  - name: maximum_csfp_household_income_limit_fpg_ratio
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+              excerpt: "at or below 150 percent of the U.S. Federal Poverty Guidelines"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.50
+
+  - name: state_agency_csfp_income_limit_complies
+    kind: derived
+    entity: StateAgency
+    dtype: Judgment
+    period: Year
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          state_agency_csfp_household_income_limit_fpg_ratio <= maximum_csfp_household_income_limit_fpg_ratio
+
+  - name: certified_federal_program_adjunctive_income_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          certified_fully_eligible_for_snap
+          or certified_fully_eligible_for_food_distribution_program_on_indian_reservations
+          or certified_fully_eligible_for_ssi
+          or certified_fully_eligible_for_low_income_subsidy_program
+          or certified_fully_eligible_for_medicare_savings_programs
+
+  - name: state_administered_program_adjunctive_income_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          participates_in_state_administered_program_not_listed_in_paragraph_b
+          and state_administered_program_routinely_requires_income_documentation
+          and state_administered_program_income_guidelines_at_or_below_state_csfp_threshold
+
+  - name: adjunctively_income_eligible_for_csfp
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          certified_federal_program_adjunctive_income_eligible
+          or state_administered_program_adjunctive_income_eligible
+
+  - name: subject_to_prior_elderly_pilot_income_criteria
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+              excerpt: "participants certified before September 17, 1986"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          certified_before_current_csfp_income_rule_cutover_under_elderly_pilot_projects
+
+  - name: csfp_income_eligible_under_current_rule
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 247.9(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/247/9/b
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not subject_to_prior_elderly_pilot_income_criteria
+          and (household_income_at_or_below_state_agency_csfp_income_limit
+          or adjunctively_income_eligible_for_csfp)

--- a/us/statutes/26/164.test.yaml
+++ b/us/statutes/26/164.test.yaml
@@ -1,0 +1,54 @@
+- name: ad_valorem_annual_personal_property_tax_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164#input.tax_is_ad_valorem: true
+    us:statutes/26/164#input.tax_is_imposed_on_annual_basis_in_respect_of_personal_property: true
+  output:
+    us:statutes/26/164#personal_property_tax: holds
+- name: non_ad_valorem_tax_is_not_personal_property_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164#input.tax_is_ad_valorem: false
+    us:statutes/26/164#input.tax_is_imposed_on_annual_basis_in_respect_of_personal_property: true
+  output:
+    us:statutes/26/164#personal_property_tax: not_holds
+- name: non_annual_personal_property_basis_tax_is_not_personal_property_tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164#input.tax_is_ad_valorem: true
+    us:statutes/26/164#input.tax_is_imposed_on_annual_basis_in_respect_of_personal_property: false
+  output:
+    us:statutes/26/164#personal_property_tax: not_holds
+- name: sale_during_real_property_tax_year_apportions_tax_between_seller_and_purchaser
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164#input.real_property_sold_during_real_property_tax_year: true
+    us:statutes/26/164#input.real_property_tax_properly_allocable_to_period_before_sale: 3000
+    us:statutes/26/164#input.real_property_tax_properly_allocable_to_period_beginning_on_sale_date: 2000
+  output:
+    us:statutes/26/164#seller_real_property_tax_treated_as_imposed: 3000
+    us:statutes/26/164#purchaser_real_property_tax_treated_as_imposed: 2000
+- name: no_sale_during_real_property_tax_year_no_subsection_d_apportionment_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164#input.real_property_sold_during_real_property_tax_year: false
+    us:statutes/26/164#input.real_property_tax_properly_allocable_to_period_before_sale: 3000
+    us:statutes/26/164#input.real_property_tax_properly_allocable_to_period_beginning_on_sale_date: 2000
+  output:
+    us:statutes/26/164#seller_real_property_tax_treated_as_imposed: 0
+    us:statutes/26/164#purchaser_real_property_tax_treated_as_imposed: 0

--- a/us/statutes/26/164.yaml
+++ b/us/statutes/26/164.yaml
@@ -1,0 +1,269 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/164
+  summary: Section 164 allows specified taxes as deductions, defines personal property
+    taxes and other special rules, limits individual deductions for certain years,
+    and apportions real property taxes between seller and purchaser when real property
+    is sold during a real property tax year.
+  deferred_outputs:
+  - output: us:statutes/26/164#a_general_tax_deduction
+    reason: The general deduction combines multiple tax categories, trade-or-business
+      and section 212 activity treatment, acquisition/disposition capitalization,
+      GST treatment, and individual limitations; several cited dependencies are unavailable
+      or require separate upstream encodings.
+  - output: us:statutes/26/164/b#gst_tax_imposed_on_income_distributions
+    reason: GST tax treatment depends on unavailable sections 2601, 2604, and 666.
+  - output: us:statutes/26/164/b#state_and_local_general_sales_tax_deduction_under_secretary_tables
+    reason: The optional table method depends on tables prescribed by the Secretary
+      and on section 68(b) applicable amount mechanics not represented here.
+  - output: us:statutes/26/164/b#individual_tax_deduction_limitation_after_married_separate_adjustment_and_phaseout
+    reason: The final limitation requires upstream filing-status classification for
+      married individuals filing separate returns and temporal application across
+      taxable-year beginning dates.
+    source_values:
+    - us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2025
+    - us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2026
+    - us:statutes/26/164#applicable_limitation_amount_annual_adjustment_factor
+    - us:statutes/26/164#applicable_limitation_amount_after_calendar_year_2029
+    - us:statutes/26/164#modified_adjusted_gross_income_phaseout_rate
+    - us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2025
+    - us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2026
+    - us:statutes/26/164#modified_adjusted_gross_income_threshold_annual_adjustment_factor
+    - us:statutes/26/164#applicable_limitation_amount_phaseout_floor
+    - us:statutes/26/164#married_separate_applicable_limitation_fraction
+  - output: us:statutes/26/164/d#real_property_tax_treated_as_paid_or_accrued_on_sale_date
+    reason: Subsection (d)(2) depends on method-of-accounting consequences and liability
+      under the law imposing the real property tax; this artifact encodes only the
+      subsection (d)(1) apportionment amounts.
+rules:
+- name: personal_property_tax
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: 26 USC 164(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: "The term \u201Cpersonal property tax\u201D means an ad valorem\
+            \ tax which is imposed on an annual basis in respect of personal property."
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'tax_is_ad_valorem
+
+      and tax_is_imposed_on_annual_basis_in_respect_of_personal_property'
+- name: applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2025
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(A)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning in calendar year 2025,
+            $40,000
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '40000'
+- name: applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2026
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(A)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning in calendar year 2026,
+            $40,400
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '40400'
+- name: applicable_limitation_amount_annual_adjustment_factor
+  kind: parameter
+  dtype: Decimal
+  source: 26 USC 164(b)(7)(A)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: 101 percent of the dollar amount in effect under this subparagraph
+            for taxable years beginning in the preceding calendar year
+  versions:
+  - effective_from: '2027-01-01'
+    formula: '1.01'
+- name: applicable_limitation_amount_after_calendar_year_2029
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(A)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning after calendar year 2029,
+            $10,000
+  versions:
+  - effective_from: '2030-01-01'
+    formula: '10000'
+- name: modified_adjusted_gross_income_phaseout_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 164(b)(7)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: reduced by 30 percent of the excess
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '0.30'
+- name: modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2025
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(B)(ii)(I)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning in calendar year 2025,
+            $500,000
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '500000'
+- name: modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2026
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(B)(ii)(II)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning in calendar year 2026,
+            $505,000
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '505000'
+- name: modified_adjusted_gross_income_threshold_annual_adjustment_factor
+  kind: parameter
+  dtype: Decimal
+  source: 26 USC 164(b)(7)(B)(ii)(III)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: in the case of any taxable year beginning after calendar year 2026,
+            101 percent of the dollar amount in effect under this subparagraph for
+            taxable years beginning in the preceding calendar year
+  versions:
+  - effective_from: '2027-01-01'
+    formula: '1.01'
+- name: applicable_limitation_amount_phaseout_floor
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 164(b)(7)(B)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: shall not result in the applicable limitation amount being less
+            than $10,000
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '10000'
+- name: married_separate_applicable_limitation_fraction
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 164(b)(6)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: half the applicable limitation amount in the case of a married
+            individual filing a separate return
+  versions:
+  - effective_from: '2018-01-01'
+    formula: 1 / 2
+- name: seller_real_property_tax_treated_as_imposed
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 164(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: so much of the real property tax as is properly allocable to that
+            part of such year which ends on the day before the date of the sale shall
+            be treated as a tax imposed on the seller
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if real_property_sold_during_real_property_tax_year: max(0, real_property_tax_properly_allocable_to_period_before_sale)
+      else: 0'
+- name: purchaser_real_property_tax_treated_as_imposed
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 164(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/164
+          excerpt: so much of such tax as is properly allocable to that part of such
+            year which begins on the date of the sale shall be treated as a tax imposed
+            on the purchaser
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if real_property_sold_during_real_property_tax_year: max(0, real_property_tax_properly_allocable_to_period_beginning_on_sale_date)
+      else: 0'

--- a/us/statutes/26/219/b.test.yaml
+++ b/us/statutes/26/219/b.test.yaml
@@ -1,0 +1,67 @@
+- name: general deduction limited by deductible amount with catch-up
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/b#input.age: 50
+    us:statutes/26/219/b#input.compensation_includible_in_gross_income: 10000
+  output:
+    us:statutes/26/219/b#deductible_amount_before_compensation_limit: 6000
+    us:statutes/26/219/b#maximum_general_deduction_amount: 6000
+- name: general deduction limited by compensation without catch-up
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/b#input.age: 49
+    us:statutes/26/219/b#input.compensation_includible_in_gross_income: 3000
+  output:
+    us:statutes/26/219/b#deductible_amount_before_compensation_limit: 5000
+    us:statutes/26/219/b#maximum_general_deduction_amount: 3000
+- name: section does not apply to excluded contribution categories
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/b#input.contribution_is_employer_contribution_to_simplified_employee_pension: true
+    us:statutes/26/219/b#input.contribution_is_amount_contributed_to_simple_retirement_account: false
+  output:
+    us:statutes/26/219/b#section_applies_to_contribution: not_holds
+- name: plan contribution deduction uses lesser of dollar cap and twenty five percent
+    compensation
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/b#input.contribution_on_behalf_of_employee_to_plan_described_in_section_501_c_18: true
+    us:statutes/26/219/b#input.compensation: 20000
+  output:
+    us:statutes/26/219/b#maximum_plan_contribution_deduction_amount: 5000
+- name: auto_zero_maximum_plan_contribution_deduction_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/219/b#input.age: 0
+    us:statutes/26/219/b#input.compensation: false
+    us:statutes/26/219/b#input.compensation_includible_in_gross_income: 0
+    us:statutes/26/219/b#input.contribution_is_amount_contributed_to_simple_retirement_account: false
+    us:statutes/26/219/b#input.contribution_is_employer_contribution_to_simplified_employee_pension: false
+    us:statutes/26/219/b#input.contribution_on_behalf_of_employee_to_plan_described_in_section_501_c_18: false
+  output:
+    us:statutes/26/219/b#maximum_plan_contribution_deduction_amount: 0
+- name: auto_positive_section_applies_to_contribution
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/219/b#input.contribution_is_amount_contributed_to_simple_retirement_account: false
+    us:statutes/26/219/b#input.contribution_is_employer_contribution_to_simplified_employee_pension: false
+  output:
+    us:statutes/26/219/b#section_applies_to_contribution: holds

--- a/us/statutes/26/219/b.yaml
+++ b/us/statutes/26/219/b.yaml
@@ -1,0 +1,221 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/219/b
+  summary: Section 219(b) limits an individual's subsection (a) deduction to the lesser
+    of the deductible amount or compensation includible in gross income; excludes
+    employer simplified employee pension contributions and SIMPLE retirement account
+    contributions from section 219; provides a separate $7,000 / 25 percent compensation
+    cap for section 501(c)(18) plan contributions; and defines the deductible amount,
+    catch-up increase, and cost-of-living adjustment rounding rules.
+rules:
+- name: statutory_deductible_amount_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IRC section 219(b)(5)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: The deductible amount is $5,000.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '5000'
+- name: catch_up_age_threshold
+  kind: parameter
+  dtype: Count
+  source: IRC section 219(b)(5)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: has attained the age of 50 before the close of the taxable year
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '50'
+- name: catch_up_applicable_amount_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IRC section 219(b)(5)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: the applicable amount is $1,000.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1000'
+- name: deductible_amount_cost_of_living_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IRC section 219(b)(5)(C)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: not a multiple of $500, such amount shall be rounded to the next
+            lower multiple of $500.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '500'
+- name: catch_up_cost_of_living_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IRC section 219(b)(5)(C)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: not a multiple of $100, such amount shall be rounded to the next
+            lower multiple of $100.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '100'
+- name: plan_contribution_limit_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: IRC section 219(b)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: "shall not exceed the lesser of\u2014 (A) $7,000"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '7000'
+- name: plan_contribution_compensation_limit_rate
+  kind: parameter
+  dtype: Rate
+  source: IRC section 219(b)(3)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: 25 percent of the compensation
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.25'
+- name: section_applies_to_contribution
+  kind: derived
+  entity: Payment
+  dtype: Judgment
+  period: Year
+  source: IRC section 219(b)(2), (4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: This section shall not apply with respect to an employer contribution
+            to a simplified employee pension.
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: This section shall not apply with respect to any amount contributed
+            to a simple retirement account
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'not contribution_is_employer_contribution_to_simplified_employee_pension
+
+      and not contribution_is_amount_contributed_to_simple_retirement_account'
+- name: deductible_amount_before_compensation_limit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: IRC section 219(b)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: the deductible amount is $5,000
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: attained the age of 50 before the close of the taxable year
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: the applicable amount is $1,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'statutory_deductible_amount_base + (if age >= catch_up_age_threshold:
+      catch_up_applicable_amount_base else: 0)'
+- name: maximum_general_deduction_amount
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: IRC section 219(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: "shall not exceed the lesser of\u2014 (A) the deductible amount,\
+            \ or (B) an amount equal to the compensation includible in the individual\u2019\
+            s gross income"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: min(deductible_amount_before_compensation_limit, max(0, compensation_includible_in_gross_income))
+- name: maximum_plan_contribution_deduction_amount
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: IRC section 219(b)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/219/b
+          excerpt: "shall not exceed the lesser of\u2014 (A) $7,000, or (B) an amount\
+            \ equal to 25 percent of the compensation"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if contribution_on_behalf_of_employee_to_plan_described_in_section_501_c_18:
+      min(plan_contribution_limit_amount, plan_contribution_compensation_limit_rate
+      * max(0, compensation)) else: 0'

--- a/us/statutes/26/219/g.test.yaml
+++ b/us/statutes/26/219/g.test.yaml
@@ -1,0 +1,100 @@
+- name: active_participant_401_plan_without_exceptions
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/g#input.active_participant_in_section_401_a_plan_with_section_501_a_trust: true
+    us:statutes/26/219/g#input.active_participant_in_section_403_a_annuity_plan: false
+    ? us:statutes/26/219/g#input.active_participant_in_government_employee_plan_other_than_section_457_b_eligible_deferred_compensation_plan
+    : false
+    us:statutes/26/219/g#input.active_participant_in_section_403_b_annuity_contract: false
+    us:statutes/26/219/g#input.active_participant_in_simplified_employee_pension: false
+    us:statutes/26/219/g#input.active_participant_in_simple_retirement_account: false
+    us:statutes/26/219/g#input.makes_deductible_contributions_to_section_501_c_18_trust: false
+    us:statutes/26/219/g#input.participates_in_government_plan_by_reason_of_reserve_component_service: false
+    us:statutes/26/219/g#input.active_duty_days_other_than_training_during_year: 0
+    ? us:statutes/26/219/g#input.volunteer_firefighter_participates_in_government_plan_based_on_activity_as_volunteer_firefighter
+    : false
+    us:statutes/26/219/g#input.volunteer_firefighter_accrued_annual_benefit_as_single_life_annuity_at_age_65: 0
+  output:
+    us:statutes/26/219/g#active_participant_before_exceptions: holds
+    us:statutes/26/219/g#reserve_component_participation_not_active_participant_solely_for_that_participation: not_holds
+    us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation: not_holds
+    us:statutes/26/219/g#active_participant: holds
+- name: reserve_component_exception_blocks_active_participant
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/g#input.active_participant_in_section_401_a_plan_with_section_501_a_trust: false
+    us:statutes/26/219/g#input.active_participant_in_section_403_a_annuity_plan: false
+    ? us:statutes/26/219/g#input.active_participant_in_government_employee_plan_other_than_section_457_b_eligible_deferred_compensation_plan
+    : true
+    us:statutes/26/219/g#input.active_participant_in_section_403_b_annuity_contract: false
+    us:statutes/26/219/g#input.active_participant_in_simplified_employee_pension: false
+    us:statutes/26/219/g#input.active_participant_in_simple_retirement_account: false
+    us:statutes/26/219/g#input.makes_deductible_contributions_to_section_501_c_18_trust: false
+    us:statutes/26/219/g#input.participates_in_government_plan_by_reason_of_reserve_component_service: true
+    us:statutes/26/219/g#input.active_duty_days_other_than_training_during_year: 90
+    ? us:statutes/26/219/g#input.volunteer_firefighter_participates_in_government_plan_based_on_activity_as_volunteer_firefighter
+    : false
+    us:statutes/26/219/g#input.volunteer_firefighter_accrued_annual_benefit_as_single_life_annuity_at_age_65: 0
+  output:
+    us:statutes/26/219/g#active_participant_before_exceptions: holds
+    us:statutes/26/219/g#reserve_component_participation_not_active_participant_solely_for_that_participation: holds
+    us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation: not_holds
+    us:statutes/26/219/g#active_participant: not_holds
+- name: spouse_only_joint_return_phaseout_with_two_hundred_floor
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/g#input.individual_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year: false
+    us:statutes/26/219/g#input.spouse_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year: true
+    us:statutes/26/219/g#input.husband_and_wife_file_separate_returns: false
+    us:statutes/26/219/g#input.husband_and_wife_live_apart_at_all_times_during_taxable_year: false
+    ? us:statutes/26/219/g#input.adjusted_gross_income_after_sections_86_and_469_without_sections_85_c_135_137_221_911_or_section_219_deduction
+    : 159800
+  output:
+    us:statutes/26/219/g#spouses_filing_separately_living_apart_not_treated_as_married: not_holds
+    us:statutes/26/219/g#subsection_applies_to_individual: holds
+    us:statutes/26/219/g#adjusted_gross_income_for_subsection: 159800
+- name: complete_phaseout_reduces_limitation_to_zero
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/219/g#input.individual_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year: true
+    us:statutes/26/219/g#input.spouse_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year: false
+    us:statutes/26/219/g#input.husband_and_wife_file_separate_returns: false
+    us:statutes/26/219/g#input.husband_and_wife_live_apart_at_all_times_during_taxable_year: false
+    ? us:statutes/26/219/g#input.adjusted_gross_income_after_sections_86_and_469_without_sections_85_c_135_137_221_911_or_section_219_deduction
+    : 60000
+  output:
+    us:statutes/26/219/g#subsection_applies_to_individual: holds
+    us:statutes/26/219/g#adjusted_gross_income_for_subsection: 60000
+- name: auto_positive_spouses_filing_separately_living_apart_not_treated_as_married
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/219/g#input.husband_and_wife_file_separate_returns: true
+    us:statutes/26/219/g#input.husband_and_wife_live_apart_at_all_times_during_taxable_year: true
+  output:
+    us:statutes/26/219/g#spouses_filing_separately_living_apart_not_treated_as_married: holds
+- name: auto_positive_volunteer_firefighter_participation_not_active_participant_solely_for_that_participation
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/219/g#input.volunteer_firefighter_accrued_annual_benefit_as_single_life_annuity_at_age_65: 0
+    ? us:statutes/26/219/g#input.volunteer_firefighter_participates_in_government_plan_based_on_activity_as_volunteer_firefighter
+    : true
+  output:
+    us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation: holds

--- a/us/statutes/26/219/g.yaml
+++ b/us/statutes/26/219/g.yaml
@@ -1,0 +1,385 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/219/g
+  summary: 26 USC 219(g) reduces the subsection (b)(1)(A) and (c)(1)(A) dollar limitations
+    for a taxable year when an individual or spouse is an active participant in specified
+    pension plans. The reduction is based on adjusted gross income over the applicable
+    dollar amount, divided by $10,000 or $20,000 for a joint return; reductions are
+    not below $200 until complete phase-out and are rounded down to the next $10.
+    The subsection also states applicable dollar amounts, special rules for spouses,
+    active-participant categories and exceptions, and inflation adjustment for listed
+    thresholds after 2006.
+  deferred_outputs:
+  - output: us:statutes/26/219/g#applicable_dollar_amount
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/219/g#applicable_dollar_amount_before_inflation
+    reason: Generated rule treated a filing-status or marital-status legal classification
+      as a local fact. This output is deferred until the upstream status source can
+      be encoded or imported without inventing local tax-status component inputs.
+  - output: us:statutes/26/219/g#dollar_limitation_after_subsection_reduction
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/219/g#limitation_reduction
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/219/g#limitation_reduction_before_rounding
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/219/g#phaseout_denominator
+    reason: Generated rule treated a filing-status or marital-status legal classification
+      as a local fact. This output is deferred until the upstream status source can
+      be encoded or imported without inventing local tax-status component inputs.
+rules:
+- name: applicable_dollar_amount_joint_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(3)(B)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: In the case of a taxpayer filing a joint return, $80,000.
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '80000'
+- name: applicable_dollar_amount_other_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(3)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: any other taxpayer ... $50,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '50000'
+- name: applicable_dollar_amount_separate_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(3)(B)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: married individual filing a separate return, zero
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0'
+- name: spouse_not_active_participant_applicable_dollar_amount_base
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(7)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: shall be $150,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '150000'
+- name: phaseout_denominator_joint
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(2)(A)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: $20,000 in the case of a joint return
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '20000'
+- name: phaseout_denominator_other
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(2)(A)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: $10,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '10000'
+- name: minimum_limitation_before_complete_phaseout
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: No dollar limitation shall be reduced below $200
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '200'
+- name: reduction_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: multiple of $10
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '10'
+- name: inflation_adjustment_start_year_threshold
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 219(g)(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: after 2006
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '2006'
+- name: inflation_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(8)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: nearest multiple of $1,000
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1000'
+- name: reserve_component_active_duty_exception_limit_days
+  kind: parameter
+  dtype: Count
+  source: 26 USC 219(g)(6)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: in excess of 90 days
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '90'
+- name: volunteer_firefighter_accrued_benefit_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 219(g)(6)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: not more than an annual benefit of $1,800
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1800'
+- name: volunteer_firefighter_annuity_commencement_age
+  kind: parameter
+  dtype: Count
+  source: 26 USC 219(g)(6)(B)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: single life annuity commencing at age 65
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '65'
+- name: spouses_filing_separately_living_apart_not_treated_as_married
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'husband_and_wife_file_separate_returns
+
+      and husband_and_wife_live_apart_at_all_times_during_taxable_year'
+- name: reserve_component_participation_not_active_participant_solely_for_that_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)(6)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/219/g
+          excerpt: unless such individual has served in excess of 90 days on active
+            duty
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'participates_in_government_plan_by_reason_of_reserve_component_service
+
+      and active_duty_days_other_than_training_during_year <= reserve_component_active_duty_exception_limit_days'
+- name: volunteer_firefighter_participation_not_active_participant_solely_for_that_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)(6)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'volunteer_firefighter_participates_in_government_plan_based_on_activity_as_volunteer_firefighter
+
+      and volunteer_firefighter_accrued_annual_benefit_as_single_life_annuity_at_age_65
+      <= volunteer_firefighter_accrued_benefit_limit'
+- name: active_participant_before_exceptions
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'active_participant_in_section_401_a_plan_with_section_501_a_trust
+
+      or active_participant_in_section_403_a_annuity_plan
+
+      or active_participant_in_government_employee_plan_other_than_section_457_b_eligible_deferred_compensation_plan
+
+      or active_participant_in_section_403_b_annuity_contract
+
+      or active_participant_in_simplified_employee_pension
+
+      or active_participant_in_simple_retirement_account
+
+      or makes_deductible_contributions_to_section_501_c_18_trust'
+- name: active_participant
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'active_participant_before_exceptions
+
+      and not reserve_component_participation_not_active_participant_solely_for_that_participation
+
+      and not volunteer_firefighter_participation_not_active_participant_solely_for_that_participation'
+- name: subsection_applies_to_individual
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 26 USC 219(g)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'individual_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year
+
+      or spouse_is_active_participant_for_any_part_of_plan_year_ending_with_or_within_taxable_year'
+- name: adjusted_gross_income_for_subsection
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 219(g)(3)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/219/g
+  versions:
+  - effective_from: '1990-01-01'
+    formula: adjusted_gross_income_after_sections_86_and_469_without_sections_85_c_135_137_221_911_or_section_219_deduction

--- a/us/statutes/26/221.test.yaml
+++ b/us/statutes/26/221.test.yaml
@@ -1,0 +1,27 @@
+- name: non_joint_return_under_phaseout_gets_paid_interest_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/221#input.qualified_education_loan_interest_paid_by_taxpayer: 3000
+  output:
+    us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout: 2500
+- name: non_joint_return_mid_phaseout_reduces_by_ratio
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/221#input.qualified_education_loan_interest_paid_by_taxpayer: 1500
+  output:
+    us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout: 1500
+- name: joint_return_mid_phaseout_uses_joint_amounts
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/221#input.qualified_education_loan_interest_paid_by_taxpayer: 2400
+  output:
+    us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout: 2400

--- a/us/statutes/26/221.yaml
+++ b/us/statutes/26/221.yaml
@@ -1,0 +1,145 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/221
+  summary: Section 221 allows an individual a deduction for interest paid on a qualified
+    education loan, limits the deduction to $2,500, phases it out based on modified
+    adjusted gross income over $50,000 ($100,000 for a joint return) over $15,000
+    ($30,000 for a joint return), denies the deduction to certain dependents, defines
+    qualified education loan and related terms, and provides special rules and inflation
+    adjustments.
+  deferred_outputs:
+  - output: us:statutes/26/221/c#student_loan_interest_deduction_allowed_for_dependent
+    reason: Requires modeling whether a deduction under section 151 with respect to
+      the individual is allowed to another taxpayer for the taxable year beginning
+      in the relevant calendar year; the available section 151 context does not expose
+      this cross-taxpayer-with-respect-to-individual determination.
+  - output: us:statutes/26/221/d#qualified_education_loan
+    reason: Definition depends on unavailable cited legal definitions and exclusions,
+      including related persons under sections 267(b) and 707(b)(1), qualified employer
+      plans under section 72(p)(4), section 72(p)(5) contracts, section 25A(f)(2),
+      section 25A(b)(3), and section 152 as modified by subsection (d)(4).
+  - output: us:statutes/26/221/b#student_loan_interest_deduction_after_income_phaseout
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/221/b#student_loan_interest_phaseout_reduction
+    reason: Generated rule depends on an output that validation deferred because it
+      flattened thresholded, capped, base-limited, or cross-referenced mechanics,
+      or borrowed an unrelated same-named section term.
+  - output: us:statutes/26/221/b#student_loan_interest_phaseout_threshold
+    reason: Generated rule treated a filing-status or marital-status legal classification
+      as a local fact. This output is deferred until the upstream status source can
+      be encoded or imported without inventing local tax-status component inputs.
+  - output: us:statutes/26/221/b#student_loan_interest_phaseout_range
+    reason: Generated rule treated a filing-status or marital-status legal classification
+      as a local fact. This output is deferred until the upstream status source can
+      be encoded or imported without inventing local tax-status component inputs.
+rules:
+- name: statutory_student_loan_interest_deduction_cap
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: shall not exceed $2,500
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '2500'
+- name: statutory_student_loan_interest_phaseout_threshold_other_return
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: $50,000 ($100,000 in the case of a joint return)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '50000'
+- name: statutory_student_loan_interest_phaseout_threshold_joint_return
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: $50,000 ($100,000 in the case of a joint return)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '100000'
+- name: student_loan_interest_phaseout_range_other_return
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: $15,000 ($30,000 in the case of a joint return)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '15000'
+- name: student_loan_interest_phaseout_range_joint_return
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 26 USC 221(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: $15,000 ($30,000 in the case of a joint return)
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '30000'
+- name: student_loan_interest_deduction_before_income_phaseout
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 221(a), (b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/221
+          excerpt: interest paid by the taxpayer during the taxable year on any qualified
+            education loan
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/221#statutory_student_loan_interest_deduction_cap
+          output: statutory_student_loan_interest_deduction_cap
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: min(max(0, qualified_education_loan_interest_paid_by_taxpayer), statutory_student_loan_interest_deduction_cap)

--- a/us/statutes/26/223/b.test.yaml
+++ b/us/statutes/26/223/b.test.yaml
@@ -1,0 +1,12 @@
+- name: self_only_monthly_limitation_with_additional_contribution
+  period: 2026-01
+  input:
+    us:statutes/26/223/b#input.age_before_close_of_taxable_year: 55
+  output:
+    us:statutes/26/223/b#individual_attained_additional_contribution_age: holds
+- name: family_monthly_limitation_no_additional_contribution
+  period: 2026-01
+  input:
+    us:statutes/26/223/b#input.age_before_close_of_taxable_year: 54
+  output:
+    us:statutes/26/223/b#individual_attained_additional_contribution_age: not_holds

--- a/us/statutes/26/223/b.yaml
+++ b/us/statutes/26/223/b.yaml
@@ -1,0 +1,253 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/223/b
+  summary: 26 USC 223(b) limits the deduction under subsection (a) to monthly limitations
+    for eligible months; the monthly limitation is 1/12 of $2,250 for self-only HDHP
+    coverage or $4,500 for family HDHP coverage, increased for individuals age 55
+    or older by table amounts. The subsection also coordinates reductions for Archer
+    MSA, section 106(d), section 408(d)(9), married individuals, dependents, Medicare
+    entitlement, and last-month eligibility/testing-period rules.
+  deferred_outputs:
+  - output: us:statutes/26/223/b#health_savings_account_deduction_limitation
+    reason: The final annual limitation requires month-by-month aggregation, married-spouse
+      allocation, Archer MSA coordination, section 106(d) excludable contributions,
+      section 408(d)(9) contributions, section 151 dependent-denial interaction, Medicare
+      month sequencing, and last-month/testing-period mechanics; copied context does
+      not provide all required upstream legal dependencies, including section 106(d)
+      and section 72(m)(7).
+  - output: us:statutes/26/223/b#testing_period_income_increase_and_additional_tax
+    reason: Paragraph (8)(B) depends on whether the individual became disabled within
+      the meaning of section 72(m)(7), which is a missing upstream legal definition
+      in the copied context.
+  - output: us:statutes/26/223/b#additional_contribution_amount
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/26/223/b#testing_period_additional_tax_rate
+  - output: us:statutes/26/223/b#applicable_annual_limit_before_monthly_proration
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/26/223/b#testing_period_additional_tax_rate
+  - output: us:statutes/26/223/b#monthly_limitation_before_coordination
+    reason: Generated rule ignored a source-stated substitution, modification, or
+      limitation parameter. This output is deferred until the upstream cross-referenced
+      mechanics can be imported or composed without stranding the modifier.
+    source_values:
+    - us:statutes/26/223/b#testing_period_additional_tax_rate
+rules:
+- name: self_only_coverage_annual_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: self-only coverage ... $2,250
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '2250'
+- name: family_coverage_annual_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Year
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: family coverage ... $4,500
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '4500'
+- name: monthly_proration_denominator
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: The monthly limitation for any month is 1/12 of
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '12'
+- name: additional_contribution_age_threshold
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: has attained age 55 before the close of the taxable year
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '55'
+- name: additional_contribution_amount_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: &id001
+            header: Additional contribution amount
+            row_key: taxable years beginning in
+            column_key: additional contribution amount
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '1000'
+- name: additional_contribution_amount_scalar_limit_2
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: *id001
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '500'
+- name: additional_contribution_amount_scalar_limit_3
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: *id001
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '600'
+- name: additional_contribution_amount_scalar_limit_4
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: *id001
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '700'
+- name: additional_contribution_amount_scalar_limit_5
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: *id001
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '800'
+- name: additional_contribution_amount_scalar_limit_6
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          table: *id001
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '900'
+- name: individual_attained_additional_contribution_age
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: has attained age 55 before the close of the taxable year
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/223/b#additional_contribution_age_threshold
+          output: additional_contribution_age_threshold
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: age_before_close_of_taxable_year >= additional_contribution_age_threshold
+- name: testing_period_month_count
+  kind: parameter
+  dtype: Count
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: ending on the last day of the 12th month following such month
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '12'
+- name: testing_period_additional_tax_rate
+  kind: parameter
+  dtype: Rate
+  source: 26 USC 223(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/223/b
+          excerpt: increased by 10 percent of the amount of such increase
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '0.10'


### PR DESCRIPTION
## Batch-encoded 6 module(s) - us

Merge-train-style consolidation: one `oracle-coverage-pending sync`, one reverse-index regen, and the CI-faithful gate (per-module validate + the repo `tests/` pytest, cov/main). Disjoint modules each carry their own signed apply manifest.

- Updated /Users/maxghenis/TheAxiomFoundation/_bulk_drain/wt/batch-us-113150-1/rulespec-us/oracle-coverage-pending.yaml: 648 declared (+70 added, -0 drained).
- Local gate: 6 green, 0 needs-fixtures

| citation | module | gate |
| --- | --- | --- |
| `us/regulation/7/247/9/b` | `us/regulations/7-cfr/247/9/b.yaml` | green |
| `us/statute/26/164` | `us/statutes/26/164.yaml` | green |
| `us/statute/26/219/b` | `us/statutes/26/219/b.yaml` | green |
| `us/statute/26/219/g` | `us/statutes/26/219/g.yaml` | green |
| `us/statute/26/221` | `us/statutes/26/221.yaml` | green |
| `us/statute/26/223/b` | `us/statutes/26/223/b.yaml` | green |

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>