### PR TITLE
Encode us/statute/26/102

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/26/102.json
+++ b/.axiom/encoding-manifests/us/statutes/26/102.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/26/102.test.yaml",
+      "sha256": "6daf00200006d297cd0876e64f3b9f8684d5b3cf769457484c11e208ca915414"
+    },
+    {
+      "path": "us/statutes/26/102.yaml",
+      "sha256": "728d720ce0478930aea9f7cde376c1b87079f34ddb825159f32425c71cf87f44"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:statutes/26/102",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T21:14:17.321238+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3d7fyge1/sign-applied-files/us/statutes/26/102.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3d7fyge1",
+  "generated_output_sha256": "728d720ce0478930aea9f7cde376c1b87079f34ddb825159f32425c71cf87f44",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1b2fd17bb59da9a3703cfc429309c80a1ab90ed557da7699b743f3ee1d6294c8"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -25423,6 +25423,15 @@
         ]
       }
     ],
+    "us/statute/26/102": [
+      {
+        "module": "us/statutes/26/102.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/104": [
       {
         "module": "us/statutes/26/104/a/4.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 674
+ceiling: 675
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -2029,5 +2029,8 @@ entries:
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/68#itemized_deductions_allowed_after_section_68
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/102#amount_excluded_from_gross_income_under_section_102
     source: bulk
     since: 2026-07-09

--- a/us/statutes/26/102.test.yaml
+++ b/us/statutes/26/102.test.yaml
@@ -1,0 +1,57 @@
+- name: gift property value excluded when no statutory inclusion applies
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/102#input.value_of_property_acquired_by_gift_bequest_devise_or_inheritance: 10000
+    us:statutes/26/102#input.income_from_property_referred_to_in_subsection_a: 0
+    us:statutes/26/102#input.amount_of_gift_bequest_devise_or_inheritance_that_is_income_from_property: 0
+    us:statutes/26/102#input.amount_paid_credited_or_to_be_distributed_at_intervals_out_of_income_from_property: 0
+    us:statutes/26/102#input.amount_included_in_gross_income_of_beneficiary_under_subchapter_j: 0
+    us:statutes/26/102#input.amount_transferred_by_or_for_employer_to_or_for_benefit_of_employee: 0
+  output:
+    us:statutes/26/102#amount_excluded_from_gross_income_under_section_102: 10000
+- name: property income and income gifts are not excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/102#input.value_of_property_acquired_by_gift_bequest_devise_or_inheritance: 10000
+    us:statutes/26/102#input.income_from_property_referred_to_in_subsection_a: 1200
+    us:statutes/26/102#input.amount_of_gift_bequest_devise_or_inheritance_that_is_income_from_property: 800
+    us:statutes/26/102#input.amount_paid_credited_or_to_be_distributed_at_intervals_out_of_income_from_property: 0
+    us:statutes/26/102#input.amount_included_in_gross_income_of_beneficiary_under_subchapter_j: 0
+    us:statutes/26/102#input.amount_transferred_by_or_for_employer_to_or_for_benefit_of_employee: 0
+  output:
+    us:statutes/26/102#amount_excluded_from_gross_income_under_section_102: 8000
+- name: interval income distributions and subchapter j beneficiary income are not
+    excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/102#input.value_of_property_acquired_by_gift_bequest_devise_or_inheritance: 10000
+    us:statutes/26/102#input.income_from_property_referred_to_in_subsection_a: 0
+    us:statutes/26/102#input.amount_of_gift_bequest_devise_or_inheritance_that_is_income_from_property: 0
+    us:statutes/26/102#input.amount_paid_credited_or_to_be_distributed_at_intervals_out_of_income_from_property: 1500
+    us:statutes/26/102#input.amount_included_in_gross_income_of_beneficiary_under_subchapter_j: 500
+    us:statutes/26/102#input.amount_transferred_by_or_for_employer_to_or_for_benefit_of_employee: 0
+  output:
+    us:statutes/26/102#amount_excluded_from_gross_income_under_section_102: 8000
+- name: employer transfer to employee is not excluded
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/102#input.value_of_property_acquired_by_gift_bequest_devise_or_inheritance: 10000
+    us:statutes/26/102#input.income_from_property_referred_to_in_subsection_a: 0
+    us:statutes/26/102#input.amount_of_gift_bequest_devise_or_inheritance_that_is_income_from_property: 0
+    us:statutes/26/102#input.amount_paid_credited_or_to_be_distributed_at_intervals_out_of_income_from_property: 0
+    us:statutes/26/102#input.amount_included_in_gross_income_of_beneficiary_under_subchapter_j: 0
+    us:statutes/26/102#input.amount_transferred_by_or_for_employer_to_or_for_benefit_of_employee: 10000
+  output:
+    us:statutes/26/102#amount_excluded_from_gross_income_under_section_102: 0

--- a/us/statutes/26/102.yaml
+++ b/us/statutes/26/102.yaml
@@ -1,0 +1,31 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/102
+  summary: |-
+    Gross income does not include the value of property acquired by gift, bequest, devise, or inheritance. Subsection (a) does not exclude income from that property, gifts of income from property, interval distributions out of income from property, subchapter J beneficiary income, or amounts transferred by or for an employer to or for an employee.
+rules:
+  - name: amount_excluded_from_gross_income_under_section_102
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 U.S.C. 102(a)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/102
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/102
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(0, value_of_property_acquired_by_gift_bequest_devise_or_inheritance - income_from_property_referred_to_in_subsection_a - amount_of_gift_bequest_devise_or_inheritance_that_is_income_from_property - amount_paid_credited_or_to_be_distributed_at_intervals_out_of_income_from_property - amount_included_in_gross_income_of_beneficiary_under_subchapter_j - amount_transferred_by_or_for_employer_to_or_for_benefit_of_employee)


### PR DESCRIPTION
## Summary
- Encodes IRC section 102 gross-income exclusion for property acquired by gift, bequest, devise, or inheritance.
- Repairs the generated bulk output by using `entity: Person` rather than `TaxUnit`, avoiding the employer-scope validator issue from the subsection 102(c) exception while keeping the recipient-facing exclusion amount executable.
- Adds companion tests for basic exclusion, property-income exceptions, interval/subchapter J exceptions, and the employer-transfer exception.
- Updates reverse index and pending oracle coverage ceiling/entry for the new output.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-work --base-ref origin/main --head-ref HEAD --roots us`
- `axiom-encode validate us/statutes/26/102.yaml --skip-reviewers`
- `axiom-encode proof-validate us/statutes/26/102.yaml`
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json` after staging generated index
- `axiom-encode test --root /tmp/rulespec-us-work --axiom-rules-engine-path /tmp/axiom-rules-engine us/statutes/26/102.test.yaml`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py --rootdir=/tmp/rulespec-us-work`
- `axiom-encode validate us/statutes/26/102.yaml --skip-reviewers --oracle policyengine --json`

## Notes
- This is a repair PR for the failed bulk job; the retry still failed as `TaxUnit` due the employer-scope validator. The applied repair passed deterministic CI in the real checkout.
- Manifest is signed with `manual_exception: repair` because the generated output was repaired locally before application.