### PR TITLE
Compose Minnesota MSA program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-mn/msa/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-mn/msa/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-mn/msa/fy-2026.yaml",
+      "sha256": "d2a5cce414119de2fe2216a06455f2e1628c0d0b09b6c5992104ddf79d240d6a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-mn/msa/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T19:22:55.713505+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "d2a5cce414119de2fe2216a06455f2e1628c0d0b09b6c5992104ddf79d240d6a",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null,
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a0d9a334ed73178cf085929eb8081151aa6b811e471d31dd06b0614169769e84"
+  }
+}

--- a/programs/us-mn/msa/fy-2026.yaml
+++ b/programs/us-mn/msa/fy-2026.yaml
@@ -1,0 +1,54 @@
+# Minnesota Supplemental Aid -- FY 2026
+#
+# Composes the encoded DHS Combined Manual 0020.21 2026 MSA assistance
+# standards, including the 0020.24 personal needs allowance captured in the
+# same source bundle. Broader MSA categorical eligibility,
+# income budgeting, asset rules, housing assistance, and procedural rules remain
+# outside this wrapper or are represented as upstream inputs.
+
+program: us-mn/msa
+period: 2026-01
+
+outputs:
+  - mn_msa_living_alone_standard_applies
+  - mn_msa_assistance_standard_amount
+  - mn_msa_personal_needs_allowance_amount
+
+acknowledged_incomplete:
+  - mn_msa_living_alone_standard_applies
+  - mn_msa_assistance_standard_amount
+  - mn_msa_personal_needs_allowance_amount
+
+scope:
+  state:
+    - policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026
+
+transformations:
+  - pattern: derived_formula
+    name: mn_msa_living_alone_standard_applies
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: axiom-programs/us-mn/msa/fy-2026 living-alone standard bridge
+    formula: msa_living_alone_standard_applies
+
+  - pattern: derived_formula
+    name: mn_msa_assistance_standard_amount
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/msa/fy-2026 assistance standard bridge
+    formula: mn_msa_assistance_standard
+
+  - pattern: derived_formula
+    name: mn_msa_personal_needs_allowance_amount
+    effective_from: '2026-01-01'
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: axiom-programs/us-mn/msa/fy-2026 personal needs allowance bridge
+    formula: msa_personal_needs_allowance


### PR DESCRIPTION
## Summary
- adds the FY 2026 Minnesota Supplemental Aid program wrapper
- exposes the encoded MSA living-alone standard, assistance standard, and personal-needs allowance outputs
- signs the program wrapper with a manual composition manifest

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-mn-msa --base-ref origin/main --head-ref HEAD --roots programs`
- `axiom-encode test --root /tmp/rulespec-us-mn-msa us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.test.yaml` -> 1 file, 9 cases
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-mn-msa` -> 18 passed, 1 warning
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/rulespec-us-pr795-compose-venv/bin/python tools/build_program_artifacts.py --dist /tmp/program-artifacts-mn-msa-signed` -> built 33/33 programs; `us-mn-msa.compiled.json` 5d

## Validation note
- Strict leaf validation for `us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml` still fails the existing numeric-source verifier requirement for materialized `source_verification` text, even though the proof atoms, companion tests, and program artifact compile pass. This PR only composes the existing encoded leaf into a program wrapper.

/cycle