### PR TITLE
Encode Delaware TANF (16 DE Admin Code 4007/4008) + composed program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-de/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-de/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-de/tanf/fy-2026.yaml",
+      "sha256": "cf65567e64a7ac64f4b16b5fa6fc6109358da5192d10491df9c8b5c69f9b51e1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-de/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T14:35:25.993353+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "cf65567e64a7ac64f4b16b5fa6fc6109358da5192d10491df9c8b5c69f9b51e1",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2792f8cef3ce1ace032f2ec6977f0be8253251fefbae9b6d1d84c4cd2d77d2a0"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8382,6 +8382,24 @@
         ]
       }
     ],
+    "us-de/regulation/title-16/4000-financial-responsibility/4007.2": [
+      {
+        "module": "us-de/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-de/regulation/title-16/4000-financial-responsibility/4008.1.1": [
+      {
+        "module": "us-de/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-de/regulation/title-16/4000-financial-responsibility/4008.1.2": [
       {
         "module": "us-de/regulations/title-16/4000-financial-responsibility/4008/1/2.yaml",

--- a/programs/us-de/tanf/fy-2026.yaml
+++ b/programs/us-de/tanf/fy-2026.yaml
@@ -1,0 +1,91 @@
+# Delaware TANF (Temporary Assistance for Needy Families) -- FY 2026, recipient-month benefit.
+#
+# Mirrors the encoded Delaware DSS slice in rulespec-us/us-de:
+#   - regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard
+#       (16 DE Admin. Code 4007.2 payment standard table by budget size 1..8,
+#        +$69 per person above eight)
+#   - regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation
+#       (16 DE Admin. Code 4008.1.1: the 185%-of-standard-of-need gross income
+#        test, the $90 applicant net-income test against the payment standard,
+#        and the grant = min(payment standard, 50% of the standard-of-need
+#        deficit after the $90 work deduction + $30 + 1/3 disregard))
+# and adds the oracle-suite plumbing: the household-membership data relation, the
+# Count budget-size declaration, and a benefit gated on the demographic fact
+# PolicyEngine's de_tanf requires (a minor child or pregnant member) so the
+# comparison never pays childless units PE's de_tanf would not.
+#
+# Target oracle surface: PolicyEngine de_tanf (SPMUnit, MONTH):
+#   min(deficit_rate * max(standard_of_need - countable_income, 0), payment_standard),
+#   defined_for de_tanf_eligible. The standard of need is 75% of the monthly
+#   federal poverty guideline; for the zero-income units that dominate the
+#   caseload the 50% deficit remainder exceeds the payment standard, so the
+#   benefit equals the payment standard exactly. The annualized output mirrors
+#   the covered al/co/ga convention; the compare framework annualizes PE's
+#   monthly de_tanf.
+
+program: us-de/tanf
+period: 2026-01
+
+outputs:
+  - de_tanf_annual_benefit
+
+acknowledged_incomplete:
+  - de_tanf_annual_benefit
+
+scope:
+  state:
+    - regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation
+
+transformations:
+  - pattern: data_relation
+    name: member_of_household
+    arity: 2
+    source: axiom-oracles ECPS projection household membership
+
+  # The 4007.2 payment-standard chart is indexed_by de_tanf_payment_standard_budget_size_index,
+  # which is min(number_people_in_budget, 8). The encoder declared that index Count,
+  # but number_people_in_budget itself feeds the min() and the +$69/person tail, so
+  # the compiler would otherwise infer it as decimal and the chart lookup fails
+  # ("parameter key must be an integer"). Declare it Count here, bound to the AU
+  # member count supplied at household scope by the populace input mapping
+  # (assistance_unit_member_count = hh_size), the same slot Georgia's au_size uses.
+  - pattern: derived_formula
+    name: number_people_in_budget
+    effective_from: '2002-10-01'
+    entity: TanfUnit
+    dtype: Count
+    source: axiom-oracles programs/us-de/tanf budget size (integer chart key)
+    formula: assistance_unit_member_count
+
+  # de_tanf (the 4008 grant leaf output) is the pre-demographic-gate monthly
+  # benefit. The remaining leaf free inputs are supplied at HOUSEHOLD scope by the
+  # populace input mapping: applicable_tanf_standard_of_need (0.75 x monthly FPG
+  # via table_by_hh_size), gross_income and total_wage_earner_earnings (monthly AU
+  # sums), unearned_income (monthly AU unearned), and the constants wage_earner_count=1,
+  # child_care_expenses=0, thirty_plus_one_third_disregard_applies=true. The $90 + $30
+  # + 1/3 earned-income deduction is projected at household scope (wage_earner_count=1),
+  # exact for the 0- and 1-earner units that dominate the caseload and diverging only
+  # for the rare multi-earner unit (each earner's own $90/$30 pass), dispositioned --
+  # the ECPS composed-program bridge does not reliably materialise person entities for
+  # zero-earner assistance units, so a per-person leaf would collapse to None there.
+  - pattern: derived_formula
+    name: de_tanf_monthly_benefit
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-oracles programs/us-de/tanf demographic-gated monthly benefit
+    formula: |-
+      if household_has_minor_or_pregnant_member: de_tanf else: 0
+
+  - pattern: derived_formula
+    name: de_tanf_annual_benefit
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Year
+    unit: USD
+    source: axiom-oracles programs/us-de/tanf program output
+    formula: |-
+      de_tanf_monthly_benefit * 12

--- a/tests/test_encoding_manifests.py
+++ b/tests/test_encoding_manifests.py
@@ -47,6 +47,8 @@ def manifest_roots() -> list[tuple[Path, Path]]:
 
 def resolve_applied_path(base: Path, applied: str) -> Path:
     head = applied.split("/", 1)[0]
+    if base == ROOT and head == "programs":
+        return ROOT / applied
     if base == ROOT and not JURISDICTION_DIR_RE.match(head):
         # Pre-consolidation federal manifests predate the us/ prefix.
         return ROOT / "us" / applied

--- a/us-de/.axiom/encoding-manifests/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.json
+++ b/us-de/.axiom/encoding-manifests/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.yaml",
+      "sha256": "00f1b31a24d7125ade3473cb4b5bcc55862708c434425f807e82ca2983f9ee63"
+    },
+    {
+      "path": "regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.test.yaml",
+      "sha256": "17c1bdcb8c7cbc0d7d4f3726a0f9c88ed1d1023d3cee75a7a67ffa3235d4472a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "codex",
+  "citation": "us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard",
+  "context_manifest_file": "/tmp/axiom-encode-de-tanf/_eval_workspaces/codex-gpt-5.5/us-de-regulations-title-16-4000-financial-responsibility-4007-standards-of-need-and-payment-standard/workspace/context-manifest.json",
+  "context_manifest_sha256": "a52038d65e438d78a274e09cd404cfb3f703aa0db1740a7ddd385e1c0fa24512",
+  "generated_at": "2026-07-09T20:49:41.661452+00:00",
+  "generated_output_file": "/tmp/axiom-encode-de-tanf/codex-gpt-5.5/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.yaml",
+  "generated_output_root": "/tmp/axiom-encode-de-tanf",
+  "generated_output_sha256": "00f1b31a24d7125ade3473cb4b5bcc55862708c434425f807e82ca2983f9ee63",
+  "generation_prompt_sha256": "f1618ceeef5d32f10df797ebb09f156bbf26c14c62d1b6f0872805dcd3df2746",
+  "model": "gpt-5.5",
+  "run_id": "86d2a227",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c9e7f604c818e2bfd5dcedb66478656921ca88f335fd01a32b73accdc644d650"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-de-tanf/traces/codex-gpt-5.5/us-de-regulations-title-16-4000-financial-responsibility-4007-standards-of-need-and-payment-standard.json",
+  "trace_sha256": "f8a2a62bd30a00c63a966bb23709e418e0560639fa9766975dc165cdfafb6aaf"
+}

--- a/us-de/.axiom/encoding-manifests/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.json
+++ b/us-de/.axiom/encoding-manifests/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.yaml",
+      "sha256": "240a1c975097b6e001bcc104883a52a5fc90182b23147ad6c2a4b51765ed45f8"
+    },
+    {
+      "path": "regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.test.yaml",
+      "sha256": "59a5c53473f05dc33919b9305c2c28279209208633aff03e2ecacbde6d6cbdf7"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "codex",
+  "citation": "us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation",
+  "context_manifest_file": "/tmp/axiom-encode-de-tanf/_eval_workspaces/codex-gpt-5.5/us-de-regulations-title-16-4000-financial-responsibility-4008-financial-eligibility-and-grant-computation/workspace/context-manifest.json",
+  "context_manifest_sha256": "9a8eaed615a0d9d50e847b6ea21559d52a34b1691bd68154e886d6fb06068dc7",
+  "generated_at": "2026-07-09T20:56:28.039977+00:00",
+  "generated_output_file": "/tmp/axiom-encode-de-tanf/codex-gpt-5.5/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.yaml",
+  "generated_output_root": "/tmp/axiom-encode-de-tanf",
+  "generated_output_sha256": "240a1c975097b6e001bcc104883a52a5fc90182b23147ad6c2a4b51765ed45f8",
+  "generation_prompt_sha256": "63ea0d75b30eb090234c9ba4c62388582440036c4b0b24cd07d84a2dfe1abdf2",
+  "model": "gpt-5.5",
+  "run_id": "ca0e9f77",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "db1d7e6f3b617752b0031b6c00eaf41e4d01b987796e30055ca4ec48ff461727"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/tmp/axiom-encode-de-tanf/traces/codex-gpt-5.5/us-de-regulations-title-16-4000-financial-responsibility-4008-financial-eligibility-and-grant-computation.json",
+  "trace_sha256": "116e4cb09395ad4f05eb0851f9aa3ef83ee1b083c37f2841445092c70779c612"
+}

--- a/us-de/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.test.yaml
+++ b/us-de/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.test.yaml
@@ -1,0 +1,35 @@
+- name: three_person_budget_payment_standard
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 3
+  output:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard
+    : 338
+- name: eight_person_budget_payment_standard
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 8
+  output:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard
+    : 681
+- name: ten_person_budget_adds_amount_above_eight
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 10
+  output:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard
+    : 819
+- name: auto_output_de_tanf_payment_standard_budget_size_index
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 0
+  output:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_budget_size_index
+    : 0

--- a/us-de/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.yaml
+++ b/us-de/regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard.yaml
@@ -1,0 +1,154 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+  summary: |-
+    "The State pays a percentage of the deficit up to a maximum benefit level or payment standard." The payment standard table current for 10/2002 - 9/30/2003 lists monthly amounts by number of people in the budget and adds $69 per person above eight.
+rules:
+  - name: de_tanf_payment_standard_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: de_tanf_payment_standard_budget_size_index
+    source: 16 DE Admin. Code 4007.2, payment standard table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "PAYMENT STANDARD*** $201 $270 $338 $407 $475 $544 $612 $681"
+              table:
+                header: "185% of Standard of Need/ Standard of Need/Payment Standard"
+                row_key: "NUMBER OF PEOPLE IN THE BUDGET"
+                column_key: "PAYMENT STANDARD"
+    versions:
+      - effective_from: '2002-10-01'
+        values:
+          1: 201
+          2: 270
+          3: 338
+          4: 407
+          5: 475
+          6: 544
+          7: 612
+          8: 681
+
+  - name: de_tanf_payment_standard_maximum_table_budget_size
+    kind: parameter
+    dtype: Count
+    source: 16 DE Admin. Code 4007.2, payment standard table note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "Add $69 per person above eight in the family."
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          8
+
+  - name: de_tanf_payment_standard_additional_person_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4007.2, payment standard table note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "Add $69 per person above eight in the family."
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          69
+
+  - name: de_tanf_payment_standard_budget_size_index
+    kind: derived
+    entity: TanfUnit
+    dtype: Count
+    period: Month
+    source: 16 DE Admin. Code 4007.2, payment standard table and note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "Add $69 per person above eight in the family."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_maximum_table_budget_size
+              output: de_tanf_payment_standard_maximum_table_budget_size
+              hash: sha256:local
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          min(number_people_in_budget, de_tanf_payment_standard_maximum_table_budget_size)
+
+  - name: de_tanf_payment_standard
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4007.2, payment standard table and note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "The State pays a percentage of the deficit up to a maximum benefit level or payment standard."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "PAYMENT STANDARD*** $201 $270 $338 $407 $475 $544 $612 $681"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4007.2
+              excerpt: "Add $69 per person above eight in the family."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_table
+              output: de_tanf_payment_standard_table
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_budget_size_index
+              output: de_tanf_payment_standard_budget_size_index
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_maximum_table_budget_size
+              output: de_tanf_payment_standard_maximum_table_budget_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard_additional_person_amount
+              output: de_tanf_payment_standard_additional_person_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          de_tanf_payment_standard_table[de_tanf_payment_standard_budget_size_index] + max(0, number_people_in_budget - de_tanf_payment_standard_maximum_table_budget_size) * de_tanf_payment_standard_additional_person_amount

--- a/us-de/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.test.yaml
+++ b/us-de/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.test.yaml
@@ -1,0 +1,84 @@
+- name: grant_capped_at_payment_standard
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 3
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.gross_income
+    : 251
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.applicable_tanf_standard_of_need
+    : 1000
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.total_wage_earner_earnings
+    : 201
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.wage_earner_count
+    : 1
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.child_care_expenses
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.unearned_income
+    : 50
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.thirty_plus_one_third_disregard_applies
+    : true
+  output:
+    us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#de_tanf: 338
+- name: denied_when_gross_income_exceeds_limit
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 3
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.gross_income
+    : 2000
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.applicable_tanf_standard_of_need
+    : 1000
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.total_wage_earner_earnings
+    : 201
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.wage_earner_count
+    : 1
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.child_care_expenses
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.unearned_income
+    : 50
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.thirty_plus_one_third_disregard_applies
+    : true
+  output:
+    us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#de_tanf: 0
+- name: denied_when_applicant_net_income_exceeds_payment_standard
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 3
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.gross_income
+    : 500
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.applicable_tanf_standard_of_need
+    : 1000
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.total_wage_earner_earnings
+    : 500
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.wage_earner_count
+    : 1
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.child_care_expenses
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.unearned_income
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.thirty_plus_one_third_disregard_applies
+    : true
+  output:
+    us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#de_tanf: 0
+- name: grant_remainder_below_payment_standard
+  period: 2022-01
+  input:
+    ? us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#input.number_people_in_budget
+    : 3
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.gross_income
+    : 100
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.applicable_tanf_standard_of_need
+    : 500
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.total_wage_earner_earnings
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.wage_earner_count
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.child_care_expenses
+    : 0
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.unearned_income
+    : 100
+    ? us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#input.thirty_plus_one_third_disregard_applies
+    : false
+  output:
+    us-de:regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation#de_tanf: 200

--- a/us-de/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.yaml
+++ b/us-de/regulations/title-16/4000-financial-responsibility/4008-financial-eligibility-and-grant-computation.yaml
@@ -1,0 +1,152 @@
+format: rulespec/v1
+imports:
+  - us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+  summary: |-
+    "Deny assistance if the income exceeds 185% of the applicable Temporary Assistance for Needy Families standard of need." Applicant net income subtracts the $90.00 earned income deduction and child care expenses, then compares net family income to the payment standard. Grant computation subtracts the $90.00 standard work deduction, 30 plus 1/3 disregard if applicable, and child care, then pays the lesser of 50% of the deficit or the payment standard.
+rules:
+  - name: gross_income_test_standard_of_need_multiplier
+    kind: parameter
+    dtype: Rate
+    source: 16 DE Admin. Code 4008.1.1, gross income test
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "185% of the applicable Temporary Assistance for Needy Families standard of need"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          1.85
+
+  - name: applicant_earned_income_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4008.1.1, Step 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "earned income deduction ($90.00)"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          90.00
+
+  - name: standard_work_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4008.1.1, Step 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "standard work deduction ($90.00)"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          90.00
+
+  - name: thirty_dollar_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4008.1.1, Step 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "30 plus 1/3 disregard"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          30
+
+  - name: one_third_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 16 DE Admin. Code 4008.1.1, Step 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "1/3 disregard"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          1 / 3
+
+  - name: deficit_percentage
+    kind: parameter
+    dtype: Rate
+    source: 16 DE Admin. Code 4008.1.1, Step 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+              excerpt: "Multiply the deficit by 50%"
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          0.50
+
+  - name: de_tanf
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    source: 16 DE Admin. Code 4008.1.1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-de/regulation/title-16/4000-financial-responsibility/4008.1.1
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-de:regulations/title-16/4000-financial-responsibility/4007-standards-of-need-and-payment-standard#de_tanf_payment_standard
+              output: de_tanf_payment_standard
+              hash: sha256:00f1b31a24d7125ade3473cb4b5bcc55862708c434425f807e82ca2983f9ee63
+    versions:
+      - effective_from: '2002-10-01'
+        formula: |-
+          if gross_income > applicable_tanf_standard_of_need * gross_income_test_standard_of_need_multiplier:
+            0
+          else:
+            if max(0, total_wage_earner_earnings - wage_earner_count * applicant_earned_income_deduction - child_care_expenses) + unearned_income > de_tanf_payment_standard:
+              0
+            else:
+              min(
+                de_tanf_payment_standard,
+                max(0, applicable_tanf_standard_of_need - (max(0, total_wage_earner_earnings - wage_earner_count * standard_work_deduction - (if thirty_plus_one_third_disregard_applies: wage_earner_count * thirty_dollar_disregard_amount + max(0, total_wage_earner_earnings - wage_earner_count * standard_work_deduction - wage_earner_count * thirty_dollar_disregard_amount) * one_third_disregard_rate else: 0) - child_care_expenses) + unearned_income)) * deficit_percentage
+              )


### PR DESCRIPTION
Encodes Delaware TANF (16 DE Admin. Code §4000) as two RuleSpec leaves plus the composed program spec, for the wave-3 `us-pe` TANF coverage fan-out.

## Leaves (`us-de/regulations/title-16/4000-financial-responsibility/`)
- **4007** — payment-standard + standard-of-need table (§4007.2): monthly amounts by budget size 1–8 (201…681), +$69/person above eight. AU-size chart index declared `Count`.
- **4008** — financial eligibility + grant computation (§4008.1.1): 185%-of-standard-of-need gross-income test, $90 applicant net-income test against the payment standard, and grant = `min(payment_standard, 0.5 × max(standard_of_need − countable_income, 0))` after the $90 work + $30 + 1/3 earned-income disregard.

Each ships its companion `.test.yaml` and a signed encoding manifest.

## Program (`programs/us-de/tanf/fy-2026.yaml`)
Deterministic composition: declares `number_people_in_budget` as `Count` for the chart subscript, gates the benefit on a minor/pregnant member, and annualizes `de_tanf`. Mirrors the axiom-oracles program driving the `de-tanf-ecps` population suite.

## Validation
Composed and Rust-compiled clean; the `de-tanf-ecps` ECPS-population suite (axiom-oracles) reproduces PolicyEngine `de_tanf` on **781/781** Delaware households, **0 residuals** (PE pin 1.752.2, populace-us 2024, FIPS 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
