### PR TITLE
Compose Wyoming POWER program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-wy/power/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-wy/power/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-wy/power/fy-2026.yaml",
+      "sha256": "62ae0dd518be85ddfd1ac7848a9ac72f760c26b69aad6e7de4a6441d41698796"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-wy/power/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T18:53:21.123841+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "62ae0dd518be85ddfd1ac7848a9ac72f760c26b69aad6e7de4a6441d41698796",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7fcfad632613423787bead428467f60ac1e1e7702716a16a8693b4bb073b2860"
+  }
+}

--- a/programs/us-wy/power/fy-2026.yaml
+++ b/programs/us-wy/power/fy-2026.yaml
@@ -1,0 +1,78 @@
+# Wyoming POWER -- FY 2026
+#
+# Composes the encoded DFS SNAP/POWER policy manual 1101 POWER payment tests
+# and computations: earned-income disregards, countable income for maximum
+# benefit level testing, performance payment computation, and child-support
+# termination condition. Broader POWER eligibility, benefit-level tables,
+# sanctions, work participation, and procedural rules remain outside this
+# wrapper or are represented as upstream inputs.
+
+program: us-wy/power
+period: 2026-01
+
+outputs:
+  - wy_power_countable_income_for_maximum_benefit_test
+  - wy_power_maximum_benefit_level_test_met
+  - wy_power_performance_payment_countable_income
+  - wy_power_performance_payment
+  - wy_power_child_support_termination
+
+acknowledged_incomplete:
+  - wy_power_countable_income_for_maximum_benefit_test
+  - wy_power_maximum_benefit_level_test_met
+  - wy_power_performance_payment_countable_income
+  - wy_power_performance_payment
+  - wy_power_child_support_termination
+
+scope:
+  state:
+    - policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations
+
+transformations:
+  - pattern: derived_formula
+    name: wy_power_countable_income_for_maximum_benefit_test
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-wy/power/fy-2026 maximum benefit test income bridge
+    formula: power_maximum_benefit_level_countable_income
+
+  - pattern: derived_formula
+    name: wy_power_maximum_benefit_level_test_met
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-wy/power/fy-2026 maximum benefit test bridge
+    formula: power_maximum_benefit_level_test_met
+
+  - pattern: derived_formula
+    name: wy_power_performance_payment_countable_income
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-wy/power/fy-2026 performance payment income bridge
+    formula: power_performance_payment_countable_income
+
+  - pattern: derived_formula
+    name: wy_power_performance_payment
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-wy/power/fy-2026 performance payment bridge
+    formula: power_performance_payment_amount
+
+  - pattern: derived_formula
+    name: wy_power_child_support_termination
+    effective_from: '2026-01-01'
+    entity: TanfUnit
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-wy/power/fy-2026 child support termination bridge
+    formula: power_case_terminates_for_ongoing_child_support_ineligibility


### PR DESCRIPTION
## Summary
- add a Wyoming POWER (`us-wy/power`) FY 2026 program wrapper over the encoded DFS SNAP/POWER policy manual 1101 payment tests and computations
- expose maximum-benefit test income, maximum-benefit test judgment, performance-payment income, performance payment, and child-support termination outputs
- add the signed program manifest for the wrapper

## Scope notes
This wrapper covers currently encoded POWER payment-test and performance-payment computations only. Broader POWER eligibility, benefit-level tables, sanctions, work participation, and procedural rules remain outside this wrapper or are represented as upstream inputs, so all exposed outputs are acknowledged incomplete.

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-wy-power --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-wy-power us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.test.yaml` (1 file, 6 cases)
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-wy-power` (18 passed, 1 existing warning)
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-wy-power-rebased-ut` (built 33/33; `us-wy-power.compiled.json` 16d)

## Known validation debt
Local strict leaf validation still reports a score-threshold failure for the pre-existing Wyoming POWER leaf:
- `us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml`

That file is not changed here. Its companion tests pass, and the composed program artifact compiles; follow-up repair should address the leaf scoring separately.

/cycle