### PR TITLE
Compose Minnesota MFIP program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-mn/mfip/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-mn/mfip/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-mn/mfip/fy-2026.yaml",
+      "sha256": "516901c3792a6b8624ee76f00bc6a5bf62ebd693a0b17c998cc6a91b70b8aacc"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-mn/mfip/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T17:55:44.868338+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "516901c3792a6b8624ee76f00bc6a5bf62ebd693a0b17c998cc6a91b70b8aacc",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f859ab4b2526c8a508924040bdec2e9f3cec7f3248d8552f0a82c998bc50b052"
+  }
+}

--- a/programs/us-mn/mfip/fy-2026.yaml
+++ b/programs/us-mn/mfip/fy-2026.yaml
@@ -1,0 +1,67 @@
+# Minnesota MFIP -- FY 2026
+#
+# Composes the encoded DHS Combined Manual 0022.12 MFIP grant calculation
+# procedure: pre-proration grant amount, final grant after applicant proration
+# and recoupment, and food/cash issuance split. Eligibility, standards tables,
+# income disregards outside this procedure, sanctions, and procedural gates
+# remain outside this wrapper.
+
+program: us-mn/mfip
+period: 2026-01
+
+outputs:
+  - mn_mfip_total_grant_before_proration
+  - mn_mfip_final_total_grant
+  - mn_mfip_food_portion
+  - mn_mfip_cash_portion
+
+acknowledged_incomplete:
+  - mn_mfip_total_grant_before_proration
+  - mn_mfip_final_total_grant
+  - mn_mfip_food_portion
+  - mn_mfip_cash_portion
+
+scope:
+  state:
+    - policies/dhs/combined-manual/0022-12/mfip-total-grant
+
+transformations:
+  - pattern: derived_formula
+    name: mn_mfip_total_grant_before_proration
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/mfip/fy-2026 total grant before proration bridge
+    formula: total_mfip_grant_before_proration
+
+  - pattern: derived_formula
+    name: mn_mfip_final_total_grant
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/mfip/fy-2026 final grant bridge
+    formula: final_total_mfip_grant
+
+  - pattern: derived_formula
+    name: mn_mfip_food_portion
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/mfip/fy-2026 food portion bridge
+    formula: mfip_food_portion_issued_as_ebt
+
+  - pattern: derived_formula
+    name: mn_mfip_cash_portion
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/mfip/fy-2026 cash portion bridge
+    formula: mfip_cash_portion_issued_as_cash


### PR DESCRIPTION
## Summary
- add a Minnesota MFIP (`us-mn/mfip`) FY 2026 program wrapper over the encoded DHS Combined Manual 0022.12 grant calculation procedure
- expose pre-proration grant, final grant, food portion, and cash portion outputs
- add the signed program manifest for the wrapper

## Scope notes
This wrapper covers the encoded MFIP grant calculation procedure only. Eligibility, standards tables, income disregards outside this procedure, sanctions, and procedural gates remain outside this wrapper, so all exposed outputs are acknowledged incomplete. Minnesota MSA assistance standards are intentionally left for a separate program wrapper.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-mn-mfip --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-mn-mfip us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml` (1 file, 5 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-mn-mfip` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-mn-mfip-final` (built 30/30; `us-mn-mfip.compiled.json` 8d)

## Known validation debt
Local strict leaf validation still reports a score-threshold failure for the pre-existing Minnesota MFIP leaf:
- `us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml`

That file is not changed here. Its companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring separately.

/cycle