### PR TITLE
Encode Utah SNAP utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.json
+++ b/.axiom/encoding-manifests/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.test.yaml",
+      "sha256": "99584b3646b704b3b2db84e42fa92165f990348764fc34eb397bf94fc6633224"
+    },
+    {
+      "path": "us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml",
+      "sha256": "43ac2fc5f109e56b129665ec08ce7edb8460bdeeed0db7c8ad6dcb260afe022c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T20:02:03.549573+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpuioph5z8/sign-applied-files/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpuioph5z8",
+  "generated_output_sha256": "43ac2fc5f109e56b129665ec08ce7edb8460bdeeed0db7c8ad6dcb260afe022c",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "85c2446cb609f747d6a788237c852d54fde276e6be81b5263f949e8df1045eb1"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -22876,6 +22876,15 @@
         ]
       }
     ],
+    "us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6": [
+      {
+        "module": "us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-1-financial-monthly-income-limits-/block-2": [
       {
         "module": "us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 683
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -1260,6 +1260,21 @@ entries:
   - legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
     source: bulk
     since: 2026-07-08
+  - legal_id: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#local_snap_utility_allowance_for_shelter_costs
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_standard_utility_allowance_amount
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_standard_utility_allowance_state_value
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_telephone_only_allowance_amount
+    source: bulk
+    since: 2026-07-10
+  - legal_id: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_without_heating_cooling_allowance_amount
+    source: bulk
+    since: 2026-07-10
   - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
     source: bulk
     since: 2026-07-08

--- a/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.test.yaml
+++ b/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.test.yaml
@@ -1,0 +1,123 @@
+- name: heating_or_cooling_expense_gets_sua
+  period: 2026-01
+  input:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage
+    : true
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_heating_or_cooling
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_utility_expense_other_than_heating_cooling_or_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_other_utilities_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_only_utility_expense_is_telephone
+    : false
+  output:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#local_snap_utility_allowance_for_shelter_costs
+    : 514
+- name: other_utility_without_heating_or_cooling_gets_woha
+  period: 2026-01
+  input:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_heating_or_cooling
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_utility_expense_other_than_heating_cooling_or_telephone
+    : true
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_other_utilities_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_only_utility_expense_is_telephone
+    : false
+  output:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#local_snap_utility_allowance_for_shelter_costs
+    : 420
+- name: telephone_only_gets_toa
+  period: 2026-01
+  input:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_heating_or_cooling
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_utility_expense_other_than_heating_cooling_or_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_other_utilities_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_only_utility_expense_is_telephone
+    : true
+  output:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#local_snap_utility_allowance_for_shelter_costs
+    : 57
+- name: no_utility_expense_gets_zero
+  period: 2026-01
+  input:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_heating_or_cooling
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_utility_expense_other_than_heating_cooling_or_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_other_utilities_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_only_utility_expense_is_telephone
+    : false
+  output:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#local_snap_utility_allowance_for_shelter_costs
+    : 0
+- name: auto_output_snap_standard_utility_allowance_state_value
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_only_utility_expense_is_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_heating_or_cooling
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_flat_utility_charge_for_other_utilities_besides_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_pays_utility_expense_other_than_heating_cooling_or_telephone
+    : false
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#input.household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount
+    : false
+  output:
+    ? us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_standard_utility_allowance_state_value
+    : 514

--- a/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml
+++ b/us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml
@@ -1,0 +1,152 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+      - us:regulations/7-cfr/273/9
+      - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: Federal SNAP regulations delegate standard utility allowance administration
+        to state agencies. This Utah DWS manual source supplies the operative Utah
+        monthly allowance amounts and state-specific eligibility branches for the
+        encoded utility allowance.
+  summary: '"If the household has a utility expense, the household is allowed one
+    of the following standard utility allowances: 1) Standard Utility Allowance (SUA),
+    2) Without Heating Allowance (WOHA), or 3) Telephone Only Allowance (TOA)." SUA
+    is "$514 each month" for heating or cooling costs; WOHA is "$420 each month" when
+    the household has no heating or cooling cost but pays other listed utilities;
+    TOA is "$57" when the only utility expense is telephone, including mobile phone.'
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Utah DWS Eligibility Manual 442-6, Utility costs, Standard Utility Allowance
+- name: snap_standard_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_standard_utility_allowance_amount
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ut:policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6#snap_standard_utility_allowance_amount
+          output: snap_standard_utility_allowance_amount
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Utah DWS Eligibility Manual 442-6, Utility costs, Standard Utility Allowance
+- name: snap_standard_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Utah DWS Eligibility Manual 442-6, Utility costs, Standard Utility Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: The amount of the SUA is $514 each month.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '514'
+- name: snap_without_heating_cooling_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Utah DWS Eligibility Manual 442-6, Utility costs, Without Heating/Cooling
+    Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: The amount of the WOHA is $420 each month.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '420'
+- name: snap_telephone_only_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Utah DWS Eligibility Manual 442-6, Utility costs, Telephone Only Allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: the household is eligible for a $57 telephone deduction.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '57'
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+  source: Utah DWS Eligibility Manual 442-6, Utility costs
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: eligible for the SUA when the household has a heating or cooling
+            cost
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: does not have a heating or cooling cost, but pays some utilities
+            including electricity, garbage, sewer, and water
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: If the only utility expense the household has is the telephone
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm/block-6
+          excerpt: $514 each month; $420 each month; $57 telephone deduction
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "if household_has_heating_or_cooling_expense_separate_from_rent_or_mortgage\
+      \ or household_has_qualified_elderly_or_disabled_eligible_member_and_received_heat_payment_current_heat_year\
+      \ or household_receives_hud_utility_allowance_and_utility_bills_exceed_reimbursement_amount\
+      \ or household_pays_flat_utility_charge_for_heating_or_cooling or condominium_or_homeowner_fee_contains_identifiable_heating_or_cooling_utility_charge:\n\
+      \  snap_standard_utility_allowance_amount\nelse:\n  if household_pays_utility_expense_other_than_heating_cooling_or_telephone\
+      \ or household_pays_flat_utility_charge_for_other_utilities_besides_telephone\
+      \ or condominium_or_homeowner_fee_contains_identifiable_other_utility_charge_besides_telephone:\n\
+      \    snap_without_heating_cooling_allowance_amount\n  else:\n    if household_only_utility_expense_is_telephone:\n\
+      \      snap_telephone_only_allowance_amount\n    else:\n      0"
+imports:
+- us:regulations/7-cfr/273/9


### PR DESCRIPTION
## Summary\n- encode Utah DWS SNAP utility allowance rules for SUA, WOHA, and TOA from Eligibility Manual 442-6\n- add companion tests covering SUA, WOHA, TOA, zero-utility, and exported state-value behavior\n- add signed encoder manifest and reverse-index entry\n\n## Checks\n- axiom-encode guard-generated --repo /tmp/rulespec-us-ut-snap-utility --base-ref origin/main --head-ref HEAD\n- axiom-encode validate --skip-reviewers us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml\n- axiom-encode proof-validate us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.yaml\n- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ut-snap-utility us-ut/policies/dws/eligibility-manual/442-6-shelter-cost-deduction-snap/block-6.test.yaml\n- python tests/generate_reverse_index.py\n- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ut-snap-utility\n\n## Cycle\n- Local focused checks are clean; requesting independent cycle review after PR creation.