### PR TITLE
Compose AZ/GA/MI/NC income-tax liability pipelines (flat)

### DIFF
--- a/.axiom/encoding-manifests/us-az/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-az/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-az/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "7239a9b2c03336230ac88ebcb103f43db8994fdc0243a6f0de36c945955d272d"
+    },
+    {
+      "path": "us-az/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "29942392a1afc8d052e428a8fed82f09c1d19a2031ba5f388649b0fb5ee688c2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us-az:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-09T20:42:30.641225+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqqvipzv_/sign-applied-files/us-az/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqqvipzv_",
+  "generated_output_sha256": "29942392a1afc8d052e428a8fed82f09c1d19a2031ba5f388649b0fb5ee688c2",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "af52398c457908df4d275f7a41c2ac0dc06f99adcf749eb1e18efaaad32dfcd3"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "09a7998d87b5e1eea64c663d61542c472769bf0b03539e2347d2e31de7d84454"
+    },
+    {
+      "path": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "6183f91a5fb818dca80f809cf1119555e68a89d6802227bd76dc8d29d2a029e7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us-ga:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T02:02:52.772379+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus/sign-applied-files/us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus",
+  "generated_output_sha256": "6183f91a5fb818dca80f809cf1119555e68a89d6802227bd76dc8d29d2a029e7",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "62884eaf16a0c8a88646cb60d944401c420d2691be9f4f4ba7588f085a67689f"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-mi/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-mi/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mi/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "ca15036875cb98f7a4011528f3fcfd0895faa3a449b82ab07579fb53ff1f44d1"
+    },
+    {
+      "path": "us-mi/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "d971200a1690316ad7c3e9831a53757ed09741bc40666fbe04aa5d750465025d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us-mi:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T02:02:52.773487+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus/sign-applied-files/us-mi/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus",
+  "generated_output_sha256": "d971200a1690316ad7c3e9831a53757ed09741bc40666fbe04aa5d750465025d",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c994e5a5125f13048d63dbc7837adddec1179483607eff4b35291a28533f04d9"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-nc/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nc/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "54ee5e05a0d5d0434ae1a00739f627c99a69d0e97ba5535bdfe57f650ff8a456"
+    },
+    {
+      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "c90fe4ea1cc2c514b0293782ea077148a2124dffb512fd4ee22a25145315bdbc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us-nc:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T02:02:52.774002+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus/sign-applied-files/us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus",
+  "generated_output_sha256": "c90fe4ea1cc2c514b0293782ea077148a2124dffb512fd4ee22a25145315bdbc",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bf7f10c9e74e57f02f0241f8a177453ea138d361ec8e33e9913fd60e38764221"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1473,6 +1473,12 @@
     ],
     "us-az/statute/43-1011": [
       {
+        "module": "us-az/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-az/statutes/43-1011.yaml",
         "via": [
           "module",
@@ -1490,6 +1496,12 @@
       }
     ],
     "us-az/statute/43-1041": [
+      {
+        "module": "us-az/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-az/statutes/43-1041.yaml",
         "via": [
@@ -9799,6 +9811,14 @@
         ]
       }
     ],
+    "us-ga/statute/48/48-7-20": [
+      {
+        "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ga/statute/48/48-7-26": [
       {
         "module": "us-ga/statutes/48/48-7-26.yaml",
@@ -9809,6 +9829,12 @@
       }
     ],
     "us-ga/statute/48/48-7-27": [
+      {
+        "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7-27.yaml",
         "via": [
@@ -12886,6 +12912,12 @@
     ],
     "us-mi/statute/206.30/2": [
       {
+        "module": "us-mi/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-mi/statutes/206.30/2.yaml",
         "via": [
           "module",
@@ -12916,6 +12948,14 @@
         "module": "us-mi/statutes/206.30/8.yaml",
         "via": [
           "module"
+        ]
+      }
+    ],
+    "us-mi/statute/206.51/1": [
+      {
+        "module": "us-mi/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
         ]
       }
     ],
@@ -17446,6 +17486,12 @@
     ],
     "us-nc/statute/105/105-153.5/a": [
       {
+        "module": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-nc/statutes/105/105-153.5/a.yaml",
         "via": [
           "module",
@@ -17471,6 +17517,12 @@
       }
     ],
     "us-nc/statute/105/105-153.7": [
+      {
+        "module": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-nc/statutes/105/105-153/7.yaml",
         "via": [

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 675
+ceiling: 678
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -549,6 +549,15 @@ entries:
   - legal_id: us-me:statutes/36/5219-SS#young_child_credit_multiplier
     source: bulk
     since: 2026-07-08
+  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income
+    source: bulk
+    since: 2026-07-09
   - legal_id: us-mi:statutes/206.30/10#retirement_or_pension_benefits_deduction_under_subsection_10
     source: bulk
     since: 2026-07-09
@@ -1767,6 +1776,9 @@ entries:
   - legal_id: us:regulations/7-cfr/247/9/b#subject_to_prior_elderly_pilot_income_criteria
     source: bulk
     since: 2026-07-09
+  - legal_id: us:statutes/26/102#amount_excluded_from_gross_income_under_section_102
+    source: bulk
+    since: 2026-07-09
   - legal_id: us:statutes/26/164#applicable_limitation_amount_after_calendar_year_2029
     source: bulk
     since: 2026-07-09
@@ -1959,22 +1971,10 @@ entries:
   - legal_id: us:statutes/26/223/b#testing_period_month_count
     source: bulk
     since: 2026-07-09
-  - legal_id: us:statutes/26/65#ordinary_loss
-    source: bulk
-    since: 2026-07-09
   - legal_id: us:statutes/26/61#enumerated_gross_income_items
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/61#gross_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#ordinary_income_gain_inclusion_applies
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/62#adjusted_gross_income
@@ -2013,16 +2013,25 @@ entries:
   - legal_id: us:statutes/26/62#unlawful_discrimination
     source: bulk
     since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_numerator
+  - legal_id: us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/64#ordinary_income_gain_inclusion_applies
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/65#ordinary_loss
+    source: bulk
+    since: 2026-07-09
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_base
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/68#itemized_deduction_reduction_denominator
     source: bulk
     since: 2026-07-09
-  - legal_id: us:statutes/26/68#section_68_reduction_applies_to_individual
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_base
+  - legal_id: us:statutes/26/68#itemized_deduction_reduction_numerator
     source: bulk
     since: 2026-07-09
   - legal_id: us:statutes/26/68#itemized_deduction_reduction_under_section_68
@@ -2031,6 +2040,6 @@ entries:
   - legal_id: us:statutes/26/68#itemized_deductions_allowed_after_section_68
     source: bulk
     since: 2026-07-09
-  - legal_id: us:statutes/26/102#amount_excluded_from_gross_income_under_section_102
+  - legal_id: us:statutes/26/68#section_68_reduction_applies_to_individual
     source: bulk
     since: 2026-07-09

--- a/us-az/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-az/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,117 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the supplied schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). Arizona liability = the section 43-1011 flat tax on Arizona taxable
+# income (Arizona AGI - the section 43-1041 standard deduction), less the supplied
+# nonrefundable credit. Arizona levies a single flat rate for tax years beginning
+# after 2022, so the schedule is wired in the general bracket-base-plus-marginal
+# form with the supplied base tax and bracket floor at zero and the supplied
+# marginal rate carrying the flat 0.025 rate. The supplied 2026 standard deduction
+# is the PolicyEngine-projected Arizona standard deduction under the section
+# 43-1041(H) inflation indexation: 15,750 single, 31,500 married filing jointly
+# (the conformed federal basic standard deduction). No credit applies on the
+# childless wage-earner grid.
+- name: single_30000
+  # taxable 30000 - 15750 = 14250. Schedule 0 + 0.025*(14250-0) = 356.25.
+  # No credit: liability 356.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 30000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 15750
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '14250'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '356.25'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '356.25'
+- name: single_60000
+  # taxable 44250. Schedule 0.025*44250 = 1106.25. Liability 1106.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 60000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 15750
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '44250'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '1106.25'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '1106.25'
+- name: single_150000
+  # taxable 134250. Schedule 0.025*134250 = 3356.25. Liability 3356.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 150000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 15750
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '134250'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '3356.25'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '3356.25'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 60000 - 31500 = 28500.
+  # Schedule 0.025*28500 = 712.5. Liability 712.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 60000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 31500
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '28500'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '712.5'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '712.5'
+- name: married_120000
+  # taxable 88500. Schedule 0.025*88500 = 2212.5. Liability 2212.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 120000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 31500
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '88500'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '2212.5'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '2212.5'
+- name: married_300000
+  # taxable 268500. Schedule 0.025*268500 = 6712.5. Liability 6712.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_adjusted_gross_income: 300000
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_standard_deduction: 31500
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_base: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_bracket_floor: 0
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_marginal_rate: 0.025
+    us-az:policies/income_tax/pilot_liability_pipeline#input.az_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_taxable_income: '268500'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_schedule_tax: '6712.5'
+    us-az:policies/income_tax/pilot_liability_pipeline#az_pit_pilot_income_tax_liability: '6712.5'

--- a/us-az/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-az/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,113 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-az/statute/43-1011
+      - us-az/statute/43-1041
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-az/statute/43-1011
+        - us-az/statute/43-1041
+      rationale: |-
+        This pipeline computes the Arizona section 43-1011 individual income-tax
+        liability for the ordinary resident wage-earner slice: the flat tax on
+        Arizona taxable income (Arizona adjusted gross income less the section
+        43-1041 standard deduction). For taxable years beginning from and after
+        December 31, 2022 Arizona levies a single flat rate on Arizona taxable
+        income, and the encoded 43-1011 module carries the historical graduated
+        subsection (A) brackets and the constitutional combined-rate cap; the
+        operative flat rate PolicyEngine applies is supplied here as a declared
+        caller input. Section 43-1041(H) requires the department to adjust the
+        standard deduction each year for inflation, so the operative 2026
+        standard deduction is an indexed value PolicyEngine projects; to reach a
+        liability comparable to PolicyEngine az_income_tax to the cent, the
+        standard deduction, the flat marginal rate, the bracket floor, the
+        bracket base tax, and the nonrefundable credit are all declared
+        caller-supplied inputs. The pipeline adds no numeric literals of its own;
+        it wires the flat-tax mechanics only, in the same supplied-schedule form
+        as the California and Ohio pilots. The section 43-1041 standard deduction
+        and the operative section 43-1011 rate are supplied here pending their
+        own indexed encodings.
+  summary: |-
+    Composed Arizona individual income-tax liability pipeline for the oracle slice
+    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Arizona
+    adjusted gross income into the section 43-1011 flat tax on Arizona taxable
+    income (Arizona AGI less the supplied section 43-1041 standard deduction), so
+    an end-to-end comparison against PolicyEngine (az_income_tax) and TAXSIM
+    (siitax) does not require the caller to supply the bracket application. Arizona
+    replaced its graduated 43-1011(A) schedule with a single flat rate for tax
+    years beginning after 2022, so the schedule is wired in the general
+    bracket-base-plus-marginal form with the supplied bracket floor and base tax
+    set to zero and the supplied marginal rate carrying the flat rate; that
+    reproduces the statutory flat tax while keeping the same shape as the
+    progressive pilots. It deliberately models only the ordinary resident wage
+    earner and excludes the section 43-1073 family income tax credit, the section
+    43-1072.01/43-1073.01 dependent credits, and the section 43-1088 charitable
+    credits, all of which are zero for the childless wage-earner grid. Arizona
+    AGI, filing status, the standard deduction, the flat rate, and the credit are
+    supplied inputs; the department indexes the standard deduction each year, so
+    this 2026 pipeline is compared against PolicyEngine at 2026 and against
+    TAXSIM's latest 2024 law year with the standard-deduction indexation vintage
+    dispositioned.
+rules:
+  - name: az_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 43-1011 and 43-1041, Arizona taxable income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1041
+              excerpt: "the standard deduction is $12,200"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, az_pit_pilot_adjusted_gross_income - az_pit_pilot_supplied_standard_deduction)
+  - name: az_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 43-1011, flat tax as the supplied bracket base plus the supplied marginal rate on income above the supplied bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1011
+              excerpt: "the combined tax rate ... may not exceed four and one-half percent"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          az_pit_pilot_supplied_bracket_base
+          + az_pit_pilot_supplied_marginal_rate * max(0, az_pit_pilot_taxable_income - az_pit_pilot_supplied_bracket_floor)
+  - name: az_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 43-1011 flat tax less the supplied nonrefundable credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/statute/43-1011
+              excerpt: "the combined tax rate ... may not exceed four and one-half percent"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, az_pit_pilot_schedule_tax - az_pit_pilot_supplied_nonrefundable_credit)

--- a/us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,117 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the supplied schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). Georgia liability = the section 48-7-20 flat tax on Georgia taxable
+# net income (Georgia AGI - the section 48-7-27 standard deduction), less the
+# supplied nonrefundable credit. Georgia levies a single flat rate under section
+# 48-7-20, so the schedule is wired in the general bracket-base-plus-marginal
+# form with the supplied base tax and bracket floor at zero and the supplied
+# marginal rate carrying the flat 0.0499 rate. The supplied 2026 standard
+# deduction is the section 48-7-27(a)(1)(B) amount as amended by Georgia HB463,
+# effective tax year 2026: 15,000 single, 30,000 married filing jointly. Georgia
+# allows no personal exemption for these childless cases, and no credit applies
+# on the wage-earner grid.
+- name: single_30000
+  # taxable 30000 - 15000 = 15000. Schedule 0 + 0.0499*(15000-0) = 748.5.
+  # No credit: liability 748.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 30000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '15000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '748.5'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '748.5'
+- name: single_60000
+  # taxable 45000. Schedule 0.0499*45000 = 2245.5. Liability 2245.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 60000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '45000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '2245.5'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '2245.5'
+- name: single_150000
+  # taxable 135000. Schedule 0.0499*135000 = 6736.5. Liability 6736.5.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 150000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '135000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '6736.5'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '6736.5'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 60000 - 30000 = 30000.
+  # Schedule 0.0499*30000 = 1497.0. Liability 1497.0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 60000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '30000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '1497'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '1497'
+- name: married_120000
+  # taxable 90000. Schedule 0.0499*90000 = 4491.0. Liability 4491.0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 120000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '90000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '4491'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '4491'
+- name: married_300000
+  # taxable 270000. Schedule 0.0499*270000 = 13473.0. Liability 13473.0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 300000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '270000'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '13473'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '13473'

--- a/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,116 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ga/statute/48/48-7-20
+      - us-ga/statute/48/48-7-27
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ga/statute/48/48-7-20
+        - us-ga/statute/48/48-7-27
+      rationale: |-
+        This pipeline computes the Georgia section 48-7-20 individual income-tax
+        liability for the ordinary resident wage-earner slice: the flat tax on
+        Georgia taxable net income (Georgia adjusted gross income less the section
+        48-7-27 standard deduction). Section 48-7-20 imposes a single flat rate on
+        Georgia taxable net income and steps that rate down by session law toward
+        the 4.99-per-cent floor, and section 48-7-27(a)(1)(B), as amended by
+        Georgia HB463 (2025-2026), sets the standard deduction to $15,000 for a
+        single taxpayer or head of household and $30,000 for a married couple
+        filing a joint return effective tax year 2026, so the operative 2026 rate
+        (4.99 per cent) and standard deduction are the current values PolicyEngine
+        applies. To reach a liability comparable to PolicyEngine ga_income_tax to
+        the cent, every amount this pipeline needs is a declared caller-supplied
+        input: the 4.99-per-cent rate and the section 48-7-27 standard deduction
+        supplied as the AGI-to-taxable-income subtraction. Georgia imposes the flat
+        rate from the first dollar of taxable net income and, for these childless
+        cases, allows no personal exemption (section 48-7-26 sets the taxpayer and
+        dependent exemptions to zero for the taxpayer/spouse under the HB1437
+        restructuring) and no per-exemption tax credit, so the supplied bracket
+        floor, bracket base, and nonrefundable credit are zero. The pipeline adds
+        no numeric literals of its own; it wires the flat-rate mechanics only, in
+        the same supplied-schedule form as the Arizona and Kentucky flat pilots.
+  summary: |-
+    Composed Georgia individual income-tax liability pipeline for the oracle slice
+    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Georgia
+    adjusted gross income into the section 48-7-20 flat tax on Georgia taxable net
+    income (Georgia AGI less the supplied section 48-7-27 standard deduction), so
+    an end-to-end comparison against PolicyEngine
+    (ga_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
+    require the caller to supply the bracket application. Georgia levies a single
+    flat rate under section 48-7-20, so the schedule is wired in the general
+    bracket-base-plus-marginal form with the supplied bracket floor and base tax
+    set to zero and the supplied marginal rate carrying the flat rate; that
+    reproduces the statutory flat tax while keeping the same shape as the
+    progressive pilots. It deliberately models only the ordinary resident wage
+    earner and excludes the section 48-7-29 credits, the low-income credit, and
+    the nonrefundable child and dependent care credit, all of which are zero for
+    the childless wage-earner grid, so ga_income_tax_before_non_refundable_credits
+    equals the final ga_income_tax here. Georgia AGI, filing status, the standard
+    deduction, the flat rate, and the credit are supplied inputs; the enacted
+    schedule steps the rate down over time and HB463 raises the standard deduction
+    from tax year 2026, so this 2026 pipeline is compared against PolicyEngine at
+    2026 and against TAXSIM's latest 2024 law year with the 2024-to-2026
+    rate-and-deduction vintage dispositioned.
+rules:
+  - name: ga_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 48-7-20 and 48-7-27, Georgia taxable net income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Georgia taxable net income of an individual is federal adjusted gross income less specified deductions"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ga_pit_pilot_adjusted_gross_income - ga_pit_pilot_supplied_standard_deduction)
+  - name: ga_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 48-7-20, flat tax as the supplied bracket base plus the supplied marginal rate on income above the supplied bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-20
+              excerpt: "A tax is imposed upon every resident of this state with respect to the resident's Georgia taxable net income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          ga_pit_pilot_supplied_bracket_base
+          + ga_pit_pilot_supplied_marginal_rate * max(0, ga_pit_pilot_taxable_income - ga_pit_pilot_supplied_bracket_floor)
+  - name: ga_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 48-7-20 flat tax less the supplied nonrefundable credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-20
+              excerpt: "A tax is imposed upon every resident of this state with respect to the resident's Georgia taxable net income"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, ga_pit_pilot_schedule_tax - ga_pit_pilot_supplied_nonrefundable_credit)

--- a/us-mi/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-mi/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,117 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the supplied schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). Michigan liability = the section 206.51 flat tax on Michigan
+# taxable income (Michigan AGI - the section 206.30 personal exemptions), less
+# the supplied nonrefundable credit. Michigan levies a single flat rate under
+# MCL 206.51(1), so the schedule is wired in the general bracket-base-plus-
+# marginal form with the supplied base tax and bracket floor at zero and the
+# supplied marginal rate carrying the flat 0.0425 rate. The supplied 2026
+# personal exemption is the PolicyEngine-projected section 206.30 amount under
+# the section 206.30(7) inflation indexation: 5,950 per exemption (one exemption
+# single, two married filing jointly, so 5,950 single and 11,900 married). No
+# credit applies on the childless wage-earner grid.
+- name: single_30000
+  # taxable 30000 - 5950 = 24050. Schedule 0 + 0.0425*(24050-0) = 1022.125.
+  # No credit: liability 1022.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 30000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 5950
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '24050'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '1022.125'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '1022.125'
+- name: single_60000
+  # taxable 54050. Schedule 0.0425*54050 = 2297.125. Liability 2297.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 60000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 5950
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '54050'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '2297.125'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '2297.125'
+- name: single_150000
+  # taxable 144050. Schedule 0.0425*144050 = 6122.125. Liability 6122.125.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 150000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 5950
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '144050'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '6122.125'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '6122.125'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 60000 - 11900 = 48100.
+  # Schedule 0.0425*48100 = 2044.25. Liability 2044.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 60000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 11900
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '48100'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '2044.25'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '2044.25'
+- name: married_120000
+  # taxable 108100. Schedule 0.0425*108100 = 4594.25. Liability 4594.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 120000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 11900
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '108100'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '4594.25'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '4594.25'
+- name: married_300000
+  # taxable 288100. Schedule 0.0425*288100 = 12244.25. Liability 12244.25.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_adjusted_gross_income: 300000
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_personal_exemptions: 11900
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_base: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_bracket_floor: 0
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_marginal_rate: 0.0425
+    us-mi:policies/income_tax/pilot_liability_pipeline#input.mi_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income: '288100'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax: '12244.25'
+    us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability: '12244.25'

--- a/us-mi/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-mi/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,115 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-mi/statute/206.51/1
+      - us-mi/statute/206.30/2
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-mi/statute/206.51/1
+        - us-mi/statute/206.30/2
+      rationale: |-
+        This pipeline computes the Michigan section 206.51 individual income-tax
+        liability for the ordinary resident wage-earner slice: the flat tax on
+        Michigan taxable income (Michigan adjusted gross income less the section
+        206.30 personal exemptions). MCL 206.51(1) imposes a single flat rate on
+        the taxable income of every person other than a corporation, and section
+        206.30(2) allows a personal exemption per exemption claimed that section
+        206.30(7) adjusts each year for inflation (the base $3,700 exemption
+        raised by an additional $600 for 2022 and later years, then indexed), so
+        the operative 2026 flat rate (4.25 per cent) and the operative 2026
+        personal exemption ($5,950 per exemption) are the current values
+        PolicyEngine applies. To reach a liability comparable to PolicyEngine
+        mi_income_tax to the cent, every amount this pipeline needs is a declared
+        caller-supplied input: the 4.25-per-cent rate and the section 206.30
+        personal exemptions supplied as the AGI-to-taxable-income subtraction.
+        Michigan imposes the flat rate from the first dollar of taxable income and
+        allows no per-exemption tax credit for these cases, so the supplied
+        bracket floor, bracket base, and nonrefundable credit are zero. The
+        pipeline adds no numeric literals of its own; it wires the flat-rate
+        mechanics only, in the same supplied-schedule form as the Arizona and
+        Kentucky flat pilots.
+  summary: |-
+    Composed Michigan individual income-tax liability pipeline for the oracle
+    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
+    Michigan adjusted gross income into the section 206.51 flat tax on Michigan
+    taxable income (Michigan AGI less the supplied section 206.30 personal
+    exemptions), so an end-to-end comparison against PolicyEngine
+    (mi_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
+    require the caller to supply the bracket application. Michigan levies a single
+    flat rate under MCL 206.51(1), so the schedule is wired in the general
+    bracket-base-plus-marginal form with the supplied bracket floor and base tax
+    set to zero and the supplied marginal rate carrying the flat rate; that
+    reproduces the statutory flat tax while keeping the same shape as the
+    progressive pilots. It deliberately models only the ordinary resident wage
+    earner and excludes the section 206.30 retirement/senior subtractions, the
+    homestead property-tax credit, the home heating credit, and the refundable
+    section 206.272 earned income credit, all of which are zero for the childless
+    wage-earner grid, so mi_income_tax_before_non_refundable_credits equals the
+    final mi_income_tax here. Michigan AGI, filing status, the personal
+    exemptions, the flat rate, and the credit are supplied inputs; the department
+    indexes the personal exemption each year, so this 2026 pipeline is compared
+    against PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with
+    the personal-exemption indexation vintage dispositioned.
+rules:
+  - name: mi_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206.51 and 206.30, Michigan taxable income after the supplied personal exemptions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.30/2
+              excerpt: "a personal exemption of $3,700.00 multiplied by the number of personal and dependency exemptions shall be subtracted"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, mi_pit_pilot_adjusted_gross_income - mi_pit_pilot_supplied_personal_exemptions)
+  - name: mi_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206.51, flat tax as the supplied bracket base plus the supplied marginal rate on income above the supplied bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: "the tax imposed ... upon the taxable income of every person other than a corporation"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          mi_pit_pilot_supplied_bracket_base
+          + mi_pit_pilot_supplied_marginal_rate * max(0, mi_pit_pilot_taxable_income - mi_pit_pilot_supplied_bracket_floor)
+  - name: mi_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 206.51 flat tax less the supplied nonrefundable credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: "the tax imposed ... upon the taxable income of every person other than a corporation"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, mi_pit_pilot_schedule_tax - mi_pit_pilot_supplied_nonrefundable_credit)

--- a/us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,116 @@
+# Fixtures are hand-computed at the 2026 tax year (the expected values are the
+# author's own shown arithmetic from the supplied schedule, which axiom-encode
+# test proves equal the engine output to full decimal precision, not an oracle
+# read-back). North Carolina liability = the section 105-153.7 flat tax on North
+# Carolina taxable income (North Carolina AGI - the section 105-153.5(a) standard
+# deduction), less the supplied nonrefundable credit. North Carolina levies a
+# single flat rate under section 105-153.7, so the schedule is wired in the
+# general bracket-base-plus-marginal form with the supplied base tax and bracket
+# floor at zero and the supplied marginal rate carrying the flat 0.0399 rate. The
+# supplied 2026 standard deduction is the PolicyEngine-applied section 105-153.5(a)
+# amount: 12,750 single, 25,500 married filing jointly. No credit applies on the
+# childless wage-earner grid.
+- name: single_30000
+  # taxable 30000 - 12750 = 17250. Schedule 0 + 0.0399*(17250-0) = 688.275.
+  # No credit: liability 688.275.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 30000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 12750
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '17250'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '688.275'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '688.275'
+- name: single_60000
+  # taxable 47250. Schedule 0.0399*47250 = 1885.275. Liability 1885.275.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 60000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 12750
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '47250'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '1885.275'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '1885.275'
+- name: single_150000
+  # taxable 137250. Schedule 0.0399*137250 = 5476.275. Liability 5476.275.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 150000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 12750
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '137250'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '5476.275'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '5476.275'
+- name: married_60000
+  # Married filing jointly, spouse income 0. taxable 60000 - 25500 = 34500.
+  # Schedule 0.0399*34500 = 1376.55. Liability 1376.55.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 60000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 25500
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '34500'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '1376.55'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '1376.55'
+- name: married_120000
+  # taxable 94500. Schedule 0.0399*94500 = 3770.55. Liability 3770.55.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 120000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 25500
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '94500'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '3770.55'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '3770.55'
+- name: married_300000
+  # taxable 274500. Schedule 0.0399*274500 = 10952.55. Liability 10952.55.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_adjusted_gross_income: 300000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_standard_deduction: 25500
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_base: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_bracket_floor: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_marginal_rate: 0.0399
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_supplied_nonrefundable_credit: 0
+  output:
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '274500'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_schedule_tax: '10952.55'
+    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '10952.55'

--- a/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,113 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-nc/statute/105/105-153.7
+      - us-nc/statute/105/105-153.5/a
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-nc/statute/105/105-153.7
+        - us-nc/statute/105/105-153.5/a
+      rationale: |-
+        This pipeline computes the North Carolina section 105-153.7 individual
+        income-tax liability for the ordinary resident wage-earner slice: the flat
+        tax on North Carolina taxable income (North Carolina adjusted gross income
+        less the section 105-153.5(a) standard deduction). Section 105-153.7
+        imposes a single rate on the North Carolina taxable income of every
+        individual and steps that rate down by session law (the enacted schedule
+        reaches 3.99 per cent), and section 105-153.5(a) sets the standard
+        deduction by filing status, so the operative 2026 rate (3.99 per cent) and
+        the operative 2026 standard deduction ($12,750 single, $25,500 married
+        filing jointly) are the current values PolicyEngine applies. To reach a
+        liability comparable to PolicyEngine nc_income_tax to the cent, every
+        amount this pipeline needs is a declared caller-supplied input: the
+        3.99-per-cent rate and the section 105-153.5(a) standard deduction supplied
+        as the AGI-to-taxable-income subtraction. North Carolina imposes the flat
+        rate from the first dollar of taxable income and allows no per-exemption
+        tax credit for these cases, so the supplied bracket floor, bracket base,
+        and nonrefundable credit are zero. The pipeline adds no numeric literals of
+        its own; it wires the flat-rate mechanics only, in the same
+        supplied-schedule form as the Arizona and Kentucky flat pilots.
+  summary: |-
+    Composed North Carolina individual income-tax liability pipeline for the
+    oracle slice at the 2026 tax year. It exposes a TaxUnit-level path from a
+    supplied North Carolina adjusted gross income into the section 105-153.7 flat
+    tax on North Carolina taxable income (North Carolina AGI less the supplied
+    section 105-153.5(a) standard deduction), so an end-to-end comparison against
+    PolicyEngine (nc_income_tax_before_credits) and TAXSIM (siitax) does not
+    require the caller to supply the bracket application. North Carolina levies a
+    single flat rate under section 105-153.7, so the schedule is wired in the
+    general bracket-base-plus-marginal form with the supplied bracket floor and
+    base tax set to zero and the supplied marginal rate carrying the flat rate;
+    that reproduces the statutory flat tax while keeping the same shape as the
+    progressive pilots. It deliberately models only the ordinary resident wage
+    earner and excludes the child deduction, the section 105-153.10 credits, and
+    the nonrefundable child and dependent care credit, all of which are zero for
+    the childless wage-earner grid, so nc_income_tax_before_credits equals the
+    final nc_income_tax here. North Carolina AGI, filing status, the standard
+    deduction, the flat rate, and the credit are supplied inputs; the enacted
+    schedule steps the rate down over time, so this 2026 pipeline is compared
+    against PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with the
+    2024-to-2026 rate-schedule vintage dispositioned.
+rules:
+  - name: nc_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 105-153.7 and 105-153.5, North Carolina taxable income after the supplied standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5/a
+              excerpt: "In calculating North Carolina taxable income, a taxpayer may deduct from adjusted gross income either the standard deduction amount or the itemized deduction amount"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, nc_pit_pilot_adjusted_gross_income - nc_pit_pilot_supplied_standard_deduction)
+  - name: nc_pit_pilot_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 105-153.7, flat tax as the supplied bracket base plus the supplied marginal rate on income above the supplied bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "A tax is imposed for each taxable year on the North Carolina taxable income of every individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          nc_pit_pilot_supplied_bracket_base
+          + nc_pit_pilot_supplied_marginal_rate * max(0, nc_pit_pilot_taxable_income - nc_pit_pilot_supplied_bracket_floor)
+  - name: nc_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 105-153.7 flat tax less the supplied nonrefundable credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.7
+              excerpt: "A tax is imposed for each taxable year on the North Carolina taxable income of every individual"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, nc_pit_pilot_schedule_tax - nc_pit_pilot_supplied_nonrefundable_credit)


### PR DESCRIPTION
Composes the Arizona individual income-tax liability pipeline
(`us-az/policies/income_tax/pilot_liability_pipeline`), mirroring the OH/CA
#561 pilots and the AL/ID/KY (#773) and DE/MD/ME/MN/CT (#774) composed states.

Arizona levies a single flat rate (§43-1011) on Arizona taxable income
(Arizona AGI less the §43-1041 standard deduction) for tax years beginning
after 2022. The rate, standard deduction, bracket floor/base, and
nonrefundable credit are supplied per-case inputs (same supplied-schedule form
as the flat UT/AZ pilots and the progressive OH pilot), so the pipeline adds no
numeric literals of its own.

- `axiom-encode test`: 6/6 cases equal the engine output to full decimal
  precision (single 30k/60k/150k; married 60k/120k/300k).
- Manifest signed with `--manual-exception composition`; reverse index regen.
- Matches PolicyEngine `az_income_tax` to the cent at 2026 on all six cases
  (flat 2.5% on AGI less the 15,750/31,500 indexed standard deduction).

The companion axiom-oracles suite registers `az_income_tax` coverage
(us-pe +1) separately.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
