### PR TITLE
Compose Georgia SNAP program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-ga/snap/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ga/snap/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-ga/snap/fy-2026.yaml",
+      "sha256": "41a1eb20ac4ded93cd25a9d2a70765ca55749d8b398f7fafdc570c92e88b6793"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-ga/snap/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T15:57:03.893119+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "41a1eb20ac4ded93cd25a9d2a70765ca55749d8b398f7fafdc570c92e88b6793",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bb09be965b0da9089887fcf2aef943d6dc3dd4ab0e480c2b2f5bb16f8414cfcd"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/programs/us-ga/snap/fy-2026.yaml
+++ b/programs/us-ga/snap/fy-2026.yaml
@@ -1,0 +1,175 @@
+# Georgia SNAP -- FY 2026
+#
+# Georgia DFCS SNAP encodings currently cover categorical eligibility and the
+# core income/deduction surfaces from manual sections 3210 and 3612-3618. This
+# wrapper scopes those state modules with the federal SNAP baseline and exposes
+# the dashboard-facing benefit output.
+
+program: us-ga/snap
+period: 2026-01
+
+outputs:
+  - snap_eligible
+  - snap_benefit
+
+auto_gate_outputs:
+  - snap_eligible
+
+scope:
+  federal:
+    - regulations/7-cfr/273/2/j
+    - regulations/7-cfr/273/3
+    - regulations/7-cfr/273/4
+    - regulations/7-cfr/273/5
+    - regulations/7-cfr/273/6
+    - regulations/7-cfr/273/7
+    - regulations/7-cfr/273/8
+    - regulations/7-cfr/273/9
+    - regulations/7-cfr/273/9/d/6/iii
+    - regulations/7-cfr/273/10
+    - regulations/7-cfr/273/24
+    - regulations/7-cfr/275/23/d/1
+    - regulations/7-cfr/275/23/d/2
+    - regulations/7-cfr/275/23/e/1
+    - statutes/7/2012/j
+    - statutes/7/2012/m/4
+    - statutes/7/2014/a
+    - statutes/7/2014/c
+    - statutes/7/2014/d
+    - statutes/7/2014/e/2
+    - statutes/7/2014/e/6/A
+    - statutes/7/2014/g
+    - statutes/7/2015/b/1
+    - statutes/7/2015/d/2
+    - statutes/7/2015/d/2/A
+    - statutes/7/2015/d/2/B
+    - statutes/7/2015/d/2/C
+    - statutes/7/2015/d/2/D
+    - statutes/7/2015/d/2/E
+    - statutes/7/2015/d/2/F
+    - statutes/7/2015/e
+    - statutes/7/2017/a
+
+  state:
+    - policies/dfcs/snap/3210/block-2
+    - policies/dfcs/snap/3612
+    - policies/dfcs/snap/3613
+    - policies/dfcs/snap/3614
+    - policies/dfcs/snap/3615
+    - policies/dfcs/snap/3616
+    - policies/dfcs/snap/3617
+    - policies/dfcs/snap/3618
+
+transformations:
+  - pattern: all_of
+    name: snap_member_eligible
+    effective_from: '2026-01-01'
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: us:statutes/7/2014
+    conditions:
+      - snap_member_citizenship_or_alien_status_eligible
+      - snap_member_ssn_requirement_eligible
+      - snap_member_work_requirement_eligible
+      - snap_member_student_eligible
+
+  - pattern: any_related
+    name: snap_eligible
+    effective_from: '2026-01-01'
+    entity: Household
+    period: Month
+    source: us:statutes/7/2014
+    relation: member_of_household
+    condition: snap_member_eligible
+
+  - pattern: any_of
+    name: snap_income_eligible
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ga/snap/fy-2026 income-standard composition
+    conditions:
+      - categorically_eligible_for_snap
+      - snap_standard_income_eligible
+
+  - pattern: sum_terms
+    name: snap_countable_earned_income
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 income composition
+    terms:
+      - snap_gross_monthly_earned_income
+
+  - pattern: sum_terms
+    name: snap_countable_unearned_income
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 income composition
+    terms:
+      - snap_total_monthly_unearned_income
+
+  - pattern: sum_terms
+    name: snap_gross_monthly_income
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 income composition
+    terms:
+      - snap_countable_earned_income
+      - snap_countable_unearned_income
+
+  - pattern: sum_terms
+    name: snap_monthly_household_income
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 income composition
+    terms:
+      - snap_countable_earned_income
+      - snap_countable_unearned_income
+
+  - pattern: sum_terms
+    name: snap_total_allowable_shelter_expenses
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 shelter-cost composition
+    terms:
+      - monthly_allowable_shelter_costs
+
+  - pattern: sum_terms
+    name: snap_excess_shelter_deduction
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 shelter deduction composition
+    terms:
+      - excess_shelter_deduction
+
+  - pattern: conditional_value
+    name: snap_benefit
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ga/snap/fy-2026 benefit composition
+    condition: snap_eligible
+    when_true: snap_monthly_allotment
+    when_false: 0


### PR DESCRIPTION
## Summary
- add programs/us-ga/snap/fy-2026.yaml for Georgia SNAP
- scope existing DFCS SNAP encodings for categorical eligibility and manual sections 3612-3618 with the federal SNAP baseline
- publish snap_benefit as snap_monthly_allotment gated by snap_eligible
- add a signed manual composition manifest for the program wrapper

## Checks
- axiom-encode guard-generated --roots "programs"
- axiom-encode test for GA SNAP 3210/3612/3613/3614/3615/3616/3617/3618 companion suites: 8 files, 32 cases
- python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ga-snap (18 passed, 1 existing warning)
- tools/build_program_artifacts.py --dist /tmp/program-artifacts-ga-snap-rebased (built 25/25 programs; us-ga-snap.compiled.json 189d)

## Notes
- Existing Georgia SNAP leaf modules have strict standalone source-verification debt: several cited us-ga/manual/dfcs/snap provisions are missing from corpus.provisions or need numeric source text. This PR does not alter those leaf modules; it composes the already-encoded, companion-tested surfaces into a program wrapper.