### PR TITLE
Compose Maryland TCA program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-md/tca/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-md/tca/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-md/tca/fy-2026.yaml",
+      "sha256": "f6370016bdd04edc8939f915bb9f9083d8632f2f76245ddd30cad3ca4b5882d4"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-md/tca/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T17:24:14.952126+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "f6370016bdd04edc8939f915bb9f9083d8632f2f76245ddd30cad3ca4b5882d4",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "93444c32a9cfd276de2822677a79f904aad0fb10edb923a0779995e1c2b5875c"
+  }
+}

--- a/programs/us-md/tca/fy-2026.yaml
+++ b/programs/us-md/tca/fy-2026.yaml
@@ -1,0 +1,29 @@
+# Maryland Temporary Cash Assistance -- FY 2026
+#
+# Composes the encoded DHS/FIA IM 26-13 payment schedule for the allowable
+# monthly TCA amount effective 2026-01-01. Full TCA eligibility, need, income,
+# resource, sanction, and procedural rules remain outside this wrapper.
+
+program: us-md/tca
+period: 2026-01
+
+outputs:
+  - md_tca_maximum_monthly_benefit
+
+acknowledged_incomplete:
+  - md_tca_maximum_monthly_benefit
+
+scope:
+  state:
+    - policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment
+
+transformations:
+  - pattern: derived_formula
+    name: md_tca_maximum_monthly_benefit
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-md/tca/fy-2026 maximum benefit bridge
+    formula: md_tca_maximum_benefit


### PR DESCRIPTION
## Summary
- add a Maryland Temporary Cash Assistance (`us-md/tca`) FY 2026 program wrapper over the encoded DHS/FIA IM 26-13 payment schedule
- expose `md_tca_maximum_monthly_benefit` as a program-level bridge to the encoded maximum benefit table
- add the signed program manifest for the wrapper

## Scope notes
This wrapper only covers the allowable monthly TCA payment table effective 2026-01-01. Full TCA eligibility, need, income, resource, sanction, and procedural rules remain outside this wrapper, so the output is acknowledged incomplete.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-md-tca --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-md-tca us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.test.yaml` (1 file, 4 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-md-tca` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-md-tca-final` (built 29/29; `us-md-tca.compiled.json` 2d)

## Known validation debt
Local strict leaf validation still reports a score-threshold failure for the pre-existing Maryland payment-table leaf:
- `us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.yaml`

That file is not changed here. Its companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring separately.

/cycle