### PR TITLE
Compose Arizona SNAP program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-az/snap/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-az/snap/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-az/snap/fy-2026.yaml",
+      "sha256": "808f9ec8d3f54a19b84a02c1ea5d540169b6b6c4e769ccb84ed15135a90c168c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-az/snap/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T15:38:29.177835+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "808f9ec8d3f54a19b84a02c1ea5d540169b6b6c4e769ccb84ed15135a90c168c",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7292b3992e33ed27aa6c5bbed038036ef631a7d5a059de188a8be25d45eb0070"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/programs/us-az/snap/fy-2026.yaml
+++ b/programs/us-az/snap/fy-2026.yaml
@@ -1,0 +1,51 @@
+# Arizona Nutrition Assistance (SNAP) -- FY 2026
+#
+# Arizona's executable Nutrition Assistance surface lives in the DES FAA5
+# FY 2026 benefit-calculation composition. This wrapper publishes the
+# dashboard-facing SNAP outputs and scopes the encoded Arizona NA eligibility,
+# deduction, utility, shelter, disqualification, transitional-benefit, and
+# benefit-amount modules. The federal executable SNAP modules are not pulled
+# into this wrapper because Arizona's composition intentionally owns the
+# dashboard-facing `snap_net_income`, `snap_eligible`, and allotment surfaces.
+
+program: us-az/snap
+period: 2026-01
+
+outputs:
+  - snap_eligible
+  - snap_benefit
+
+auto_gate_outputs:
+  - snap_eligible
+
+scope:
+  state:
+    - policies/des/faa5/dependent-care-expense/na-dependent-care
+    - policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount
+    - policies/des/faa5/na-categorical-eligibility/basic-categorical-eligibility
+    - policies/des/faa5/na-categorical-eligibility/categorical-eligibility-benefit-calculation
+    - policies/des/faa5/na-categorical-eligibility/expanded-categorical-eligibility
+    - policies/des/faa5/na-child-support-expense/allowable-deductions
+    - policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount
+    - policies/des/faa5/na-eligibility-and-benefit-determination/first-month-benefit-proration
+    - policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation
+    - policies/des/faa5/na-eligibility-and-benefit-determination/gross-income-test
+    - policies/des/faa5/na-eligibility-and-benefit-determination/net-income-test
+    - policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction
+    - policies/des/faa5/na-transitional-benefit-assistance-tba
+    - policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility
+    - policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction
+    - policies/des/faa5/supplemental-payments-and-restored-benefits
+
+transformations:
+  - pattern: conditional_value
+    name: snap_benefit
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-az/snap/fy-2026 benefit composition
+    condition: snap_eligible
+    when_true: snap_regular_month_allotment
+    when_false: 0


### PR DESCRIPTION
## Summary
- add programs/us-az/snap/fy-2026.yaml for Arizona Nutrition Assistance / SNAP
- scope the encoded DES FAA5 NA benefit, income, deduction, utility, shelter, disqualification, transitional-benefit, and restored-benefit modules
- publish snap_benefit as the Arizona regular-month allotment gated by snap_eligible
- add a signed manual composition manifest for the program wrapper

## Checks
- axiom-encode guard-generated --roots "programs"
- axiom-encode validate us-az/.../fy-2026-benefit-calculation.yaml --skip-reviewers
- axiom-encode proof-validate us-az/.../fy-2026-benefit-calculation.yaml
- axiom-encode test for AZ SNAP benefit/gross/net/amount companion suites: 4 files, 16 cases
- python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-work (18 passed, 1 existing warning)
- tools/build_program_artifacts.py --dist /tmp/program-artifacts-az-snap-2 (built 24/24 programs; us-az-snap.compiled.json 87d)

## Notes
- The wrapper intentionally does not include the federal executable SNAP modules because Arizona's FY 2026 composition owns the dashboard-facing snap_net_income, snap_eligible, and allotment surfaces; including the federal executable baseline creates duplicate producers.