### PR TITLE
Compose Arkansas TEA program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-ar/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ar/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-ar/tanf/fy-2026.yaml",
+      "sha256": "afec741755e71021aa8daafb66b093a24f8382e6e63d2d3eae49b3a0c28ee496"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-ar/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T16:28:30.659726+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "afec741755e71021aa8daafb66b093a24f8382e6e63d2d3eae49b3a0c28ee496",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ba297d0dbde95ede74eb71eb2c54e9fdf2bca5c76bcd3b38d6b1c7a76e517993"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/programs/us-ar/tanf/fy-2026.yaml
+++ b/programs/us-ar/tanf/fy-2026.yaml
@@ -1,0 +1,49 @@
+# Arkansas TEA (TANF) -- FY 2026
+#
+# Composes the encoded Arkansas DHS TEA manual rules for income standards,
+# earned-income deductions, income budgeting, resource eligibility, payment
+# levels, and the reduced-payment gross-income trigger.
+
+program: us-ar/tanf
+period: 2026-01
+
+outputs:
+  - ar_tea_eligible
+  - ar_tea_benefit
+
+acknowledged_incomplete:
+  - ar_tea_eligible
+  - ar_tea_benefit
+
+scope:
+  state:
+    - policies/dhs/tea/manual/2024/earned-income-deductions
+    - policies/dhs/tea/manual/2024/income-eligibility-budget
+    - policies/dhs/tea/manual/2024/income-eligibility-standard
+    - policies/dhs/tea/manual/2024/payment-levels
+    - policies/dhs/tea/manual/2024/reduced-payment-gross-income-trigger
+    - policies/dhs/tea/manual/2024/resource-eligibility
+
+transformations:
+  - pattern: all_of
+    name: ar_tea_eligible
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ar/tanf/fy-2026 eligibility composition
+    conditions:
+      - local_ar_tea_income_eligible
+      - ar_tea_resources_eligible
+
+  - pattern: conditional_value
+    name: ar_tea_benefit
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ar/tanf/fy-2026 benefit composition
+    condition: ar_tea_eligible
+    when_true: ar_tea
+    when_false: 0


### PR DESCRIPTION
## Summary
- add programs/us-ar/tanf/fy-2026.yaml for Arkansas TEA/TANF
- scope existing DHS TEA manual modules for income standards, earned-income deductions, income budgeting, resource eligibility, payment levels, and reduced-payment gross-income trigger
- expose ar_tea_eligible and ar_tea_benefit as the program outputs
- add a signed manual composition manifest for the program wrapper

## Checks
- axiom-encode guard-generated --roots "programs"
- axiom-encode validate for all six Arkansas TEA leaf modules
- axiom-encode test for Arkansas TEA companion suites: 6 files, 24 cases
- python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ar-tanf (18 passed, 1 existing warning)
- tools/build_program_artifacts.py --dist /tmp/program-artifacts-ar-tanf-rebased (built 27/27 programs; us-ar-tanf.compiled.json 15d)

## Notes
- ar_tea_eligible and ar_tea_benefit are acknowledged incomplete because broader demographic and procedural TANF gates are outside the currently encoded Arkansas TEA slice.