### PR TITLE
Compose Utah TANF program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-ut/tanf/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ut/tanf/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-ut/tanf/fy-2026.yaml",
+      "sha256": "b1a696305984c8ac7efe67929be9af6c2880f098d3fb4806d045787e14d747ee"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-ut/tanf/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T18:24:11.256398+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "b1a696305984c8ac7efe67929be9af6c2880f098d3fb4806d045787e14d747ee",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0208abf6ff81aae2c793074079260de588072fa27e6d045e3013577b807be853"
+  }
+}

--- a/programs/us-ut/tanf/fy-2026.yaml
+++ b/programs/us-ut/tanf/fy-2026.yaml
@@ -1,0 +1,93 @@
+# Utah FEP/FEP-TP (TANF) -- FY 2026
+#
+# Composes the encoded Utah DWS FEP/FEP-TP financial table and Utah Admin.
+# Code R986-200 components currently available: payment standard, section 204
+# demographic/procedural component, resource eligibility, gross-income screen,
+# and work-expense allowance. Broader eligibility, net-income/payment
+# calculation, participation, sanctions, and procedural gates remain outside
+# this wrapper or are represented as upstream inputs.
+
+program: us-ut/tanf
+period: 2026-01
+
+outputs:
+  - ut_fep_payment_standard_amount
+  - ut_fep_204_component_eligible
+  - ut_fep_resources_eligible_output
+  - ut_fep_gross_income_eligible
+  - ut_fep_work_expense_allowance
+  - ut_fep_eligible
+
+acknowledged_incomplete:
+  - ut_fep_204_component_eligible
+  - ut_fep_resources_eligible_output
+  - ut_fep_gross_income_eligible
+  - ut_fep_work_expense_allowance
+  - ut_fep_eligible
+
+scope:
+  state:
+    - policies/dws/eligibility-manual/table-1-financial-monthly-income-limits
+    - regulations/admin-rules/r986/200/204
+    - regulations/admin-rules/r986/200/230
+    - regulations/admin-rules/r986/200/239
+
+transformations:
+  - pattern: derived_formula
+    name: ut_fep_payment_standard_amount
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ut/tanf/fy-2026 payment-standard bridge
+    formula: ut_fep_payment_standard
+
+  - pattern: derived_formula
+    name: ut_fep_204_component_eligible
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ut/tanf/fy-2026 section-204 component bridge
+    formula: ut_fep_or_feptp_204_eligibility_component_met
+
+  - pattern: derived_formula
+    name: ut_fep_resources_eligible_output
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ut/tanf/fy-2026 resource eligibility bridge
+    formula: ut_fep_resources_eligible
+
+  - pattern: derived_formula
+    name: ut_fep_gross_income_eligible
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ut/tanf/fy-2026 gross-income eligibility bridge
+    formula: financial_assistance_gross_countable_income_eligible
+
+  - pattern: derived_formula
+    name: ut_fep_work_expense_allowance
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-ut/tanf/fy-2026 work-expense allowance bridge
+    formula: work_expense_allowance_deduction
+
+  - pattern: all_of
+    name: ut_fep_eligible
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-ut/tanf/fy-2026 eligibility component rollup
+    conditions:
+      - ut_fep_204_component_eligible
+      - ut_fep_resources_eligible_output
+      - ut_fep_gross_income_eligible


### PR DESCRIPTION
## Summary
- add a Utah FEP/FEP-TP (`us-ut/tanf`) FY 2026 program wrapper over the encoded DWS table and Utah Admin. Code R986-200 components
- expose payment standard, section 204 component eligibility, resource eligibility, gross-income eligibility, work-expense allowance, and a conservative component rollup
- add the signed program manifest for the wrapper

## Scope notes
This wrapper composes currently encoded FEP/FEP-TP components only. Broader eligibility, net-income/payment calculation, participation, sanctions, and procedural gates remain outside this wrapper or are represented as upstream inputs, so component and rollup outputs are acknowledged incomplete.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ut-tanf --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-ut-tanf <4 us-ut DWS/R986 companion test files>` (4 files, 16 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ut-tanf` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-ut-tanf-rebased-md` (built 32/32; `us-ut-tanf.compiled.json` 13d)

## Known validation debt
Local strict leaf validation passes three of the four scoped leaves but still reports a score-threshold failure for the pre-existing DWS income-limit table leaf:
- `us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml`

That file is not changed here. Its companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring separately.

/cycle