### PR TITLE
Encode us/statute/26/61 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -28043,6 +28043,15 @@
         ]
       }
     ],
+    "us/statute/26/61": [
+      {
+        "module": "us/statutes/26/61.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/63": [
       {
         "module": "us/statutes/26/63.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 650
+ceiling: 652
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1957,5 +1957,11 @@ entries:
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/65#ordinary_loss
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/61#enumerated_gross_income_items
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/61#gross_income
     source: bulk
     since: 2026-07-09

--- a/us/.axiom/encoding-manifests/statutes/26/61.json
+++ b/us/.axiom/encoding-manifests/statutes/26/61.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/61.yaml",
+      "sha256": "c3face49a6140d586293c601bb3b331ede9bfc7ec3a86ee394d6fa86f7e8feca"
+    },
+    {
+      "path": "statutes/26/61.test.yaml",
+      "sha256": "61caa19a05ad63a224e80fd89936c9991bc173a816e4b9abfc77941c403c76c7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "openai",
+  "citation": "us/statute/26/61",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-statute-26-61/workspace/context-manifest.json",
+  "context_manifest_sha256": "cc3df77325043398305b1f5a436f71cf880fca6b7e41f0f6733b8c9360d0ad96",
+  "generated_at": "2026-07-09T20:19:09.467557+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/26/61.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "c3face49a6140d586293c601bb3b331ede9bfc7ec3a86ee394d6fa86f7e8feca",
+  "generation_prompt_sha256": "ea65072abcdc7fe627a709447240368c25602e7874359d43df27de042904743a",
+  "model": "gpt-5.5",
+  "run_id": "2349528d",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8e907220739c14774f4f711a3a2f67f37d6623b200f080ea70891fce50d5f3a7"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-statute-26-61.json",
+  "trace_sha256": "6ed5a5bac889206d33295aecb0570f54d838e29f4be1c68b3514bbe7cf486aeb"
+}

--- a/us/statutes/26/61.test.yaml
+++ b/us/statutes/26/61.test.yaml
@@ -1,0 +1,50 @@
+- name: gross_income_includes_all_income_when_no_subtitle_exclusion
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/61#input.compensation_for_services: 50000
+    us:statutes/26/61#input.gross_income_derived_from_business: 10000
+    us:statutes/26/61#input.gains_derived_from_dealings_in_property: 2000
+    us:statutes/26/61#input.interest: 300
+    us:statutes/26/61#input.rents: 4000
+    us:statutes/26/61#input.royalties: 500
+    us:statutes/26/61#input.dividends: 700
+    us:statutes/26/61#input.annuities: 800
+    us:statutes/26/61#input.income_from_life_insurance_and_endowment_contracts: 900
+    us:statutes/26/61#input.pensions: 6000
+    us:statutes/26/61#input.income_from_discharge_of_indebtedness: 1200
+    us:statutes/26/61#input.distributive_share_of_partnership_gross_income: 3000
+    us:statutes/26/61#input.income_in_respect_of_a_decedent: 400
+    us:statutes/26/61#input.income_from_an_interest_in_an_estate_or_trust: 600
+    us:statutes/26/61#input.all_income_from_whatever_source_derived: 80400
+    us:statutes/26/61#input.amounts_otherwise_provided_excluded_from_gross_income_under_this_subtitle: 0
+  output:
+    us:statutes/26/61#enumerated_gross_income_items: 80400
+    us:statutes/26/61#gross_income: 80400
+- name: subtitle_exclusion_reduces_gross_income_but_not_below_zero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/61#input.compensation_for_services: 1000
+    us:statutes/26/61#input.gross_income_derived_from_business: 0
+    us:statutes/26/61#input.gains_derived_from_dealings_in_property: 0
+    us:statutes/26/61#input.interest: 0
+    us:statutes/26/61#input.rents: 0
+    us:statutes/26/61#input.royalties: 0
+    us:statutes/26/61#input.dividends: 0
+    us:statutes/26/61#input.annuities: 0
+    us:statutes/26/61#input.income_from_life_insurance_and_endowment_contracts: 0
+    us:statutes/26/61#input.pensions: 0
+    us:statutes/26/61#input.income_from_discharge_of_indebtedness: 0
+    us:statutes/26/61#input.distributive_share_of_partnership_gross_income: 0
+    us:statutes/26/61#input.income_in_respect_of_a_decedent: 0
+    us:statutes/26/61#input.income_from_an_interest_in_an_estate_or_trust: 0
+    us:statutes/26/61#input.all_income_from_whatever_source_derived: 1000
+    us:statutes/26/61#input.amounts_otherwise_provided_excluded_from_gross_income_under_this_subtitle: 1500
+  output:
+    us:statutes/26/61#enumerated_gross_income_items: 1000
+    us:statutes/26/61#gross_income: 0

--- a/us/statutes/26/61.yaml
+++ b/us/statutes/26/61.yaml
@@ -1,0 +1,70 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/61
+  summary: |-
+    (a) Except as otherwise provided in this subtitle, gross income means all income from whatever source derived, including compensation for services, business income, gains from property, interest, rents, royalties, dividends, annuities, life-insurance and endowment-contract income, pensions, discharge-of-indebtedness income, distributive share of partnership gross income, income in respect of a decedent, and income from an interest in an estate or trust. (b) Cross references point to part II for specific inclusions and part III for specific exclusions.
+rules:
+  - name: enumerated_gross_income_items
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 61(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/61
+              excerpt: "including (but not limited to) the following items"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, compensation_for_services)
+          + max(0, gross_income_derived_from_business)
+          + max(0, gains_derived_from_dealings_in_property)
+          + max(0, interest)
+          + max(0, rents)
+          + max(0, royalties)
+          + max(0, dividends)
+          + max(0, annuities)
+          + max(0, income_from_life_insurance_and_endowment_contracts)
+          + max(0, pensions)
+          + max(0, income_from_discharge_of_indebtedness)
+          + max(0, distributive_share_of_partnership_gross_income)
+          + max(0, income_in_respect_of_a_decedent)
+          + max(0, income_from_an_interest_in_an_estate_or_trust)
+
+  - name: gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: "26 USC 61(a): General definition Except as otherwise provided in this subtitle, gross income means all income f..."
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/61
+              excerpt: "Except as otherwise provided in this subtitle, gross income means all income from whatever source derived"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/61
+              excerpt: "Except as otherwise provided in this subtitle"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              all_income_from_whatever_source_derived
+              - amounts_otherwise_provided_excluded_from_gross_income_under_this_subtitle
+          )


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us/statute/26/61`
- Module: `us/statutes/26/61.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1200)
- Encode wall time: 63s
- Local gate status: **green**

Produced by `axiom-encode encode us/statute/26/61 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us/statute/26/61",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "2349528d",
  "axiom_encode_version": "0.2.1200",
  "applied_files": [
    {
      "path": "statutes/26/61.yaml",
      "sha256": "c3face49a6140d586293c601bb3b331ede9bfc7ec3a86ee394d6fa86f7e8feca"
    },
    {
      "path": "statutes/26/61.test.yaml",
      "sha256": "61caa19a05ad63a224e80fd89936c9991bc173a816e4b9abfc77941c403c76c7"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
