### PR TITLE
Compose Maine TANF program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-me/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-me/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-me/tanf/fy-2026.yaml",
+      "sha256": "46bf1fa45d7f3a2d4b1fe46896e741d53f21546844fd04a467008503dec3c24c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-me/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T17:36:38.017818+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "46bf1fa45d7f3a2d4b1fe46896e741d53f21546844fd04a467008503dec3c24c",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9cc4e31dca248116d556a056f036e42d3feb38042ac2211856443fdee28ffbef"
+  }
+}

--- a/programs/us-me/tanf/fy-2026.yaml
+++ b/programs/us-me/tanf/fy-2026.yaml
@@ -1,0 +1,67 @@
+# Maine TANF -- FY 2026
+#
+# Composes the encoded Maine DHHS/OFI Chapter 331 TANF Rule 125A standard of
+# need and maximum grant tables, including child-only and adult-included
+# households and the special-need housing addition. Broader eligibility,
+# countable-income, resource, sanction, and procedural rules remain outside
+# this wrapper.
+
+program: us-me/tanf
+period: 2026-01
+
+outputs:
+  - me_tanf_adult_included_standard_of_need
+  - me_tanf_adult_included_maximum_grant
+  - me_tanf_child_only_standard_of_need
+  - me_tanf_child_only_maximum_grant
+
+acknowledged_incomplete:
+  - me_tanf_adult_included_standard_of_need
+  - me_tanf_adult_included_maximum_grant
+  - me_tanf_child_only_standard_of_need
+  - me_tanf_child_only_maximum_grant
+
+scope:
+  state:
+    - regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need
+
+transformations:
+  - pattern: derived_formula
+    name: me_tanf_adult_included_standard_of_need
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-me/tanf/fy-2026 adult-included standard-of-need bridge
+    formula: adult_included_standard_of_need
+
+  - pattern: derived_formula
+    name: me_tanf_adult_included_maximum_grant
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-me/tanf/fy-2026 adult-included maximum-grant bridge
+    formula: adult_included_maximum_grant
+
+  - pattern: derived_formula
+    name: me_tanf_child_only_standard_of_need
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-me/tanf/fy-2026 child-only standard-of-need bridge
+    formula: child_only_standard_of_need
+
+  - pattern: derived_formula
+    name: me_tanf_child_only_maximum_grant
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-me/tanf/fy-2026 child-only maximum-grant bridge
+    formula: child_only_maximum_grant


### PR DESCRIPTION
## Summary
- add a Maine TANF (`us-me/tanf`) FY 2026 program wrapper over the encoded DHHS/OFI Chapter 331 TANF Rule 125A standard-of-need and maximum-grant tables
- expose adult-included and child-only standard-of-need and maximum-grant outputs
- add the signed program manifest for the wrapper

## Scope notes
This wrapper covers financial standard and grant tables only, including add-member and special-need housing adjustments. Full TANF eligibility, countable-income, resource, sanction, and procedural rules remain outside this wrapper, so all exposed outputs are acknowledged incomplete.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-me-tanf --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-me-tanf us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.test.yaml` (1 file, 3 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-me-tanf` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-me-tanf-final` (built 30/30; `us-me-tanf.compiled.json` 8d)

## Known validation debt
Local strict leaf validation still reports a score-threshold failure for the pre-existing Maine Rule 125A leaf:
- `us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.yaml`

That file is not changed here. Its companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring separately.

/cycle