### PR TITLE
Encode us/statute/26/64 (bulk)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -28081,6 +28081,15 @@
         ]
       }
     ],
+    "us/statute/26/64": [
+      {
+        "module": "us/statutes/26/64.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/6401": [
       {
         "module": "us/statutes/26/6401.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 652
+ceiling: 655
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1963,5 +1963,14 @@ entries:
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/61#gross_income
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/64#ordinary_income_gain_inclusion_applies
     source: bulk
     since: 2026-07-09

--- a/us/.axiom/encoding-manifests/statutes/26/64.json
+++ b/us/.axiom/encoding-manifests/statutes/26/64.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/26/64.yaml",
+      "sha256": "d2b802c7065634a11f68804172c4a19b14ab0330bfdce37383a7b3db8935e236"
+    },
+    {
+      "path": "statutes/26/64.test.yaml",
+      "sha256": "21e5906498fcf463f528a832e23e0c965693c5daf9a2cb2e73651038917d9b31"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "openai",
+  "citation": "us/statute/26/64",
+  "context_manifest_file": "/home/runner/work/_temp/encode-out/_eval_workspaces/openai-gpt-5.5/us-statute-26-64/workspace/context-manifest.json",
+  "context_manifest_sha256": "529b3af1772fbdae0d448d6782f4d7a80b00d032c71699974ebcb5e9ad280fb6",
+  "generated_at": "2026-07-09T20:19:16.094398+00:00",
+  "generated_output_file": "/home/runner/work/_temp/encode-out/openai-gpt-5.5/statutes/26/64.yaml",
+  "generated_output_root": "/home/runner/work/_temp/encode-out",
+  "generated_output_sha256": "d2b802c7065634a11f68804172c4a19b14ab0330bfdce37383a7b3db8935e236",
+  "generation_prompt_sha256": "2d3ab33e0f2c3c93e9910ec9bacdca01ba08bd348826c19d6724f6c96073f6e2",
+  "model": "gpt-5.5",
+  "run_id": "6fc084a0",
+  "runner": "openai-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9fac615d79c24de0a441fb0d0b6956326268f13ab3c959708447d6a0d5031011"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/encode-out/traces/openai-gpt-5.5/us-statute-26-64.json",
+  "trace_sha256": "207b0431240d28b066886a536a0d92f3e2169891194305753b45a4fa1c344db5"
+}

--- a/us/statutes/26/64.test.yaml
+++ b/us/statutes/26/64.test.yaml
@@ -1,0 +1,42 @@
+- name: noncapital_non1231_property_gain_is_ordinary_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/64#input.gain_is_from_sale_or_exchange_of_property: true
+    us:statutes/26/64#input.property_is_neither_capital_asset_nor_property_described_in_section_1231_b: true
+    us:statutes/26/64#input.gain_is_treated_or_considered_as_ordinary_income_under_other_provisions_of_subtitle: false
+    us:statutes/26/64#input.gain_from_sale_or_exchange_of_property: 5000
+  output:
+    us:statutes/26/64#ordinary_income_gain_inclusion_applies: holds
+    us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property: not_holds
+    us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange: 5000
+- name: other_subtitle_ordinary_income_treatment_deems_gain_included
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/64#input.gain_is_from_sale_or_exchange_of_property: true
+    us:statutes/26/64#input.property_is_neither_capital_asset_nor_property_described_in_section_1231_b: false
+    us:statutes/26/64#input.gain_is_treated_or_considered_as_ordinary_income_under_other_provisions_of_subtitle: true
+    us:statutes/26/64#input.gain_from_sale_or_exchange_of_property: 3200
+  output:
+    us:statutes/26/64#ordinary_income_gain_inclusion_applies: holds
+    us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property: holds
+    us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange: 3200
+- name: capital_or_1231_property_gain_without_other_ordinary_treatment_not_included
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/64#input.gain_is_from_sale_or_exchange_of_property: true
+    us:statutes/26/64#input.property_is_neither_capital_asset_nor_property_described_in_section_1231_b: false
+    us:statutes/26/64#input.gain_is_treated_or_considered_as_ordinary_income_under_other_provisions_of_subtitle: false
+    us:statutes/26/64#input.gain_from_sale_or_exchange_of_property: 4100
+  output:
+    us:statutes/26/64#ordinary_income_gain_inclusion_applies: not_holds
+    us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property: not_holds
+    us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange: 0

--- a/us/statutes/26/64.yaml
+++ b/us/statutes/26/64.yaml
@@ -1,0 +1,88 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/64
+  summary: "For purposes of this subtitle, \u201Cordinary income\u201D includes gain\
+    \ from the sale or exchange of property which is neither a capital asset nor property\
+    \ described in section 1231(b), and gain treated under other subtitle provisions\
+    \ as \u201Cordinary income\u201D is treated as such gain."
+rules:
+- name: ordinary_income_gain_inclusion_applies
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 64
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/26/64
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/64
+          excerpt: neither a capital asset nor property described in section 1231(b)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/64
+          excerpt: "treated or considered, under other provisions of this subtitle,\
+            \ as \u201Cordinary income\u201D"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: "gain_is_from_sale_or_exchange_of_property\nand (\n    property_is_neither_capital_asset_nor_property_described_in_section_1231_b\n\
+      \    or gain_is_treated_or_considered_as_ordinary_income_under_other_provisions_of_subtitle\n\
+      )"
+- name: gain_treated_as_from_noncapital_non1231_property
+  kind: derived
+  entity: Asset
+  dtype: Judgment
+  period: Year
+  source: 26 USC 64
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/64
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/64
+          excerpt: "Any gain from the sale or exchange of property which is treated\
+            \ or considered ... as \u201Cordinary income\u201D"
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'gain_is_from_sale_or_exchange_of_property
+
+      and gain_is_treated_or_considered_as_ordinary_income_under_other_provisions_of_subtitle'
+- name: ordinary_income_gain_from_sale_or_exchange
+  kind: derived
+  entity: Asset
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 64
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/64
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/64#ordinary_income_gain_inclusion_applies
+          output: ordinary_income_gain_inclusion_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '1990-01-01'
+    formula: 'if ordinary_income_gain_inclusion_applies: max(0, gain_from_sale_or_exchange_of_property)
+      else: 0'


### PR DESCRIPTION
## Bulk-encoded module

- Citation: `us/statute/26/64`
- Module: `us/statutes/26/64.yaml`
- Encoder: `openai:gpt-5.5` (toolchain-pinned axiom-encode 0.2.1200)
- Encode wall time: 63s
- Local gate status: **green**

Produced by `axiom-encode encode us/statute/26/64 --apply` in the bulk-encode dispatcher
(`.github/workflows/bulk-encode.yml`). Values are the encoder's; this PR is plumbing.

### Manifest summary
```json
{
  "citation": "us-ma/statute/62/64",
  "model": "gpt-5.5",
  "backend": "openai",
  "run_id": "546aa807",
  "axiom_encode_version": "0.2.1184",
  "applied_files": [
    {
      "path": "statutes/62/64.yaml",
      "sha256": "be87c015199e4ce578150c4486a6ab2264db01cfebb0477f0d997d058267a89e"
    },
    {
      "path": "statutes/62/64.test.yaml",
      "sha256": "03b309284890aebefec7ca9d59e6f9d92ee69397dfc780da0bbbb202239a4aad"
    }
  ]
}
```

### Local gate battery output
```
guard-generated: pass (signed apply manifest present)
validate:        pass
proof-validate:  pass
companion test:  pass
```

The authoritative gate is the required `validate / validate` check on this PR.
