### PR TITLE
Compose California CalWORKs program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-ca/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ca/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-ca/tanf/fy-2026.yaml",
+      "sha256": "6ee5a3f1f31be6ae534b15d59538b15b795e2629d4b185b37629b8d74ebd5d55"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-ca/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T16:45:24.072895+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "6ee5a3f1f31be6ae534b15d59538b15b795e2629d4b185b37629b8d74ebd5d55",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2ed807be1f4b0851cf85ab3e00c536959981670fce60ddd284518f8c827704f0"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/programs/us-ca/tanf/fy-2026.yaml
+++ b/programs/us-ca/tanf/fy-2026.yaml
@@ -1,0 +1,64 @@
+# California CalWORKs (TANF) -- FY 2026
+#
+# Composes the encoded CalWORKs financial standards currently available under
+# CDSS/WIC sources: resource limits, vehicle equity, income tests, recipient
+# income disregard, regional standards, maximum aid payment tables, and monthly
+# aid payment. Broader demographic, assistance-unit composition, time-limit,
+# sanction, and cross-entity eligibility gates remain outside this wrapper.
+
+program: us-ca/tanf
+period: 2026-01
+
+outputs:
+  - calworks_applicant_income_eligible
+  - calworks_recipient_income_eligible
+  - calworks_monthly_aid_payment
+
+acknowledged_incomplete:
+  - calworks_applicant_income_eligible
+  - calworks_recipient_income_eligible
+  - calworks_monthly_aid_payment
+
+scope:
+  state:
+    - policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value
+    - policies/cdss/calworks/financial-eligibility-income-tests
+    - policies/cdss/calworks/maximum-aid-payment-region-1
+    - policies/cdss/calworks/maximum-aid-payment-region-2
+    - policies/cdss/calworks/maximum-resource-limit
+    - policies/cdss/calworks/minimum-basic-standard-of-adequate-care
+    - policies/cdss/calworks/monthly-aid-payment
+    - policies/cdss/calworks/recipient-income-disregard
+    - policies/cdss/calworks/regional-minimum-basic-standard
+
+transformations:
+  - pattern: all_of
+    name: calworks_applicant_income_eligible
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ca/tanf/fy-2026 applicant income eligibility bridge
+    conditions:
+      - applicant_family_satisfies_minimum_basic_standard_income_test
+      - applicant_family_satisfies_maximum_aid_payment_income_test
+
+  - pattern: all_of
+    name: calworks_recipient_income_eligible
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ca/tanf/fy-2026 recipient income eligibility bridge
+    conditions:
+      - recipient_family_satisfies_income_reporting_threshold_for_further_aid
+
+  - pattern: derived_formula
+    name: calworks_monthly_aid_payment
+    effective_from: '2026-01-01'
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ca/tanf/fy-2026 monthly aid payment bridge
+    formula: monthly_aid_payment


### PR DESCRIPTION
## Summary
- add a California CalWORKs (`us-ca/tanf`) FY 2026 program wrapper over the currently encoded CDSS CalWORKs financial standards
- expose applicant income eligibility, recipient income eligibility, and monthly aid payment outputs
- add the signed program manifest for the wrapper

## Scope notes
This is intentionally marked incomplete for the exposed outputs. The wrapper composes the encoded financial standards and payment calculation surfaces currently present in the repo; broader CalWORKs demographic, assistance-unit composition, time-limit, sanction, and cross-entity eligibility gates remain outside this program wrapper.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ca-calworks --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-ca-calworks <9 us-ca/policies/cdss/calworks/*.test.yaml files>` (9 files, 30 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ca-calworks` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-ca-calworks-rebased` (built 28/28; `us-ca-tanf.compiled.json` 30d)

/cycle