### PR TITLE
Encode us/statute/26/68

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/26/68.json
+++ b/.axiom/encoding-manifests/us/statutes/26/68.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/26/68.test.yaml",
+      "sha256": "c083ae88520f5985c1ff7cdb29c2729628978948c53b91bdfcea72415407c81a"
+    },
+    {
+      "path": "us/statutes/26/68.yaml",
+      "sha256": "b1bc1c5a6a7d1bb9249e87a58ff816a38d725f9a6a81529c929f3f7f7456cb26"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:statutes/26/68",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T21:03:38.042056+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp46y5k_lt/sign-applied-files/us/statutes/26/68.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp46y5k_lt",
+  "generated_output_sha256": "b1bc1c5a6a7d1bb9249e87a58ff816a38d725f9a6a81529c929f3f7f7456cb26",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c95a9a0507dfa58b4bc96bbbd2999dd4b54dd9e2fc95b1d99e8e2afba01f0f4d"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -28137,6 +28137,13 @@
     ],
     "us/statute/26/68": [
       {
+        "module": "us/statutes/26/68.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us/statutes/26/68/b.yaml",
         "via": [
           "module",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 668
+ceiling: 674
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -2011,5 +2011,23 @@ entries:
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/62#unlawful_discrimination
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_numerator
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_denominator
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#section_68_reduction_applies_to_individual
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_base
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_under_section_68
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deductions_allowed_after_section_68
     source: bulk
     since: 2026-07-09

--- a/us/statutes/26/68.test.yaml
+++ b/us/statutes/26/68.test.yaml
@@ -1,0 +1,45 @@
+- name: individual_reduction_limited_by_itemized_deductions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-32/income-tax-brackets#input.filing_status: 0
+    us:statutes/26/68#input.taxpayer_is_individual: true
+    us:statutes/26/68#input.itemized_deductions_otherwise_allowable_after_other_limitations: 37000
+    us:statutes/26/68#input.taxable_income_determined_without_section_68: 640600
+  output:
+    us:statutes/26/68#section_68_reduction_applies_to_individual: holds
+    us:statutes/26/68#itemized_deduction_reduction_base: 37000
+    us:statutes/26/68#itemized_deduction_reduction_under_section_68: 2000
+    us:statutes/26/68#itemized_deductions_allowed_after_section_68: 35000
+- name: individual_below_threshold_has_no_reduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-32/income-tax-brackets#input.filing_status: 0
+    us:statutes/26/68#input.taxpayer_is_individual: true
+    us:statutes/26/68#input.itemized_deductions_otherwise_allowable_after_other_limitations: 10000
+    us:statutes/26/68#input.taxable_income_determined_without_section_68: 600000
+  output:
+    us:statutes/26/68#section_68_reduction_applies_to_individual: holds
+    us:statutes/26/68#itemized_deduction_reduction_base: 0
+    us:statutes/26/68#itemized_deduction_reduction_under_section_68: 0
+    us:statutes/26/68#itemized_deductions_allowed_after_section_68: 10000
+- name: nonindividual_not_reduced_by_section_68
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:policies/irs/rev-proc-2025-32/income-tax-brackets#input.filing_status: 0
+    us:statutes/26/68#input.taxpayer_is_individual: false
+    us:statutes/26/68#input.itemized_deductions_otherwise_allowable_after_other_limitations: 37000
+    us:statutes/26/68#input.taxable_income_determined_without_section_68: 640600
+  output:
+    us:statutes/26/68#section_68_reduction_applies_to_individual: not_holds
+    us:statutes/26/68#itemized_deduction_reduction_base: 0
+    us:statutes/26/68#itemized_deduction_reduction_under_section_68: 0
+    us:statutes/26/68#itemized_deductions_allowed_after_section_68: 37000

--- a/us/statutes/26/68.yaml
+++ b/us/statutes/26/68.yaml
@@ -1,0 +1,146 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/68
+  summary: For an individual, itemized deductions otherwise allowable are reduced
+    by 2/37 of the lesser of the deductions or the excess of taxable income, increased
+    by those deductions, over the dollar amount at which the 37 percent rate bracket
+    under section 1 begins. Section 68 applies after any other limitation on itemized
+    deductions.
+imports:
+- us:statutes/26/68/b#section_68_applied_after_other_itemized_deduction_limitations
+- us:policies/irs/rev-proc-2025-32/income-tax-brackets#income_tax_bracket_6_threshold
+rules:
+- name: itemized_deduction_reduction_numerator
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 68(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: reduced by 2 / 37
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '2'
+- name: itemized_deduction_reduction_denominator
+  kind: parameter
+  dtype: Integer
+  source: 26 USC 68(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: reduced by 2 / 37
+  versions:
+  - effective_from: '1990-01-01'
+    formula: '37'
+- name: section_68_reduction_applies_to_individual
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: 26 USC 68(a)-(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: In the case of an individual
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/68/b#section_68_applied_after_other_itemized_deduction_limitations
+          output: section_68_applied_after_other_itemized_deduction_limitations
+          hash: sha256:b414ea74c35ae01658716b730dec1427c8db0e9ae0b7e0be3f4c8f08a8ec5906
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'taxpayer_is_individual
+
+      and section_68_applied_after_other_itemized_deduction_limitations'
+- name: itemized_deduction_reduction_base
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 68(a)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: "lesser of\u2014 (1) such amount of itemized deductions, or (2)\
+            \ so much of the taxable income ... as exceeds the dollar amount at which\
+            \ the 37 percent rate bracket under section 1 begins"
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:policies/irs/rev-proc-2025-32/income-tax-brackets#income_tax_bracket_6_threshold
+          output: income_tax_bracket_6_threshold
+          hash: sha256:71d48be45e0ef2301d016959a784d2f27cb18c8e2a1c79c941f096790199e1c2
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if section_68_reduction_applies_to_individual: min( itemized_deductions_otherwise_allowable_after_other_limitations,
+      max( 0, taxable_income_determined_without_section_68 + itemized_deductions_otherwise_allowable_after_other_limitations
+      - income_tax_bracket_6_threshold ) ) else: 0'
+- name: itemized_deduction_reduction_under_section_68
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 68(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: shall be reduced by 2 / 37 of the lesser of
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'itemized_deduction_reduction_base
+
+      * itemized_deduction_reduction_numerator
+
+      / itemized_deduction_reduction_denominator'
+- name: itemized_deductions_allowed_after_section_68
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: 26 USC 68(a)-(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: the amount of the itemized deductions otherwise allowable ... shall
+            be reduced
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us/statute/26/68
+          excerpt: applied after the application of any other limitation on the allowance
+            of any itemized deduction
+  versions:
+  - effective_from: '2026-01-01'
+    formula: "max(\n    0,\n    itemized_deductions_otherwise_allowable_after_other_limitations\n\
+      \    - itemized_deduction_reduction_under_section_68\n)"


### PR DESCRIPTION
## Summary
- Encodes IRC section 68 itemized deduction limitation using the successful local retry output for `us/statute/26/68`.
- Adds companion tests covering reduction, no-reduction below threshold, and nonindividual behavior.
- Updates reverse index and pending oracle coverage ceiling/entries for six new outputs.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-work --base-ref origin/main --head-ref HEAD --roots us`
- `axiom-encode validate us/statutes/26/68.yaml --skip-reviewers`
- `axiom-encode proof-validate us/statutes/26/68.yaml`
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json` after staging generated index
- `axiom-encode test --root /tmp/rulespec-us-work --axiom-rules-engine-path /tmp/axiom-rules-engine us/statutes/26/68.test.yaml`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py --rootdir=/tmp/rulespec-us-work`
- `axiom-encode validate us/statutes/26/68.yaml --skip-reviewers --oracle policyengine --json`

## Notes
- This is a repair PR for the failed bulk job; the original failure was a decimal precision assertion in the generated companion test. The local retry passed deterministic CI before application.
- Manifest is signed with `manual_exception: repair` because the successful generated output was applied from the local retry artifact rather than via `encode --apply`.