### PR TITLE
Encode Oregon SNAP utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/utility-allowances/page-259.json
+++ b/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/utility-allowances/page-259.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-or/policies/odhs/open/snap/utility-allowances/page-259.test.yaml",
+      "sha256": "14ab647e419aaec81ac9d383ea4c11f54fbd7031d525a8866d70b441c825f8fc"
+    },
+    {
+      "path": "us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml",
+      "sha256": "fbf63811a4d37af9217b33c34f3478bed2abf7d3e9f7372376dce983161f305d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-or:policies/odhs/open/snap/utility-allowances/page-259",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T19:49:58.677703+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphwk18x_m/sign-applied-files/us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphwk18x_m",
+  "generated_output_sha256": "fbf63811a4d37af9217b33c34f3478bed2abf7d3e9f7372376dce983161f305d",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a8a1e8f6f8c34c516409caed24d290e8b7e7d308f97eea6518653c50c00e8f07"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/utility-allowances/page-260.json
+++ b/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/utility-allowances/page-260.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-or/policies/odhs/open/snap/utility-allowances/page-260.test.yaml",
+      "sha256": "21c20caa2c4cf965fb49f990f3f2a7d428ec52010841fcd0a0546edc04432ae5"
+    },
+    {
+      "path": "us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml",
+      "sha256": "71c2b128f2b290e5cc7af04ca3b6addda2c1be7d094a61ffdbb558a05bf70bf6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-or:policies/odhs/open/snap/utility-allowances/page-260",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T19:49:58.679044+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphwk18x_m/sign-applied-files/us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphwk18x_m",
+  "generated_output_sha256": "71c2b128f2b290e5cc7af04ca3b6addda2c1be7d094a61ffdbb558a05bf70bf6",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2c55672a6a3d2cecb5cf34710abe41b4dd9448e4f1b1ef22c82d3beab65196b6"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18074,6 +18074,24 @@
         ]
       }
     ],
+    "us-or/manual/odhs/open/page-259": [
+      {
+        "module": "us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-or/manual/odhs/open/page-260": [
+      {
+        "module": "us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-or/statute/315.264": [
       {
         "module": "us-or/statutes/315/264.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 689
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1230,6 +1230,39 @@ entries:
   - legal_id: us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
     source: bulk
     since: 2026-07-08
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-259#allowable_utility_expense
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-259#full_utility_allowance_applies
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-259#wood_heat_cost_allowed
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#energy_assistance_lookback_months_for_full_utility_allowance
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#full_utility_allowance_special_case_applies
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#individual_utility_allowance_applies
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#limited_utility_allowance_applies
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#limited_utility_allowance_minimum_non_heating_expense_count
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#minimum_energy_assistance_payment_for_full_utility_allowance
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#telephone_expense_count_limit_for_limited_utility_allowance
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-or:policies/odhs/open/snap/utility-allowances/page-260#telephone_utility_allowance_applies
+    source: bulk
+    since: 2026-07-10
   - legal_id: us-ri:statutes/44-30-103#child_for_rebate
     source: bulk
     since: 2026-07-08

--- a/us-or/policies/odhs/open/snap/utility-allowances/page-259.test.yaml
+++ b/us-or/policies/odhs/open/snap/utility-allowances/page-259.test.yaml
@@ -1,0 +1,58 @@
+- name: full utility allowance applies when all FUA conditions hold
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_responsible_for_payment_of_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_identified_separate_cost: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_allowable_type: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_incurs_heating_or_cooling_cost_on_regular_basis
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_out_of_pocket_heating_or_cooling_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_separate_from_rent: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_based_on_individual_usage_or_flat_rate
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_not_portable_home_fan: true
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#allowable_utility_expense: holds
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#full_utility_allowance_applies: holds
+- name: utility expense included in rent without separate identification is not allowable
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_responsible_for_payment_of_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_identified_separate_cost: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_allowable_type: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_incurs_heating_or_cooling_cost_on_regular_basis
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_out_of_pocket_heating_or_cooling_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_separate_from_rent: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_based_on_individual_usage_or_flat_rate
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_not_portable_home_fan: true
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#allowable_utility_expense: not_holds
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#full_utility_allowance_applies: not_holds
+- name: portable home fan cooling cost does not support FUA
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_responsible_for_payment_of_utility_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_identified_separate_cost: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.utility_expense_is_allowable_type: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_incurs_heating_or_cooling_cost_on_regular_basis
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_has_out_of_pocket_heating_or_cooling_expense: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_separate_from_rent: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_based_on_individual_usage_or_flat_rate
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.heating_or_cooling_expense_is_not_portable_home_fan: false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#full_utility_allowance_applies: not_holds
+- name: purchased wood heat allowed but cutting permit or truck gas is not
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#input.filing_group_purchases_wood_for_heat: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-259#input.wood_heat_cost_is_cutting_permit_truck_gas_chainsaw_or_similar
+    : false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-259#wood_heat_cost_allowed: holds

--- a/us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml
+++ b/us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml
@@ -1,0 +1,89 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/manual/odhs/open/page-259
+    upstream_source_check:
+      status: no_higher_authority_found
+      checked_paths:
+        - us:regulations/7/273/9/d/6/iii
+      rationale: The copied context records a higher-authority check for the federal SNAP utility-allowance delegation but provides no higher-authority source text or executable target. This Oregon OPEN manual page is therefore used for the Oregon filing-group utility-expense and FUA conditions it states.
+  summary: |-
+    "The filing group must be responsible for payment of the utility expense." "Utility expenses that are included in rent without being identified as separate costs cannot be considered." "To be eligible for FUA, the filing group must incur the cost on a regular basis for its heating and cooling expenses."
+  deferred_outputs:
+    - output: us-or:policies/odhs/open/snap/utility-allowances/page-259#snap_standard_utility_allowance
+      reason: The source states that applicants with allowable expenses receive one of four standard utility allowances, but this page does not state the allowance amounts or the full selector for all four allowance levels.
+rules:
+  - name: allowable_utility_expense
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-or/manual/odhs/open/page-259, Allowable Utility Expenses
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          filing_group_has_utility_expense
+          and filing_group_responsible_for_payment_of_utility_expense
+          and utility_expense_is_identified_separate_cost
+          and utility_expense_is_allowable_type
+  - name: full_utility_allowance_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-or/manual/odhs/open/page-259, Utility Allowances - Full utility allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          allowable_utility_expense
+          and filing_group_incurs_heating_or_cooling_cost_on_regular_basis
+          and filing_group_has_out_of_pocket_heating_or_cooling_expense
+          and heating_or_cooling_expense_is_separate_from_rent
+          and heating_or_cooling_expense_is_based_on_individual_usage_or_flat_rate
+          and heating_or_cooling_expense_is_not_portable_home_fan
+  - name: wood_heat_cost_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-or/manual/odhs/open/page-259, Utility Allowances - wood heat
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-259
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          filing_group_purchases_wood_for_heat
+          and not wood_heat_cost_is_cutting_permit_truck_gas_chainsaw_or_similar

--- a/us-or/policies/odhs/open/snap/utility-allowances/page-260.test.yaml
+++ b/us-or/policies/odhs/open/snap/utility-allowances/page-260.test.yaml
@@ -1,0 +1,112 @@
+- name: fua_hud_balance_and_lua_two_expenses_apply
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_hud_utility_reimbursement: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_responsible_for_balance_of_utility_bill: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_energy_assistance_payments_received_per_year: 0
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.months_since_filing_group_received_energy_assistance: 13
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_includes_elderly_or_disabled_member: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_shares_dwelling_and_utility_expenses_with_another_group
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_share_of_heating_expenses: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_is_only_source_of_heat: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_uses_cooking_stove_or_electric_blanket_as_heat_source
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_supplements_main_heat_source: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_charged_flat_rent_and_utilities_without_separate_heating_or_cooling_expenses
+    : false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.allowable_non_heating_utility_expense_count_excluding_telephone
+    : 1
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_for_telephone_or_prepaid_cell_phone: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_for_landline_cell_phone_or_internet_phone_service
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_for_prepaid_phone_card: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.prepaid_phone_card_is_associated_with_specific_device: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.prepaid_phone_card_is_ongoing_monthly_cost: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_additional_utility_expenses: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_is_billed_regularly_for_allowable_non_heating_cost
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_only_non_heating_cost_is_telephone: false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#full_utility_allowance_special_case_applies: holds
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#limited_utility_allowance_applies: holds
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#telephone_utility_allowance_applies: not_holds
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#individual_utility_allowance_applies: holds
+- name: cooking_stove_or_electric_blanket_blocks_fua
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_hud_utility_reimbursement: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_responsible_for_balance_of_utility_bill: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_energy_assistance_payments_received_per_year: 0
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.months_since_filing_group_received_energy_assistance: 13
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_includes_elderly_or_disabled_member: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_shares_dwelling_and_utility_expenses_with_another_group
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_share_of_heating_expenses: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_is_only_source_of_heat: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_uses_cooking_stove_or_electric_blanket_as_heat_source
+    : true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_supplements_main_heat_source: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_charged_flat_rent_and_utilities_without_separate_heating_or_cooling_expenses
+    : false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#full_utility_allowance_special_case_applies: not_holds
+- name: supplemental_space_heater_blocks_fua
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_hud_utility_reimbursement: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_responsible_for_balance_of_utility_bill: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_energy_assistance_payments_received_per_year: 0
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.months_since_filing_group_received_energy_assistance: 13
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_includes_elderly_or_disabled_member: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_shares_dwelling_and_utility_expenses_with_another_group
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_share_of_heating_expenses: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_is_only_source_of_heat: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_uses_cooking_stove_or_electric_blanket_as_heat_source
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_supplements_main_heat_source: true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_charged_flat_rent_and_utilities_without_separate_heating_or_cooling_expenses
+    : false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#full_utility_allowance_special_case_applies: not_holds
+- name: flat_rent_and_utilities_blocks_fua
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_hud_utility_reimbursement: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_responsible_for_balance_of_utility_bill: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_energy_assistance_payments_received_per_year: 0
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.months_since_filing_group_received_energy_assistance: 13
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_includes_elderly_or_disabled_member: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_shares_dwelling_and_utility_expenses_with_another_group
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_share_of_heating_expenses: false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_is_only_source_of_heat: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_uses_cooking_stove_or_electric_blanket_as_heat_source
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.space_heater_or_heating_stove_supplements_main_heat_source: false
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_charged_flat_rent_and_utilities_without_separate_heating_or_cooling_expenses
+    : true
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#full_utility_allowance_special_case_applies: not_holds
+- name: telephone_allowance_for_prepaid_phone_card_without_other_utilities
+  period: 2026-04
+  input:
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_for_landline_cell_phone_or_internet_phone_service
+    : false
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_pays_for_prepaid_phone_card: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.prepaid_phone_card_is_associated_with_specific_device: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.prepaid_phone_card_is_ongoing_monthly_cost: true
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_has_additional_utility_expenses: false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#telephone_utility_allowance_applies: holds
+- name: individual_allowance_for_one_regular_non_heating_nontelephone_cost
+  period: 2026-04
+  input:
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_is_billed_regularly_for_allowable_non_heating_cost
+    : true
+    ? us-or:policies/odhs/open/snap/utility-allowances/page-260#input.allowable_non_heating_utility_expense_count_excluding_telephone
+    : 1
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#input.filing_group_only_non_heating_cost_is_telephone: false
+  output:
+    us-or:policies/odhs/open/snap/utility-allowances/page-260#individual_utility_allowance_applies: holds

--- a/us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml
+++ b/us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml
@@ -1,0 +1,231 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/manual/odhs/open/page-260
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: 7 CFR 273.9(d)(6)(iii) provides the federal SNAP utility-allowance delegation and minimum conditions; this Oregon OPEN manual page supplies Oregon's operative FUA, LUA, TUA, and IUA implementation conditions.
+  summary: |-
+    Filing groups may receive FUA for HUD utility reimbursement balances, qualifying energy assistance, shared heating expenses, or a space heater/stove used as the only heat source, with exclusions for cooking stoves, electric blankets, supplemental heat, and flat rent-and-utilities charges without separately identified heating/cooling. LUA applies with at least two allowable non-heating utility expenses, counting no more than one telephone cost. TUA applies for telephone or prepaid cell phone costs with no additional utilities. IUA applies for one regular allowable non-heating cost that is not telephone.
+rules:
+  - name: minimum_energy_assistance_payment_for_full_utility_allowance
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), energy assistance FUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+              excerpt: "must be at least $20 per year"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          20
+
+  - name: energy_assistance_lookback_months_for_full_utility_allowance
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), energy assistance FUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+              excerpt: "in the month of the filing date or the previous 12 months"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          12
+
+  - name: limited_utility_allowance_minimum_non_heating_expense_count
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), LUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+              excerpt: "at least two allowable non-heating utility expenses"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          2
+
+  - name: telephone_expense_count_limit_for_limited_utility_allowance
+    kind: parameter
+    dtype: Count
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), LUA telephone-counting rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+              excerpt: "One cost may be for a telephone. More than one phone does not count as more than one utility expense."
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          1
+
+  - name: full_utility_allowance_special_case_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), FUA special-case and exclusion rules
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/utility-allowances/page-260#minimum_energy_assistance_payment_for_full_utility_allowance
+              output: minimum_energy_assistance_payment_for_full_utility_allowance
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/utility-allowances/page-260#energy_assistance_lookback_months_for_full_utility_allowance
+              output: energy_assistance_lookback_months_for_full_utility_allowance
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          (
+            (
+              filing_group_has_hud_utility_reimbursement
+              and filing_group_responsible_for_balance_of_utility_bill
+            )
+            or (
+              filing_group_energy_assistance_payments_received_per_year >= minimum_energy_assistance_payment_for_full_utility_allowance
+              and months_since_filing_group_received_energy_assistance <= energy_assistance_lookback_months_for_full_utility_allowance
+              and (
+                filing_group_includes_elderly_or_disabled_member
+                or filing_group_responsible_for_balance_of_utility_bill
+              )
+            )
+            or (
+              filing_group_shares_dwelling_and_utility_expenses_with_another_group
+              and filing_group_pays_share_of_heating_expenses
+            )
+            or space_heater_or_heating_stove_is_only_source_of_heat
+          )
+          and not filing_group_uses_cooking_stove_or_electric_blanket_as_heat_source
+          and not space_heater_or_heating_stove_supplements_main_heat_source
+          and not filing_group_charged_flat_rent_and_utilities_without_separate_heating_or_cooling_expenses
+
+  - name: limited_utility_allowance_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), LUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/utility-allowances/page-260#limited_utility_allowance_minimum_non_heating_expense_count
+              output: limited_utility_allowance_minimum_non_heating_expense_count
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/utility-allowances/page-260#telephone_expense_count_limit_for_limited_utility_allowance
+              output: telephone_expense_count_limit_for_limited_utility_allowance
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          allowable_non_heating_utility_expense_count_excluding_telephone
+          >= limited_utility_allowance_minimum_non_heating_expense_count
+          or (
+            filing_group_pays_for_telephone_or_prepaid_cell_phone
+            and allowable_non_heating_utility_expense_count_excluding_telephone
+            >= telephone_expense_count_limit_for_limited_utility_allowance
+          )
+
+  - name: telephone_utility_allowance_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), TUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          (
+            filing_group_pays_for_landline_cell_phone_or_internet_phone_service
+            or (
+              filing_group_pays_for_prepaid_phone_card
+              and prepaid_phone_card_is_associated_with_specific_device
+              and prepaid_phone_card_is_ongoing_monthly_cost
+            )
+          )
+          and not filing_group_has_additional_utility_expenses
+
+  - name: individual_utility_allowance_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: ODHS OPEN SNAP utility allowances, page 260 (04/2026), IUA rule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-260
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          filing_group_is_billed_regularly_for_allowable_non_heating_cost
+          and allowable_non_heating_utility_expense_count_excluding_telephone == 1
+          and not filing_group_only_non_heating_cost_is_telephone


### PR DESCRIPTION
## Summary
- encodes Oregon OPEN SNAP utility allowance pages 259-260 from the local Axiom Corpus
- adds Household-level rules for allowable utility expenses, FUA conditions/special cases, LUA, TUA, and IUA applicability
- adds 10 companion test cases and reverse-index entries for the two Oregon corpus pages
- signs the applied files with encoder apply manifests; page 260 uses a deterministic repair manifest path after the generated candidate needed metadata/formula cleanup

## Checks
- `axiom-encode guard-generated --repo /tmp/rulespec-us-or-snap-utility --base-ref origin/main --head-ref HEAD`
- `axiom-encode validate --skip-reviewers us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml`
- `axiom-encode proof-validate us-or/policies/odhs/open/snap/utility-allowances/page-259.yaml us-or/policies/odhs/open/snap/utility-allowances/page-260.yaml` -> 21 atoms checked
- `axiom-encode test --root /tmp/rulespec-us-or-snap-utility us-or/policies/odhs/open/snap/utility-allowances/page-259.test.yaml us-or/policies/odhs/open/snap/utility-allowances/page-260.test.yaml` -> 2 files, 10 cases
- `python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json` after committing generated index
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-or-snap-utility` -> 18 passed, 1 warning

## Notes
- The CI-equivalent deterministic validator passes. Full reviewer-mode validation for page 260 still scores low without a specific deterministic CI issue, so this PR records the generated/repaired path explicitly rather than claiming reviewer-mode readiness for that page.
- This starts Oregon SNAP source-backed coverage; it is not yet a full Oregon SNAP program wrapper because OPEN pages 259-260 cover utility allowance applicability, not full benefit/allotment computation.

/cycle