### PR TITLE
Bootstrap strict validation waiver schema

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -40,1801 +40,5388 @@ uncovered_derived_rules:
 # time — see https://github.com/TheAxiomFoundation/rulespec-us/issues/396 for the per-jurisdiction burn-down (vendor corpus slices
 # per the rulespec-uk data/corpus pattern, then remove entries).
 validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/396
-  # Social Security Title II AIME/PIA/COLA modules: the 415(b) AIME chain uses the
-  # engine's sum_top_n_over_periods over-periods reduction (valid only under lifetime
-  # execution), so their AIME/PIA/COLA-adjusted derived outputs cannot be asserted by
-  # the per-period companion-test harness, and `validate`'s unconditional derived-output
-  # coverage check therefore rejects them. Their parameters, single-year 415(b)(3)
-  # indexing, and the 416(l)/402(q)/402(w) chains they feed are fully validated and
-  # tested; the AIME->PIA->COLA end-to-end arithmetic is hand-verified in each module.
-  # Remove these once lifetime companion-test execution lands
-  # (https://github.com/TheAxiomFoundation/axiom-encode/issues/1036).
-  - us/statutes/42/415/a.yaml
-  - us/statutes/42/415/b.yaml
-  - us/statutes/42/415/i.yaml
-  - us-al/policies/dhr/poe/chapter-02-application-processing/211.yaml
-  - us-al/policies/dhr/poe/chapter-02-application-processing/212.yaml
-  - us-al/policies/dhr/poe/chapter-02-application-processing/213.yaml
-  - us-az/policies/des/faa5/na-child-support-expense/allowable-deductions.yaml
-  - us-az/policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml
-  - us-az/policies/des/faa5/na-eligibility-and-benefit-determination/first-month-benefit-proration.yaml
-  - us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml
-  - us-ca/policies/cdss/snap/standard-utility-allowance.yaml
-  - us-ca/regulations/mpp/63-300/1.yaml
-  - us-ca/regulations/mpp/63-300/21.yaml
-  - us-ca/regulations/mpp/63-300/23.yaml
-  - us-ca/regulations/mpp/63-300/232.yaml
-  - us-ca/regulations/mpp/63-300/233.yaml
-  - us-ca/regulations/mpp/63-300/234.yaml
-  - us-ca/regulations/mpp/63-300/24.yaml
-  - us-ca/regulations/mpp/63-300/25.yaml
-  - us-ca/regulations/mpp/63-300/3.yaml
-  - us-ca/regulations/mpp/63-300/31.yaml
-  - us-ca/regulations/mpp/63-300/32.yaml
-  - us-ca/regulations/mpp/63-300/321.yaml
-  - us-ca/regulations/mpp/63-300/322.yaml
-  - us-ca/regulations/mpp/63-300/34.yaml
-  - us-ca/regulations/mpp/63-300/36.yaml
-  - us-ca/regulations/mpp/63-300/37.yaml
-  - us-ca/regulations/mpp/63-300/381.yaml
-  - us-ca/regulations/mpp/63-300/42.yaml
-  - us-ca/regulations/mpp/63-300/43.yaml
-  - us-ca/regulations/mpp/63-300/44.yaml
-  - us-ca/regulations/mpp/63-300/45.yaml
-  - us-ca/regulations/mpp/63-300/46.yaml
-  - us-ca/regulations/mpp/63-300/461.yaml
-  - us-ca/regulations/mpp/63-300/462.yaml
-  - us-ca/regulations/mpp/63-300/463.yaml
-  - us-ca/regulations/mpp/63-300/464.yaml
-  - us-ca/regulations/mpp/63-300/465.yaml
-  - us-ca/regulations/mpp/63-300/5.yaml
-  - us-ca/regulations/mpp/63-300/6.yaml
-  - us-ca/regulations/mpp/63-300/622.yaml
-  - us-ca/regulations/mpp/63-300/623.yaml
-  - us-ca/regulations/mpp/63-301/1.yaml
-  - us-ca/regulations/mpp/63-301/2.yaml
-  - us-ca/regulations/mpp/63-301/3.yaml
-  - us-ca/regulations/mpp/63-301/31.yaml
-  - us-ca/regulations/mpp/63-301/311.yaml
-  - us-ca/regulations/mpp/63-301/33.yaml
-  - us-ca/regulations/mpp/63-301/4.yaml
-  - us-ca/regulations/mpp/63-301/411.yaml
-  - us-ca/regulations/mpp/63-301/412.yaml
-  - us-ca/regulations/mpp/63-301/42.yaml
-  - us-ca/regulations/mpp/63-301/421.yaml
-  - us-ca/regulations/mpp/63-301/422.yaml
-  - us-ca/regulations/mpp/63-301/423.yaml
-  - us-ca/regulations/mpp/63-301/424.yaml
-  - us-ca/regulations/mpp/63-301/431.yaml
-  - us-ca/regulations/mpp/63-301/432.yaml
-  - us-ca/regulations/mpp/63-301/441.yaml
-  - us-ca/regulations/mpp/63-301/442.yaml
-  - us-ca/regulations/mpp/63-301/511.yaml
-  - us-ca/regulations/mpp/63-301/512.yaml
-  - us-ca/regulations/mpp/63-301/513.yaml
-  - us-ca/regulations/mpp/63-301/523.yaml
-  - us-ca/regulations/mpp/63-301/531.yaml
-  - us-ca/regulations/mpp/63-301/532.yaml
-  - us-ca/regulations/mpp/63-301/533.yaml
-  - us-ca/regulations/mpp/63-301/541.yaml
-  - us-ca/regulations/mpp/63-301/542.yaml
-  - us-ca/regulations/mpp/63-301/543.yaml
-  - us-ca/regulations/mpp/63-301/544.yaml
-  - us-ca/regulations/mpp/63-301/545.yaml
-  - us-ca/regulations/mpp/63-301/546.yaml
-  - us-ca/regulations/mpp/63-301/547.yaml
-  - us-ca/regulations/mpp/63-301/548.yaml
-  - us-ca/regulations/mpp/63-301/61.yaml
-  - us-ca/regulations/mpp/63-301/611.yaml
-  - us-ca/regulations/mpp/63-301/62.yaml
-  - us-ca/regulations/mpp/63-301/63.yaml
-  - us-ca/regulations/mpp/63-301/631.yaml
-  - us-ca/regulations/mpp/63-301/632.yaml
-  - us-ca/regulations/mpp/63-301/633.yaml
-  - us-ca/regulations/mpp/63-301/71.yaml
-  - us-ca/regulations/mpp/63-301/72.yaml
-  - us-ca/regulations/mpp/63-301/73.yaml
-  - us-ca/regulations/mpp/63-301/733.yaml
-  - us-ca/regulations/mpp/63-301/734.yaml
-  - us-ca/regulations/mpp/63-301/741.yaml
-  - us-ca/regulations/mpp/63-301/751.yaml
-  - us-ca/regulations/mpp/63-301/752.yaml
-  - us-ca/regulations/mpp/63-301/753.yaml
-  - us-ca/regulations/mpp/63-301/755.yaml
-  - us-ca/regulations/mpp/63-301/756.yaml
-  - us-ca/regulations/mpp/63-301/76.yaml
-  - us-ca/regulations/mpp/63-301/81.yaml
-  - us-ca/regulations/mpp/63-301/812.yaml
-  - us-ca/regulations/mpp/63-301/821.yaml
-  - us-ca/regulations/mpp/63-301/823.yaml
-  - us-ca/regulations/mpp/63-301/824.yaml
-  - us-ca/regulations/mpp/63-301/825.yaml
-  - us-ca/regulations/mpp/63-301/9.yaml
-  - us-ca/regulations/mpp/63-301/91.yaml
-  - us-ca/regulations/mpp/63-301/92.yaml
-  - us-ca/regulations/mpp/63-401/1.yaml
-  - us-ca/regulations/mpp/63-401/2.yaml
-  - us-ca/regulations/mpp/63-401/4.yaml
-  - us-ca/regulations/mpp/63-401/5.yaml
-  - us-ca/regulations/mpp/63-401/6.yaml
-  - us-ca/regulations/mpp/63-402/1.yaml
-  - us-ca/regulations/mpp/63-402/11.yaml
-  - us-ca/regulations/mpp/63-402/13.yaml
-  - us-ca/regulations/mpp/63-402/131.yaml
-  - us-ca/regulations/mpp/63-402/141.yaml
-  - us-ca/regulations/mpp/63-402/142.yaml
-  - us-ca/regulations/mpp/63-402/143.yaml
-  - us-ca/regulations/mpp/63-402/144.yaml
-  - us-ca/regulations/mpp/63-402/146.yaml
-  - us-ca/regulations/mpp/63-402/15.yaml
-  - us-ca/regulations/mpp/63-402/151.yaml
-  - us-ca/regulations/mpp/63-402/16.yaml
-  - us-ca/regulations/mpp/63-402/17.yaml
-  - us-ca/regulations/mpp/63-402/21.yaml
-  - us-ca/regulations/mpp/63-402/211.yaml
-  - us-ca/regulations/mpp/63-403/1.yaml
-  - us-ca/regulations/mpp/63-403/2.yaml
-  - us-ca/regulations/mpp/63-403/21.yaml
-  - us-ca/regulations/mpp/63-403/31.yaml
-  - us-ca/regulations/mpp/63-403/4.yaml
-  - us-ca/regulations/mpp/63-404/1.yaml
-  - us-ca/regulations/mpp/63-404/11.yaml
-  - us-ca/regulations/mpp/63-404/13.yaml
-  - us-ca/regulations/mpp/63-404/21.yaml
-  - us-ca/regulations/mpp/63-404/31.yaml
-  - us-ca/regulations/mpp/63-404/33.yaml
-  - us-ca/regulations/mpp/63-404/34.yaml
-  - us-ca/regulations/mpp/63-404/41.yaml
-  - us-ca/regulations/mpp/63-404/511.yaml
-  - us-ca/regulations/mpp/63-404/52.yaml
-  - us-ca/regulations/mpp/63-404/53.yaml
-  - us-ca/regulations/mpp/63-404/62.yaml
-  - us-ca/regulations/mpp/63-404/63.yaml
-  - us-ca/regulations/mpp/63-404/64.yaml
-  - us-ca/regulations/mpp/63-404/7.yaml
-  - us-ca/regulations/mpp/63-405/1.yaml
-  - us-ca/regulations/mpp/63-405/111.yaml
-  - us-ca/regulations/mpp/63-405/112.yaml
-  - us-ca/regulations/mpp/63-405/113.yaml
-  - us-ca/regulations/mpp/63-405/114.yaml
-  - us-ca/regulations/mpp/63-405/115.yaml
-  - us-ca/regulations/mpp/63-405/116.yaml
-  - us-ca/regulations/mpp/63-405/117.yaml
-  - us-ca/regulations/mpp/63-405/121.yaml
-  - us-ca/regulations/mpp/63-405/122.yaml
-  - us-ca/regulations/mpp/63-405/123.yaml
-  - us-ca/regulations/mpp/63-405/124.yaml
-  - us-ca/regulations/mpp/63-405/125.yaml
-  - us-ca/regulations/mpp/63-405/126.yaml
-  - us-ca/regulations/mpp/63-405/211.yaml
-  - us-ca/regulations/mpp/63-405/212.yaml
-  - us-ca/regulations/mpp/63-405/221.yaml
-  - us-ca/regulations/mpp/63-405/222.yaml
-  - us-ca/regulations/mpp/63-405/3.yaml
-  - us-ca/regulations/mpp/63-405/311.yaml
-  - us-ca/regulations/mpp/63-405/312.yaml
-  - us-ca/regulations/mpp/63-405/331.yaml
-  - us-ca/regulations/mpp/63-405/332.yaml
-  - us-ca/regulations/mpp/63-405/333.yaml
-  - us-ca/regulations/mpp/63-405/4.yaml
-  - us-ca/regulations/mpp/63-405/411.yaml
-  - us-ca/regulations/mpp/63-405/412.yaml
-  - us-ca/regulations/mpp/63-405/42.yaml
-  - us-ca/regulations/mpp/63-405/51.yaml
-  - us-ca/regulations/mpp/63-405/511.yaml
-  - us-ca/regulations/mpp/63-405/512.yaml
-  - us-ca/regulations/mpp/63-405/52.yaml
-  - us-ca/regulations/mpp/63-405/522.yaml
-  - us-ca/regulations/mpp/63-405/53.yaml
-  - us-ca/regulations/mpp/63-405/531.yaml
-  - us-ca/regulations/mpp/63-405/532.yaml
-  - us-ca/regulations/mpp/63-405/551.yaml
-  - us-ca/regulations/mpp/63-405/552.yaml
-  - us-ca/regulations/mpp/63-405/553.yaml
-  - us-ca/regulations/mpp/63-405/555.yaml
-  - us-ca/regulations/mpp/63-405/556.yaml
-  - us-ca/regulations/mpp/63-405/557.yaml
-  - us-ca/regulations/mpp/63-405/558.yaml
-  - us-ca/regulations/mpp/63-405/71.yaml
-  - us-ca/regulations/mpp/63-405/72.yaml
-  - us-ca/regulations/mpp/63-406/1.yaml
-  - us-ca/regulations/mpp/63-406/11.yaml
-  - us-ca/regulations/mpp/63-406/111.yaml
-  - us-ca/regulations/mpp/63-406/121.yaml
-  - us-ca/regulations/mpp/63-406/122.yaml
-  - us-ca/regulations/mpp/63-406/21.yaml
-  - us-ca/regulations/mpp/63-406/212.yaml
-  - us-ca/regulations/mpp/63-406/213.yaml
-  - us-ca/regulations/mpp/63-406/214.yaml
-  - us-ca/regulations/mpp/63-406/215.yaml
-  - us-ca/regulations/mpp/63-406/216.yaml
-  - us-ca/regulations/mpp/63-406/217.yaml
-  - us-ca/regulations/mpp/63-406/22.yaml
-  - us-ca/regulations/mpp/63-406/231.yaml
-  - us-ca/regulations/mpp/63-406/232.yaml
-  - us-ca/regulations/mpp/63-406/233.yaml
-  - us-ca/regulations/mpp/63-406/3.yaml
-  - us-ca/regulations/mpp/63-407/1.yaml
-  - us-ca/regulations/mpp/63-407/21.yaml
-  - us-ca/regulations/mpp/63-407/211.yaml
-  - us-ca/regulations/mpp/63-407/221.yaml
-  - us-ca/regulations/mpp/63-407/222.yaml
-  - us-ca/regulations/mpp/63-407/23.yaml
-  - us-ca/regulations/mpp/63-407/231.yaml
-  - us-ca/regulations/mpp/63-407/24.yaml
-  - us-ca/regulations/mpp/63-407/241.yaml
-  - us-ca/regulations/mpp/63-407/242.yaml
-  - us-ca/regulations/mpp/63-407/311.yaml
-  - us-ca/regulations/mpp/63-407/313.yaml
-  - us-ca/regulations/mpp/63-407/41.yaml
-  - us-ca/regulations/mpp/63-407/42.yaml
-  - us-ca/regulations/mpp/63-407/43.yaml
-  - us-ca/regulations/mpp/63-407/44.yaml
-  - us-ca/regulations/mpp/63-407/51.yaml
-  - us-ca/regulations/mpp/63-407/53.yaml
-  - us-ca/regulations/mpp/63-407/531.yaml
-  - us-ca/regulations/mpp/63-407/532.yaml
-  - us-ca/regulations/mpp/63-407/533.yaml
-  - us-ca/regulations/mpp/63-407/54.yaml
-  - us-ca/regulations/mpp/63-407/542.yaml
-  - us-ca/regulations/mpp/63-407/543.yaml
-  - us-ca/regulations/mpp/63-407/61.yaml
-  - us-ca/regulations/mpp/63-407/62.yaml
-  - us-ca/regulations/mpp/63-407/711.yaml
-  - us-ca/regulations/mpp/63-407/713.yaml
-  - us-ca/regulations/mpp/63-407/714.yaml
-  - us-ca/regulations/mpp/63-407/721.yaml
-  - us-ca/regulations/mpp/63-407/722.yaml
-  - us-ca/regulations/mpp/63-407/723.yaml
-  - us-ca/regulations/mpp/63-407/724.yaml
-  - us-ca/regulations/mpp/63-407/725.yaml
-  - us-ca/regulations/mpp/63-407/81.yaml
-  - us-ca/regulations/mpp/63-407/811.yaml
-  - us-ca/regulations/mpp/63-407/813.yaml
-  - us-ca/regulations/mpp/63-407/814.yaml
-  - us-ca/regulations/mpp/63-407/815.yaml
-  - us-ca/regulations/mpp/63-407/82.yaml
-  - us-ca/regulations/mpp/63-407/821.yaml
-  - us-ca/regulations/mpp/63-407/83.yaml
-  - us-ca/regulations/mpp/63-407/841.yaml
-  - us-ca/regulations/mpp/63-407/842.yaml
-  - us-ca/regulations/mpp/63-407/851.yaml
-  - us-ca/regulations/mpp/63-407/852.yaml
-  - us-ca/regulations/mpp/63-407/853.yaml
-  - us-ca/regulations/mpp/63-407/854.yaml
-  - us-ca/regulations/mpp/63-407/855.yaml
-  - us-ca/regulations/mpp/63-407/856.yaml
-  - us-ca/regulations/mpp/63-407/857.yaml
-  - us-ca/regulations/mpp/63-407/861.yaml
-  - us-ca/regulations/mpp/63-407/862.yaml
-  - us-ca/regulations/mpp/63-407/863.yaml
-  - us-ca/regulations/mpp/63-407/87.yaml
-  - us-ca/regulations/mpp/63-407/89.yaml
-  - us-ca/regulations/mpp/63-407/892.yaml
-  - us-ca/regulations/mpp/63-407/893.yaml
-  - us-ca/regulations/mpp/63-408/1.yaml
-  - us-ca/regulations/mpp/63-408/11.yaml
-  - us-ca/regulations/mpp/63-408/111.yaml
-  - us-ca/regulations/mpp/63-408/12.yaml
-  - us-ca/regulations/mpp/63-408/121.yaml
-  - us-ca/regulations/mpp/63-408/211.yaml
-  - us-ca/regulations/mpp/63-408/212.yaml
-  - us-ca/regulations/mpp/63-408/214.yaml
-  - us-ca/regulations/mpp/63-408/221.yaml
-  - us-ca/regulations/mpp/63-408/222.yaml
-  - us-ca/regulations/mpp/63-408/223.yaml
-  - us-ca/regulations/mpp/63-408/225.yaml
-  - us-ca/regulations/mpp/63-408/31.yaml
-  - us-ca/regulations/mpp/63-408/4.yaml
-  - us-ca/regulations/mpp/63-408/41.yaml
-  - us-ca/regulations/mpp/63-408/42.yaml
-  - us-ca/regulations/mpp/63-408/5.yaml
-  - us-ca/regulations/mpp/63-408/61.yaml
-  - us-ca/regulations/mpp/63-408/62.yaml
-  - us-ca/regulations/mpp/63-408/63.yaml
-  - us-ca/regulations/mpp/63-409/1.yaml
-  - us-ca/regulations/mpp/63-409/111.yaml
-  - us-ca/regulations/mpp/63-409/112.yaml
-  - us-ca/regulations/mpp/63-409/12.yaml
-  - us-ca/regulations/mpp/63-410/1.yaml
-  - us-ca/regulations/mpp/63-410/12.yaml
-  - us-ca/regulations/mpp/63-410/13.yaml
-  - us-ca/regulations/mpp/63-410/14.yaml
-  - us-ca/regulations/mpp/63-410/211.yaml
-  - us-ca/regulations/mpp/63-410/212.yaml
-  - us-ca/regulations/mpp/63-410/213.yaml
-  - us-ca/regulations/mpp/63-410/221.yaml
-  - us-ca/regulations/mpp/63-410/222.yaml
-  - us-ca/regulations/mpp/63-410/321.yaml
-  - us-ca/regulations/mpp/63-410/322.yaml
-  - us-ca/regulations/mpp/63-410/323.yaml
-  - us-ca/regulations/mpp/63-410/33.yaml
-  - us-ca/regulations/mpp/63-410/34.yaml
-  - us-ca/regulations/mpp/63-410/35.yaml
-  - us-ca/regulations/mpp/63-410/41.yaml
-  - us-ca/regulations/mpp/63-410/411.yaml
-  - us-ca/regulations/mpp/63-410/412.yaml
-  - us-ca/regulations/mpp/63-410/413.yaml
-  - us-ca/regulations/mpp/63-410/42.yaml
-  - us-ca/regulations/mpp/63-410/43.yaml
-  - us-ca/regulations/mpp/63-410/431.yaml
-  - us-ca/regulations/mpp/63-410/44.yaml
-  - us-ca/regulations/mpp/63-410/51.yaml
-  - us-ca/regulations/mpp/63-410/511.yaml
-  - us-ca/regulations/mpp/63-410/512.yaml
-  - us-ca/regulations/mpp/63-410/513.yaml
-  - us-ca/regulations/mpp/63-410/52.yaml
-  - us-ca/regulations/mpp/63-410/521.yaml
-  - us-ca/regulations/mpp/63-410/53.yaml
-  - us-ca/regulations/mpp/63-410/6.yaml
-  - us-ca/regulations/mpp/63-411/1.yaml
-  - us-ca/regulations/mpp/63-411/11.yaml
-  - us-ca/regulations/mpp/63-411/2.yaml
-  - us-ca/regulations/mpp/63-411/21.yaml
-  - us-ca/regulations/mpp/63-411/22.yaml
-  - us-ca/regulations/mpp/63-411/3.yaml
-  - us-ca/regulations/mpp/63-501/11.yaml
-  - us-ca/regulations/mpp/63-501/112.yaml
-  - us-ca/regulations/mpp/63-502/1.yaml
-  - us-ca/regulations/mpp/63-502/11.yaml
-  - us-ca/regulations/mpp/63-502/111.yaml
-  - us-ca/regulations/mpp/63-502/112.yaml
-  - us-ca/regulations/mpp/63-502/121.yaml
-  - us-ca/regulations/mpp/63-503/12.yaml
-  - us-ca/regulations/mpp/63-503/131.yaml
-  - us-ca/regulations/mpp/63-503/132.yaml
-  - us-ca/regulations/mpp/63-503/14.yaml
-  - us-ca/regulations/mpp/63-503/141.yaml
-  - us-ca/regulations/mpp/63-503/15.yaml
-  - us-ca/regulations/mpp/63-503/151.yaml
-  - us-ca/regulations/mpp/63-503/16.yaml
-  - us-ca/regulations/mpp/63-503/22.yaml
-  - us-ca/regulations/mpp/63-503/241.yaml
-  - us-ca/regulations/mpp/63-503/25.yaml
-  - us-ca/regulations/mpp/63-503/253.yaml
-  - us-ca/regulations/mpp/63-503/254.yaml
-  - us-ca/regulations/mpp/63-503/255.yaml
-  - us-ca/regulations/mpp/63-503/31.yaml
-  - us-ca/regulations/mpp/63-503/311.yaml
-  - us-ca/regulations/mpp/63-503/312.yaml
-  - us-ca/regulations/mpp/63-503/321.yaml
-  - us-ca/regulations/mpp/63-503/322.yaml
-  - us-ca/regulations/mpp/63-503/323.yaml
-  - us-ca/regulations/mpp/63-503/324.yaml
-  - us-ca/regulations/mpp/63-503/326.yaml
-  - us-ca/regulations/mpp/63-503/327.yaml
-  - us-ca/regulations/mpp/63-503/328.yaml
-  - us-ca/regulations/mpp/63-503/329.yaml
-  - us-ca/regulations/mpp/63-503/41.yaml
-  - us-ca/regulations/mpp/63-503/411.yaml
-  - us-ca/regulations/mpp/63-503/412.yaml
-  - us-ca/regulations/mpp/63-503/413.yaml
-  - us-ca/regulations/mpp/63-503/414.yaml
-  - us-ca/regulations/mpp/63-503/416.yaml
-  - us-ca/regulations/mpp/63-503/421.yaml
-  - us-ca/regulations/mpp/63-503/423.yaml
-  - us-ca/regulations/mpp/63-503/43.yaml
-  - us-ca/regulations/mpp/63-503/431.yaml
-  - us-ca/regulations/mpp/63-503/432.yaml
-  - us-ca/regulations/mpp/63-503/433.yaml
-  - us-ca/regulations/mpp/63-503/434.yaml
-  - us-co/policies/cdhs/colorado-works/basic-cash-assistance.yaml
-  - us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml
-  - us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml
-  - us-co/regulations/10-ccr-2506-1/4.207.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.401.1.yaml
-  - us-co/regulations/10-ccr-2506-1/4.401.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.401.yaml
-  - us-co/regulations/10-ccr-2506-1/4.402.1.yaml
-  - us-co/regulations/10-ccr-2506-1/4.402.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.402.yaml
-  - us-co/regulations/10-ccr-2506-1/4.403.11.yaml
-  - us-co/regulations/10-ccr-2506-1/4.403.12.yaml
-  - us-co/regulations/10-ccr-2506-1/4.403.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.403.3.yaml
-  - us-co/regulations/10-ccr-2506-1/4.403.yaml
-  - us-co/regulations/10-ccr-2506-1/4.404.yaml
-  - us-co/regulations/10-ccr-2506-1/4.405.yaml
-  - us-co/regulations/10-ccr-2506-1/4.406.1.yaml
-  - us-co/regulations/10-ccr-2506-1/4.406.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.1.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.3.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.31.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.61.yaml
-  - us-co/regulations/10-ccr-2506-1/4.408.1.yaml
-  - us-co/regulations/10-ccr-2506-1/4.408.2.yaml
-  - us-co/regulations/10-ccr-2506-1/4.408.yaml
-  - us-co/regulations/10-ccr-2506-1/4.409.yaml
-  - us-co/regulations/10-ccr-2506-1/4.410.yaml
-  - us-co/regulations/10-ccr-2506-1/4.411.yaml
-  - us-co/regulations/10-ccr-2506-1/4.609.1.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/E.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/F.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.6.yaml
-  - us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml
-  - us-ga/policies/dfcs/snap/3612.yaml
-  - us-ga/policies/dfcs/snap/3614.yaml
-  - us-ga/policies/dfcs/snap/3615.yaml
-  - us-ga/policies/dfcs/snap/3616.yaml
-  - us-ga/policies/dfcs/snap/3617.yaml
-  - us-ga/policies/dfcs/snap/3618.yaml
-  - us-co/statutes/39/39-22-104/1.5.yaml
-  - us-co/statutes/39/39-22-104/1.7/a.yaml
-  - us-co/statutes/39/39-22-104/1.7/b.yaml
-  - us-co/statutes/39/39-22-104/1.7/c.yaml
-  - us-co/statutes/39/39-22-104/4/z.yaml
-  - us-co/statutes/39/39-22-105.yaml
-  - us-co/statutes/39/39-22-119.5.yaml
-  - us-ma/regulations/106-cmr/362/220/block-1.yaml
-  - us-ma/regulations/106-cmr/362/270/block-1.yaml
-  - us-ma/regulations/106-cmr/362/300/block-1.yaml
-  - us-ma/regulations/106-cmr/366/140/block-1.yaml
-  - us-ma/regulations/106-cmr/366/150/block-1.yaml
-  - us-ma/regulations/106-cmr/366/200/block-1.yaml
-  - us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml
-  - us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml
-  - us-ny/regulations/18-nycrr/385/3.yaml
-  - us-ny/regulations/18-nycrr/387/10.yaml
-  - us-ny/regulations/18-nycrr/387/12/a.yaml
-  - us-ny/regulations/18-nycrr/387/12/b.yaml
-  - us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml
-  - us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml
-  - us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml
-  - us-ny/regulations/18-nycrr/387/12/f/3/vi.yaml
-  - us-ny/regulations/18-nycrr/387/14/a/1.yaml
-  - us-ny/regulations/18-nycrr/387/14/a/5.yaml
-  - us-ny/regulations/18-nycrr/387/9/a/1.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-211.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-214.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-215.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-340.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-341.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-345.yaml
-  - us/policies/irs/rev-proc-2025-25/aca-ptc.yaml
-  - us/policies/ssa/pia-bend-points/2026.yaml
-  - us/policies/ssa/quarter-of-coverage/2026.yaml
-  - us/policies/ssa/retirement-earnings-test/2026.yaml
-  - us/regulations/7-cfr/273/10.yaml
-  - us/regulations/7-cfr/273/2/j.yaml
-  - us/regulations/7-cfr/273/24.yaml
-  - us/regulations/7-cfr/273/3.yaml
-  - us/regulations/7-cfr/273/4.yaml
-  - us/regulations/7-cfr/273/5.yaml
-  - us/regulations/7-cfr/273/6.yaml
-  - us/regulations/7-cfr/273/7.yaml
-  - us/statutes/26/1212/a/1.yaml
-  - us/statutes/26/1222.yaml
-  - us/statutes/26/1401.yaml
-  - us/statutes/26/1402/b.yaml
-  - us/statutes/26/1411.yaml
-  - us/statutes/26/151.yaml
-  - us/statutes/26/152.yaml
-  - us/statutes/26/152/c.yaml
-  - us/statutes/26/2/a.yaml
-  - us/statutes/26/2/b.yaml
-  - us/statutes/26/21.yaml
-  - us/statutes/26/213.yaml
-  - us/statutes/26/225.yaml
-  - us/statutes/26/24.yaml
-  - us/statutes/26/24/d.yaml
-  - us/statutes/26/24/h.yaml
-  - us/statutes/26/25A.yaml
-  - us/statutes/26/25B.yaml
-  - us/statutes/26/26.yaml
-  - us/statutes/26/3134/h.yaml
-  - us/statutes/26/3134/i.yaml
-  - us/statutes/26/32.yaml
-  - us/statutes/26/3232.yaml
-  - us/statutes/26/3233.yaml
-  - us/statutes/26/3241/a.yaml
-  - us/statutes/26/3302/e.yaml
-  - us/statutes/26/3302/f.yaml
-  - us/statutes/26/3303.yaml
-  - us/statutes/26/3306/b/3.yaml
-  - us/statutes/26/3306/b/4.yaml
-  - us/statutes/26/3306/b/5.yaml
-  - us/statutes/26/3306/c/8.yaml
-  - us/statutes/26/3306/c/9.yaml
-  - us/statutes/26/3306/d.yaml
-  - us/statutes/26/3307.yaml
-  - us/statutes/26/3308.yaml
-  - us/statutes/26/3309.yaml
-  - us/statutes/26/408/p/2/A/i.yaml
-  - us/statutes/26/443/a/1.yaml
-  - us/statutes/26/45A.yaml
-  - us/statutes/26/45A/f.yaml
-  - us/statutes/26/55.yaml
-  - us/statutes/26/6012.yaml
-  - us/statutes/26/63/c.yaml
-  - us/statutes/26/63/c/5.yaml
-  - us/statutes/26/63/f.yaml
-  - us/statutes/26/6401.yaml
-  - us/statutes/37/556.yaml
-  - us/statutes/42/1396a/xx.yaml
-  - us/statutes/5/5566.yaml
-  - us/statutes/7/2014/c.yaml
-  - us/statutes/7/2014/d.yaml
-  - us/statutes/7/2014/e/2.yaml
-  - us/statutes/7/2014/e/6/A.yaml
-  - us/statutes/7/2014/g.yaml
-  - us/statutes/7/2015/b/1.yaml
-  # Second tranche surfaced by the first true full-toolchain revalidation
-  # (#397): the prior extraction under-captured batched validator output.
-  - us-al/policies/dhr/poe/chapter-01-household-concept/103.yaml
-  - us-al/policies/dhr/poe/chapter-03-residency/300.yaml
-  - us-al/policies/dhr/poe/chapter-04-citizenship-and-alien-status/401.yaml
-  - us-al/policies/dhr/poe/chapter-04-citizenship-and-alien-status/404.yaml
-  - us-al/policies/dhr/poe/chapter-04-citizenship-and-alien-status/405.yaml
-  - us-al/policies/dhr/poe/chapter-04-citizenship-and-alien-status/406.yaml
-  - us-al/policies/dhr/poe/chapter-05-students/502.yaml
-  - us-al/policies/dhr/poe/chapter-05-students/504.yaml
-  - us-al/policies/dhr/poe/chapter-06-social-security-numbers/600.yaml
-  - us-al/policies/dhr/poe/chapter-06-social-security-numbers/602.yaml
-  - us-al/policies/dhr/poe/chapter-06-social-security-numbers/603.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/700.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/702.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/704.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/705.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/707.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/708.yaml
-  - us-al/policies/dhr/poe/chapter-07-work-requirements/710.yaml
-  - us-al/policies/dhr/poe/chapter-08-resource-eligibility-standards/802.yaml
-  - us-al/policies/dhr/poe/chapter-08-resource-eligibility-standards/803.yaml
-  - us-al/policies/dhr/poe/chapter-08-resource-eligibility-standards/804.yaml
-  - us-al/policies/dhr/poe/chapter-09-income-and-deductions/900.yaml
-  - us-al/policies/dhr/poe/chapter-09-income-and-deductions/903.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1000.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1001.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1002.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1003.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1004.yaml
-  - us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1005.yaml
-  - us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1101.yaml
-  - us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1110.yaml
-  - us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1111.yaml
-  - us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1112.yaml
-  - us-al/policies/dhr/poe/chapter-12-reporting-changes/1201.yaml
-  - us-al/policies/dhr/poe/chapter-13-notice-of-adverse-action/1300.yaml
-  - us-al/policies/dhr/poe/chapter-13-notice-of-adverse-action/1301.yaml
-  - us-al/policies/dhr/poe/chapter-14-recertification/1402.yaml
-  - us-al/policies/dhr/poe/chapter-14-recertification/1403.yaml
-  - us-al/policies/dhr/poe/chapter-14-recertification/1404.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1502.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1503.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1504.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1508.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1509.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1510.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1511.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1514.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1518.yaml
-  - us-al/policies/dhr/poe/chapter-15-fair-hearings/1519.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1600.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1601.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1602.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1603.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1604.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1605.yaml
-  - us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1606.yaml
-  - us-al/policies/dhr/poe/chapter-17-simplified-reporting-procedures-for-all-households/1702.yaml
-  - us-al/policies/dhr/poe/chapter-17-simplified-reporting-procedures-for-all-households/1709.yaml
-  - us-al/policies/dhr/poe/chapter-17-simplified-reporting-procedures-for-all-households/1710.yaml
-  - us-al/regulations/660-4/1/03/block-1.yaml
-  - us-al/regulations/660-4/2/03/block-1.yaml
-  - us-al/regulations/660-4/2/06/block-1.yaml
-  - us-al/regulations/660-4/2/11/block-1.yaml
-  - us-al/regulations/660-4/2/12/block-1.yaml
-  - us-al/regulations/660-4/7/05/block-1.yaml
-  - us-al/regulations/660-4/7/07/block-1.yaml
-  - us-al/regulations/660-4/7/08/block-1.yaml
-  - us-az/policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction.yaml
-  - us-az/policies/des/faa5/ca-benefit-determination/earned-income-deduction.yaml
-  - us-az/policies/des/faa5/ca-benefit-determination/needy-family-test.yaml
-  - us-az/policies/des/faa5/ca-benefit-determination/payment-standard-test.yaml
-  - us-az/policies/des/faa5/ca-benefit-determination/payments-under-10-dollars.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/age-18-not-referred.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/age.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/cuban-or-haitian-entrants.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/tribal-new.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/working-in-unsubsidized-employment.yaml
-  - us-az/policies/des/faa5/ca-jobs-mandatory-referrals.yaml
-  - us-az/policies/des/faa5/ca-jobs-program-preliminary-orientation-jppo.yaml
-  - us-az/policies/des/faa5/ca-jobs-work-program-requirements.yaml
-  - us-az/policies/des/faa5/ca-payment-standard-a1-2fa2.yaml
-  - us-az/policies/des/faa5/dependent-care-expense/na-dependent-care.yaml
-  - us-az/policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount.yaml
-  - us-az/policies/des/faa5/na-categorical-eligibility/basic-categorical-eligibility.yaml
-  - us-az/policies/des/faa5/na-categorical-eligibility/categorical-eligibility-benefit-calculation.yaml
-  - us-az/policies/des/faa5/na-categorical-eligibility/expanded-categorical-eligibility.yaml
-  - us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml
-  - us-az/policies/des/faa5/na-eligibility-and-benefit-determination/gross-income-test.yaml
-  - us-az/policies/des/faa5/na-eligibility-and-benefit-determination/net-income-test.yaml
-  - us-az/policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction.yaml
-  - us-az/policies/des/faa5/na-transitional-benefit-assistance-tba.yaml
-  - us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility.yaml
-  - us-az/policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction.yaml
-  - us-az/policies/des/faa5/supplemental-payments-and-restored-benefits.yaml
-  - us-az/policies/des/faa5/transitional-child-care-tcc.yaml
-  - us-az/policies/des/faa5/two-parent-employment-program-tpep-jobs.yaml
-  - us-co/regulations/10-ccr-2506-1/4.207.3.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.4.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.5.yaml
-  - us-co/regulations/10-ccr-2506-1/4.407.6.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/G.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/H.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/I.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/J.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.1/K.yaml
-  - us-co/regulations/9-ccr-2503-6/3.606.2.yaml
-  - us-co/statutes/39/39-22-104/2.yaml
-  - us-co/statutes/39/39-22-104/3/a.yaml
-  - us-co/statutes/39/39-22-104/3/b.yaml
-  - us-co/statutes/39/39-22-104/3/d.yaml
-  - us-co/statutes/39/39-22-104/3/e.yaml
-  - us-co/statutes/39/39-22-104/3/f.yaml
-  - us-co/statutes/39/39-22-104/3/g.yaml
-  - us-co/statutes/39/39-22-104/3/i.yaml
-  - us-co/statutes/39/39-22-104/3/j.yaml
-  - us-co/statutes/39/39-22-104/3/l.yaml
-  - us-co/statutes/39/39-22-104/3/m.yaml
-  - us-co/statutes/39/39-22-104/3/n.yaml
-  - us-co/statutes/39/39-22-104/3/o.yaml
-  - us-co/statutes/39/39-22-104/3/p.yaml
-  - us-co/statutes/39/39-22-104/3/p/5.yaml
-  - us-co/statutes/39/39-22-104/3/p/7.yaml
-  - us-co/statutes/39/39-22-104/3/q.yaml
-  - us-co/statutes/39/39-22-104/3/s.yaml
-  - us-co/statutes/39/39-22-104/3/t.yaml
-  - us-co/statutes/39/39-22-104/3/u.yaml
-  - us-co/statutes/39/39-22-104/4/a.yaml
-  - us-co/statutes/39/39-22-104/4/b.yaml
-  - us-co/statutes/39/39-22-104/4/c.yaml
-  - us-co/statutes/39/39-22-104/4/e.yaml
-  - us-co/statutes/39/39-22-104/4/f.yaml
-  - us-co/statutes/39/39-22-104/4/h.yaml
-  - us-co/statutes/39/39-22-104/4/i.yaml
-  - us-co/statutes/39/39-22-104/4/m.yaml
-  - us-co/statutes/39/39-22-104/4/n/5.yaml
-  - us-co/statutes/39/39-22-104/4/o.yaml
-  - us-co/statutes/39/39-22-104/4/p.yaml
-  - us-co/statutes/39/39-22-104/4/q.yaml
-  - us-co/statutes/39/39-22-104/4/r.yaml
-  - us-co/statutes/39/39-22-104/4/r/5.yaml
-  - us-co/statutes/39/39-22-104/4/t.yaml
-  - us-co/statutes/39/39-22-104/4/u.yaml
-  - us-co/statutes/39/39-22-104/4/w.yaml
-  - us-co/statutes/39/39-22-104/4/x.yaml
-  - us-co/statutes/39/39-22-104/4/y.yaml
-  - us-co/statutes/39/39-22-119.yaml
-  - us-co/statutes/39/39-22-123.5.yaml
-  - us-co/statutes/39/39-22-129/4.5.yaml
-  - us-fl/regulations/fac/65a-1/711/block-1.yaml
-  - us-id/regulations/idapa/16/03/04/page-13.yaml
-  - us-id/regulations/idapa/16/03/04/page-16.yaml
-  - us-id/regulations/idapa/16/03/04/page-20.yaml
-  - us-ma/regulations/106-cmr/360/030/block-1.yaml
-  - us-ma/regulations/106-cmr/360/250/block-1.yaml
-  - us-ma/regulations/106-cmr/360/600/block-1.yaml
-  - us-ma/regulations/106-cmr/360/950/block-1.yaml
-  - us-ma/regulations/106-cmr/361/080/block-1.yaml
-  - us-ma/regulations/106-cmr/361/100/block-1.yaml
-  - us-ma/regulations/106-cmr/361/120/block-1.yaml
-  - us-ma/regulations/106-cmr/361/160/block-1.yaml
-  - us-ma/regulations/106-cmr/361/190/block-1.yaml
-  - us-ma/regulations/106-cmr/361/200/block-1.yaml
-  - us-ma/regulations/106-cmr/361/210/block-1.yaml
-  - us-ma/regulations/106-cmr/361/220/block-1.yaml
-  - us-ma/regulations/106-cmr/361/240/block-1.yaml
-  - us-ma/regulations/106-cmr/361/310/block-1.yaml
-  - us-ma/regulations/106-cmr/361/330/block-1.yaml
-  - us-ma/regulations/106-cmr/361/350/block-1.yaml
-  - us-ma/regulations/106-cmr/361/400/block-1.yaml
-  - us-ma/regulations/106-cmr/361/500/block-1.yaml
-  - us-ma/regulations/106-cmr/361/520/block-1.yaml
-  - us-ma/regulations/106-cmr/361/540/block-1.yaml
-  - us-ma/regulations/106-cmr/361/610/block-1.yaml
-  - us-ma/regulations/106-cmr/361/620/block-1.yaml
-  - us-ma/regulations/106-cmr/361/700/block-1.yaml
-  - us-ma/regulations/106-cmr/361/900/block-1.yaml
-  - us-ma/regulations/106-cmr/361/910/block-1.yaml
-  - us-ma/regulations/106-cmr/361/930/block-1.yaml
-  - us-ma/regulations/106-cmr/361/940/block-1.yaml
-  - us-ma/regulations/106-cmr/361/950/block-1.yaml
-  - us-ma/regulations/106-cmr/361/960/block-1.yaml
-  - us-ma/regulations/106-cmr/362/100/block-1.yaml
-  - us-ma/regulations/106-cmr/362/120/block-1.yaml
-  - us-ma/regulations/106-cmr/362/210/block-1.yaml
-  - us-ma/regulations/106-cmr/362/310/block-1.yaml
-  - us-ma/regulations/106-cmr/362/330/block-1.yaml
-  - us-ma/regulations/106-cmr/362/340/block-1.yaml
-  - us-ma/regulations/106-cmr/362/400/block-1.yaml
-  - us-ma/regulations/106-cmr/362/420/block-1.yaml
-  - us-ma/regulations/106-cmr/362/500/block-1.yaml
-  - us-ma/regulations/106-cmr/363/100/block-1.yaml
-  - us-ma/regulations/106-cmr/363/110/block-1.yaml
-  - us-ma/regulations/106-cmr/363/130/block-1.yaml
-  - us-ma/regulations/106-cmr/363/140/block-1.yaml
-  - us-ma/regulations/106-cmr/363/200/block-1.yaml
-  - us-ma/regulations/106-cmr/363/210/block-1.yaml
-  - us-ma/regulations/106-cmr/363/220/block-1.yaml
-  - us-ma/regulations/106-cmr/363/230/block-1.yaml
-  - us-ma/regulations/106-cmr/364/120/block-1.yaml
-  - us-ma/regulations/106-cmr/364/200/block-1.yaml
-  - us-ma/regulations/106-cmr/364/310/block-1.yaml
-  - us-ma/regulations/106-cmr/364/320/block-1.yaml
-  - us-ma/regulations/106-cmr/364/330/block-1.yaml
-  - us-ma/regulations/106-cmr/364/340/block-1.yaml
-  - us-ma/regulations/106-cmr/364/360/block-1.yaml
-  - us-ma/regulations/106-cmr/364/370/block-1.yaml
-  - us-ma/regulations/106-cmr/364/400/block-1.yaml
-  - us-ma/regulations/106-cmr/364/410/block-1.yaml
-  - us-ma/regulations/106-cmr/364/420/block-1.yaml
-  - us-ma/regulations/106-cmr/364/430/block-1.yaml
-  - us-ma/regulations/106-cmr/364/450/block-1.yaml
-  - us-ma/regulations/106-cmr/364/500/block-1.yaml
-  - us-ma/regulations/106-cmr/364/550/block-1.yaml
-  - us-ma/regulations/106-cmr/364/600/block-1.yaml
-  - us-ma/regulations/106-cmr/364/650/block-1.yaml
-  - us-ma/regulations/106-cmr/364/700/block-1.yaml
-  - us-ma/regulations/106-cmr/364/870/block-1.yaml
-  - us-ma/regulations/106-cmr/364/900/block-1.yaml
-  - us-ma/regulations/106-cmr/364/980/block-1.yaml
-  - us-ma/regulations/106-cmr/365/110/block-1.yaml
-  - us-ma/regulations/106-cmr/365/120/block-1.yaml
-  - us-ma/regulations/106-cmr/365/130/block-1.yaml
-  - us-ma/regulations/106-cmr/365/140/block-1.yaml
-  - us-ma/regulations/106-cmr/365/150/block-1.yaml
-  - us-ma/regulations/106-cmr/365/170/block-1.yaml
-  - us-ma/regulations/106-cmr/365/180/block-1.yaml
-  - us-ma/regulations/106-cmr/365/190/block-1.yaml
-  - us-ma/regulations/106-cmr/365/200/block-1.yaml
-  - us-ma/regulations/106-cmr/365/430/block-1.yaml
-  - us-ma/regulations/106-cmr/365/510/block-1.yaml
-  - us-ma/regulations/106-cmr/365/600/block-1.yaml
-  - us-ma/regulations/106-cmr/365/605/block-1.yaml
-  - us-ma/regulations/106-cmr/365/610/block-1.yaml
-  - us-ma/regulations/106-cmr/365/620/block-1.yaml
-  - us-ma/regulations/106-cmr/365/670/block-1.yaml
-  - us-ma/regulations/106-cmr/365/700/block-1.yaml
-  - us-ma/regulations/106-cmr/365/730/block-1.yaml
-  - us-ma/regulations/106-cmr/365/810/block-1.yaml
-  - us-ma/regulations/106-cmr/365/830/block-1.yaml
-  - us-ma/regulations/106-cmr/365/840/block-1.yaml
-  - us-ma/regulations/106-cmr/365/850/block-1.yaml
-  - us-ma/regulations/106-cmr/365/910/block-1.yaml
-  - us-ma/regulations/106-cmr/365/920/block-1.yaml
-  - us-ma/regulations/106-cmr/365/940/block-1.yaml
-  - us-ma/regulations/106-cmr/365/970/block-1.yaml
-  - us-ma/regulations/106-cmr/366/110/block-1.yaml
-  - us-ma/regulations/106-cmr/366/130/block-1.yaml
-  - us-ma/regulations/106-cmr/366/215/block-1.yaml
-  - us-ma/regulations/106-cmr/366/220/block-1.yaml
-  - us-ma/regulations/106-cmr/366/300/block-1.yaml
-  - us-ma/regulations/106-cmr/366/320/block-1.yaml
-  - us-ma/regulations/106-cmr/366/330/block-1.yaml
-  - us-ma/regulations/106-cmr/366/340/block-1.yaml
-  - us-ma/regulations/106-cmr/366/550/block-1.yaml
-  - us-ma/regulations/106-cmr/366/560/block-1.yaml
-  - us-ma/regulations/106-cmr/366/570/block-1.yaml
-  - us-ma/regulations/106-cmr/366/580/block-1.yaml
-  - us-ma/regulations/106-cmr/366/610/block-1.yaml
-  - us-ma/regulations/106-cmr/367/025/block-1.yaml
-  - us-ma/regulations/106-cmr/367/100/block-1.yaml
-  - us-ma/regulations/106-cmr/367/125/block-1.yaml
-  - us-ma/regulations/106-cmr/367/200/block-1.yaml
-  - us-ma/regulations/106-cmr/367/275/block-1.yaml
-  - us-ma/regulations/106-cmr/367/325/block-1.yaml
-  - us-ma/regulations/106-cmr/367/490/block-1.yaml
-  - us-ma/regulations/106-cmr/367/495/block-1.yaml
-  - us-ma/regulations/106-cmr/367/500/block-1.yaml
-  - us-ma/regulations/106-cmr/367/510/block-1.yaml
-  - us-ma/regulations/106-cmr/367/625/block-1.yaml
-  - us-ma/regulations/106-cmr/367/700/block-1.yaml
-  - us-ma/regulations/106-cmr/367/750/block-1.yaml
-  - us-ma/regulations/106-cmr/367/800/block-1.yaml
-  - us-ma/regulations/106-cmr/367/900/block-1.yaml
-  - us-ma/regulations/106-cmr/367/925/block-1.yaml
-  - us-ma/regulations/106-cmr/367/950/block-1.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-1.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-10.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-12.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-13.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-2.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-4.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-5.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-6.yaml
-  - us-nc/policies/dhhs/fns/appendix-3300-glossary/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-110-purpose-and-authority-of-the-food-and-nutrition-services-program/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-110-purpose-and-authority-of-the-food-and-nutrition-services-program/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-115-administration-of-the-food-and-nutrition-services-program/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-115-administration-of-the-food-and-nutrition-services-program/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-115-administration-of-the-food-and-nutrition-services-program/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-120-complaints-and-fair-hearing-process/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-120-complaints-and-fair-hearing-process/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-125-disclosure-of-information-and-inquiries/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-125-disclosure-of-information-and-inquiries/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-130-records-retention-ownership-and-documentation/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-130-records-retention-ownership-and-documentation/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-135-second-party-review-and-quality-control/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-135-second-party-review-and-quality-control/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-140-personnel-requirements/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-140-personnel-requirements/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-140-personnel-requirements/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-145-claims/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-150-commodities-programs/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-155-lifeline-link-up-assistance-programs/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-160-automated-inquiry-and-match-procedures/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-160-automated-inquiry-and-match-procedures/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-160-automated-inquiry-and-match-procedures/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-160-automated-inquiry-and-match-procedures/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-160-automated-inquiry-and-match-procedures/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-165-inactive-electronic-benefit-transfer-ebt-accounts-report/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-165-inactive-electronic-benefit-transfer-ebt-accounts-report/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-170-notices/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-170-notices/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-170-notices/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-175-authorized-representative/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-175-authorized-representative/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-175-authorized-representative/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-200-eligibility-requirements-overview/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-205-identity/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-205-identity/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-210-household-composition/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-212-household-composition-special-arrangements/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-212-household-composition-special-arrangements/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-212-household-composition-special-arrangements/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-212-household-composition-special-arrangements/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-212-household-composition-special-arrangements/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-215-residence/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-215-residence/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-215-residence/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-225-citizenship/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-225-citizenship/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-225-citizenship/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-225-citizenship/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-17.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-18.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-20.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-22.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-23.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-24.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-29.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-30.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-31.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-32.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-35.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-37.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-235-student-of-higher-education/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-235-student-of-higher-education/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-235-student-of-higher-education/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-240-work-registration/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-240-work-registration/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-240-work-registration/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-250-workfare/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-17.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-20.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-21.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-23.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-27.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-31.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-32.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-15.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-17.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-18.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-20.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-21.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-28.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-29.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-30.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-15.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-17.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-18.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-21.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-23.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-27.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-28.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-18.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-20.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-22.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-27.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-28.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-29.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-340-deductions/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-15.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-17.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-18.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-22.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-23.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-24.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-390-resources/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-400-how-to-apply-for-food-and-nutrition-services/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-400-how-to-apply-for-food-and-nutrition-services/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-400-how-to-apply-for-food-and-nutrition-services/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-405-applicant-responsibilities/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-410-county-responsibilities/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-410-county-responsibilities/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-410-county-responsibilities/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-415-interviewing/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-440-application-disposition/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-450-social-security-administration-application/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-450-social-security-administration-application/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-500-sr-category-and-reporting-requirements/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-500-sr-category-and-reporting-requirements/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-500-sr-category-and-reporting-requirements/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-505-sr-recertifications-requirements/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-515-sr-changes-during-the-certification-period/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-650-transitional-food-and-nutrition-services-benefits/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-650-transitional-food-and-nutrition-services-benefits/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-650-transitional-food-and-nutrition-services-benefits/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-700-hearings/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-800-claims/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-11.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-15.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-10.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-12.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-13.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-14.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-15.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-16.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-19.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-20.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-22.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-24.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-26.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-830-ebt-recipient-and-retailer-fraud/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-830-ebt-recipient-and-retailer-fraud/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-835-report-of-erroneous-issuance-dss-1682/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-835-report-of-erroneous-issuance-dss-1682/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-840-front-end-referrals/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-840-front-end-referrals/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-840-front-end-referrals/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-7.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-8.yaml
-  - us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-9.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-855-claims-discharged-through-bankruptcy/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-860-move-by-a-household/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-865-nc-education-lottery-interceptions/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-865-nc-education-lottery-interceptions/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-900-restoration-of-lost-benefits/page-1.yaml
-  - us-nc/policies/dhhs/fns/fns-905-replacement-of-authorized-issuance/page-2.yaml
-  - us-nc/policies/dhhs/fns/fns-905-replacement-of-authorized-issuance/page-3.yaml
-  - us-nc/policies/dhhs/fns/fns-905-replacement-of-authorized-issuance/page-5.yaml
-  - us-nc/policies/dhhs/fns/fns-905-replacement-of-authorized-issuance/page-6.yaml
-  - us-nc/policies/dhhs/fns/fns-910-cancellation-of-benefits/page-1.yaml
-  - us-nc/regulations/10a-ncac/71u/0210/block-1.yaml
-  - us-nc/regulations/10a-ncac/71u/0212/block-1.yaml
-  - us-nc/regulations/10a-ncac/71u/0302/block-1.yaml
-  - us-ny/policies/otda/tanf-state-plan-2024-2026/financial-eligibility-and-income-disregards.yaml
-  - us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml
-  - us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml
-  - us-ny/statutes/NYC/11-1701.yaml
-  - us-ny/statutes/NYC/11-1704/1.yaml
-  - us-ny/statutes/NYC/11-1706.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-100.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-101.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-102.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-103.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-104.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-105.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-106.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-110.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-111.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-113.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-114.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-115.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-116.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-120.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-121.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-123.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-125.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-126.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-128.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-131.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-132.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-133.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-134.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-135.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-137.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-138.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-139.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-140.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-141.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-142.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-143.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-144.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-145.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-146.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-147.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-151.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-152.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-153.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-154.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-155.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-156.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-157.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-158.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-160.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-161.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-162.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-163.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-164.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-165.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-167.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-169.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-17.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-170.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-171.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-172.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-173.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-174.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-175.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-176.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-178.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-18.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-180.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-185.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-186.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-187.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-189.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-191.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-193.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-195.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-196.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-197.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-20.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-200.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-201.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-202.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-203.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-204.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-205.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-206.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-207.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-208.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-209.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-21.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-216.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-217.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-218.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-219.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-22.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-221.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-223.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-224.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-225.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-226.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-229.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-231.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-232.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-234.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-235.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-236.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-237.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-238.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-241.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-242.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-243.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-244.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-245.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-246.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-247.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-249.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-251.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-252.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-254.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-255.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-256.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-257.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-26.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-260.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-261.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-262.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-264.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-265.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-267.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-268.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-269.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-27.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-270.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-271.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-272.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-278.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-29.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-290.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-295.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-296.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-297.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-298.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-30.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-300.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-301.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-302.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-303.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-304.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-305.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-306.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-307.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-308.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-309.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-311.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-312.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-314.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-315.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-316.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-317.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-318.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-319.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-32.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-320.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-321.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-322.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-323.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-324.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-325.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-326.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-327.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-328.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-329.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-33.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-330.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-332.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-333.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-334.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-335.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-336.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-338.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-34.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-346.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-348.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-349.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-35.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-351.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-352.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-354.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-357.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-358.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-359.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-360.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-362.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-363.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-366.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-367.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-368.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-369.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-37.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-377.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-378.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-381.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-383.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-385.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-386.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-388.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-389.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-39.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-40.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-404.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-405.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-406.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-407.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-41.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-416.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-42.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-421.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-424.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-427.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-429.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-44.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-445.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-446.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-449.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-45.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-451.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-452.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-454.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-455.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-457.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-46.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-47.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-48.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-49.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-53.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-55.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-56.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-57.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-59.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-60.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-61.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-62.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-63.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-64.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-65.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-67.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-68.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-69.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-70.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-72.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-73.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-74.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-75.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-78.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-79.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-80.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-81.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-82.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-83.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-84.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-85.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-86.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-89.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-90.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-91.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-92.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-93.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-94.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-95.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-97.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-98.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-99.yaml
-  - us-tn/policies/dhs/snap/24-02/page-1.yaml
-  - us-tn/policies/dhs/snap/24-02/page-10.yaml
-  - us-tn/policies/dhs/snap/24-02/page-13.yaml
-  - us-tn/policies/dhs/snap/24-02/page-15.yaml
-  - us-tn/policies/dhs/snap/24-02/page-16.yaml
-  - us-tn/policies/dhs/snap/24-02/page-3.yaml
-  - us-tn/policies/dhs/snap/24-02/page-6.yaml
-  - us-tn/policies/dhs/snap/24-02/page-7.yaml
-  - us-tn/policies/dhs/snap/24-02/page-8.yaml
-  - us-tn/policies/dhs/snap/24-03/page-1.yaml
-  - us-tn/policies/dhs/snap/24-03/page-2.yaml
-  - us-tn/policies/dhs/snap/24-03/page-3.yaml
-  - us-tn/policies/dhs/snap/24-03/page-6.yaml
-  - us-tn/policies/dhs/snap/24-04/page-1.yaml
-  - us-tn/policies/dhs/snap/24-04/page-2.yaml
-  - us-tn/policies/dhs/snap/24-04/page-3.yaml
-  - us-tn/policies/dhs/snap/24-05/page-1.yaml
-  - us-tn/policies/dhs/snap/24-05/page-3.yaml
-  - us-tn/policies/dhs/snap/24-06/page-10.yaml
-  - us-tn/policies/dhs/snap/24-06/page-12.yaml
-  - us-tn/policies/dhs/snap/24-06/page-13.yaml
-  - us-tn/policies/dhs/snap/24-06/page-3.yaml
-  - us-tn/policies/dhs/snap/24-06/page-6.yaml
-  - us-tn/policies/dhs/snap/24-06/page-7.yaml
-  - us-tn/policies/dhs/snap/24-07/page-3.yaml
-  - us-tn/policies/dhs/snap/24-07/page-4.yaml
-  - us-tn/policies/dhs/snap/24-07/page-5.yaml
-  - us-tn/policies/dhs/snap/24-07/page-6.yaml
-  - us-tn/policies/dhs/snap/24-08/page-1.yaml
-  - us-tn/policies/dhs/snap/24-08/page-2.yaml
-  - us-tn/policies/dhs/snap/24-10/page-3.yaml
-  - us-tn/policies/dhs/snap/24-10/page-4.yaml
-  - us-tn/policies/dhs/snap/24-11/page-1.yaml
-  - us-tn/policies/dhs/snap/24-11/page-11.yaml
-  - us-tn/policies/dhs/snap/24-11/page-14.yaml
-  - us-tn/policies/dhs/snap/24-11/page-4.yaml
-  - us-tn/policies/dhs/snap/24-11/page-5.yaml
-  - us-tn/policies/dhs/snap/24-11/page-7.yaml
-  - us-tn/policies/dhs/snap/24-11/page-9.yaml
-  - us-tn/policies/dhs/snap/24-14/page-1.yaml
-  - us-tn/policies/dhs/snap/24-14/page-10.yaml
-  - us-tn/policies/dhs/snap/24-14/page-2.yaml
-  - us-tn/policies/dhs/snap/24-14/page-4.yaml
-  - us-tn/policies/dhs/snap/24-14/page-5.yaml
-  - us-tn/policies/dhs/snap/24-14/page-6.yaml
-  - us-tn/policies/dhs/snap/24-14/page-8.yaml
-  - us-tn/policies/dhs/snap/24-14/page-9.yaml
-  - us-tn/policies/dhs/snap/24-17/page-2.yaml
-  - us-tn/policies/dhs/snap/24-17/page-3.yaml
-  - us-tn/policies/dhs/snap/24-18/page-1.yaml
-  - us-tn/policies/dhs/snap/24-18/page-10.yaml
-  - us-tn/policies/dhs/snap/24-18/page-11.yaml
-  - us-tn/policies/dhs/snap/24-18/page-12.yaml
-  - us-tn/policies/dhs/snap/24-18/page-13.yaml
-  - us-tn/policies/dhs/snap/24-18/page-14.yaml
-  - us-tn/policies/dhs/snap/24-18/page-16.yaml
-  - us-tn/policies/dhs/snap/24-18/page-17.yaml
-  - us-tn/policies/dhs/snap/24-18/page-18.yaml
-  - us-tn/policies/dhs/snap/24-18/page-19.yaml
-  - us-tn/policies/dhs/snap/24-18/page-4.yaml
-  - us-tn/policies/dhs/snap/24-18/page-5.yaml
-  - us-tn/policies/dhs/snap/24-18/page-6.yaml
-  - us-tn/policies/dhs/snap/24-18/page-7.yaml
-  - us-tn/policies/dhs/snap/24-19/page-1.yaml
-  - us-tn/policies/dhs/snap/24-20/page-1.yaml
-  - us-tn/policies/dhs/snap/24-20/page-2.yaml
-  - us-tn/policies/dhs/snap/24-21/page-1.yaml
-  - us-tn/policies/dhs/snap/24-22/page-1.yaml
-  - us-tn/policies/dhs/snap/24-22/page-10.yaml
-  - us-tn/policies/dhs/snap/24-22/page-11.yaml
-  - us-tn/policies/dhs/snap/24-22/page-12.yaml
-  - us-tn/policies/dhs/snap/24-22/page-13.yaml
-  - us-tn/policies/dhs/snap/24-22/page-14.yaml
-  - us-tn/policies/dhs/snap/24-22/page-2.yaml
-  - us-tn/policies/dhs/snap/24-22/page-3.yaml
-  - us-tn/policies/dhs/snap/24-22/page-7.yaml
-  - us-tn/policies/dhs/snap/24-22/page-8.yaml
-  - us-tn/policies/dhs/snap/24-22/page-9.yaml
-  - us-tn/policies/dhs/snap/24-23/page-1.yaml
-  - us-tn/policies/dhs/snap/24-23/page-2.yaml
-  - us-tn/policies/dhs/snap/24-23/page-3.yaml
-  - us-tn/policies/dhs/snap/24-23/page-4.yaml
-  - us-tn/policies/dhs/snap/24-24/page-3.yaml
-  - us-tn/policies/dhs/snap/24-25/page-1.yaml
-  - us-tn/policies/dhs/snap/24-25/page-10.yaml
-  - us-tn/policies/dhs/snap/24-25/page-11.yaml
-  - us-tn/policies/dhs/snap/24-25/page-13.yaml
-  - us-tn/policies/dhs/snap/24-25/page-2.yaml
-  - us-tn/policies/dhs/snap/24-25/page-3.yaml
-  - us-tn/policies/dhs/snap/24-25/page-5.yaml
-  - us-tn/policies/dhs/snap/24-25/page-6.yaml
-  - us-tn/policies/dhs/snap/24-25/page-7.yaml
-  - us-tn/policies/dhs/snap/24-25/page-8.yaml
-  - us-tn/policies/dhs/snap/24-25/page-9.yaml
-  - us-tn/policies/dhs/snap/24-27/page-2.yaml
-  - us-tn/policies/dhs/snap/24-27/page-5.yaml
-  - us-tn/policies/dhs/snap/24-27/page-6.yaml
-  - us-tn/policies/dhs/snap/24-27/page-7.yaml
-  - us-tn/policies/dhs/snap/24-30/page-2.yaml
-  - us-tn/policies/dhs/snap/24-31/page-1.yaml
-  - us-tn/policies/dhs/snap/24-31/page-2.yaml
-  - us-tn/policies/dhs/snap/24-31/page-3.yaml
-  - us-tn/regulations/1240-01/03/10/block-1.yaml
-  - us-tn/regulations/1240-01/03/13/block-1.yaml
-  - us-tn/regulations/1240-01/03/15/block-1.yaml
-  - us-tn/regulations/1240-01/03/46/block-1.yaml
-  - us-tn/regulations/1240-01/04/07/block-1.yaml
-  - us-tn/regulations/1240-01/04/09/block-1.yaml
-  - us-tn/regulations/1240-01/04/16/block-1.yaml
-  - us-tn/regulations/1240-01/04/27/block-1.yaml
-  - us-tn/regulations/1240-01/14/09/block-1.yaml
-  - us-tn/regulations/1240-01/14/11/block-1.yaml
-  # Additional upstream-source-check failures exposed by axiom-encode 0.2.1024; tracked by issue #396.
-  - us-ak/policies/dpa/apa/standards/2026/state-supplement-payment-standard.yaml
-  - us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml
-  - us-az/policies/des/ccap/reimbursement-rates.yaml
-  - us-az/policies/des/faa5/ca-jobs-exemptions/ca-gd.yaml
-  - us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml
-  - us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.yaml
-  - us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.yaml
-  - us-ca/policies/cdss/calworks/maximum-resource-limit.yaml
-  - us-ca/policies/dor/spotlight-on-social-security/2026-01/block-7.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-cic-rap/page-42.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-10.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-11.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-13.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-14.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-15.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-16.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-17.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-18.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-19.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-20.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-21.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-22.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-26.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-28.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-33.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-34.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-35.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-36.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-37.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-38.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-39.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-41.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-42.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-43.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-44.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-45.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-46.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-47.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-48.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-49.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-50.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-51.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-52.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-53.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-54.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-55.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-56.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-57.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-58.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-59.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-6.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-60.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-61.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-62.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-63.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-64.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-65.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-66.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-68.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-69.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-7.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-70.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-71.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-76.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-77.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-78.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-8.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-9.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-cic-rap/page-12.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-cic-rap/page-9.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-10.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-11.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-13.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-14.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-16.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-17.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-18.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-20.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-21.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-22.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-23.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-24.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-25.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-26.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-27.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-28.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-29.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-30.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-31.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-32.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-34.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-35.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-37.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-38.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-39.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-40.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-5.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-6.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-7.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-9.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/200-general-program-information/page-15.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-27.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-28.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-29.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-30.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-10.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-14.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-15.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-16.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-20.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-21.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-58.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-8.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-9-net-income-test.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/appendix-a-1-food-assistance-income-eligibility-standards-and-deductions/page-1.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/appendix-a-12-state-funded-programs-eligibility-standards/page-1.yaml
-  - us-fl/policies/dcf/ess-program-policy-manual/appendix-a-5-temporary-cash-assistance-income-standards/page-1.yaml
-  - us-ga/policies/decal/caps/appendix-a-income-limits.yaml
-  - us-ga/policies/decal/caps/appendix-c-payment-zones.yaml
-  - us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml
-  - us-ga/policies/decal/caps/appendix-d-family-fee-chart.yaml
-  - us-ga/policies/decal/caps/family-fees-policy-page-54.yaml
-  - us-ga/policies/decal/caps/family-fees-policy-page-55.yaml
-  - us-ga/policies/dfcs/medicaid/2578.yaml
-  - us-ga/policies/dfcs/snap/3210/block-2.yaml
-  - us-ga/policies/dfcs/tanf/1605/block-14.yaml
-  - us-ga/policies/dfcs/tanf/1605/block-3.yaml
-  - us-ga/policies/dfcs/tanf/1605/block-4.yaml
-  - us-ga/policies/dfcs/tanf/1605/block-6.yaml
-  - us-ga/policies/dfcs/tanf/1615/block-5.yaml
-  - us-ga/policies/dfcs/tanf/1615/block-6.yaml
-  - us-ga/policies/dfcs/tanf/appendix-a.yaml
-  - us-ga/policies/dfcs/tanf/appendix-a/block-3.yaml
-  - us-ga/policies/dfcs/tanf/eligibility-requirements.yaml
-  - us-ga/policies/dfcs/tanf/eligibility-requirements/income-resources.yaml
-  - us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml
-  - us-il/policies/dhs/csmm/15232/block-1.yaml
-  - us-il/policies/dhs/csmm/15820/block-1.yaml
-  - us-il/policies/dhs/csmm/25-06-01.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml
-  - us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml
-  - us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml
-  - us-ks/policies/dcf/keesm/keesm7410.yaml
-  - us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml
-  - us-mi/policies/mdhhs/bridges/bem/660.yaml
-  - us-mi/policies/mdhhs/rft/248.yaml
-  - us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml
-  - us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml
-  - us-nc/policies/dhhs/fns/fns-110-purpose-and-authority-of-the-food-and-nutrition-services-program/page-4.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-38.yaml
-  - us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-40.yaml
-  - us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-276.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-439.yaml
-  - us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml
-  - us/policies/cms/original-medicare-part-a-b.yaml
-  - us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml
-  - us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml
-  - us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml
-  - us/policies/ed/fsa/gen-26-01-pell-award-amounts/block-1.yaml
-  - us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml
-  - us/policies/irs/rev-proc-2025-32/capital-gains.yaml
-  - us/policies/irs/rev-proc-2025-32/child-tax-credit.yaml
-  - us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml
-  - us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml
-  - us/policies/irs/rev-proc-2025-32/standard-deduction.yaml
-  - us/policies/ssa/contribution-and-benefit-base/2024.yaml
-  - us/policies/ssa/contribution-and-benefit-base/2026.yaml
-  - us/policies/ssa/substantial-gainful-activity/2026.yaml
-  - us/policies/usda/snap/fy-2026-cola/deductions.yaml
-  - us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml
-  - us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml
+  "us/statutes/42/415/a.yaml":
+    active:
+      fingerprint: "sha256:1b2eefed0f9acb3ec685e1aee7deb0e778bdfc873e3d150c429e517b52e6dd29"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/415/b.yaml":
+    active:
+      fingerprint: "sha256:b701558fc8f6a779070f14b09b7731d761596c6f29e92caa0f291e7cd0f15da7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/415/i.yaml":
+    active:
+      fingerprint: "sha256:02ccbb5f461d70876b3493dcfe2e8390e7f33894f2aabd5e5f43e57b84bb8e73"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-02-application-processing/213.yaml":
+    active:
+      fingerprint: "sha256:cc42e8a5d3d78f95b646ae624c0bd159c91abf560d9da287b13d090f950214f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/na-child-support-expense/allowable-deductions.yaml":
+    active:
+      fingerprint: "sha256:1898c680951814483298e015a16e1af3b3c86efffd17038ade0a62f3f724609c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml":
+    active:
+      fingerprint: "sha256:54de7bc26ed246710b93d9ba3b9338dab05f1dd272a80f0f62a2c8df91bdc1f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/1.yaml":
+    active:
+      fingerprint: "sha256:7b3c16813f90287f74293ef71353801c923c1e15bc1f925fe39e41c58528076f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/21.yaml":
+    active:
+      fingerprint: "sha256:8891960ee2295f5f1d1fe0e927afe361a5631a3b3443ba6d4b2160608b5ba6b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/23.yaml":
+    active:
+      fingerprint: "sha256:f54f11fae1ac43ddff70387761b4316bec3e8cb13001542a848f28742b949595"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/232.yaml":
+    active:
+      fingerprint: "sha256:c3cee438fb4582d7543f7cc90dc80658d1dd6ed22af691843773fe937757fff4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/233.yaml":
+    active:
+      fingerprint: "sha256:500a2fd0c34efc58c4c68d7e6dc2b4097f8fd8210d7d29584056a3d75f4341a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/234.yaml":
+    active:
+      fingerprint: "sha256:d671173f8aa3dc7ac90a260bab3851fa49d666af87a8236e54c417835d2e53d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/24.yaml":
+    active:
+      fingerprint: "sha256:a3f15893742187e856ee468b1d00d5d00eebc24d101fc2ad41f0e01bf4fb5deb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/25.yaml":
+    active:
+      fingerprint: "sha256:a79b074afad207a37f34fd00b286cb3d3ba445c905f076be2100688cbf52d7ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/3.yaml":
+    active:
+      fingerprint: "sha256:537ab8ab73e6ec3af02ef58252fd2fc492e057f047e751927f99f6a9927324c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/31.yaml":
+    active:
+      fingerprint: "sha256:1df47b8eace1a4125ccb8d402bc6973c1974eb0db73d1f74fb28c3b0c6a8b029"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/32.yaml":
+    active:
+      fingerprint: "sha256:3b8e716e950b02e93de940e7cccbc2d79be5d43eac6d0cf1a04b3d094bbb2e2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/321.yaml":
+    active:
+      fingerprint: "sha256:b6cff65cdae8518e4382266b026bd8dc8dce0adc370fd4d337daa30c8525b893"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/322.yaml":
+    active:
+      fingerprint: "sha256:0ea48e4ef070fabe6d78132c82c6385eb72b3d81749a5376576814c3814f61d2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/34.yaml":
+    active:
+      fingerprint: "sha256:fa5d5f54783469aa3edd9ac659586bf66ce17ce7898f8b34f4b1b00b5d6506b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/36.yaml":
+    active:
+      fingerprint: "sha256:8b41c965498a973940e323df1ab52e201f42b8849292c402cb75ffe233677499"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/37.yaml":
+    active:
+      fingerprint: "sha256:54c2b6bada50e179a3c2ed5f3be1046b6916cdce6bef23668b9f3613fd1fc916"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/381.yaml":
+    active:
+      fingerprint: "sha256:3db93164a4e8b2b7895598f3229b5feef957c64a39cef8def9ae4c26b80b4795"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/42.yaml":
+    active:
+      fingerprint: "sha256:7c74e4a1b95f8c6b0d3594c04f56b5f96e85a24e89e59c0a2ae8bce71e63552b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/43.yaml":
+    active:
+      fingerprint: "sha256:3413c3da5c9c08bfa188dbb708db9ca23d3b20ea67eef61947cad474d10c4767"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/44.yaml":
+    active:
+      fingerprint: "sha256:9efa531edbb201c2f3f26a5d94254214e31b8a425a4538ac0954ebff9e26406b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/45.yaml":
+    active:
+      fingerprint: "sha256:17f7b382e728e2ce5e6915c53c8441c84341238c15b0ad4a030ae24beafec278"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/46.yaml":
+    active:
+      fingerprint: "sha256:0f5607e9945e5f16643fc7aec729d3d5a3fe60d05993d1d629bbbc2d84fe4cba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/461.yaml":
+    active:
+      fingerprint: "sha256:e58294b0b4696a48afe0365c14698ebce9354cb123b859648e8478f827f51a70"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/462.yaml":
+    active:
+      fingerprint: "sha256:d45fbcdbfc61f446d492cdc27820ad18b48752957c5c7a2abad8690c79e7b103"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/463.yaml":
+    active:
+      fingerprint: "sha256:a29df7655264b50f43c72fe138b8308b7adf7dda5c8ceecb809c91cebab4a7f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/464.yaml":
+    active:
+      fingerprint: "sha256:c137a9446603ba849769afc865284d8c68f8a1e45a3392389ce118735e8fa384"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/465.yaml":
+    active:
+      fingerprint: "sha256:68b446d639b8472f2ffcd2d12bc33377dd2413b8167d0f56b82023895d7b620e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/5.yaml":
+    active:
+      fingerprint: "sha256:c94c2728a4f84b023cd88a24f0a5479aeb0415952414311bf7810b34bda50a8d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/6.yaml":
+    active:
+      fingerprint: "sha256:8bae556559852cb2e5c34074ae19631c993307f3a7ebdf9e309a77f7b9be8196"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/622.yaml":
+    active:
+      fingerprint: "sha256:b7a7da44a8d992257d14834429892847ac3db9b55951f0ff98a502d4a53f9f45"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/623.yaml":
+    active:
+      fingerprint: "sha256:46aa6f5f15aeeba963973e125b8ab6a2a50a1ef94ab7135b36cec077159c2b92"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/1.yaml":
+    active:
+      fingerprint: "sha256:d9177a947f63aae47e23f2198049d2a3525808b73435484547aafd73d4de5323"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/2.yaml":
+    active:
+      fingerprint: "sha256:c5b8109d2545c7ce0f270a32f38ec0ca763b0d3ca0177fa776244bc88665efa2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/3.yaml":
+    active:
+      fingerprint: "sha256:56322ee4dfb171c023beb0002c3dc715eb6f9896c100d99711aa50a60ac1f241"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/31.yaml":
+    active:
+      fingerprint: "sha256:afb66c69c7c2345cdbe43d8d87a7d5001bb1bf5ff14654b874c4903d3f2a001f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/311.yaml":
+    active:
+      fingerprint: "sha256:1eff92f6773c1f38bc4411e219a9d44d731e8d09634895fa0c9e329c6ace580a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/33.yaml":
+    active:
+      fingerprint: "sha256:9690902a7a24a68d537480842e69f3a6d9e58eccc261c0eb18f955069090313e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/4.yaml":
+    active:
+      fingerprint: "sha256:48fa6ee300d6fe393b7460b9978c74090590ba019499d504410bc7f9202a13cb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/411.yaml":
+    active:
+      fingerprint: "sha256:c98a49ff9ba6dd8aee24484bda2b477dc6376f27078eaaa41d142ff2034c5968"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/412.yaml":
+    active:
+      fingerprint: "sha256:2213b9373c075f0aae3f15f2ee82ed9efff00990171f1e50d4d824c6a81afc1e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/42.yaml":
+    active:
+      fingerprint: "sha256:e4ad5378717f46dacdd64f6850c5a6f9a2ec309cffac760595fc0c52462b6d0a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/421.yaml":
+    active:
+      fingerprint: "sha256:fa75627a4a35f0c837bfb949ea76c6bf776686fc9b176030303b18f6d4edcc4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/422.yaml":
+    active:
+      fingerprint: "sha256:543410426ca6edc11ab0a601105b8e96c291c9bf81aed81902aa37d1bd1bdc51"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/423.yaml":
+    active:
+      fingerprint: "sha256:4c23cd91985eb6c33f2d5270548f688baddc6a553c888fa9c8bc10b495f3f468"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/424.yaml":
+    active:
+      fingerprint: "sha256:e790758e767fb6819498c24e388ef1b9488f9ca66160ff4b9dcce157620b074b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/431.yaml":
+    active:
+      fingerprint: "sha256:b51fa9770d919d371ac7f866a1d855e9de0192c1e118cae03a42d60349c46476"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/432.yaml":
+    active:
+      fingerprint: "sha256:10319990c23fe829a3906e56b20fcf082e87e1c02a03f1685370055732b6ac9a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/441.yaml":
+    active:
+      fingerprint: "sha256:071b22292b540108fad90af8c833f0162c5b314b29d8f1990ad9ecbafe1d48bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/442.yaml":
+    active:
+      fingerprint: "sha256:81ec47f4c224199ead172f436f6443ea77b3fc7c114ae7e9d53655894546e3e0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/511.yaml":
+    active:
+      fingerprint: "sha256:1e0f3574b1ffa47c15455c4d2ffe8fd850a838bfa3d18e4e18f96dcca68ad639"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/512.yaml":
+    active:
+      fingerprint: "sha256:22ad001646d6e783a48495c5545d0ca243792dd0f02b336ce3e76154a928ca05"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/513.yaml":
+    active:
+      fingerprint: "sha256:19f0a9f6fb3d667737b8a29f2b42abe1edf63c8affe705016d3e96cd595d9a8d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/523.yaml":
+    active:
+      fingerprint: "sha256:f757a860e45aadcaf131af7cf113df560d6d77038e16fafade3296737da098c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/531.yaml":
+    active:
+      fingerprint: "sha256:2344428457aa0114a5c18bff4f7958989cf671c1d905199e8862c051b5e5e0e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/532.yaml":
+    active:
+      fingerprint: "sha256:313b2dadfeec7fe22a75c5b4f46d65dbcbbf46f5875f2b298e3c1653f9471457"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/533.yaml":
+    active:
+      fingerprint: "sha256:1b502ac90944befecf9d77aa58fbd3b14b39d6534aa70855853d97ddb2134b02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/541.yaml":
+    active:
+      fingerprint: "sha256:da8f834688b4acdb49f7866e344fa27cce23a59462e4ac51eeb575ae85d0e88c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/542.yaml":
+    active:
+      fingerprint: "sha256:2f0c80fe952e08ca54f57b2f011317c8e10e5ac0f311b73b55ad65232f959ee3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/543.yaml":
+    active:
+      fingerprint: "sha256:a770c2cee04dee970aa0d98a1a3be70f049cd16a666f363fb73c63eb48db837b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/544.yaml":
+    active:
+      fingerprint: "sha256:e0ac9c5d96dc78d9ee9dca9e420ef4a177960c6c4b360c5f64a69075f76667ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/545.yaml":
+    active:
+      fingerprint: "sha256:6ed6eec2e434758a9d125de07fbeee25755eafd0c180f03f81f53eee3911948d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/546.yaml":
+    active:
+      fingerprint: "sha256:5a5c64b92d376de263c3ce5a3bfbf852fa6fa3943748dec1ce51b6632db22615"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/547.yaml":
+    active:
+      fingerprint: "sha256:532e72707bbe9ffbea521f4bad9127301e6795ab88a4b6ed4582502c7337a069"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/548.yaml":
+    active:
+      fingerprint: "sha256:7be57a3a820ed27d396ac203fa4f6a9bff46d98b506d12c1a91cac214bb37e19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/61.yaml":
+    active:
+      fingerprint: "sha256:4b10f0c6bbfd2ddb95792f5b26ae476e9f8553c2639588d68b52568b060e9f14"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/611.yaml":
+    active:
+      fingerprint: "sha256:672b6f24346ca1dcd63c1ce25ab587f906eabeebcfbaeb3f3a680f573fa98fba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/62.yaml":
+    active:
+      fingerprint: "sha256:622ac94426cd191b141581603035cf992a6870e9096711ac3d252252b92c74c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/63.yaml":
+    active:
+      fingerprint: "sha256:59657a0c23099629b30e726fa2399f073b9a04ba3763db63477f9d03b60d4921"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/631.yaml":
+    active:
+      fingerprint: "sha256:e7f48cc25de2c6117c36555356333d33c4d4362c7d7a1007ddd5e46d2a0c80cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/632.yaml":
+    active:
+      fingerprint: "sha256:aa817e99164c92ce8dc0e6f9b4e4f0fd56766dc8b43597520e96b0fbb643450a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/633.yaml":
+    active:
+      fingerprint: "sha256:5da17d1723b247f03267218463954817b28ced60432344004b1da4c0e186e830"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/71.yaml":
+    active:
+      fingerprint: "sha256:f1bda9784a5a344a3c83cfd7b87d4bb62f558d9686de1d5e054ce4f65da63905"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/72.yaml":
+    active:
+      fingerprint: "sha256:1103060d2db74325c5ace64009e8a242dce00bd86c6c459af89c3992b5f68f8f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/73.yaml":
+    active:
+      fingerprint: "sha256:f98495cd28d4e56a33ac2239d2f81b3c4f7a54df07dd1d2d7bcf0d9e8922758d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/733.yaml":
+    active:
+      fingerprint: "sha256:0baa93f1097ebc3b17a1ad2178eba901d787a55a10be79b72d746c67604f5ea1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/734.yaml":
+    active:
+      fingerprint: "sha256:411481083756d1344cd103770de820bf3a9881d6363aca30d509828154507b35"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/741.yaml":
+    active:
+      fingerprint: "sha256:1d719798d550a00c42b7718d4ee87146af23c279037f9fbbbddca2e45177a8b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/751.yaml":
+    active:
+      fingerprint: "sha256:20c7b3e8317742ce1f6bea9708ecfaf42c08620faeece37c79a21bbc82ee0fe8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/752.yaml":
+    active:
+      fingerprint: "sha256:0bef5f4b54269120391c891a98fc841a758ab53f218302a5c22feb16367517fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/753.yaml":
+    active:
+      fingerprint: "sha256:2068f652834430316a60fa6d96e07dd5c78199892e2f96698359d1f0191758b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/755.yaml":
+    active:
+      fingerprint: "sha256:f427337c35d5871d95217f28d8f4af4cdb1bf54f49618267028d9474beb1b3b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/756.yaml":
+    active:
+      fingerprint: "sha256:cff8fe17276b3acaf6851cf5162c5c21bc0495d48eba023cf191c413adc4bf67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/76.yaml":
+    active:
+      fingerprint: "sha256:addbaa7207c2341f32adb576c7d084a85c1d2370e22dd080e0295f348bd1b9fc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/81.yaml":
+    active:
+      fingerprint: "sha256:156b9e16ffeb02f3287292f9b85706c2f2d3001be2e78f3bb6db9335a5cf4d3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/812.yaml":
+    active:
+      fingerprint: "sha256:ee4b76dd036cd9c4d41a67873bf5d8c2ab83d958884972220ea8186e0a3f56b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/821.yaml":
+    active:
+      fingerprint: "sha256:4a10bf850ae97892a9ceb9981a10970fcaa8cb5ed0b172b7a226cd28aaf7a469"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/823.yaml":
+    active:
+      fingerprint: "sha256:c6a3815c89de89b3585e2c604a8ba0d0d2d6d8778d1df871dcd6af271c8132ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/824.yaml":
+    active:
+      fingerprint: "sha256:c30358eaca32bb8f0869da4310258617bdebc581c946f4bcaa176309c82a8382"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/825.yaml":
+    active:
+      fingerprint: "sha256:5d4878baec039cf0a6b7bb8743d4dc9a05ff6a46f54911d991fdc103337cb033"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/9.yaml":
+    active:
+      fingerprint: "sha256:31133c9eef91d1dbda7b54d742b055286b4cea860ac34260c8c55d51c1b6f9ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/91.yaml":
+    active:
+      fingerprint: "sha256:95d3d4d4397097ed0ef22be84ff708b047579b764ab63eff0ffed1fca78e9568"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/92.yaml":
+    active:
+      fingerprint: "sha256:ba8f62134d366c0504066c373e41bcfabf0a27af5868db47bf994ca7b9ff8dae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/1.yaml":
+    active:
+      fingerprint: "sha256:f5eb9f3eb8807d8cd485575554deb9a7d391bf590d19fdd32c4320febb16c0b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/2.yaml":
+    active:
+      fingerprint: "sha256:40d96db44813d2fe53a96a4ab06d577b8ad77399568aa46ee20e1e9bd603dd00"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/4.yaml":
+    active:
+      fingerprint: "sha256:c3bf97ebcb0aa9533420d07e340d10b98a1941d6bd1d618534ae41c591f298c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/5.yaml":
+    active:
+      fingerprint: "sha256:346f09d77ff7a708cd7e0d4efcec0aa81e5be6a45c415cc5ca8eec3796d78271"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/6.yaml":
+    active:
+      fingerprint: "sha256:20cff2da3558cafc12c42e496aad154be392e708eb25920e11f46c992926f5c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/1.yaml":
+    active:
+      fingerprint: "sha256:b38ee361224fbbadf2814fe09626cf3d6aeaa63864a64317612a6eb0a31c05ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/11.yaml":
+    active:
+      fingerprint: "sha256:74973ef4897fdf502b4475a0c9d58e37c491b77537a083bdd7a1e9d637643576"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/13.yaml":
+    active:
+      fingerprint: "sha256:f8014cfa0ecc12f8c13a579ae2d42b3af7c53563eaca758582dd3c46b227b1a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/131.yaml":
+    active:
+      fingerprint: "sha256:b103fb4424f871bd55454c417fce7cc96bfc367949248e22ffb54eb5ca51d7b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/141.yaml":
+    active:
+      fingerprint: "sha256:8bc5c5d183675c6f4339dc13ef5b099d6d66d878d5f76c49f5a9cfcdec5c2341"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/142.yaml":
+    active:
+      fingerprint: "sha256:619d43ce734732ce668924f54a17c1dc7198a764174143278b7367c6c0195ea0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/143.yaml":
+    active:
+      fingerprint: "sha256:9fbec893bc8fe21fa2521363c5885c622cd840f10756dc2f968c54353b4c59bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/144.yaml":
+    active:
+      fingerprint: "sha256:c25cf53ee35e1a026f6345547dd1d9cc6f47d0073b01b632d5fd598673a3cd53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/146.yaml":
+    active:
+      fingerprint: "sha256:79dc68c1fc733feb903ec1888fe82f607df4a53029be792cdfdb7ddfd8c34840"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/15.yaml":
+    active:
+      fingerprint: "sha256:573f2e535d374fb057fd910349d87f163729990ccee9a4c163d25f337ae144e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/151.yaml":
+    active:
+      fingerprint: "sha256:4e88c0fd82a90321f2c9845d01b382fa11e6ba9bfc8fc6b98977247eb6610bf9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/16.yaml":
+    active:
+      fingerprint: "sha256:02d75a18dc15d0c7ab59caee7abef69d81bacaef802a9a11036e329ca9da0d5e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/17.yaml":
+    active:
+      fingerprint: "sha256:ac7288c337ea11901af8d749f349398fae0c2313ce8daa6cd1e8086ce77331c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/21.yaml":
+    active:
+      fingerprint: "sha256:f50922ba38790ff1ad040af19a5c2be9cafd6be70f9c2135f0ac88651906a6b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/211.yaml":
+    active:
+      fingerprint: "sha256:925ba06515533a24fc0026b0c2c10a4edccdb0d8b7cabdd5b8e992402965c1d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/1.yaml":
+    active:
+      fingerprint: "sha256:c363f36a4a662ce1582f2c37e796dc06912adfde909ff3c676d72576508393ab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/2.yaml":
+    active:
+      fingerprint: "sha256:1cc656b4b9c0edc280a750633083c52bc818e27c3100c13f021a0c394d227b0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/21.yaml":
+    active:
+      fingerprint: "sha256:43baf4982336646eca69708cc9df14e5ef1be8187f0f375eba937159db84787e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/31.yaml":
+    active:
+      fingerprint: "sha256:2a62bb6c128b85acfc729a0b2c9b73cb3942741809d552888357e5779c9238d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/4.yaml":
+    active:
+      fingerprint: "sha256:c5f342101f6c709fdbbb11d05311c4e7f7ab229ddac65ddf26cea8fc7231179e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/1.yaml":
+    active:
+      fingerprint: "sha256:8c6c4cf5ebc8f22793a0afcd704dca390d5ea3ed3f7aa77e564d84cb003b0e79"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/11.yaml":
+    active:
+      fingerprint: "sha256:ccbc76fcf2f0f748a56e550878497c17162a4a79dcfda57502bda7f8afb1690c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/13.yaml":
+    active:
+      fingerprint: "sha256:e6eedf1f453aa24305d4853d7a8c84b78c44cbf2cff6f6996f1b754e78c91086"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/21.yaml":
+    active:
+      fingerprint: "sha256:d9bdf00f28673b970eab9ca36f977cc31e9611ae2a08ea5a20529e777b41bdc7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/31.yaml":
+    active:
+      fingerprint: "sha256:cfbee4e9555937bca79f6f7ee4698678270e78946fca753ef94b9153d6179f1c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/33.yaml":
+    active:
+      fingerprint: "sha256:5bb0838b0b996fab076772e2157da4a20bb9cf5c3f7de7c3b147e23da5066b37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/34.yaml":
+    active:
+      fingerprint: "sha256:7ec0c4c2efd7d291b82b9fab825b88819a14130ce98da111936b0e994ded2808"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/41.yaml":
+    active:
+      fingerprint: "sha256:e9af3090a2337def3e789ed93b4fc4a6c0755b0983b0ab8585ce5036c922fc5d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/511.yaml":
+    active:
+      fingerprint: "sha256:d58d3395253f13d72b8082ccaf3c0ef3cdd8df6088dfd474065449ea1a71b1c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/52.yaml":
+    active:
+      fingerprint: "sha256:06997e040d23782fe55fc03c41a41a0f16f7ecb4621f0c4c3878d98280b0bf08"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/53.yaml":
+    active:
+      fingerprint: "sha256:c2da170c2f3581dc4567c59b465d4fe25e989c22fd2a4a111fd13887f7f02923"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/62.yaml":
+    active:
+      fingerprint: "sha256:79a4d48fd827ffa6dcf27642f5b8633f685e6d5b560611b2a60328c19b7b4dbe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/63.yaml":
+    active:
+      fingerprint: "sha256:ec512ce11d2821e22eb57e4d82ba0aa5899853a87773aa88276e708f4b6e25b8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/64.yaml":
+    active:
+      fingerprint: "sha256:542fc12342e2b3a3335bb1314177ef5916531ce5dd4c8ab7b2a784516812f4c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/7.yaml":
+    active:
+      fingerprint: "sha256:bda64c0fc331a20d67af9c8e01c16aef5327b44b24cbddb5d93f9ceb96649e48"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/1.yaml":
+    active:
+      fingerprint: "sha256:b79e97e403ed5e1f95e4cb254fcf95cde4f278ff91136bb9cbf992062a2195a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/111.yaml":
+    active:
+      fingerprint: "sha256:03dd91a19e9c3e633b51f064021ac1ecad9948f103f60c43572e6041512ba34c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/112.yaml":
+    active:
+      fingerprint: "sha256:fc5ac7781dea8e433c293aa8de7993fe979b80185fde7f2c6cefae28ce6c5f3b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/113.yaml":
+    active:
+      fingerprint: "sha256:9975bf79a7e3fc4666bc530792fd91a1da2c5fe820acc4da1a38a6c494c26ca0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/114.yaml":
+    active:
+      fingerprint: "sha256:475174885dcfe37ee10f43194b273d3f68a0ef5bf2c19680027140b5ca9f891f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/115.yaml":
+    active:
+      fingerprint: "sha256:9243ff684b9c06310cec072730341ae34df4ea4b90a74c6995a17659e40fcdeb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/116.yaml":
+    active:
+      fingerprint: "sha256:a7614c2f1b88a30c01e4dd6a14d0265f39e34524586d6b7a3d90547e6e016a8b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/117.yaml":
+    active:
+      fingerprint: "sha256:537c825a7104c67433e07cb9ba7947d819d694eaf0d05f8ab1e9adb74aa26370"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/121.yaml":
+    active:
+      fingerprint: "sha256:a03ed8c98ec4ac7a85e313304b5e52460f287d9acb797895e381f6ffece88ea4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/122.yaml":
+    active:
+      fingerprint: "sha256:2467614c5fd3a47f27d007a5c75d52cb441b9d8c061bfd7dec5f22853d049325"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/123.yaml":
+    active:
+      fingerprint: "sha256:1242554c4edeabe7f59d3b77da3b6d39898fd1759dbfa073aaa5f438834f9a57"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/124.yaml":
+    active:
+      fingerprint: "sha256:888705969e3ee54bd2df8bd1d54bfc418acffb43ebe44230478a1363d36ab064"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/125.yaml":
+    active:
+      fingerprint: "sha256:f42f61e8783e21192644081755441b4918c5ce81c74814dd49a63c2834b78edf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/126.yaml":
+    active:
+      fingerprint: "sha256:bd5406742496c7cc2ddbb4d2ee25628548d1aa344844db35e0b8a50d476ce827"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/211.yaml":
+    active:
+      fingerprint: "sha256:78f59a06d6459089191272609f5a1a4d68a735a5d373cca9071202b39665fe5c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/212.yaml":
+    active:
+      fingerprint: "sha256:34191422d8eeeb60c65c9a90143e8544aec0212a99974fa62209c4729a1c96d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/221.yaml":
+    active:
+      fingerprint: "sha256:f4f9a3ee7d877584692d46f3a2e822b396fe4170032dd55f848f2279ddbc23db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/222.yaml":
+    active:
+      fingerprint: "sha256:c5c3cf13ebffdc92d27ee6557a061b1d430b5d3243b71276f4240c5c2578f2f4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/3.yaml":
+    active:
+      fingerprint: "sha256:05b7c7d686ddbb029cea751fbab805cf16c4cd03f802fc625c6460d6d620fa3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/311.yaml":
+    active:
+      fingerprint: "sha256:b25a3a21e3eba94d083f1fa300a05da8f35ed7743b379bb3764b6d86a24b9af3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/312.yaml":
+    active:
+      fingerprint: "sha256:42dc777b7974a70311815e5a33b83686235bc209053f1da88be59ab123eb52a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/331.yaml":
+    active:
+      fingerprint: "sha256:fc48862381420c305228010dd43b265b179371e8e7d8770078f9a09071f68a92"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/332.yaml":
+    active:
+      fingerprint: "sha256:1f080f697dae81f0073a8d800345f8480d35ef6d2c565ea2535df8a1aea47273"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/333.yaml":
+    active:
+      fingerprint: "sha256:78fa7afd36f7aafd9d1d7e2f935142ad7965f1918e6646cf92140ef964081d23"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/4.yaml":
+    active:
+      fingerprint: "sha256:30e8e96c0b0b407ac0dfd0bc075128e2c0e6708fd6ad0993ca08fac76a3221b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/411.yaml":
+    active:
+      fingerprint: "sha256:1a03ccd2718082e6879795a8ca9c48bd298dbbccbc4a31a309edd14094d7f4c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/412.yaml":
+    active:
+      fingerprint: "sha256:a7347f4401f7959d37285332df660dfd5d1aa4461b37c91415b18af85072acfc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/42.yaml":
+    active:
+      fingerprint: "sha256:ad3d6abcfb19a6e780fc40cdb258df6224d5289f2d8f663e6c176aca193b8631"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/51.yaml":
+    active:
+      fingerprint: "sha256:b86001d3dfeeef18d8e62805f71cb78341f12d5ac85d59f2511c085cecf65472"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/511.yaml":
+    active:
+      fingerprint: "sha256:c06f29d36d322c26770955db339a5273b059bab52924cf187b5ac5a80a04a4ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/512.yaml":
+    active:
+      fingerprint: "sha256:8e727a3dc75ad2ddb43691169cfc5e7ae22ecc56cf6fe5a20fd4e37221b93d53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/52.yaml":
+    active:
+      fingerprint: "sha256:b84b9d72a03f301e625fab658706cae45e6adb786781e46a3c251a57237b7a9a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/522.yaml":
+    active:
+      fingerprint: "sha256:50e061e5fb2d766b71818f720ddbddaf88a5e62947a04481b2e1eb2d1c446e83"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/53.yaml":
+    active:
+      fingerprint: "sha256:d9f6279006178431cfa69fb1fc4bce451be6df4ef77aab109184278e959e9b0d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/531.yaml":
+    active:
+      fingerprint: "sha256:6102b6be76eee1efcb848aa364860fc3a4a357065328ea933cf075e8e2b00774"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/532.yaml":
+    active:
+      fingerprint: "sha256:69f0781e745cfaf31b9bf7fcf04eb7e9dbd29f5f23742b54d30c4e2123d27462"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/551.yaml":
+    active:
+      fingerprint: "sha256:bf6d18854d972d82c71033b76317e81d58eff62962340e82acdd08392ba20802"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/552.yaml":
+    active:
+      fingerprint: "sha256:5345e260613c57667e18aa6e60c869d7af5cc5a957d17be9ee6528d984b76722"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/553.yaml":
+    active:
+      fingerprint: "sha256:6297caa3c6371f11168e6c9ee566d12818b2a013ca8f72cb7792073c16b2c340"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/555.yaml":
+    active:
+      fingerprint: "sha256:90d7c02d76f747c422b913b0d3dbe89e97a7f858b43f73ad23aa46a658c928d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/556.yaml":
+    active:
+      fingerprint: "sha256:545e18a5ef2d6e3bfde4f812d59e8fa252abc153ab4edc139ea806378ef72858"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/557.yaml":
+    active:
+      fingerprint: "sha256:bd84e7735e4a4d8055a07d7b6a14f631a1ba5a825c781bb06833712a1a1eb515"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/558.yaml":
+    active:
+      fingerprint: "sha256:1f96484987a9b8116cc2be81d7a1db0ecabf57609e76daeb8b3c2519efb4234a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/71.yaml":
+    active:
+      fingerprint: "sha256:0f95b112b26a473b4083af5450e688d6c94d6a8335301f7eb3c5ceec6d8a065e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/72.yaml":
+    active:
+      fingerprint: "sha256:5fcbb8d27793ce80dd9b1203c95f6a7f30541f43519ee28c86a5d70a4ed5a945"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/1.yaml":
+    active:
+      fingerprint: "sha256:5282940d6007b5982201fcf151dc415588dfcbf47d54ee14b4304d363a0bee4d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/11.yaml":
+    active:
+      fingerprint: "sha256:7c0c599cbb24e9d5fd6f2669e0ecc11574739d0cde089b792ac65cc8c3bd80fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/111.yaml":
+    active:
+      fingerprint: "sha256:7bbbbeb76cc286a89fb3a06bbe0ba5f9a54b384e86fa0efe258e05cbb90e6eff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/121.yaml":
+    active:
+      fingerprint: "sha256:80b1b992f63cb371723dbd70946d5badfc5ba6f4599d4ca2180784fed28db5ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/122.yaml":
+    active:
+      fingerprint: "sha256:aac633f9c44c6f495ad90554449e585158ff65d7febede557e5a8f41bd346fb0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/21.yaml":
+    active:
+      fingerprint: "sha256:94857df67d83ff5da4ff5742c94eb57745344907b3ebe28bac1f3d71235bf717"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/212.yaml":
+    active:
+      fingerprint: "sha256:3f17024a2ff6e658ef10d5eb50ffe709bb9b18ced952a3dfc22332176358f4c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/213.yaml":
+    active:
+      fingerprint: "sha256:e4531b1c8030c9078a4f7699a2d057f8e6b2425dcc6272542e0e9b84ae59d2ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/214.yaml":
+    active:
+      fingerprint: "sha256:b3f3917a6e0224bc377621577473be0a581e9a0c90a86d3633efb6f849eb47b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/215.yaml":
+    active:
+      fingerprint: "sha256:8ca2747c96bb89d2ff3661ef845b7b3c81412b2b980dbf8f014353f3a18ec141"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/216.yaml":
+    active:
+      fingerprint: "sha256:f52b1e674cd61a93b37f021a9ed22134c32cfded879f209d5f342b3d0464cfc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/217.yaml":
+    active:
+      fingerprint: "sha256:0f6b42813d36a2b3502289c0412697521f252c80809fff7c767c90d7a92f0bfa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/22.yaml":
+    active:
+      fingerprint: "sha256:cdd4207bebcc19d55f48c86deb780d70bababd15f4ad433c0fc9b52f22ccb27d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/231.yaml":
+    active:
+      fingerprint: "sha256:ab432757f6963c277ff42b44133172a96538e3bdcadccb4ec8d7334e5ec2933b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/232.yaml":
+    active:
+      fingerprint: "sha256:82968ea87724347aed86dc435afd1a9d892962bb1adc034378f86c57a2fe141c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/233.yaml":
+    active:
+      fingerprint: "sha256:44dab1d04347687ef3f2c597f8b51836a090294f23aeba65fde1547944e7320a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/3.yaml":
+    active:
+      fingerprint: "sha256:d4273f578a56cd9d1e5030643d0eda1bde108ea03f08cc725110390248357c96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/1.yaml":
+    active:
+      fingerprint: "sha256:45093f26ae23baf426df8c32d3f0629c7843f105515f19a6876a942369220455"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/21.yaml":
+    active:
+      fingerprint: "sha256:4668c60c19bd9c2c840a82952c68bea57643d638cb99aefb7987974ee0652c38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/211.yaml":
+    active:
+      fingerprint: "sha256:b47aafd82ba1415279ecf78420aa77a5d790f73749aadf17dce20f9804d0c708"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/221.yaml":
+    active:
+      fingerprint: "sha256:a60bbfff494320e6f5a367d752cacba7a345efdfa3adfb6496de976ae0446c02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/222.yaml":
+    active:
+      fingerprint: "sha256:27e376eaf48f09cf14e8d4648cbf882f9dac0326dd72dab1d447c251d43c8dba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/23.yaml":
+    active:
+      fingerprint: "sha256:c8af50854425d3339e4fc8cb455cd30bc67debb60e15c8830383deec5b1e21ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/231.yaml":
+    active:
+      fingerprint: "sha256:17d2db6c22e86a270dd740776c81d1589ea5dbf30acf1e0152b105aa6f57edc1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/24.yaml":
+    active:
+      fingerprint: "sha256:b9fc71182f2cb0707926bc6632731398c7e0139509d26b3fc86a03009b961eac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/241.yaml":
+    active:
+      fingerprint: "sha256:c7d8c0b27fcb96dad46b504fdefc57b91f89cb8970bb1c4578fba9a3e09ac0af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/242.yaml":
+    active:
+      fingerprint: "sha256:b20c66864283f8da5a883f09ee2843e50b1cca9c343a9bf3ccfc2e063b4b5dca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/311.yaml":
+    active:
+      fingerprint: "sha256:d86755742f57adc788b27b20fe72ac68043518b935e16614d1990ef151c85635"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/313.yaml":
+    active:
+      fingerprint: "sha256:8e797c3adc3bfe2da7005d40368176a82e372f352d26aee433887f1d221ed029"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/41.yaml":
+    active:
+      fingerprint: "sha256:2343a19ab0731268ee3d5bbeb3bc77fe502e9e1d7f333cdaeb4457cb2521be4d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/42.yaml":
+    active:
+      fingerprint: "sha256:9ac8d33a206b7e4e2fcc945efb2fbd62ff8818d4a82b282781cf0e05b94388f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/43.yaml":
+    active:
+      fingerprint: "sha256:3ba55009cb450fb1f8c30a74e30edc39191adbcfb082743b181ca32dccac542b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/44.yaml":
+    active:
+      fingerprint: "sha256:3aa8c9f85d4be43a78be1ad21b68c731232b908563b937ed8f76290d69b9db0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/51.yaml":
+    active:
+      fingerprint: "sha256:80b9af2383bb3e5aafafb7811a5d02be17bbc1e34fb22d23061fe62d2cf0713c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/53.yaml":
+    active:
+      fingerprint: "sha256:cbaa0b5dd7254705828fa9813da076573a5dff0ddf6181f48b71ae9584b666d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/531.yaml":
+    active:
+      fingerprint: "sha256:ca819f1744d91900a108fa150ae08e9bc76377282d1144448d0654c9728afb2a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/532.yaml":
+    active:
+      fingerprint: "sha256:468e627415cbbe262e82d28983a66d8b9a276b6a69db2d34896eaec317d4a7b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/533.yaml":
+    active:
+      fingerprint: "sha256:a1585f895eb142af3dce6164de7fc67af93551b3d16dae830c71b4c5c60a8e60"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/54.yaml":
+    active:
+      fingerprint: "sha256:b9106400f7c9726d0512d7c8454f656c3559b1e247e1aa875f20e37800ebf8e8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/542.yaml":
+    active:
+      fingerprint: "sha256:0ca29fc4e34299586531eee1a29202c167ea9738a3b4b9d4f969f9ae064abeff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/543.yaml":
+    active:
+      fingerprint: "sha256:cf1d9ab4b95fe04bdf3449f33f031273e24eb2bccb00d511894538594f3512b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/61.yaml":
+    active:
+      fingerprint: "sha256:ab8e5e88e20c4a6c5b918a5ee42c52c371484d59de4e9c4819aa488783b02d0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/62.yaml":
+    active:
+      fingerprint: "sha256:12da782c0d99294d149031767bc7c7e4d7a0a3cb312222d86cde793f67a61c95"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/711.yaml":
+    active:
+      fingerprint: "sha256:6f50126c4f3ffd730850e4caf72473a5c87e5a70c42a7b7bf5514a5ede5e23ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/713.yaml":
+    active:
+      fingerprint: "sha256:cfb98d19236b0409922543ef25ae7f203243e759db4d1a08c57b3d2cd0bc866b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/714.yaml":
+    active:
+      fingerprint: "sha256:a74fecbb57d5c981c6154d29e1b8f3f49f7ef70ffe0c6ae34bfcde75b5bdc9c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/721.yaml":
+    active:
+      fingerprint: "sha256:2e1e48b94fd8f79a54ecd0b51a699932ce48063c5583c6ae209236b9764d6ce0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/722.yaml":
+    active:
+      fingerprint: "sha256:287f7810fb1a77583e6e91fe83ed7bb861c62c865ddbe2511391d69b8c9e67ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/723.yaml":
+    active:
+      fingerprint: "sha256:913d31cf4c6b2cf534a2c145f20b6cc17559f3390221a07fdfd11c23c1e7815d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/724.yaml":
+    active:
+      fingerprint: "sha256:cc28d95e8c9c22d39a398c11f6ffec7b21d8a638db96f5a00d0fa8728221180e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/725.yaml":
+    active:
+      fingerprint: "sha256:8b36d20b14d89eefe8912fc886c57f624ef41ea3e64c24b4f8864db535c6c19a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/81.yaml":
+    active:
+      fingerprint: "sha256:5be3db33198a726b3c68e52bb6e1fe2ebe6544df10b74871790e44793565ef81"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/811.yaml":
+    active:
+      fingerprint: "sha256:831231581dc005ac9e0222ddcc293d4c70971f928f3f9010e2ef48c66c23d4d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/813.yaml":
+    active:
+      fingerprint: "sha256:0a5f48c561ce6b4550c788ac9cf8950b81b99a7c7d06211e9cff77e4b731bd3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/814.yaml":
+    active:
+      fingerprint: "sha256:de24b3ae7c46ae3d3f99c6a6ccbd2788ae8cb79baf4a3be76ba2678bf64c0402"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/815.yaml":
+    active:
+      fingerprint: "sha256:6df6c7433fa1e9f0369fba337b13041c90833b81992daf70a57e8f93bfe172ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/82.yaml":
+    active:
+      fingerprint: "sha256:a8785bfbe6aea4d1070d144f5895a8f12c32f839f88f545f9e71c9ac73122f66"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/821.yaml":
+    active:
+      fingerprint: "sha256:1db9a38cb8462b20ed383ce08cc653f395e28c1683a87d25ad1140d5eb79c837"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/83.yaml":
+    active:
+      fingerprint: "sha256:2935d5627fa8ddce0159072270330efeabbec22ff7f58d340cf5e56786f0995e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/841.yaml":
+    active:
+      fingerprint: "sha256:214aacdfd4c4e8ad0681213388c7ba2bad61b6f2c7a2055d7c3d43e190da01ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/842.yaml":
+    active:
+      fingerprint: "sha256:db769ab17869c23015575824f97a6b0a8a7f267a920131dbe61bb81bb58e0f6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/851.yaml":
+    active:
+      fingerprint: "sha256:a8029426ac056081adcdee7158de1f8e246d53002e40ee64f262215406a8e5ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/852.yaml":
+    active:
+      fingerprint: "sha256:5adf1a16665b1310341526519287f3f4c415e103e7e78967d95a994c9c72c5d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/853.yaml":
+    active:
+      fingerprint: "sha256:daa68c8acb4af693e419e345bb9dcac204df636dde0abd2c63fb712bad34f409"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/854.yaml":
+    active:
+      fingerprint: "sha256:e3ed1ff3181ef3d6722e01a22ac6b2fd9df6443a965600f861dcfdfd34da6adf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/855.yaml":
+    active:
+      fingerprint: "sha256:297d0dc46846d1c5199045ce8a0c2b370610e777546ca51b8ec197f728693c41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/856.yaml":
+    active:
+      fingerprint: "sha256:0a685885e5e98f6d2ac390451e7fc7a46cdc4251b919a473b80b71dcd67391d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/857.yaml":
+    active:
+      fingerprint: "sha256:f019389a5deb017171dcd9a283819b7456cdbc467e5e1bd9ccc1b8d1d9ee2fb7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/861.yaml":
+    active:
+      fingerprint: "sha256:90177f65b05b39bea49794859c8d45d2dafa5537de6bc6ecd5625521f5b544f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/862.yaml":
+    active:
+      fingerprint: "sha256:b7a9143ef8c6dc2093870bdc788ddf616ec39a7bc99ecdd6f6afd20e4bf617d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/863.yaml":
+    active:
+      fingerprint: "sha256:31c43c636535e22efc40721932e8d121309ae78e51ddb51f8ed6e44fc75f3907"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/87.yaml":
+    active:
+      fingerprint: "sha256:fb03f7b4abcd7af3523a58ee4e31f62de4cfde009e128d43bcf180fc9c893779"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/89.yaml":
+    active:
+      fingerprint: "sha256:5831f013ac5e495ed44a9b449fc681459258e327e7e41c51bf52cbefb82585c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/892.yaml":
+    active:
+      fingerprint: "sha256:aeff0078c4185f039c373f53767cbca6191ae09fd698104a3b6b849aaa2066f6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/893.yaml":
+    active:
+      fingerprint: "sha256:a91d23fd38faa4e77f96a59ddcb7f0f05a7601651eb7e473b00e7ff67c64a2af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/1.yaml":
+    active:
+      fingerprint: "sha256:31605f9fb49854a04f246046823c12d9112b8d55a1af9a35fbb5851f13c0088d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/11.yaml":
+    active:
+      fingerprint: "sha256:dbf1903c7058a09facb624681ac8ad78464410c6a177492793cdb5141ca35fc9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/111.yaml":
+    active:
+      fingerprint: "sha256:bb056b1cb9dc0303a4044d93d9396ca6b3776dcdd8a399d6748838cc8799c05a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/12.yaml":
+    active:
+      fingerprint: "sha256:e85448eadd6b20f707b365ca01ea20bd480705dba569c14b1ea308997b9a9cac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/121.yaml":
+    active:
+      fingerprint: "sha256:91a8543239fcb661a281c0b490096028e51033f4ad94c3d818af0b8d2cdec8c2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/211.yaml":
+    active:
+      fingerprint: "sha256:deeeeca835ef032a3411f7eb8fdfe8836e21c25e7e72822623d8731298670b63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/212.yaml":
+    active:
+      fingerprint: "sha256:110f34062d9b8952ca537edbe9052d444db5792d5fa906f127aae21573e16e84"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/214.yaml":
+    active:
+      fingerprint: "sha256:b6f9e7f466419afe2dfe368787bc5937f686e5b15de5ebea448406b1d37a5404"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/221.yaml":
+    active:
+      fingerprint: "sha256:a8f33049b4de1ae6fb98c09ab3b808ded7acef97e4f870573ec6888c114ec7be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/222.yaml":
+    active:
+      fingerprint: "sha256:541661dcae8501e583d5f49098164f33476c6b4c3d7b277d89c307c86b8a4b14"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/223.yaml":
+    active:
+      fingerprint: "sha256:9582302612518a4273dec032615effc0eaf3fa269cb19b589e55710e64ca49eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/225.yaml":
+    active:
+      fingerprint: "sha256:6114a05a12d4fce8051c5666e1789c60d7a8afaccc7d13ad75595a793b388067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/31.yaml":
+    active:
+      fingerprint: "sha256:57b0ad5f919aea73f4d7b563085dfdf8d3edd5aaeb058b91e7b18a87a18fd919"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/4.yaml":
+    active:
+      fingerprint: "sha256:9571989514347b697e2e29dee620841f01eac59ee79cb6e9f8922efc74ab1d12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/41.yaml":
+    active:
+      fingerprint: "sha256:1220d32773cf59cc32d3583a40af3843bee4c84e3596736c0cbe559c840ec3c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/42.yaml":
+    active:
+      fingerprint: "sha256:89380c542c3326b888c8fb12376f9afd2c4e1af744e188dd67ac07f88161f72d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/5.yaml":
+    active:
+      fingerprint: "sha256:2ee7e54eea2c77ba0c09d6047e0b0e5e8b5a17172a71ca9177cb3a900405afa4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/61.yaml":
+    active:
+      fingerprint: "sha256:ff1dfd9c1511f67eff24845d1577b66f851c7b09a06bd5c402d3b1130f7d1935"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/62.yaml":
+    active:
+      fingerprint: "sha256:eb3d58d7b6b92f27bb64b2959d5df79e304e7ad169c654a1fd09b1329e9af8f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/63.yaml":
+    active:
+      fingerprint: "sha256:207bd1dfbdd0ac6db2993f42981a1deff459f25b742c0d1cc8363740ed04f903"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-409/1.yaml":
+    active:
+      fingerprint: "sha256:8ed97630bbc497271b1219fa49975b16c69fa2576e2de20a19c63dfeec15df5f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-409/111.yaml":
+    active:
+      fingerprint: "sha256:af23ebaafdb5f552661b344c0cd5487d737dfbf29482ad86efa717f4412b7ba1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-409/112.yaml":
+    active:
+      fingerprint: "sha256:02ce6554eaf865d9db06457ab142e0b70912644d5f4d7e0c4bfa8d62793b1fde"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-409/12.yaml":
+    active:
+      fingerprint: "sha256:611484fed946e905e2b5b37e7f0d0b154dbb2500a2d725589d4596f27d7ff740"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/1.yaml":
+    active:
+      fingerprint: "sha256:0a981611e6f59311557d2de3d5d1c2ab3a3a4efae1afc1101d82a8554ff3cadd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/12.yaml":
+    active:
+      fingerprint: "sha256:5d3950e74506da2dfa935532cef64f4b5102fe4dc75f6ea1eaec3b7bea327fca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/13.yaml":
+    active:
+      fingerprint: "sha256:99ecd1a619bcfe199af54621fa0b138ab6131bb8491c5727382d598bd9ac21b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/14.yaml":
+    active:
+      fingerprint: "sha256:29e9fff08220642535b853cd425eb72a8f990f398af7dd97b548d677ae0f61ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/211.yaml":
+    active:
+      fingerprint: "sha256:942d2529f0c5457dd0bdbbb8f976c3d22ad1ee56949f98bbc21296c3c6645fa9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/212.yaml":
+    active:
+      fingerprint: "sha256:8e354a899695a9bd209e76e649292e81c3317856239ed1f71396460d3f46a963"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/213.yaml":
+    active:
+      fingerprint: "sha256:c9ea03537d8ac7879c4f807fd6b7e7bf9e47ccc21602043b4d908b47af1ff445"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/221.yaml":
+    active:
+      fingerprint: "sha256:262055122bbd0bf9d52535bde798f2422299cb213ff29175e03a1b07dfaa20f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/222.yaml":
+    active:
+      fingerprint: "sha256:c365c0e99b36881e0d409d894a37ec99d66b9f4abbd41681a3bcf1c72d502d08"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/321.yaml":
+    active:
+      fingerprint: "sha256:ac58b72eb321c463f33454a3cbaee705efac27fbe609e733bb3595ed13ad16bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/322.yaml":
+    active:
+      fingerprint: "sha256:fb281ca41d49734fc756d4268d4afa6dab099c2d77c5f7da4ca02f8ab110483c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/323.yaml":
+    active:
+      fingerprint: "sha256:6d15b02c50079c68aedec5a4a3e1f394efd6b968c5a34a5fa577515acb7d3637"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/33.yaml":
+    active:
+      fingerprint: "sha256:d1e9f1fb81f276c279e6ec1f53b7d11363b45fbe5da69efd08045ce972a9f188"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/34.yaml":
+    active:
+      fingerprint: "sha256:965a0999503c7e91205d34fc6032b17f1f8cb8a098f04fa586c1d121912aaeb0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/35.yaml":
+    active:
+      fingerprint: "sha256:9e6d039db6bc60710aef65f3a7b06632f19dca0ea452a9b1530542bd08063842"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/41.yaml":
+    active:
+      fingerprint: "sha256:f13d2bbb10cb38b2d79e2112b726f9f5569947abdc0e15693e7c196031956942"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/411.yaml":
+    active:
+      fingerprint: "sha256:06d15fdc02451f736494d8ca84bed798db9b3785f4999cab2515cc3227dbdddb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/412.yaml":
+    active:
+      fingerprint: "sha256:4fe152ef0e97603cecb8707fdf5d6538aa8a46796fb215665adac51a38626dcb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/413.yaml":
+    active:
+      fingerprint: "sha256:dcc744da916c840be2d6de53b27aedc898ee0aa9fba2e373c63fafc75845deb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/42.yaml":
+    active:
+      fingerprint: "sha256:d1718957f719b5a65fc01b1a030213b8f36f89be75212072141acac9281c3951"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/43.yaml":
+    active:
+      fingerprint: "sha256:cd8cd61d5c823884b187868c49cd6b553083ba5c1ff733fa1091a18924f5c215"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/431.yaml":
+    active:
+      fingerprint: "sha256:086e94a0f40f39df05fe1174dcc676cd76dc8af205033ebf724f7b18064b3a41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/44.yaml":
+    active:
+      fingerprint: "sha256:a6b5d979c6bd6f74136a8ed6a86937e254e72f8ee368bce5bd8f80e9685c19bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/51.yaml":
+    active:
+      fingerprint: "sha256:196abdc9f119574cc59279f3f005e45f2dd5279e0d6cfca830b6c8bb919a75db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/511.yaml":
+    active:
+      fingerprint: "sha256:c5d27e252c0b4027b255de1c18f1cac3cef0d6452b39dd6f8a25da9b856e2acf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/512.yaml":
+    active:
+      fingerprint: "sha256:208fde43d7bacb9d771cba602e018a1de0bf6b8a739837eb0801b81701a5b13d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/513.yaml":
+    active:
+      fingerprint: "sha256:133563919ecee737d4e13b4ffb5d847742befc49d27f950169f675966cde6835"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/52.yaml":
+    active:
+      fingerprint: "sha256:c28f2e495fca544702c4a064e8f8a0a9508c2bf7d779eb561180d4541e147ca0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/521.yaml":
+    active:
+      fingerprint: "sha256:9c35a0c39b8f508fc590929c734f5ab21d5743ba23ce4cdc20b4906a48745257"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/53.yaml":
+    active:
+      fingerprint: "sha256:f81cea7da3ef0df4938b25cb37facb77d5270e561d3604eb0c01a1d3608879b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/6.yaml":
+    active:
+      fingerprint: "sha256:150fa6018167a9c273dfe9907928dc1e7cefd40a1e44a6f7d4e93e1421b6bcfa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/1.yaml":
+    active:
+      fingerprint: "sha256:cd4318b3b5a5d277b5db53b2656042b0ea1f68d52059bd1cdcc73ca2262880c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/11.yaml":
+    active:
+      fingerprint: "sha256:313502c71443e0787c01a78ab8e049e7f6dcb8e0a2ed3c5ff98448bb292d6de4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/2.yaml":
+    active:
+      fingerprint: "sha256:7d54c6e5fc5a305ad761881b6e714d0e8b110fdd6dac6e6fb93d533af0472638"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/21.yaml":
+    active:
+      fingerprint: "sha256:ea3993ca4fcdf92320eba30fa1b605aa95420c0ea9550cfc2f1466ee866edd8f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/22.yaml":
+    active:
+      fingerprint: "sha256:623999753055822cf2a40ad79d6ba999ca3afcde8397ac7092fde4019ea69efe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/3.yaml":
+    active:
+      fingerprint: "sha256:1000a483037dd70bfc1ca2d8c0febaae31c8db31b4cbe7feab16dc51b41fc5da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-501/11.yaml":
+    active:
+      fingerprint: "sha256:9331dfadc10f2a375ea1d1d5f48e043d5f5b80757d8135035834a39ea17b01f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-501/112.yaml":
+    active:
+      fingerprint: "sha256:c2a799b0da18028914fb764ec1a74b963e1025cd39c732955a3ba196842df50f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/1.yaml":
+    active:
+      fingerprint: "sha256:b448afe663786d8e6af95f293ed3dd45d2e2f4961e727760ded8854e875f4249"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/11.yaml":
+    active:
+      fingerprint: "sha256:38c7deda081bde0c6a79e2170154233233610ba99a2a7662859a96f5cbe96e43"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/111.yaml":
+    active:
+      fingerprint: "sha256:a91114e146915158a8a3b5cee2fa356cdcb328d5c7f5d79435b78ca807463cfb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/112.yaml":
+    active:
+      fingerprint: "sha256:1ca61e6c79f9aa38a7a3c88b7f3ed4e5df745b194430b5c452c67a65868b559b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/121.yaml":
+    active:
+      fingerprint: "sha256:7809ed461dfe835776ea212794dd547e9f22079e3756f7cb69480d13d661ab25"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/12.yaml":
+    active:
+      fingerprint: "sha256:d46987782e044ba414259cfed587610f98679ab0dc545b27b077448d727276ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/131.yaml":
+    active:
+      fingerprint: "sha256:2175bb1b77a532f341a080cc205aa8ff594a520207b41d079dda69cb7a8f5116"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/132.yaml":
+    active:
+      fingerprint: "sha256:d8f40e56a88c1f01049fc9a83e1c59fef9b0531c2e5f93ec1875842d0ec34813"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/14.yaml":
+    active:
+      fingerprint: "sha256:5acc4eb20af098da82c434a1e525e62800621ab5401fc8607c8b7abfa0c91b72"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/141.yaml":
+    active:
+      fingerprint: "sha256:f50d558207495f4a95a3b2857eaab7ba81021514b895457b72f8187eb3a7f409"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/15.yaml":
+    active:
+      fingerprint: "sha256:ffab2b9da2a09211942834013efa4d369a5290c4486281eb3d7ee559ed1be13a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/151.yaml":
+    active:
+      fingerprint: "sha256:060c35b5d45ca1b44867818660a0e4e1e1ad3e6aef2e386877d0c7dcfa812597"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/16.yaml":
+    active:
+      fingerprint: "sha256:220708bd8fb9d46f6e7e0341eec9fa21108b030f415cef5415de9217e5e1201e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/22.yaml":
+    active:
+      fingerprint: "sha256:a8800872e0153684ff07e510042ffce60d624ad82a101e61c8927d8d3f3eeba4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/241.yaml":
+    active:
+      fingerprint: "sha256:56bb7c477068d5b1e8c792172feae7094aa1501e91e77f05051e2b1e5afb1d0c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/25.yaml":
+    active:
+      fingerprint: "sha256:cc73925fc75d9781c2440f629d3db0bd1b681233d6812caf6fadaecd01d973c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/253.yaml":
+    active:
+      fingerprint: "sha256:20f5befe0535cd671c9de6b7e7a78de64b3684d018b2aee69d9cba6da087d71e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/254.yaml":
+    active:
+      fingerprint: "sha256:377409fe53735a7e152afc5c3e1487dfe28f8b1ac0932103121aab278f016374"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/255.yaml":
+    active:
+      fingerprint: "sha256:d6dcedf2c1298d31bfa0abb630b02e1060d61d21cf1b466d922d5f8f84a2163a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/31.yaml":
+    active:
+      fingerprint: "sha256:2c6533a0552b721554d3e48880ab097a27560910b32532f3fecce63a3bcb5ed0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/311.yaml":
+    active:
+      fingerprint: "sha256:ba4900f21cb0f3bbaa9c051fbc09b35eb34f28aab9cdfe81513decad47dff79a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/312.yaml":
+    active:
+      fingerprint: "sha256:afa3923a790620263647ad7dffdddc8a21211deafa4f77ed180b89d1bd56b3d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/321.yaml":
+    active:
+      fingerprint: "sha256:89ed01f661388c240237a301242fc42be90cfade39b48264cf08df90604eb63d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/322.yaml":
+    active:
+      fingerprint: "sha256:055146f27b26f64617bd8c4e3ceff256bd4f2bbe77c1f365e377d5ec053ac722"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/323.yaml":
+    active:
+      fingerprint: "sha256:87a53ecd732480294f060e0a747df7bdd0ace5b6e82983e5e09853d534e86a69"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/324.yaml":
+    active:
+      fingerprint: "sha256:1a923b029ac3ca27876b66a35d529bcfde1b56ebcbf82fbe5b3aba8ee6c603a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/326.yaml":
+    active:
+      fingerprint: "sha256:0c62705d87a5f3a837eca3419427eb2bb21cd41ee0214cc5fa253afe65fa1f75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/327.yaml":
+    active:
+      fingerprint: "sha256:35b0e777c8550cc0eb36b95d090b3b753eb605a2bd2d17c52f85b8972e146f20"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/328.yaml":
+    active:
+      fingerprint: "sha256:39de5c9211fa5694ef16b3894cc44f272e63a1b68d7933974608d7dffea07bed"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/329.yaml":
+    active:
+      fingerprint: "sha256:c68f3f1ad9a4d231fda5887529b52808b4192404b78de351574f547f3982d86d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/41.yaml":
+    active:
+      fingerprint: "sha256:20ec7367b6b241b796583fb0d29b6c82320b322fdf0706ebf6ec24b15b1eecc1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/411.yaml":
+    active:
+      fingerprint: "sha256:8d6f01fdb5dd18fa80396aba6355f51d658bc607bfe3f5f2952e20a2ae2eb5c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/412.yaml":
+    active:
+      fingerprint: "sha256:3c72844f2f6cc274c7af9ad348d41175ca7d7ef89207ae9919b7943324321c2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/413.yaml":
+    active:
+      fingerprint: "sha256:e517a1f233bbee0c1ae541309cfa64e065abb0c7eb55fb406a19b1d2627314c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/414.yaml":
+    active:
+      fingerprint: "sha256:d01e7be8aafbf72d2c3eb9fc4b6061e08c01787f4788a50278efd355719313ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/416.yaml":
+    active:
+      fingerprint: "sha256:e80625bd595dfc8dd6f93a1caaf6247c41eed588b6d1f17cb0f208e7ef50a9bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/421.yaml":
+    active:
+      fingerprint: "sha256:ab23f1ac86fe5a535216251f1a7d01a34aa77a0c49370cea3ec946ff74bd68f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/423.yaml":
+    active:
+      fingerprint: "sha256:d23ddeb6b1432483d7c33d20ea2bff7a32548cd19e1acd567a32465351fb4af6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/43.yaml":
+    active:
+      fingerprint: "sha256:34c431faeae943b72f34cc657d1b5b1e8b9999cfa45e8164dacf33c75537b500"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/431.yaml":
+    active:
+      fingerprint: "sha256:b3185f50c58113502a483a25efa18dc32cddd8b14f5d340e56fe5bd0d65910c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/432.yaml":
+    active:
+      fingerprint: "sha256:a3b8fd427355aa8b8b07bc71ba39b10449728bd576a7c6c6c8cd21e192c47b38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/433.yaml":
+    active:
+      fingerprint: "sha256:fafa7559f9db34de360d9d79046b9722b4248df45a8378badfcdcafd6fda9e6a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/434.yaml":
+    active:
+      fingerprint: "sha256:292cbfe786e2e0c479c9d3d451df9c28b7f07a93cc0e50df5f11440999803d11"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/10-ccr-2506-1/4.403.yaml":
+    active:
+      fingerprint: "sha256:8405f6bad0615f44233ea6d7a86ae68bc79b4760385fc1e5d3beef7a0bc05c23"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/10-ccr-2506-1/4.404.yaml":
+    active:
+      fingerprint: "sha256:ee51e83fd095924c10a431d1168609ec0ab95e22f4b3e6e6fcaa19c5ee970fd7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/10-ccr-2506-1/4.407.31.yaml":
+    active:
+      fingerprint: "sha256:bc72a6845b739935c8757431a8ac82f4c83a7173ef9195c5f14bb6ae700da4d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/10-ccr-2506-1/4.609.1.yaml":
+    active:
+      fingerprint: "sha256:c0d42ae4dae5ad713598164837e8553b0859a3575a3d73f8edc49c485e27ff7d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/E.yaml":
+    active:
+      fingerprint: "sha256:00dc41fe87ad993d8bc4260e85a2b39ae2827c0aaca0e7c9e2425f6b464395fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/F.yaml":
+    active:
+      fingerprint: "sha256:63719eb46d5471f3410c1f71fe7bae2e43b901405b383b1b3eaa04613312bec5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.6.yaml":
+    active:
+      fingerprint: "sha256:274925140a57db7cdb5926abbf5439a23caae27e8bd3eadb39d19027894d560a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/snap/3614.yaml":
+    active:
+      fingerprint: "sha256:8ea5d5ab2b9ed1cfd300460127a6d17da2d7c6ed45ab147792a941b2211cfeac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/snap/3615.yaml":
+    active:
+      fingerprint: "sha256:11aa7ca4d99eeb820a15e2995b5c4c326c12149a11d54b51089aa2f695dc43e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/snap/3617.yaml":
+    active:
+      fingerprint: "sha256:e780526d7b9e99db1961f97950df412bee42a8398e449a53ecc1b27f20082eb3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/snap/3618.yaml":
+    active:
+      fingerprint: "sha256:c4c24950955a071e286e19d883a7b132e17d81863d43b7494b67073a11018051"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/1.5.yaml":
+    active:
+      fingerprint: "sha256:321124427489d8897601244e8d860d6f427b6a3481983fff2c7926ccd6504e46"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/z.yaml":
+    active:
+      fingerprint: "sha256:486d4ae2a845cfae939add76d87c111b165e53e7d1bde9e1c7c8664483a51af8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-119.5.yaml":
+    active:
+      fingerprint: "sha256:1ff37fd4020e0791fee184f1ed8a7620accea42ed67e69148a84d1912fa49bda"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/220/block-1.yaml":
+    active:
+      fingerprint: "sha256:9d24181076a17b12d8e0bb31fcfadf0d006d03a43b35c46cbf1d541d7093e7c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/270/block-1.yaml":
+    active:
+      fingerprint: "sha256:1ac54fbcc6547bbff6c2662ca6f2095eb7f07f3189c73930dbf189532d4c533b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/300/block-1.yaml":
+    active:
+      fingerprint: "sha256:793164b6b117e321adb4d9ec8a67924a75150a92ab4446085016e5010ea430de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/140/block-1.yaml":
+    active:
+      fingerprint: "sha256:4bd892def2e9cc48f8cfc8862241b15962c0db4a347432a23bbfe060b8091cb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/150/block-1.yaml":
+    active:
+      fingerprint: "sha256:60200ea858f3edee0966cd9c0bbf38ee576a8f92b8ffba6132b2b8d3efbdb778"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:5657c74a3284cfbaaad56c1c91c77b6640bf9b9dc030f68d2c8872cac049ad06"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml":
+    active:
+      fingerprint: "sha256:881eda4279377e626a7c2af7051aead8e4b785c286d65eaa3ae2c599bc155e1d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/385/3.yaml":
+    active:
+      fingerprint: "sha256:b8d41cdb748fd44e6cfcd59d250cc9233ef9a733d34106f531bccf9e84ae22c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/10.yaml":
+    active:
+      fingerprint: "sha256:d369487fc459ea0fa0f0a78cd069f780e8acd93cf336b2f67568cc43fe300152"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/a.yaml":
+    active:
+      fingerprint: "sha256:c8f784bfc03f7e50a7303b7afecc1b9f26793fd184e6ff94d285bf5208d5c90a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/b.yaml":
+    active:
+      fingerprint: "sha256:9ffea41849f1a9811a083d25b6edea845226872c08105e95df716d84f323456d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml":
+    active:
+      fingerprint: "sha256:60907875325cc1742971e3fa4f0b2c390e301fa10ef4e62b4294a96ef866e17b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml":
+    active:
+      fingerprint: "sha256:d808f0bb924b9e9600f76638ef8b7093f1a6fe6fbc20d854a412682ac16d89c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml":
+    active:
+      fingerprint: "sha256:7a6839ab86c25d12a58cb23cf7e1fcfbac79664b78535c72e609bc5d6799fcc6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/12/f/3/vi.yaml":
+    active:
+      fingerprint: "sha256:efb21e4a133d3b1b4d0b4bfebe969280a89f9a3da0414ab362e117de6d8087c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/14/a/1.yaml":
+    active:
+      fingerprint: "sha256:908aedd922588a1c9c71a500565ccbd1140170d917034a1c173473be4947de65"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/14/a/5.yaml":
+    active:
+      fingerprint: "sha256:3631a5f5f71c26e988d8ba2895f6f42d8767f41ddcc2d976b8103d829fe4b30b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/regulations/18-nycrr/387/9/a/1.yaml":
+    active:
+      fingerprint: "sha256:d8d6dec604f4fbbc75e6cf049e2ad2490ee992f34c34a1649484c5ab9ab519a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-341.yaml":
+    active:
+      fingerprint: "sha256:9edbbeff0a6020a929e989ad22ea91f4fb42994224ca72421ba554feff3da6dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/irs/rev-proc-2025-25/aca-ptc.yaml":
+    active:
+      fingerprint: "sha256:c872bf5ce414ceaa9770a7294411d3d2ccc1a0ecabf1b9b8b5235ed51bb53623"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/pia-bend-points/2026.yaml":
+    active:
+      fingerprint: "sha256:11b2c43fbf71bbae759ea89d5df734df1857f8ae990e748e9e8052e6a44e6387"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/quarter-of-coverage/2026.yaml":
+    active:
+      fingerprint: "sha256:d3a3a4282e6b777c6233cb48dd9b030c3848321dd1b385ba4da40e3ebdd4006a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/retirement-earnings-test/2026.yaml":
+    active:
+      fingerprint: "sha256:67dad39297d8c5ac06afb6d071c9f55068560d214c0d652f35489fedc9a45ec7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/7-cfr/273/10.yaml":
+    active:
+      fingerprint: "sha256:be5d6a73152eb3d146fbf55e0c3d19e25423713060f66902860592a64907ef51"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/7-cfr/273/2/j.yaml":
+    active:
+      fingerprint: "sha256:7debb221efd253a1ecf5fb479ab06dbaa493841ece0a531af116a87dd0103ce5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/1212/a/1.yaml":
+    active:
+      fingerprint: "sha256:9c8e1d3642e3e833d1126e050e523eea20e1f312fae056270b02ec284787126a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/1401.yaml":
+    active:
+      fingerprint: "sha256:5ea0092ea4efe21e29827016a1fa0f023be1385f52836509d2ea36e2498c18aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/1402/b.yaml":
+    active:
+      fingerprint: "sha256:faf6c47edafa4d179deceb6545c7aec0c8f25d3b59b63c261ec48d40c90ff325"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/151.yaml":
+    active:
+      fingerprint: "sha256:2a898e8691b13d46969b2d5288ad9d045edab79c3ad7fde76891cc7e395d4890"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/152/c.yaml":
+    active:
+      fingerprint: "sha256:2efdd8fedc3f6d30a82eaaee35e0d78cc66f305707eb42d7fcee1a09de9fd85b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/225.yaml":
+    active:
+      fingerprint: "sha256:a219ad7589c35f79737b6453c6ad9cfcd9bc5a41736c219e4dcb7df6a61d2c3f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/24/d.yaml":
+    active:
+      fingerprint: "sha256:0e7b209649ff6cedf46b5f75e4d84adb23054fde3ed991637cac9e1c7f33a277"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/24/h.yaml":
+    active:
+      fingerprint: "sha256:4131f1d832bed539a791952aeb313bc2d1a830fe05f9cbc33a0e34e7e0f5e8cd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/25A.yaml":
+    active:
+      fingerprint: "sha256:33697f39bd8c1cf0406052c529deb1c73b39d812b1e1cc41b11b3ea948023bf6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/26.yaml":
+    active:
+      fingerprint: "sha256:8d2d0805fe1a7549b59dae797c14723ef0b224cff8f7b532df4cd98aa88489b4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/32.yaml":
+    active:
+      fingerprint: "sha256:aaf9b762c1faa0d4c80929e91a09116b01a991b1445236e6f442071467c4e62b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3232.yaml":
+    active:
+      fingerprint: "sha256:1fb0ea431d931ef2c5a2562888c60b68917c33664b9d885813fe2b21b541aad1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3241/a.yaml":
+    active:
+      fingerprint: "sha256:a3377538a56cc7aaf505ab1048089ee00c892c41c91e4e059feaa437feb29595"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3302/e.yaml":
+    active:
+      fingerprint: "sha256:0af73c3bf6818da80638582adf6d7b43daa9e57dd1e08fbda1f2d4e7aae99871"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3302/f.yaml":
+    active:
+      fingerprint: "sha256:f58df1af06bdc1106695bce7e7957e2777b5c6fea54884a2ba57d2b052217118"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3306/d.yaml":
+    active:
+      fingerprint: "sha256:d0067a1698c7494123119063d45440597a02a2ae4a01a37ec7c13af9aae49d03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/3309.yaml":
+    active:
+      fingerprint: "sha256:b0bb0bb2eebb4793fa4fe161f7d788e0524319d53b2a4f7f51db744091fe92c7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/6012.yaml":
+    active:
+      fingerprint: "sha256:ad0c18c36b80f1ada7c7f877891e95870fed17726f193cac689f34d4f4c618da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/63/f.yaml":
+    active:
+      fingerprint: "sha256:53b1816fd3631969020de7133d2f833553cf80ed4f2deb9f846ced149b44a56d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/6401.yaml":
+    active:
+      fingerprint: "sha256:fa8096f8b7aa31627ab849fe71f984b43d90bb2a5e010b4c04bec4fb33e6383e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/5/5566.yaml":
+    active:
+      fingerprint: "sha256:8b331a89871b22a8836a183efbd580acd9605f7b266e5599e979d2abdb1e2cf8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/7/2014/g.yaml":
+    active:
+      fingerprint: "sha256:db8b9b6e95d68296d46b984ada2f60954a55577c6a14b759e856b6cfc1806e2c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-01-household-concept/103.yaml":
+    active:
+      fingerprint: "sha256:e5ff5497fe750474282dfaca0e6351bc806e67d42f146464628a4f1438d42efb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-04-citizenship-and-alien-status/404.yaml":
+    active:
+      fingerprint: "sha256:f062be577ed453b69846fb1496fa88f2f25a86dcf75546bae91899e5f61b211b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-06-social-security-numbers/603.yaml":
+    active:
+      fingerprint: "sha256:865ed4bb71f7d29651d7aaf25747548995c802a125d63c03c8926ef9c6b0c68b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-07-work-requirements/704.yaml":
+    active:
+      fingerprint: "sha256:efd1cce7bfbeaa443741682b48734e9af03c1ab8dde28e0a6bf55d941bea5a6e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-07-work-requirements/705.yaml":
+    active:
+      fingerprint: "sha256:7943d3bd224782d4116e99ce634296aebaa97d013b3964866b211264d825d124"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-07-work-requirements/707.yaml":
+    active:
+      fingerprint: "sha256:d1fc6fd36533195f12248b8ed1a7063b0eb2a19a6bb1d19135d7fc13f92d9abc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-07-work-requirements/708.yaml":
+    active:
+      fingerprint: "sha256:6f69032f7effae6c76b06822a5bccfdaa6f885fd5d99b257455af771886dcac4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-07-work-requirements/710.yaml":
+    active:
+      fingerprint: "sha256:85a9de58b4a3186fff2081495f67dba056cb58d27496526c95c7e16dd8a5ae01"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-08-resource-eligibility-standards/804.yaml":
+    active:
+      fingerprint: "sha256:2eb5e419446c231ba674fb879895b959aec2d0feac3a0a059c9fb0f83a0af7d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-09-income-and-deductions/903.yaml":
+    active:
+      fingerprint: "sha256:9265405251da90b4ac8c49d8d58ca4e73f8822024381ccbfd7c32d842b2e756b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1002.yaml":
+    active:
+      fingerprint: "sha256:f049d8af1840d61d4aa9d8d70736e1b30d33565e28baf84722faa2fdb616f480"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1004.yaml":
+    active:
+      fingerprint: "sha256:942c4219137c8cf023f99f94c5f3ddafb02e522e590e8f08c5a1cd2b4cd6c784"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-10-determining-household-eligibility-and-benefit-levels/1005.yaml":
+    active:
+      fingerprint: "sha256:c1d9e042d3142bbe3012e1ff55912ebbf4bb9216d7a66f6f0d55e8c9d9eb6975"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1101.yaml":
+    active:
+      fingerprint: "sha256:1898b23c383e0fb9db9cafeb543d304c62fc8dba375dbe1d9ed39301cee71589"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-11-action-on-households-with-special-circumstances/1110.yaml":
+    active:
+      fingerprint: "sha256:498589ef2c2b6b09949e042496a243107a1260890d0e792b2d445ab0656628d8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-12-reporting-changes/1201.yaml":
+    active:
+      fingerprint: "sha256:90b0d7158f0eba346dea0f97efef7267e58be0d545d69591876989371db5b7af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-13-notice-of-adverse-action/1300.yaml":
+    active:
+      fingerprint: "sha256:290e44cb18ffa7271a84c029efa432cfd7cdd9aab5581718918ad550e38dae12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-14-recertification/1403.yaml":
+    active:
+      fingerprint: "sha256:5693d2a3ffeb7fed4c6fccfac25c3751aba690af0fdf023ffd863462dce38561"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-15-fair-hearings/1510.yaml":
+    active:
+      fingerprint: "sha256:2e08561f6e82e6fd2e813ec83cf10bd6f50170894af7aadf40b92e1bd52de652"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-15-fair-hearings/1511.yaml":
+    active:
+      fingerprint: "sha256:32ce74f68e5f1a1be126d10fdfc56aff2046c7e0eb58bc3c8a76b940ab071067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-15-fair-hearings/1519.yaml":
+    active:
+      fingerprint: "sha256:d548e4b31d66ff4e737d0f8463198a652ed89e67a350b17f937580dc731cc5da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1602.yaml":
+    active:
+      fingerprint: "sha256:a4f440316e04597cc573c4e59150a000f7147c646b05252ef2fecd743bbd9a34"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-16-restoration-of-lost-benefits/1604.yaml":
+    active:
+      fingerprint: "sha256:c6bdf72184b2ad0661179d2bc8e6454fad9501128431ab6ada999bbc12c65df7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-17-simplified-reporting-procedures-for-all-households/1709.yaml":
+    active:
+      fingerprint: "sha256:37a4bc5b8ac9f97bb002d3c03a5cb98dd8fa4da27d9654d4421ca45ea835e8e0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/dhr/poe/chapter-17-simplified-reporting-procedures-for-all-households/1710.yaml":
+    active:
+      fingerprint: "sha256:0d393631b56db1f40e8ea75b2853571039ba3584e54354d0523bcf4bc1054409"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/regulations/660-4/1/03/block-1.yaml":
+    active:
+      fingerprint: "sha256:9a64bfdd4632315aa57041fcd42ad4669339ae6e4267034f45a8eef659de5bb2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/regulations/660-4/7/07/block-1.yaml":
+    active:
+      fingerprint: "sha256:29b4a68e0d310e42d7a03ad48a4a5eb0841519124af87917b8385523cbaa21d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-benefit-determination/earned-income-deduction.yaml":
+    active:
+      fingerprint: "sha256:a51784b42f1b3ca4004a4270acb9cb0391cf0c19a7573fa60d0cce9272424b1b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-benefit-determination/needy-family-test.yaml":
+    active:
+      fingerprint: "sha256:7bfa725bc2577c3158c9f5f1583a2bd06bc4a0ea37d6b69db686f7076bcba136"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-benefit-determination/payments-under-10-dollars.yaml":
+    active:
+      fingerprint: "sha256:ef14b856f67b9f9e80e57375b064c7745096706ca34234263841aeb9634b9938"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-jobs-exemptions/tribal-new.yaml":
+    active:
+      fingerprint: "sha256:acce92679000b4334052389e655ad0aa0dcedee1bf48011055e8475db4ea5dc0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-jobs-mandatory-referrals.yaml":
+    active:
+      fingerprint: "sha256:2397a3a79a8713a5283bc99bacc9127e5be4ba2846064ca02a006cdedeabea68"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/ca-jobs-work-program-requirements.yaml":
+    active:
+      fingerprint: "sha256:703802a1cff441eca21cb1e46fb49e3256ea4f6452dc318fa4e579663b6c5574"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/dependent-care-expense/na-dependent-care.yaml":
+    active:
+      fingerprint: "sha256:5485fc5fc14cc9951097c42cb23275fdedf93e438663b7d8ccad5975985800a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/na-categorical-eligibility/expanded-categorical-eligibility.yaml":
+    active:
+      fingerprint: "sha256:27940a4cfcc2838abd6d0bf62c80aa737155b4d808b3cbd717d6f08bcfc873b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction.yaml":
+    active:
+      fingerprint: "sha256:490860199a0e69dd9706b6699891dd998ea63e44feeffb30df11ab68216bdbcc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/na-transitional-benefit-assistance-tba.yaml":
+    active:
+      fingerprint: "sha256:480a446ac6d3afb5a07a4264cbf1ab2ba72c2eeb06ce5ddab103c538f8475868"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction.yaml":
+    active:
+      fingerprint: "sha256:a9d41ea5c1fbe4fb6b1bbe6d79d53cdde8792a32c8304a88f8d5b4589110ccb7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/faa5/transitional-child-care-tcc.yaml":
+    active:
+      fingerprint: "sha256:aff68b8d51fbb748bd49842fdf6db68a7144f5db11361361c3c237de5441d34b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/G.yaml":
+    active:
+      fingerprint: "sha256:dff468da54da05e63f50d3c9171691eb0cec3b8bf2dc39a678aa7f0e98bd3480"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/H.yaml":
+    active:
+      fingerprint: "sha256:bc0e2e49bf1736af142dba2340c084f16f721d13feb13a7a7c87863416cb2109"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/I.yaml":
+    active:
+      fingerprint: "sha256:f095e66f165be6401e1ce6e5c1019b600b0b49b14d8c2eceb2315eb4ea8d61cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.1/J.yaml":
+    active:
+      fingerprint: "sha256:38e5539d105b0a3f95583e5cc84421fe7c0b0c924c74cbdb8ebf96643d984031"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/regulations/9-ccr-2503-6/3.606.2.yaml":
+    active:
+      fingerprint: "sha256:43c8f861d32c3602b88b016e9e27b0713567c8d2a3a1d4e020fd860aec3d4eec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/3/d.yaml":
+    active:
+      fingerprint: "sha256:78919d7c5bb4799c662b2ddec76b851a6be33abb37d538bb459e21cd51a157fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/3/p.yaml":
+    active:
+      fingerprint: "sha256:cd05a8a29fbfc51eb5a97e38c3819a0a38075051e1da582621570482fde1b6d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/3/p/5.yaml":
+    active:
+      fingerprint: "sha256:b49bfa5ccdd0425b89e61cfb4759a4053406589ec4f35ad7f85b29c4d2fe9866"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/3/p/7.yaml":
+    active:
+      fingerprint: "sha256:b8d48c8aad564c74c46b2955bd1a892f3eb673992c1d9bd9c01a65af70005925"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/f.yaml":
+    active:
+      fingerprint: "sha256:6dc5b0b5be8498f8339a9db5bd9f2fa732bbbe3927ed84854e8bc39ac796168b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/i.yaml":
+    active:
+      fingerprint: "sha256:089aa3b92c0a7e4f97092b62d49a245ce1199331e9158de54f9570f0ca952695"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/m.yaml":
+    active:
+      fingerprint: "sha256:5a6e3c17d7972ead2dc596cc33fbf44a13acf5885338e72a8decfe4dfca7dd2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/n/5.yaml":
+    active:
+      fingerprint: "sha256:82b403a82db8381d5b600246e573bf9337d702fdb7e49854583075160c44af75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/r.yaml":
+    active:
+      fingerprint: "sha256:37f884f683d0a87f8de2bffccc3bb39de24b6dedb3a307330ba8b502ace3b203"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/x.yaml":
+    active:
+      fingerprint: "sha256:e76e243587a1c97a015603d422c454c451615d206f656eae48932f521cfeb40d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104/4/y.yaml":
+    active:
+      fingerprint: "sha256:f992e179af8c22fd7f2fa5a0e63c9284dbf2e6d410d31e0d0184c3f43f39d753"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-119.yaml":
+    active:
+      fingerprint: "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-123.5.yaml":
+    active:
+      fingerprint: "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-id/regulations/idapa/16/03/04/page-16.yaml":
+    active:
+      fingerprint: "sha256:7b61f2613e596fadcbc28b9206222bad5c07628388dbdc337a265d92a103ddb1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/360/030/block-1.yaml":
+    active:
+      fingerprint: "sha256:b46b58f7b3f42cc3b8a213f4ab39df4cb609176fbbb0b7e484c7910bab821d20"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/360/250/block-1.yaml":
+    active:
+      fingerprint: "sha256:a1d997e244f37d5b7f7b56be6c4cefbb1194a701b38f83254049541fe6e68a2b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/360/600/block-1.yaml":
+    active:
+      fingerprint: "sha256:6a6999ec7fff235bae7cc5761233260f08329726534dd8da8a323fe1224e61d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/360/950/block-1.yaml":
+    active:
+      fingerprint: "sha256:bb8d14590a405e03acd31c2d928265f16ade0d9ab03098307838f11c5de2d698"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/080/block-1.yaml":
+    active:
+      fingerprint: "sha256:995180e719751651aed3b6341c405609724dea4ce010115ec0393ed7d1bf73c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/100/block-1.yaml":
+    active:
+      fingerprint: "sha256:1d9d3906ecdf5a782157a435cb1bebda11e68f16f0a4244f656cc6e866123315"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/120/block-1.yaml":
+    active:
+      fingerprint: "sha256:909f50f5677bab87dbbe136cad96121c63b476d98938f59e00f460e564172b1b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/160/block-1.yaml":
+    active:
+      fingerprint: "sha256:3b1db25724af9fad2edf58e214a927e4f03a8573f5708d8964cc3c2847a5d74b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/190/block-1.yaml":
+    active:
+      fingerprint: "sha256:b87c9b4e6fd29104feff48ee9826958113b474f1240865fe541792a9ee7e6d17"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:d32fbcf7f2a762ca3cd0e8e3fa5e3d0a2a53fd5fe5555b74c52eb531216423b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/210/block-1.yaml":
+    active:
+      fingerprint: "sha256:cc018767214ec052f888aeabc61dca4c8be27e9e300bdd0db804a9d6031a29be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/220/block-1.yaml":
+    active:
+      fingerprint: "sha256:6138862daab260ad730e04aba8f2dde5de2a14fb016c7e482238b11c0311cee5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/240/block-1.yaml":
+    active:
+      fingerprint: "sha256:ef3a7bf241a840624d69a503c7240ccfab42c89c8e63324ec435f61963d432a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/310/block-1.yaml":
+    active:
+      fingerprint: "sha256:291e66af9c79345f8645f56b4e3e47f4ae0e5cb6f6300aca7eee4549ad2422b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/330/block-1.yaml":
+    active:
+      fingerprint: "sha256:090f2da7c725e8a78a35a099ada9548b4b70232d31759aa408fa482c20be00fc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/350/block-1.yaml":
+    active:
+      fingerprint: "sha256:285f93375daa1ebd9197bf35a7aeb49437e9254e8ca0e2e654ddb82983f7f22c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/400/block-1.yaml":
+    active:
+      fingerprint: "sha256:73f8f52a9a8e8d744f0fcfac301b4140043d349ee5eb55cc33d3294df16286d1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/500/block-1.yaml":
+    active:
+      fingerprint: "sha256:cd71272621ae00c8df2dca242f79ce939ef38709aed8896988c58f15cc303109"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/520/block-1.yaml":
+    active:
+      fingerprint: "sha256:4c1233a44c3c3b5d25400d4cc728c547bd4d122164b475be8845272da1c58e01"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/540/block-1.yaml":
+    active:
+      fingerprint: "sha256:d9da24871692ccf42fe185695c0c83348916e64db7c8747fd8cd93d9633e026f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/610/block-1.yaml":
+    active:
+      fingerprint: "sha256:b3b6955295f063ca47e85e8aa4a9a7680443cfc62f61e7c55607faf4c8b6ceb8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/620/block-1.yaml":
+    active:
+      fingerprint: "sha256:17a2294aecbad5b7eff1b599ee2180a5aad0c458075b919ebbe944530eeb8291"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/700/block-1.yaml":
+    active:
+      fingerprint: "sha256:b4a2cbf76b33f30dd611773fba57883ef56fc3cb3614e6ec03c0af6de4fb5a04"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/900/block-1.yaml":
+    active:
+      fingerprint: "sha256:79c6f3341482acc5871590f31ea50f033ae7786077a875493a434680c20f41aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/910/block-1.yaml":
+    active:
+      fingerprint: "sha256:937386dca705208430b37f5404e0c72c0ecd84b8a27b36ae8d50bf09af479705"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/930/block-1.yaml":
+    active:
+      fingerprint: "sha256:ed69a1331164ea598bb6d628027ab0c5fd994c91033145297ebc062b65fcdd56"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/940/block-1.yaml":
+    active:
+      fingerprint: "sha256:7b123705ed6f5778fe7a89975760fc07eea503ea8111e9b7df874efc91b553c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/950/block-1.yaml":
+    active:
+      fingerprint: "sha256:1816b75fa075e26c1a5544ba14edce03b85befd2c419241a44b0a55cc282098b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/361/960/block-1.yaml":
+    active:
+      fingerprint: "sha256:9640e209184b33c75daf1bf7e66cefdef01445bdfe068c708edefa842588bf07"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/100/block-1.yaml":
+    active:
+      fingerprint: "sha256:2e47e459065d4ed1751fb5f15ff7776e6d7a4ac326a478192fb28a6698ea6c90"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/120/block-1.yaml":
+    active:
+      fingerprint: "sha256:b428860c9c3d3f4e733e50c45ddf27cdce6c9951080509129db1d324375b9588"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/210/block-1.yaml":
+    active:
+      fingerprint: "sha256:b520efdb0ac89916699a46ad2836f2739afa33ed882886a5a2795f1387c84b96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/310/block-1.yaml":
+    active:
+      fingerprint: "sha256:b8b9afe4842d3343a149ba2356ce45cc48fddca8152e8ffc4026f4f59e53d43b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/330/block-1.yaml":
+    active:
+      fingerprint: "sha256:76120daa0367c4d9b640c192ec2b4ecb8af41c45923b6340829b51937b622c87"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/340/block-1.yaml":
+    active:
+      fingerprint: "sha256:ff5ab8f0ee483c8f1921d03495ddc7750edc1882ba18f766398fa44f643da2d7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/400/block-1.yaml":
+    active:
+      fingerprint: "sha256:f5bf4be3420685e7a462357ee68eabbc997f8bff644cf65903577437f1cd02a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/420/block-1.yaml":
+    active:
+      fingerprint: "sha256:ea42a6bde8017a31e1e3557ce47f3a3255217a507ae1f8482bf23f5e8e206ca8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/362/500/block-1.yaml":
+    active:
+      fingerprint: "sha256:7f5afb810dcbe44301531fccf60c6d7240944512f7753370994e563302827e7a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/100/block-1.yaml":
+    active:
+      fingerprint: "sha256:7c22a86ef128ac0d735575e4f480c1c54ec136d648bfe628195e972a76d09bc2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/110/block-1.yaml":
+    active:
+      fingerprint: "sha256:79a9b174481518c8c778d76a8a355ce444f217892e78b229dad7cf6aeb0cd1fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/130/block-1.yaml":
+    active:
+      fingerprint: "sha256:a0e1906bde449799aa64d8ece90efdfdaae383b73896e46dd3919cb424a48a28"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/140/block-1.yaml":
+    active:
+      fingerprint: "sha256:dd7c64f372e0b7bad5fb1a10d8b30773c8d362077ea31116f3f76f61ac12fa12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:c617c32aebb84be4d5a369ad8599d021e9bf01e9a7f697d8f0ab70caac9abb5c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/210/block-1.yaml":
+    active:
+      fingerprint: "sha256:f9c473127924962d490e885b635a06d2f034fcb004a2419faf072ebb8d3075a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/220/block-1.yaml":
+    active:
+      fingerprint: "sha256:44cbfadaa1fa662ca54a4ab76e2e91ad9dce3ef984ebdc1669fc2506c15af343"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/363/230/block-1.yaml":
+    active:
+      fingerprint: "sha256:a8ec93c57b6103ba18cc8fcdd5fba9219703fc6db9d3718c39d4811ac28685be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/120/block-1.yaml":
+    active:
+      fingerprint: "sha256:d1c707ae67e60356632918cdb8acd72d277acbddd8f0ee005c5e70f56186d2cd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:43e06fef71ee3e3dc42a4f9d8800ee6ac8d98c7125a25b0b165f2e686059ceee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/310/block-1.yaml":
+    active:
+      fingerprint: "sha256:c8883f8a22bdd840d4805f90b38e2389bad84862c9d78acb62245f6e04a93fac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/320/block-1.yaml":
+    active:
+      fingerprint: "sha256:697d146f5e5e68538875adc0fbdb345247abbee235a783dc4f61b0add00d35af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/330/block-1.yaml":
+    active:
+      fingerprint: "sha256:e3c4a020ef1675c13037e09916d8711a07b0ffd5c49311c9592c9878acf4cd8b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/340/block-1.yaml":
+    active:
+      fingerprint: "sha256:508ce8b68b9261ed7188490479325de36c55896c9a2569ddaa40f23a9aff048b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/360/block-1.yaml":
+    active:
+      fingerprint: "sha256:28c1af16521ecae7d87a69bb03ae9fb5b491329da9b5cee4838a4e96fc00b476"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/370/block-1.yaml":
+    active:
+      fingerprint: "sha256:701b530d396ef91ffc519178801a03d61e23b78473c3c96d7a2e4caa3ccefc41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/400/block-1.yaml":
+    active:
+      fingerprint: "sha256:e20c21076f2794abb70e9da78ddd069cb75f831245f899addb729179beaee230"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/410/block-1.yaml":
+    active:
+      fingerprint: "sha256:ec9e2ea528b99bdd1e16f982bd8784efc58416a3fc029edef0cab7da2929c438"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/420/block-1.yaml":
+    active:
+      fingerprint: "sha256:f9ec0a8a76b443d9ad2dc60b1da49d4f7615d7d2b50f8bbed45ab19e8a68ff97"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/430/block-1.yaml":
+    active:
+      fingerprint: "sha256:c0ee5a033560f5ea65669cb7a7c878e17f732b4e655d9af3e16b97d2e32085a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/450/block-1.yaml":
+    active:
+      fingerprint: "sha256:f0f151d2a47da49f0f19ab5ec61f0b6b9e828fe22ce9076c751fd777a7d8309e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/500/block-1.yaml":
+    active:
+      fingerprint: "sha256:e10b7829c8ddc130148646d20c3133b29a8c5e86b2017c8b76550e104d40c226"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/550/block-1.yaml":
+    active:
+      fingerprint: "sha256:58d3e72bc1a6778593ba5f6c386eeaf2dd421142a666feb7422449852df2a5a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/600/block-1.yaml":
+    active:
+      fingerprint: "sha256:23129d760adf5bed42606816642dafa940ec49ceb5a2f9ae0d75471bd81c2801"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/650/block-1.yaml":
+    active:
+      fingerprint: "sha256:e3417dbf79315890bef6f3a4de721bf41d82cfa9706a26ffde5653fa1ddb8977"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/700/block-1.yaml":
+    active:
+      fingerprint: "sha256:dce1ea2fd555b31f34b1bf49bcb3c1df760c9a4593ad65cf838d1d3a47260a2c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/870/block-1.yaml":
+    active:
+      fingerprint: "sha256:f44a5b94b3c9e5e457d4b37a5b22e272002bd8a5cedf7dab7cfacad350288cf3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/900/block-1.yaml":
+    active:
+      fingerprint: "sha256:a24f898c26788e5560b2ffd151698d30bea77918858155e8f5844bb79adb143d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/364/980/block-1.yaml":
+    active:
+      fingerprint: "sha256:e740e4181c421f6968e2ddbae978f2e12b6dd0c09a8741c2e2affd90da438ee6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/110/block-1.yaml":
+    active:
+      fingerprint: "sha256:c1053c9f6698f032db231aca8d4d3ea2e0f8fc744c336018b8050446e054c9bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/120/block-1.yaml":
+    active:
+      fingerprint: "sha256:f0d92bc988cb03b90c83b5553662c0172157856ad7ff4319e3449ba0a09f1ae6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/130/block-1.yaml":
+    active:
+      fingerprint: "sha256:407502d72d04c72d0545a3d528c0e15e788164f0e4b2dc5aa00f4393c4652234"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/140/block-1.yaml":
+    active:
+      fingerprint: "sha256:a4a2f56d2b45b59cadec866965226658c718736838f86a9a5d7cc8a692b59e23"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/150/block-1.yaml":
+    active:
+      fingerprint: "sha256:3eeb45a36e9613905fe4813c3d288696be198a9708848598e20ed5a3aab5c1d6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/170/block-1.yaml":
+    active:
+      fingerprint: "sha256:bb3023a057ef6f777a028c0abe210e8ef2c8072b673e99637dddd43eac5c6c15"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/180/block-1.yaml":
+    active:
+      fingerprint: "sha256:66b2772f9ae48a792160562cd76f77f14b2ded1bb3ba0a8c6596941b2054c7a8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/190/block-1.yaml":
+    active:
+      fingerprint: "sha256:f1ca0a19cb2c1f89dc8c56ca7fd78a9dfb88575e387dbf75e57559c82c46cc74"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:00048ce901a8f279d7e52b5d8be617311df2be3580e3954b18f772f8febb17ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/430/block-1.yaml":
+    active:
+      fingerprint: "sha256:ed6007b10f91c7aec75921b6200ee614821c2ab300388a6dc4be88c720fe8f28"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/510/block-1.yaml":
+    active:
+      fingerprint: "sha256:98e480d76a395aebd96c01f00f6888a7eb7bc0fe5c69794835cd71e7d44253c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/600/block-1.yaml":
+    active:
+      fingerprint: "sha256:2bf955c9c30ffba592bb0ffe3965f8d39d4f017eee6f529bdfd8bd9af1844390"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/605/block-1.yaml":
+    active:
+      fingerprint: "sha256:5919525a1f216695952cd1d7afdf05f30b4514b2d09a226c8ed85d212223df7f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/610/block-1.yaml":
+    active:
+      fingerprint: "sha256:b5ac921f349f5fe4a645792758f1ab0584c4dcb39b95cda818739706864be12a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/620/block-1.yaml":
+    active:
+      fingerprint: "sha256:5a32393424aae29a1e786fbe33cb6fee1113ecf94cfcd9c683a2698b7c88ee5d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/670/block-1.yaml":
+    active:
+      fingerprint: "sha256:fc6cc411d82f1270ff04cb0b0231b48b6f70702e6703f25d8780d26992b09c6b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/700/block-1.yaml":
+    active:
+      fingerprint: "sha256:65e8f883120328fa8a54152af803f85990fafb2450c3ae01dbdb34117a6663ab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/730/block-1.yaml":
+    active:
+      fingerprint: "sha256:2706c1ad69dbb48d542b0bb1813a067fcf8a48f18b4db2a972fc775a1e49da80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/810/block-1.yaml":
+    active:
+      fingerprint: "sha256:8156d28b501019b15ead0078eba375097ede2589f7cfcdcf072374e79b0b356d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/830/block-1.yaml":
+    active:
+      fingerprint: "sha256:b7ee0c86e1026db816cd23b8813593532bf1f8a6d9235a71bb2d2b45cfdf2334"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/840/block-1.yaml":
+    active:
+      fingerprint: "sha256:376fbed1a027af521451fdbc7c61106846be3b31e13e3cf32b9a9ccbfef611b4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/850/block-1.yaml":
+    active:
+      fingerprint: "sha256:92b95e7f76237d29b5b5a7bfc517619ecd02f8b0f7ff768c680ffcba8702b24f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/910/block-1.yaml":
+    active:
+      fingerprint: "sha256:b43bd4643f2205c4b8d353099ceb96ce4a6caee41f09c9f581710bc16be032a1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/920/block-1.yaml":
+    active:
+      fingerprint: "sha256:bd3b4a76321488855b4b27f0bdfab715da2008e7cf957298493c84924c45194d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/940/block-1.yaml":
+    active:
+      fingerprint: "sha256:3fdb7b9167996aea3904d45711a4e52799665ae5e86d3a3d47fb1bfd8b41f036"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/365/970/block-1.yaml":
+    active:
+      fingerprint: "sha256:d35e7f8472a41074789ef46991900ab6a6fa0ea0f405176b171f71429740b697"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/110/block-1.yaml":
+    active:
+      fingerprint: "sha256:1a0d834b1c8f3efcce7f214737c05fc355951819a7e2d8fb20129f6c369e717a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/130/block-1.yaml":
+    active:
+      fingerprint: "sha256:6612ceb93989bd90c2605b59b1306ccc8ecec08b4ad15e0bdc8dbb9f2b1aac76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/215/block-1.yaml":
+    active:
+      fingerprint: "sha256:0f5eaa50f4d47eac566aa03288b6fe2f837fdee959184c307ee0e789c393a765"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/220/block-1.yaml":
+    active:
+      fingerprint: "sha256:85ce46270144f31838e96d51829d0843a4f460efdbbc5e70107fc8deda22e566"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/300/block-1.yaml":
+    active:
+      fingerprint: "sha256:a1b15d2566360051e5409c4b723f5743011b2f7d6f79be5d496190f140932bf2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/320/block-1.yaml":
+    active:
+      fingerprint: "sha256:a5eb92de4feb1d6cb0e2c9bea036752ed8a6f0214b6569085c21b626067c1a86"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/330/block-1.yaml":
+    active:
+      fingerprint: "sha256:63a435be0b59fc0eb568c066f0b368309e75494f888b0bbae91c917f19bd3322"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/340/block-1.yaml":
+    active:
+      fingerprint: "sha256:564ac8d353c64eb2891779f2d44e2b51c5e40ad38c95914a586984deb485e8a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/550/block-1.yaml":
+    active:
+      fingerprint: "sha256:a4dbb26100e0056eb2933ef080fede81a9588f65b645ce8e6be98024ed68d455"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/560/block-1.yaml":
+    active:
+      fingerprint: "sha256:9dd4c6e31389bf83e7fcea921a37e60c1e3a8eb3f37b1ea05deb69f4bf2dca89"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/570/block-1.yaml":
+    active:
+      fingerprint: "sha256:276e2f44812a46c6661b2c7168bf1d4d40959b4348f60cedc45ecdef6eeb5649"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/580/block-1.yaml":
+    active:
+      fingerprint: "sha256:07d1a4a52eb363e15a44ba753f292bc0794e4cf2fe0660d271193dc31fff6b40"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/366/610/block-1.yaml":
+    active:
+      fingerprint: "sha256:235841f6960ed45812a195cff7e390bc78ce5a349c851590511b9d1b7a4f6196"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/025/block-1.yaml":
+    active:
+      fingerprint: "sha256:66d426359c6a36add4582aad438e64144596327b82bec87f9a74f89c5997334c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/100/block-1.yaml":
+    active:
+      fingerprint: "sha256:a3569d684fcd6d6edfb0d7d77aa572c091df4b07b2d6d061ac08e73afbdcd132"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/125/block-1.yaml":
+    active:
+      fingerprint: "sha256:e7d7d3d9c377f4fb9438228450812e38650ce94a31e8cec4a6ece7502e20994a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/200/block-1.yaml":
+    active:
+      fingerprint: "sha256:4bb4d75d8b48a9a43bdd31c0932607ceb2efdc7800d159ab769e0b027b2df2ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/275/block-1.yaml":
+    active:
+      fingerprint: "sha256:e73e6a1f702f44112950ba75b6f035f3ab40527ab25c982c75248782d92c4dfb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/325/block-1.yaml":
+    active:
+      fingerprint: "sha256:42f7cb34fb3e081656cb9cd5932d9e3a390d9b0e20aa6d5a1f4eb9c967096050"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/490/block-1.yaml":
+    active:
+      fingerprint: "sha256:036d73db70cdd0e0f8e29bf64ce104b987d3452773fe4ca69c7f752e7162ee31"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/495/block-1.yaml":
+    active:
+      fingerprint: "sha256:fa29dd45a4a50ed18f1e7145591607bf42697018f428c5bb76cea7df18ebd697"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/500/block-1.yaml":
+    active:
+      fingerprint: "sha256:41662e511913f36667ab2e129e654b7ef97eaf308b51276699687b17cb1615c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/510/block-1.yaml":
+    active:
+      fingerprint: "sha256:f7b257ed0b637fbd03a879e402fe428c525cd2c602e54b3edbf854211c33130f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/625/block-1.yaml":
+    active:
+      fingerprint: "sha256:a4c39a70473e89ed94d4ccf9fee2066b824becd2ea905c6e0172a52c226eb463"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/700/block-1.yaml":
+    active:
+      fingerprint: "sha256:80b3fbff3f2e89ee77938233b4ecfe79df156f34291242605681fe9b0dc9d4fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/750/block-1.yaml":
+    active:
+      fingerprint: "sha256:57ba36c021b94c9375435fe1d632c24645f30a3f1acdc877adb56e6629c35bc3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/800/block-1.yaml":
+    active:
+      fingerprint: "sha256:1e4ef4814903235dd0f5dc59dafe82673a08f1950e315a254140a8c546857560"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/900/block-1.yaml":
+    active:
+      fingerprint: "sha256:638764cdb95e326589e8d6ef85c39126fcbb005598b0fc34fd325c268f427043"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/925/block-1.yaml":
+    active:
+      fingerprint: "sha256:564086fca1a44345151f240fa201ad6e7381c0f9a8c0e057c44a7936bab34c54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/regulations/106-cmr/367/950/block-1.yaml":
+    active:
+      fingerprint: "sha256:0fe1b7e587ec7e675f303ccc149ba692bb48147dd5c95105db56749afce6f3e2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-110-purpose-and-authority-of-the-food-and-nutrition-services-program/page-3.yaml":
+    active:
+      fingerprint: "sha256:c0b315ffbac898eccc4e6838aac2ad71499bb353eef40e0af2599b67cffd58b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-115-administration-of-the-food-and-nutrition-services-program/page-3.yaml":
+    active:
+      fingerprint: "sha256:63ed89386911fb76305ac8d61843b7de8993c28cb3215f7ecae3ddbb1caf17fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-165-inactive-electronic-benefit-transfer-ebt-accounts-report/page-2.yaml":
+    active:
+      fingerprint: "sha256:2c034f1bca5b16910ae1c724f8e9b83444eaa97a3437a44f4822bc54ebf5dbd3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-165-inactive-electronic-benefit-transfer-ebt-accounts-report/page-3.yaml":
+    active:
+      fingerprint: "sha256:a846addc69164bff821e6088a1eb06f5a37aed9e9c05fc177106118d0fbc51de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-5.yaml":
+    active:
+      fingerprint: "sha256:466e352b397861d42ebf924ece3fc5dc4740e7ec91156a5f9fd5085eff50aff6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-6.yaml":
+    active:
+      fingerprint: "sha256:471a4ecd9fa2ddf1723da145a252040ef24df771644e178ac59d5f270caed605"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-220-categorical-eligibility/page-7.yaml":
+    active:
+      fingerprint: "sha256:6d6dc8cd44a5b56cf8d30bef4f0ab1c79d5c0fca258c1979130c678257e49e86"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-225-citizenship/page-3.yaml":
+    active:
+      fingerprint: "sha256:25a29db0c8d8d70cab6d7d6958f4adfe5287bdeda58fe57489b832287e3fa3b8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-11.yaml":
+    active:
+      fingerprint: "sha256:bfd3e0941e5e27d27e66e77c6a965c49767386eedcfb830cd5705a590ab8cdbd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-19.yaml":
+    active:
+      fingerprint: "sha256:23eefc5f880d3ee109a7e1385ac9a59143b1a9c9227c6565ffb5b6293337f666"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-25.yaml":
+    active:
+      fingerprint: "sha256:e12e3acf000e016e5c4ea92075cd44235e6ff987e1da04b82dd90ad061cada35"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-7.yaml":
+    active:
+      fingerprint: "sha256:11d16178c81b94298b19c3105f3cd5f9b7568bc29036e61b728e720d0148f9c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-4.yaml":
+    active:
+      fingerprint: "sha256:caebaba5820041d06fb51894666f24d505d37314c0614f4dcf5f3bcc38c05ee6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-245-employment-and-training-e-and-t/page-3.yaml":
+    active:
+      fingerprint: "sha256:0cc4907a790e61218079623b8e08a744781f0edee1f3e60944243c5e89eca496"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-1.yaml":
+    active:
+      fingerprint: "sha256:41746fbdeade8001834157d0dbc2e3124829e5cba1a899b6e9a71ecd77540c4a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-1.yaml":
+    active:
+      fingerprint: "sha256:da1bcbb674c39c95a1e4bff66527e5364a4175bd4d75ea141ce3bb87d9af2af7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-27.yaml":
+    active:
+      fingerprint: "sha256:24cc8fda076365e9e51a6828004bcf97ef7d136f0f640e7ee35a643181aa69bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-32.yaml":
+    active:
+      fingerprint: "sha256:bb7354f780d4d482f3579f1aaaede65e3c559d748e28de2322b027c603248da2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-1.yaml":
+    active:
+      fingerprint: "sha256:959a62ee6142e59c9ae8ed954b173b3e1b280e1cd9e638c08951491bacf90bb6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-3.yaml":
+    active:
+      fingerprint: "sha256:73f1169549b1c5967e3abacf091778d7eb64eeaeae1e5e917965339bcd834772"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-5.yaml":
+    active:
+      fingerprint: "sha256:eb7357bfacd07974f60cc37ec63ac5773d63050bf45b42dfa51c03f3a15ebfc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-270-controlled-substance-felons/page-6.yaml":
+    active:
+      fingerprint: "sha256:141b1af910b339d2e32b2abe7975f301672a3343719ecea262446f5124abeb65"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-20.yaml":
+    active:
+      fingerprint: "sha256:27f376b16056860288b5146f41eab7ac2f6d4c2f5df9aa7da26bf62012cb3bb8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-21.yaml":
+    active:
+      fingerprint: "sha256:002670540f878989340e9bc8ca748e236d397dc7b74bd3fa4f4fc712d2a1a0a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml":
+    active:
+      fingerprint: "sha256:a0426cb3ae5be118065e5a7cae8740b1bfceffcaa36af3e05d6c7f8a15d088bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml":
+    active:
+      fingerprint: "sha256:b945e06453572a6a7cd56979a7a35df5fcd36c3877013c09ae022f4079444357"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-310-budgeting-new-changed-and-terminated-income/page-4.yaml":
+    active:
+      fingerprint: "sha256:3cfed1f205e6740c51aeeeacb97a9b51dd28e465a80a9fe41c10c1e491f4261e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-1.yaml":
+    active:
+      fingerprint: "sha256:b370ef97e8d99f39cce0cc8cbf62e3c73a8854bc853e324d99e2ce04c1e0158e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-12.yaml":
+    active:
+      fingerprint: "sha256:c8bbf42bb340e4fc38a761fe82437e99b6f7c421b96529d5c0811b100fa98f8b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-19.yaml":
+    active:
+      fingerprint: "sha256:c61f41debc63ab6e6dc59a556fb52f7c1c9a043d3b8b2f70c19885631543537d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-5.yaml":
+    active:
+      fingerprint: "sha256:dd8a0c79bbf2fce61d30cbd0f5e444549f72b540ecc1e4560bc7ea6685cb8991"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-9.yaml":
+    active:
+      fingerprint: "sha256:6959193d1ac7574f0f57175cbee29d8a1b161d60b4e7bffbd093e2bc7078e49b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-340-deductions/page-22.yaml":
+    active:
+      fingerprint: "sha256:15a064d0bf5632817390d84e0b4a52b6abb2bc426d2fac1bef51520c1c4595bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-3.yaml":
+    active:
+      fingerprint: "sha256:02494a342bc00ad0888a8b313f92ac97ff316eb6f4ced1a17f16b18d7082f536"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml":
+    active:
+      fingerprint: "sha256:a788e2a2ed25f01571117ddc13bf8858d0e0b09c1a90510f44773c10eed4be21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-7.yaml":
+    active:
+      fingerprint: "sha256:f43544d5657584d6b70f78a07d93618379babfb4580779ed12932125ae54ea01"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-8.yaml":
+    active:
+      fingerprint: "sha256:ca41984cffa5e76cda9e14224310733463e6086d712bf3b8a9084df4517ee86d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-9.yaml":
+    active:
+      fingerprint: "sha256:0d588b5bc636c65f34eae14ace63ac3f1b3c4c42784299c28a9184daae637057"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-390-resources/page-1.yaml":
+    active:
+      fingerprint: "sha256:def38d0a9a7543bec089e3658d0f8eecf2795360392f3ce041db6d5b14e8c8c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-390-resources/page-2.yaml":
+    active:
+      fingerprint: "sha256:a4ea952f8b0043eb2cde8bbf65722e1aff0f6a3b199aa9ae5cc626f854c7788a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-390-resources/page-25.yaml":
+    active:
+      fingerprint: "sha256:7ed248899e86ae609b09288d38a1675498605ffbb3b44328c7dd2605ea4bfaa2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-390-resources/page-4.yaml":
+    active:
+      fingerprint: "sha256:63210a436ced6e1ff1d9d86aaf8ea0ef4fa550ca283cecebe700233d0bb86275"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-1.yaml":
+    active:
+      fingerprint: "sha256:76552e990797e9ccf4b50c68f9e4cb512d5d05914783405a337e83cf9a42d267"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-4.yaml":
+    active:
+      fingerprint: "sha256:031465f9c08cdb11859c95eb0ee13a29fc8617b48d4794fd54ab1b0576e39048"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-420-normal-application-processing/page-6.yaml":
+    active:
+      fingerprint: "sha256:8303067ef8c6c6ff97b775938f42a217e3901964cbd16113dbab8e65daee898a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml":
+    active:
+      fingerprint: "sha256:ee1e6a743452892647a9719a4b8e9ddafaafdb95b2fb1e5c1144dc39a6e83998"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-5.yaml":
+    active:
+      fingerprint: "sha256:2abc23199973df4b1e15a6a6725b0af7fee3b3477152092360ba261f0e40e5a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-435-determining-eligibility/page-6.yaml":
+    active:
+      fingerprint: "sha256:31fe66666687147c03fca8eb4ff50de8df494420ebb1d249bfeb3595deb480a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-450-social-security-administration-application/page-4.yaml":
+    active:
+      fingerprint: "sha256:7bf8242bbebbac6d6f83d8d963ac3a5cc60c2b86c31b162cb6617777a0cc210d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-500-sr-category-and-reporting-requirements/page-4.yaml":
+    active:
+      fingerprint: "sha256:29b7a59eacae1ab0390a70898850f7754d6bcebdac9d743949ad2886fc29261f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-6.yaml":
+    active:
+      fingerprint: "sha256:c3b7d3e8c278b2ed4493a7bd8b1f3813ca7c3afdec03701469114ac857f9a4f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-510-sr-recertifications-procedures/page-7.yaml":
+    active:
+      fingerprint: "sha256:10cc0cec06c644ed408c2ee87c0a56bd29af9b356dc2070902e29bcc435f724b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-1.yaml":
+    active:
+      fingerprint: "sha256:6c9a2d6b3b8c511b5681fbb824d6237826d9b0b42e9820862a3d97e7d390ead9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-4.yaml":
+    active:
+      fingerprint: "sha256:9cd47e4a758796bad6d700dc5d76999e5e0b5b458e03f2e4d1a0fc721d41d895"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-6.yaml":
+    active:
+      fingerprint: "sha256:1a418a01f3120821cb26917cd0c0ee5fc3155bf9960fa85d6f33bd49450c9d16"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-7.yaml":
+    active:
+      fingerprint: "sha256:e4334d3df02ff0ce492c6b6eafcc68a2a3c8af455524b661b1f7387ee79ea802"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-8.yaml":
+    active:
+      fingerprint: "sha256:3ee1d90b3fd040eab8c844734aa8a4a03ffb694551e5f8f4150392c478617d88"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-650-transitional-food-and-nutrition-services-benefits/page-1.yaml":
+    active:
+      fingerprint: "sha256:14b46b17facc70f6127f4f64a7ef4a901f161991011166b499740d73fa86c24a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-13.yaml":
+    active:
+      fingerprint: "sha256:7b786a44c4d3f02f7b388f1b3a3de3e4b6ac16951c4e85fbeddb68d08d7299c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-3.yaml":
+    active:
+      fingerprint: "sha256:07c950844abc929f32644166bc1d46d67deff51c39cf3afa1ab5105bbd603b06"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-705-administrative-disqualification-hearings/page-4.yaml":
+    active:
+      fingerprint: "sha256:1dd8f89328bc0a6af2b8339937604109b04120d825c0ebda323d1f6934f9ea7e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-800-claims/page-2.yaml":
+    active:
+      fingerprint: "sha256:5ace5498da11c3fe0fbd08cf81d71af2c40b2a4111a1d3bbe682621aaecef791"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-10.yaml":
+    active:
+      fingerprint: "sha256:fb6f009e4d9e0c97013b84b52f7835162fd2ee3522f86ebe402c1aaee584bb1f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-3.yaml":
+    active:
+      fingerprint: "sha256:0ee888071b501702e4b6f9061d472acfb49b17b40ece5497995833bcc63d5cfd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-805-requirements-for-establishing-recipient-claims/page-5.yaml":
+    active:
+      fingerprint: "sha256:6cf73d009da6a599590d7163a95e0d73f287dffca3de22a1f54709f08b3a38ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-11.yaml":
+    active:
+      fingerprint: "sha256:bab6eee6e896a5818d4b59ed9a2b4f49aed0597c219dc0fa57f16ad9d8284bd6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-12.yaml":
+    active:
+      fingerprint: "sha256:e9f957e33e03a4d88b5c0f81b687d4c8542362898a844d67358273d025bb8d5c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-3.yaml":
+    active:
+      fingerprint: "sha256:3490b60e817e1bf08317a38bd15eb9b7c67f8099ebd7f418fd07c48a76ef0560"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-9.yaml":
+    active:
+      fingerprint: "sha256:61c012febc009cba0825375b6e7eed072e3c6593cb66aa71324e6fbb9e29fa96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-1.yaml":
+    active:
+      fingerprint: "sha256:512a8fb252d6d73a928be08c5d71b5e32517e947cf18532f50bd8dd618d8ff99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-2.yaml":
+    active:
+      fingerprint: "sha256:d31ddd96ba33a01254033606704890ef6334797f5cddd54d0157da95e87c3cc9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml":
+    active:
+      fingerprint: "sha256:5c6ccec3728481617c138d8f6300207cb52edae4c3d52a4204e10c80b2b159f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-1.yaml":
+    active:
+      fingerprint: "sha256:21dc552e27a7fb70137dd03f96acb952bddd781879ae3666847d3ee73359ada5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-14.yaml":
+    active:
+      fingerprint: "sha256:06e2c96797bb1afbfa027e57952226d4893d1abc5943579900d3d8c69b7ef4f4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-2.yaml":
+    active:
+      fingerprint: "sha256:ccbe4ccdb349c202d339a88093a5d0e5773b44dcea901dca51bb2bc0a3cd5c27"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-20.yaml":
+    active:
+      fingerprint: "sha256:bbd11238cea3e4d29c16793e3c3f87bcf2514eeded2029dd83feb5f3e08344aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml":
+    active:
+      fingerprint: "sha256:6f6909aabfb3b2e12eab7b9a355bd9a0f3a05282c9adb75b0e209f9cd7ae385e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-26.yaml":
+    active:
+      fingerprint: "sha256:840a5aa05ae2f01454f84b18f264a5a5fe701e8043019486b6b71e94e80716fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-6.yaml":
+    active:
+      fingerprint: "sha256:ccd0c585524de48ea01233ee1f4837a69b95e95629354aca4ee13cddebadd3b4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-7.yaml":
+    active:
+      fingerprint: "sha256:c2f5bf55d1371be95471e9e84eb2085ccf5c249a97a7ffb5098ef0b9e6f24b78"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-1.yaml":
+    active:
+      fingerprint: "sha256:014c01edc3ea08540df7db6e4718316d67948d4564c9bcb0df6b13f68f2ecdc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-825-intentional-program-violation-ipv-disqualifications/page-4.yaml":
+    active:
+      fingerprint: "sha256:ce42b9d7f126e5587d6c489390eed6555d745a62b5557a9dbaaa8e3a1b8ce394"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-830-ebt-recipient-and-retailer-fraud/page-2.yaml":
+    active:
+      fingerprint: "sha256:348e5b888a84b98b2cdebb1de770d627104bed4fe2de7b7f5469372a4c8bf069"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-840-front-end-referrals/page-1.yaml":
+    active:
+      fingerprint: "sha256:0439d9f3c23fbba77a1c70bd47e4d742e863dc7919d8d30b24a6e5dfa8dbdcd4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-6.yaml":
+    active:
+      fingerprint: "sha256:73bfd6ff5f6454ae8e6921cf6a01f5fd87d86d90d743a6cd7ec518379c44b8eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-1.yaml":
+    active:
+      fingerprint: "sha256:9fa583f47014d0d37cf84997def315bc2cc5df0d387d7fcb982af50bce96b0c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-4.yaml":
+    active:
+      fingerprint: "sha256:3a254cf6fb558e8ed12fa0e52fe3feefa42298362f5b488354fb6e4a5bd3983e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-850-nc-debt-setoff-collection-dor-procedures/page-5.yaml":
+    active:
+      fingerprint: "sha256:b12c453d94e0065b9364d1180b2f0cc47d244ca3458276efe6d4b86f4f47772c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-860-move-by-a-household/page-3.yaml":
+    active:
+      fingerprint: "sha256:b482dfdf6a13c28326ccc5779e9c65c03cb71e5841f415c736cf4d62271eae39"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-865-nc-education-lottery-interceptions/page-2.yaml":
+    active:
+      fingerprint: "sha256:40855090f5ae4919fb6dd1cafd079463bdedf32754bb5149dc8cb42d6fcf8c89"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/regulations/10a-ncac/71u/0212/block-1.yaml":
+    active:
+      fingerprint: "sha256:07467c9e947652bdca3269ec215f68250bf629768eee0b0022ed981ad320ea19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/policies/otda/tanf-state-plan-2024-2026/financial-eligibility-and-income-disregards.yaml":
+    active:
+      fingerprint: "sha256:32b06d29e14b04c2ae97fcde617c2bd182560aa8aa3d3b461280a45a45af1ccc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml":
+    active:
+      fingerprint: "sha256:0bfb06cbb0bd853442b5d360c460ffd5cd1c27aae3aa5b4a376029bab4d2f410"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml":
+    active:
+      fingerprint: "sha256:aeae923fed952d4562e322f4abc7610a34392c300021d02b7cca667c1efda049"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/statutes/NYC/11-1701.yaml":
+    active:
+      fingerprint: "sha256:5b8e0003d0a6063b9b7c800fae244bb95daeddfcd1ed48a288c1d667b59b4a9d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/statutes/NYC/11-1704/1.yaml":
+    active:
+      fingerprint: "sha256:7999c09db1a9de323d84dc0b19074fdc804dbd0ea9487ce571a9b88c9b065b82"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/statutes/NYC/11-1706.yaml":
+    active:
+      fingerprint: "sha256:194b38dbe26ffe48a8b30ab2c630effd4199c03cd44f09eaf801c8f40b3e4fde"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-101.yaml":
+    active:
+      fingerprint: "sha256:d1b33a505934bb44c7a702a606f552a521e9422a4f47ad15e9137c09d56970ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-113.yaml":
+    active:
+      fingerprint: "sha256:0cf695acb09ddf40395f1fdc66a701aafe0b458cac52a15af130c11fc33b20e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-115.yaml":
+    active:
+      fingerprint: "sha256:b34692ae4b1a719c1d8f3151f1e9bde387522733e4486fd53fb6fb7283f91e16"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-121.yaml":
+    active:
+      fingerprint: "sha256:118e33a02077b802694fe51c91d179d4d287c86859208a0db55027b2f5c131c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-125.yaml":
+    active:
+      fingerprint: "sha256:71bc3c7ba4f295e64974e6f1c47d837a275bf9f398090a9b15cce7c88c5f7751"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-126.yaml":
+    active:
+      fingerprint: "sha256:b87a745a21e100fe9bfd584e8a9ebaff8103773d3c54ea82ddc119a06a4af729"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-132.yaml":
+    active:
+      fingerprint: "sha256:811ef29b5818bb2cec2a4a1a377a1523868e4e5d288683c3b305b5d2d7305fff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-137.yaml":
+    active:
+      fingerprint: "sha256:a355bf992d860892f83ed76ab3a45dd7a08cb3029be211ecabf34879328ee359"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-138.yaml":
+    active:
+      fingerprint: "sha256:f782b8a6a9c8ef0b80c173dbe9c3aeb515c561cc54739350109dfa187245bb2c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-139.yaml":
+    active:
+      fingerprint: "sha256:29022b97122f1553cf6b8b4e24108990efbc598a4b49cf964779c8f09dfd1b91"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-140.yaml":
+    active:
+      fingerprint: "sha256:491a7cb39b4049bbccacdc579b6340679dac919138c6d4521f98a6d83a0158ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-160.yaml":
+    active:
+      fingerprint: "sha256:ed75060ee1e929b040ca957cd98b82668137cdb9af577e8b99a7a5dc86d570db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-163.yaml":
+    active:
+      fingerprint: "sha256:6cc3430c3e3d5c4394d8900a7407d893e9c4f9a3acf457ba920903853abe7d34"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-167.yaml":
+    active:
+      fingerprint: "sha256:10dab0938b73712395b313d3e5da2334fc8db71d064dfdb23c0a160af5d4ec4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-173.yaml":
+    active:
+      fingerprint: "sha256:fbdf9a5557beefffc2972d3ecca7aa4336ed7c417b8ec72c141ee4c49e77f788"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-174.yaml":
+    active:
+      fingerprint: "sha256:b1bef6d8d426108fc11158d7ba7301bfeab4bf7c776a5623d32f400dc561ef80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-185.yaml":
+    active:
+      fingerprint: "sha256:e198f1d7480e0c8fd8b3d41650762a5551e21954836ce2206879726ab5a07ead"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-205.yaml":
+    active:
+      fingerprint: "sha256:afd978658688a13392d2e72b612e3945e39c89efc4e855a44030692bcc382f76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-224.yaml":
+    active:
+      fingerprint: "sha256:6a77262bab6c06a6556825d5d8ed2a4036a06bb303d7fa7c349a5566720fba51"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-236.yaml":
+    active:
+      fingerprint: "sha256:c2c0309acb82b7d8bce5ba85fc0ebdafd374567ca550d0cfcbaefb8675ce4ae4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-242.yaml":
+    active:
+      fingerprint: "sha256:f46193d59070cf6371b17eb65184753262c6cd2e0104bd41cb6038064f225eaa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-290.yaml":
+    active:
+      fingerprint: "sha256:7a731ce94b1f6391a1529da153caac47cf8a897077725b6433169f83e83876ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-302.yaml":
+    active:
+      fingerprint: "sha256:a4429d3db48b552e50036d0104ed77619418158a323009ab86371f106a493c48"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-303.yaml":
+    active:
+      fingerprint: "sha256:def0fe7c49656865d7df96c412cc084087fa6588d1ba0ebfbf806a885d23a0a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-304.yaml":
+    active:
+      fingerprint: "sha256:c1e01151b7534cb666a2933306f5cbfeba4e08d64a4a1d3092ae4ba22238f3b8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-311.yaml":
+    active:
+      fingerprint: "sha256:1f9f0e5540b2f1d652250d6faaeaa5015280c025bc4c9c6ba76bfe6e9f539c3a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-314.yaml":
+    active:
+      fingerprint: "sha256:fc77e1795e70b8b4b6649b3ea1c33476d3151e879d6c83ccec8ed23ce40048f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-317.yaml":
+    active:
+      fingerprint: "sha256:02d13c1cabad604ecd46985ae59923e79280cd8fb968f8b26e55842b15350527"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-318.yaml":
+    active:
+      fingerprint: "sha256:8fa1e0363646fc45c0820d13e2a45717ddf25b3dc5d7c34099a3c9ffdaad1927"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-320.yaml":
+    active:
+      fingerprint: "sha256:0f272ca8b6c015b486f8aea6babdfb245c77a7ba30774fd833b364626e8f53f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-322.yaml":
+    active:
+      fingerprint: "sha256:a6a1f3c9ebf3cee2a7683a0644b0e97e5bd4a9fa475607c7cdc6b30cf15d1f97"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-326.yaml":
+    active:
+      fingerprint: "sha256:e06cfc7a657324980b57d42f1e0e97ec5e956a3225fa8067d3e65134881a9e6f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-327.yaml":
+    active:
+      fingerprint: "sha256:17b586a9c6fff6d696e9b1941fd5314bb0890bbfcdc4bf5aff3b4ec1e8c82bf3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-332.yaml":
+    active:
+      fingerprint: "sha256:55d7ade436ab313e4330a46a6ea0aa6327ad39a63c4aeb23136945a07d0151ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-333.yaml":
+    active:
+      fingerprint: "sha256:365d4c41fe1c970db98131331bcb0096e4783aeefd367b624de6fafc2d15e82b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-334.yaml":
+    active:
+      fingerprint: "sha256:b11ef20cd453119dc9d5ed7a032bc7e3feb9cd31d5607a96992adbecc283b19d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-34.yaml":
+    active:
+      fingerprint: "sha256:f0fd20284d3e92eab300bf250538f8ec561c968676101426bb5f49e88c6eabee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-348.yaml":
+    active:
+      fingerprint: "sha256:47f3507e5a4c8ddb92fdf3bcb53faf4ce6f27391b72ae65096bdd40c0dccc0e8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-389.yaml":
+    active:
+      fingerprint: "sha256:8888d8c8572fd35ecd49a8e475a8eb8a796853173b46005dabcefee0ace9b17c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-40.yaml":
+    active:
+      fingerprint: "sha256:074259305c64707d7a4f30954b9cd6dad9c5c35b80cbdef8a633defd819065e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-406.yaml":
+    active:
+      fingerprint: "sha256:4fc97c58554037cc3922af34a79d76bcb46b641ad3e30265ad57700aebfa365e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-424.yaml":
+    active:
+      fingerprint: "sha256:30e66691b081d195e84ba57a2a4cd3e51b77f8cd56309c77ca2b926e122aad4a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-446.yaml":
+    active:
+      fingerprint: "sha256:0949fd8caad9fbd6f30c60b63a6f8152a63a7d71b927ff32ba1bc0796469b3af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-46.yaml":
+    active:
+      fingerprint: "sha256:d1624a0c526c18dacfe22413d1fea55c86924816bbc25211e140bc19bc72db08"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-63.yaml":
+    active:
+      fingerprint: "sha256:af1ab4a068494fe55c64ac2bcc4f4ddb975aaf6cb3847201e9a19116aaea058b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-65.yaml":
+    active:
+      fingerprint: "sha256:be9fc5ca6597c83a92795c5da4234621a874eca5712878e2cc846f0ac8bf4c84"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-70.yaml":
+    active:
+      fingerprint: "sha256:12b5208e13812b46113ea22356b7517b02eb1d05169b1a50c675a46c8f89f846"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-83.yaml":
+    active:
+      fingerprint: "sha256:9e0fb2291cd7d1df3e8b608fbf36696b1b0b8e53fb5ed7aea394ac71c12c6dd1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-84.yaml":
+    active:
+      fingerprint: "sha256:ed00c3582ee5c2116d2048c0565dece2f7192bdcd3921af3b13dece2e0c4d631"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/dss/snap-policy-manual/page-93.yaml":
+    active:
+      fingerprint: "sha256:d8a850b5a70a4b3bc75270acb3f16a71d456c4e47865e252461c284cdbdb72db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-1.yaml":
+    active:
+      fingerprint: "sha256:aacd75741390d22822594f4501faf9470db5c9897586f935113441ea5a28ab84"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-13.yaml":
+    active:
+      fingerprint: "sha256:c8707bd1dfc25aaaa185b15f336a9f3f95a885d88602fd98a6032b72132a53c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-15.yaml":
+    active:
+      fingerprint: "sha256:98eb38ca8671d2693d802db8dd9eb79431825b3b5844c317da41258a97161c63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-16.yaml":
+    active:
+      fingerprint: "sha256:c8ff2290558a3aa4a1edb61eb143962880ae116c884dfa0236e2ec9a0b5c7470"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-3.yaml":
+    active:
+      fingerprint: "sha256:ea2ca6def601dbe46b4df7eb57cf01fd5c1afc88d6717b707e6ba980d7323541"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-6.yaml":
+    active:
+      fingerprint: "sha256:4dc94497d70aa733a83f602110c2345386c47c49a3efeb28049ffb52f7e704ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-02/page-7.yaml":
+    active:
+      fingerprint: "sha256:a56112501d8bd1bd94d7f96411d69bb9efc00bb797595040454c3722eab00d4a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-03/page-3.yaml":
+    active:
+      fingerprint: "sha256:87d514046c4c4ad8fcce50f66abe270e20e378ee698625ac4be09fef6b74ef19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-03/page-6.yaml":
+    active:
+      fingerprint: "sha256:725a142a24b9b5ca1ed6a6fc55931ca051ebfdef57fcc0acee484847a332c0f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-04/page-1.yaml":
+    active:
+      fingerprint: "sha256:0da29d55a81b331b728dba4ba47f8281e3ca4eb4bd6b92ebd4c12cac3abd633c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-04/page-2.yaml":
+    active:
+      fingerprint: "sha256:87d8d218ace80af6072b7b39cb13584866a0eb3892fa9df5157fd5d049300254"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-04/page-3.yaml":
+    active:
+      fingerprint: "sha256:a583097aef07ef2a8df1350a03d2ef46ac0b8ec516071fa66c4a13d0d104c23c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-05/page-1.yaml":
+    active:
+      fingerprint: "sha256:0322a0e6fb955d14dfaff715d209837fab2ab6381f626aa67f1e18a154ef0414"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-06/page-12.yaml":
+    active:
+      fingerprint: "sha256:bf27980810456744a50174d2adf1f58983fe17f9b5b2425803e77235ba4bb9a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-06/page-7.yaml":
+    active:
+      fingerprint: "sha256:dc33dd1d88d51af10bfbdaf5b222ae0dfc623b74621d9482ca6e92fdac09bfb4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-07/page-3.yaml":
+    active:
+      fingerprint: "sha256:df3cb02468de790eccc6008aa26be22684f90c2491bbc6369ae27f8234008404"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-07/page-4.yaml":
+    active:
+      fingerprint: "sha256:c75814128fac044ef69077b49a5eefbf0bb77db9d5d406ab2c75b872fd39e139"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-07/page-5.yaml":
+    active:
+      fingerprint: "sha256:24e84f1b9f3b430dd4c801012f6c553bef5849db627a1f8bdf94dd491d95bf99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-07/page-6.yaml":
+    active:
+      fingerprint: "sha256:9953449dcdba46b9d9aff2d549c89d7c8de949cffcf716821c93a8780bc85ccd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-08/page-1.yaml":
+    active:
+      fingerprint: "sha256:44b0a3d1bad8fb6cbd3efa253aaef91f714aee2351fb4e8bbcf2cd382166c802"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-11/page-1.yaml":
+    active:
+      fingerprint: "sha256:8010923776d72e1360ad4ee6a5587e6ba3250cb3866333c5485ebfdd9a592d08"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-11/page-5.yaml":
+    active:
+      fingerprint: "sha256:42657d04ffde70274139e2b545567146374ac35751e9a3ec5608564783ad0dc6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-11/page-7.yaml":
+    active:
+      fingerprint: "sha256:9991e4612309d0f1dc6b613bb7e2d0d0650dedd7acfb3fc9b8b65b58d4f2f45e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-11/page-9.yaml":
+    active:
+      fingerprint: "sha256:03bc230ee0b4f384ff45139ce8589cfd26aabfd766c68aa7997bc9f1a56d1a0e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-14/page-9.yaml":
+    active:
+      fingerprint: "sha256:9ece67c608914dd5db3ea4808ea9d904698c6b0977ab80d733b8f72632679139"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-17/page-3.yaml":
+    active:
+      fingerprint: "sha256:167497e3ec4892ce2f091d9d044e64452b874e023c43a9cc8d6814b087e3a197"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-10.yaml":
+    active:
+      fingerprint: "sha256:cec26ba8198261df6ea17bdb5c65be7a15d71dcd444d4023b916e4405ca5dca1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-11.yaml":
+    active:
+      fingerprint: "sha256:585948be3b162b3b7353af36998d4e2d7902b76ad3d4666f506d4f3bb052c782"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-12.yaml":
+    active:
+      fingerprint: "sha256:838cbf904b3140cb8c570e68c13605890c1041dea9e861193e9ddc1759ab0303"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-18.yaml":
+    active:
+      fingerprint: "sha256:01b74c5483574ebc2d3798d5f244bf3dc8eff8239709dcaafdb2941529b9cb54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-4.yaml":
+    active:
+      fingerprint: "sha256:d70baea75e0f1bbdd7da5095dc666788c6512345afaaf9957f967cec5ca2f472"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-6.yaml":
+    active:
+      fingerprint: "sha256:69c54e8f6bdb2e7fd183c4d134354b3acf2747ae8d6107eb67239f0e1ce17525"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-18/page-7.yaml":
+    active:
+      fingerprint: "sha256:775108e561d25cba40d1b4b56935914cbe5c23b36734368253e2915aa6701808"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-21/page-1.yaml":
+    active:
+      fingerprint: "sha256:62c187f44babb99e1c9b807e66e2b37fcb376af293af6325f12b42f404c6d56e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-10.yaml":
+    active:
+      fingerprint: "sha256:02bf3b44099e54807ebd5c062db528038b417db1061615c1ba8a582666d2b3ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-11.yaml":
+    active:
+      fingerprint: "sha256:a0d9e6fd6657ff108c54105c9fea84112864609ff612e10b9023e371ace7824c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-12.yaml":
+    active:
+      fingerprint: "sha256:1faf869a84367f4eae26600940ce19764eac39ef76da572705b1677776d62a0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-13.yaml":
+    active:
+      fingerprint: "sha256:5a83717e3e9015d357cce7b9164aebed9258f7b60c342cb677b5c91b220987e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-14.yaml":
+    active:
+      fingerprint: "sha256:e881215ec45a0a71c737810d6edaa8a26f6f4a0d0773dac61d6dc035e04a5a7d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-7.yaml":
+    active:
+      fingerprint: "sha256:50ac62435d464179eb6c696c9c0c00aaf3fb4aae61467c114f31b6656e34cc59"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-22/page-8.yaml":
+    active:
+      fingerprint: "sha256:d725a693aedbd93f30b294579fc3fe827c9acaca615499071dddc557e18746d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-23/page-2.yaml":
+    active:
+      fingerprint: "sha256:a108b8f2dad3535489a64283ae2fd854cdfa95675ee58e09de995ad4503513ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-23/page-3.yaml":
+    active:
+      fingerprint: "sha256:eb71855e20348d4c3089d597dd31d2bfdc6a9b78d92f1e2af8512f4689bca960"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-23/page-4.yaml":
+    active:
+      fingerprint: "sha256:a1e17c366f6c411ad7dd7ff1474664c712de527310dc432b41db344376199990"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-1.yaml":
+    active:
+      fingerprint: "sha256:06a381a66b074f1b666236ef0a27e1fa94ab0796aba434291ce93229ba450b58"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-13.yaml":
+    active:
+      fingerprint: "sha256:348bc93b2a6e0835a536b16a59a1ba64ada0637176af64e09b1015d67cd66522"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-2.yaml":
+    active:
+      fingerprint: "sha256:f1da6eb154c6dfa597859d01adf309e05296031946eeac9dfeda00af441f2456"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-3.yaml":
+    active:
+      fingerprint: "sha256:1530786bed5ddff601833b7bfb027ef8c0922b1669c15af8903dafe3c730d5b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-5.yaml":
+    active:
+      fingerprint: "sha256:8041b09799b8d3ac03a2a94c20ffb1d5330bda6f138a3469d772cf306c0f00f7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-6.yaml":
+    active:
+      fingerprint: "sha256:f218fd0c15b7085760afc5498c6f239cd6067d3e8084a02725fb60d6d7cd9432"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-7.yaml":
+    active:
+      fingerprint: "sha256:686ecc54b44aa5c56762e40c26d034e0806faa813bc238785ff39f4a1616195f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-8.yaml":
+    active:
+      fingerprint: "sha256:932c888882d3b22c7495824144e2bb68862fea41efc920d43e162c5582be9458"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-25/page-9.yaml":
+    active:
+      fingerprint: "sha256:c0f7f78a4b976d8a3bc29490667a17187480a1237c2fa79166036cc117fde69a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-27/page-2.yaml":
+    active:
+      fingerprint: "sha256:9b7cd51284d47a8cc313af5ef25674bba26d6914356afff84102f604a637b51e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-27/page-7.yaml":
+    active:
+      fingerprint: "sha256:e3c13d44db10f2c40019b66d1b1c77f8c8d0cd0ccab719eb5e14cc92faf1e42f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-30/page-2.yaml":
+    active:
+      fingerprint: "sha256:eef9ab3d6e36b9e9e26179bb318ec949a2ff677e921b3be22797e308b73eb1c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-31/page-1.yaml":
+    active:
+      fingerprint: "sha256:07a099f41c71a5ec6a10da2648e5ff01df69aef208ef93914be5703b3c9c1749"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-31/page-2.yaml":
+    active:
+      fingerprint: "sha256:aa1afa35044b0f0c43aa1d32d7a7df07a48180ac61c02ec3015c42cd661f36eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/dhs/snap/24-31/page-3.yaml":
+    active:
+      fingerprint: "sha256:608fe594ba3265b667f34c7dcf3597d0bac746c577e2d180957836281f687a41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/regulations/1240-01/03/10/block-1.yaml":
+    active:
+      fingerprint: "sha256:54efa16fc142e73dac3b678bafb9708a4bb68200898a3c505a372f2838886fd9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/regulations/1240-01/04/16/block-1.yaml":
+    active:
+      fingerprint: "sha256:cdc947c2587cfb4aa3c3b6fcf6e8d8ae1a26a8b98cb7824b54df3b09dc35f2c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/regulations/1240-01/04/27/block-1.yaml":
+    active:
+      fingerprint: "sha256:2de50affa502dc996937ebf8889e966fe72b211a020abd4cc751e8e6b0c0e0a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/regulations/1240-01/14/09/block-1.yaml":
+    active:
+      fingerprint: "sha256:c1dbccc62213d4a54a2b4721aa7358c38f19f9de7c5ddbab6ec06caa0f2cd219"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ak/policies/dpa/apa/standards/2026/state-supplement-payment-standard.yaml":
+    active:
+      fingerprint: "sha256:540b18a476fc565093db8b1f02f5e9bbb4f46e9ddd9134d06e0d6d7cbb484a00"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml":
+    active:
+      fingerprint: "sha256:615230a3a21fbc8db701242686055291f7e113403cbc5f475e219fb61969ca1b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/des/ccap/reimbursement-rates.yaml":
+    active:
+      fingerprint: "sha256:a78cbcd954c54ebe843dc72e2cee57c9b18177f48fd500c2b05802c8925b3d9e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml":
+    active:
+      fingerprint: "sha256:4fd9430bf97b35ceb0480e9fddf2eb3406b9ae694954ff3053b841160dc50e1e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.yaml":
+    active:
+      fingerprint: "sha256:234ece0d1b701d6319dcd0d9303247f37e499a6bdd6761ac2f8470fae2330428"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.yaml":
+    active:
+      fingerprint: "sha256:b4198ef9e494b91c7c3ec683f605db0e158c47ecbe71e4dc3e31b2256d867953"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-13.yaml":
+    active:
+      fingerprint: "sha256:41b5958cd3cdd6d46d7679dbd75cc467bb0e5062755735d97771450a6cc6299f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-15.yaml":
+    active:
+      fingerprint: "sha256:bc51e07191f64ff2e82f3543cbdb1bf9e78654188aa1a408aa6c0b2311fac1dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-16.yaml":
+    active:
+      fingerprint: "sha256:a966a53e7dac8295f189f24e4753e4530dfd1cbff0966c2cc7163e003fd17f09"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-18.yaml":
+    active:
+      fingerprint: "sha256:f1829bc78756a8925e2f74316d7c65a32535f9de9c5f6e9519e6ebd88eafbc60"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-21.yaml":
+    active:
+      fingerprint: "sha256:248b051ae49cb463e4c45dfdefb5de10767f419e1a1256487da9e4e138b5044a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-22.yaml":
+    active:
+      fingerprint: "sha256:6602dc92c09a1b64ae819338477748e0aafbfcade1791951fe72fc970c4471cb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-39.yaml":
+    active:
+      fingerprint: "sha256:00bb94771ec7d4c0981a3e33fd24cf9f459ab157943d1abc9360c53e7800a65b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-41.yaml":
+    active:
+      fingerprint: "sha256:a9acd949c4c62c36bde3a98919327254c3130ef5e610231b1613bef63074fee1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-42.yaml":
+    active:
+      fingerprint: "sha256:3389b1913aac668383e518ccf2bb8df5c16ae335f64d71b20771bf551c2b1c42"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-47.yaml":
+    active:
+      fingerprint: "sha256:25b5f197e1ee6108581eee99425da57be43b6a3b9ac827cfbc7d282835877668"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-51.yaml":
+    active:
+      fingerprint: "sha256:3c1fc481a786efb7f2c2f6295d0e33a941d3950bee155ce5f963c6300a7e45d1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-6.yaml":
+    active:
+      fingerprint: "sha256:14c6c106f7250c39bbbdcd69c93a8695dfd2d1ed27c15fd6d0997b5925123d97"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-63.yaml":
+    active:
+      fingerprint: "sha256:030b124f0269546b211ebf5ece856a59c9f1b29ac45bb8c123cfae64f8c40141"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-66.yaml":
+    active:
+      fingerprint: "sha256:d2138bb2a84846c911c8f067927f606605d73b09d1ef5510a5de1061d3dc5578"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-7.yaml":
+    active:
+      fingerprint: "sha256:66e7adf4a47776a4c40d716040ef35a51fe530d1c07bc96b6924727a9f994cd8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-70.yaml":
+    active:
+      fingerprint: "sha256:2aadfc6bb467d0abd4e81059524f4c7df6a7aa25831f57e516fbd5d497a89cc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-76.yaml":
+    active:
+      fingerprint: "sha256:e5ab256406a743b5afee240a64ed7682ff919bf0d79d6d7fd78b1217b86a91d2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-8.yaml":
+    active:
+      fingerprint: "sha256:1fc70255e849df0a1e0e492dd29801af659f804fe22db8df5e2657b717768a5b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-9.yaml":
+    active:
+      fingerprint: "sha256:f10e257306c897d6ff3dcf844c91a06c04bbe874b9c4dc58ef354f5fb82c83db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-10.yaml":
+    active:
+      fingerprint: "sha256:cd86728a509cc738f7e51e9e3b3dbd529e77e073dd77ed1c5a7cdab2bdabe1ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-11.yaml":
+    active:
+      fingerprint: "sha256:0a72459eb2b2bff1523d6edec4b84f843568ce2a71568316ae4c17ec9bef26a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-20.yaml":
+    active:
+      fingerprint: "sha256:5d5fc1f40c11d168541fd055669082a95fd6017fc4c4500d59fd43cad907acd3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-27.yaml":
+    active:
+      fingerprint: "sha256:d47e82978232942fbe0c68f3ea946d3c9b18729fb076a3162d7f4e8eec43bea3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-28.yaml":
+    active:
+      fingerprint: "sha256:f3cac2f3f84e69ea7c16856c1bdd4289fe4483d01764f9578a81ae9874fcfb99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-29.yaml":
+    active:
+      fingerprint: "sha256:dc525afb0204e22417d4cfb9f759489740ed125aff031cfb5e01e24029f3529b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-37.yaml":
+    active:
+      fingerprint: "sha256:1a17411890c1e2b01c25dd5e2d95e58ddca229a5c2d21432d582be2b1729e82c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-40.yaml":
+    active:
+      fingerprint: "sha256:4d4b651f9aa4182e4a233409e93d54937a93782d2b01fa241c942671941f708d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-5.yaml":
+    active:
+      fingerprint: "sha256:4d83b2d4d367921ad7a1b126063bf3273c10dc1c97954da18d923f002810a2e7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-7.yaml":
+    active:
+      fingerprint: "sha256:9cf1cd9e54a8e385146df6582df83095db1d97ccd65079fe16615207b3cbb05b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml":
+    active:
+      fingerprint: "sha256:cdd0a1317e78e07b991e999b3b2a826b9079fb0fac8ff5a497416a7b627a7af3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-9.yaml":
+    active:
+      fingerprint: "sha256:bf01cf4697e2af71fd9adcf81ce3d749f7940bc419fd1586bb477700578ff13e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-27.yaml":
+    active:
+      fingerprint: "sha256:401c9afb4d1d48233ddcefbb6373981d91ce95a91704c00baf6ed141c544d1ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-29.yaml":
+    active:
+      fingerprint: "sha256:6ddfe2a9dba49f0a19a9e22306b6183ff0d0e9e81ddb7683c23d087486620d93"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2400-budgeting-income/page-30.yaml":
+    active:
+      fingerprint: "sha256:24f3aa8bd439e1ce6e715d2b9bde138166d7e2737bd55002d0829329a5bca46c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-10.yaml":
+    active:
+      fingerprint: "sha256:18a573a11ca024d329872381c690ab8ac2afad3c800ca7eb76729cf172b42fb4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-14.yaml":
+    active:
+      fingerprint: "sha256:3f9513235e02d2c09790e91a321f4282de01a38c91e23c975ade9f7413270ac5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-15.yaml":
+    active:
+      fingerprint: "sha256:b58fbb256c060c2de95b9de00c949b80e0a662d56595695c39c64022e601a8d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-20.yaml":
+    active:
+      fingerprint: "sha256:39d2195696120ede450aa999c276635847333af8c084139aea033a151c363010"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-21.yaml":
+    active:
+      fingerprint: "sha256:1addc6c2af9b570b8e7345523fb175c5c301757c9d0c79e5b4d6117e8132672c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-58.yaml":
+    active:
+      fingerprint: "sha256:ccc22e3a309dd23bf03c2423a279b58952c0e691809ab29560b942ff28bbd121"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-8.yaml":
+    active:
+      fingerprint: "sha256:e27a5fd8e3a90f5c04a97eb5c6a247bd0ff651ff309ccb53003f7a9caa7a2e6e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-1-food-assistance-income-eligibility-standards-and-deductions/page-1.yaml":
+    active:
+      fingerprint: "sha256:95e2225d8de18ab06be02bafe5529d570d8cb9cf1686a43a41105f8afc351240"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-12-state-funded-programs-eligibility-standards/page-1.yaml":
+    active:
+      fingerprint: "sha256:3572b1c5d5237ca5984d7ccf66f5ec37c14df7f1c0a1f03266957bb402944a2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-5-temporary-cash-assistance-income-standards/page-1.yaml":
+    active:
+      fingerprint: "sha256:d27849908eddd0987bcf31d6c499f0b10e86b23f4d651ba809e9e1ad5206da75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/decal/caps/appendix-c-payment-zones.yaml":
+    active:
+      fingerprint: "sha256:56d1760be5b422a9028e4043f619cb919b00371b0a717e0f6496f9dd8ed9a21a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml":
+    active:
+      fingerprint: "sha256:ab8818ddadeede78a363551b8c77c35eccbe24c70a0ad8e165af69e1be42a2f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/decal/caps/appendix-d-family-fee-chart.yaml":
+    active:
+      fingerprint: "sha256:f55fa99fa39201372ac02a8555e23ccbef7304f7746df01e6f585a761a8f016a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/decal/caps/family-fees-policy-page-54.yaml":
+    active:
+      fingerprint: "sha256:88974c97a75eceb727eb73178d2c5b03796b949d9630f5641fd2576df73b1e6d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/decal/caps/family-fees-policy-page-55.yaml":
+    active:
+      fingerprint: "sha256:17eb3ffbc9705c67ed5ed86ad52aa52fcd7ce4d9a7bde3a7db960bf59709a7a8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/tanf/1605/block-14.yaml":
+    active:
+      fingerprint: "sha256:1b0299cba23a98df40d7deb81719d5df2b0908a67ac4b63c1c1e3d7c4dd7685d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/tanf/1605/block-6.yaml":
+    active:
+      fingerprint: "sha256:96879491da8dbe82ecd2687680516a0b19e9a9a3578bd2bf0941a8b52a0e379d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/tanf/1615/block-6.yaml":
+    active:
+      fingerprint: "sha256:1ac387d139c1d21f4c5726f459ac174417921985db2645d56a6a9edb8a4e0f90"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/dfcs/tanf/appendix-a.yaml":
+    active:
+      fingerprint: "sha256:620cfdede09293559300504543fcde9c099691f2f91b11c2345a300cb50b2c41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml":
+    active:
+      fingerprint: "sha256:cd8b7e4c4044ce01019c5418ee6e33f35510c06f918ce9742b14876e812e8268"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-il/policies/dhs/csmm/15820/block-1.yaml":
+    active:
+      fingerprint: "sha256:8dca6e37b72f66b9047c2610bd96c48dd7bb0a78c465b4f744cc9191866ee249"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-il/policies/dhs/csmm/25-06-01.yaml":
+    active:
+      fingerprint: "sha256:73f710c8a2bba56faf1a1de705402a369901de6379d704f992a87f0331b12e99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml":
+    active:
+      fingerprint: "sha256:8f72bcc7b637b099d5dd2f7d9de34f3873daef77cbaa13bc3484c7777f47e157"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml":
+    active:
+      fingerprint: "sha256:f68e74daae667e5231239e3aa310b1cc7f3b1df53653ec6ea1bf874484be96d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml":
+    active:
+      fingerprint: "sha256:5b6e4260499a6e4b64a5a32037433b985ff41aa8d467d47ce1cb90c7390f6e3f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml":
+    active:
+      fingerprint: "sha256:2342e46a0edf6cd01b90efb435402ec062e88cc5766a086507d9f9c3602379fc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml":
+    active:
+      fingerprint: "sha256:bef9b9c146895087e16f81940ffa2701e2b169b9ad50f2c30164344d39020172"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ks/policies/dcf/keesm/keesm7410.yaml":
+    active:
+      fingerprint: "sha256:eaa3feb5630b62169b9824f8357f24c1f001fa3cfa20012702729e92753dfd77"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml":
+    active:
+      fingerprint: "sha256:bec1b4797caa7174b239b759883a0ad73b4c903cc49a945f0cdce3b756a1d87f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mi/policies/mdhhs/bridges/bem/660.yaml":
+    active:
+      fingerprint: "sha256:3c0148f0c07a846addb454ce8666aa960c8f9c97d2f377f63b5ca872da4cf581"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mi/policies/mdhhs/rft/248.yaml":
+    active:
+      fingerprint: "sha256:dc5ed1633e543ecf1e861f5392614cde7b25d46f5fb335b9020361e63d71912b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml":
+    active:
+      fingerprint: "sha256:5efdafca8e8769c4047ab48268510c2ab648ca8c5c67662308712ee8bd4bcadd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml":
+    active:
+      fingerprint: "sha256:78cb6b409c0150c5b45515f12804f19a981b76b5e58f09b8a03e2d49b2636974"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml":
+    active:
+      fingerprint: "sha256:ce9c1b4a0d051cedb6b63207fca8a61d666cb65538f33f2b30d698d5cf488a83"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/cms/original-medicare-part-a-b.yaml":
+    active:
+      fingerprint: "sha256:6a188d53d787f3ea815f4b111aea7537c451e3621274987878fde03864cc120a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ed/fsa/2026-27-sai-pell-guide/page-30.yaml":
+    active:
+      fingerprint: "sha256:1b782199a99fcbafee0639680b3f0b19467077d9d66983b27bd1996d4b55ac5b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ed/fsa/2026-27-sai-pell-guide/page-31.yaml":
+    active:
+      fingerprint: "sha256:39e7c38f689400558d6f1a77a636f1e52d15ee022fb9c07e8917e50e4d546b27"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ed/fsa/2026-27-sai-pell-guide/page-8.yaml":
+    active:
+      fingerprint: "sha256:e82b4abf6dc794b78ca4096e5f7c565eaf29c8f471d4e22741dc568c9a18eccd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/contribution-and-benefit-base/2024.yaml":
+    active:
+      fingerprint: "sha256:ae6a527dbe3934fe8c65535d10ff0191e6acb8f7e1e5195414b7a70ed9fab422"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/contribution-and-benefit-base/2026.yaml":
+    active:
+      fingerprint: "sha256:3358af462e6ab7103ad70caeffef6fa3a0badc513f7e4fbd0f2027f27003293b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/ssa/substantial-gainful-activity/2026.yaml":
+    active:
+      fingerprint: "sha256:d8d3d3a0c3234903f927b12e8027aa038cad2c96aaff3803209166157f801bf4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
 
 # Encoding-manifest sync guard (tests/test_encoding_manifests.py) — modules
 # whose axiom-encode provenance manifest is out of sync at guard-introduction


### PR DESCRIPTION
## Summary

- migrate `validate_failures` from the legacy path list to the canonical strict `active` waiver schema
- retain only the 897 modules that still fail today, with exact combined validator fingerprints
- remove 886 stale entries that now pass
- attach an owner, issue, and 90-day expiry to every active waiver

This is the schema-only bootstrap for #782. It does not activate the new enforcement workflow and contains no RuleSpec content changes; keeping those transitions separate makes the later `pending` to `active` approval boundary auditable.

## Verification

- strict full audit: 897/897 active entries still fail with the exact recorded fingerprint; 0 errors
- full legacy inventory rerun: 1,783 checked, 897 retained, 886 removed
- `pytest -q`: 21 passed (one pre-existing warning)
- `git diff --check`

Fingerprint environment: Python 3.14.4, axiom-encode 0.2.1208, axiom-rules-engine `e19f1b7573c74512f20a6b71a0c55dbbf333d41b`, axiom-corpus `7661f3c9a3655e93fc9b2420048d70d231e7d44b`.
