### PR TITLE
Compose Indiana TANF program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-in/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-in/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-in/tanf/fy-2026.yaml",
+      "sha256": "e7090563be695d5d19cb0f067830cf51325b57747bac617b7e327f84ab68d6cc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-in/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T17:05:00.623035+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "e7090563be695d5d19cb0f067830cf51325b57747bac617b7e327f84ab68d6cc",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fbe8649db2343988e81390ee69b130f4a84fe2dce12cdab0185e6cc4680bf9aa"
+  }
+}

--- a/programs/us-in/tanf/fy-2026.yaml
+++ b/programs/us-in/tanf/fy-2026.yaml
@@ -1,0 +1,60 @@
+# Indiana TANF Cash Assistance -- FY 2026
+#
+# Composes the encoded Indiana DFR SNAP/TANF Program Policy Manual cash
+# assistance rules for income standards, maximum monthly benefits, and new and
+# ongoing benefit calculations. Broader demographic, categorical, resource,
+# sanction, time-limit, and procedural eligibility gates remain outside this
+# wrapper.
+
+program: us-in/tanf
+period: 2026-01
+
+outputs:
+  - in_tanf_gross_income_eligible
+  - in_tanf_new_application_monthly_benefit
+  - in_tanf_ongoing_monthly_benefit
+
+acknowledged_incomplete:
+  - in_tanf_gross_income_eligible
+  - in_tanf_new_application_monthly_benefit
+  - in_tanf_ongoing_monthly_benefit
+
+scope:
+  state:
+    - policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards
+    - policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards
+    - policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits
+    - policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits-continuation
+    - policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation
+    - policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation
+    - policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation
+
+transformations:
+  - pattern: derived_formula
+    name: in_tanf_gross_income_eligible
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-in/tanf/fy-2026 gross-income eligibility bridge
+    formula: tanf_gross_income_test_met
+
+  - pattern: derived_formula
+    name: in_tanf_new_application_monthly_benefit
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-in/tanf/fy-2026 new-application benefit bridge
+    formula: tanf_new_application_monthly_benefit_entitlement
+
+  - pattern: derived_formula
+    name: in_tanf_ongoing_monthly_benefit
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-in/tanf/fy-2026 ongoing benefit bridge
+    formula: tanf_ongoing_monthly_benefit_entitlement


### PR DESCRIPTION
## Summary
- add an Indiana TANF Cash Assistance (`us-in/tanf`) FY 2026 program wrapper over the currently encoded DFR SNAP/TANF Program Policy Manual cash-assistance rules
- expose gross-income eligibility plus new-application and ongoing monthly benefit outputs
- add the signed program manifest for the wrapper

## Scope notes
This wrapper composes existing encoded financial rules only: income standards, maximum monthly benefit tables, work-expense/earned-income disregards, and new/ongoing benefit calculations. Broader demographic, categorical, resource, sanction, time-limit, and procedural TANF gates remain outside this wrapper, so all exposed outputs are acknowledged incomplete.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-in-tanf --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-in-tanf <7 us-in/policies/dfr/snap-tanf-program-policy-manual/*.test.yaml files>` (7 files, 25 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-in-tanf` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-in-tanf-final` (built 28/28; `us-in-tanf.compiled.json` 29d)

## Known validation debt
Local strict leaf validation still reports score-threshold failures for three pre-existing Indiana leaves that this wrapper composes:
- `3010-15-05-cash-assistance-100-percent-income-standards.yaml`
- `3050-10-cash-assistance-maximum-benefits.yaml`
- `3450-35-05-benefit-calculation.yaml`

Those files were not changed here. Their companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring/table completeness separately.

/cycle