### PR TITLE
Encode Wisconsin SNAP utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.json
+++ b/.axiom/encoding-manifests/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.test.yaml",
+      "sha256": "7ced082d25bd4c607c02c19ed4a7226739d269c1671bb2fb3e45a0018bcd0947"
+    },
+    {
+      "path": "us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml",
+      "sha256": "e8532519559a70b31e29f8d3943feb5501d3c1a10f88b3f4f71cb5d83e00e61f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T20:50:17.505088+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpw7k3ykm4/sign-applied-files/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpw7k3ykm4",
+  "generated_output_sha256": "e8532519559a70b31e29f8d3943feb5501d3c1a10f88b3f4f71cb5d83e00e61f",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c609b35eeccb553a19cbaab1440939d241e1136248b232afd696ec524f60061a"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-10T20:48:07.267460+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "af0c58532c686b3128016e499921e5046dfe6d13ec7d6beec6c7f9f280d252c2",
+    "prior_signature": "81ec502e2f776e7b733fd136baef3eec5a1da50bdc82d7c456d2a231a4669c5a",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -23072,6 +23072,15 @@
         ]
       }
     ],
+    "us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360": [
+      {
+        "module": "us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wv/statute/11-21-10": [
       {
         "module": "us-wv/statutes/11-21-10.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 689
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -219,6 +219,39 @@ entries:
   - legal_id: us-ia:statutes/422/12#tuition_credit_rate
     source: bulk
     since: 2026-07-08
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#cooking_fuel_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#electric_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#garbage_and_trash_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#heating_standard_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#limited_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#local_snap_utility_allowance_for_shelter_costs
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#phone_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_individual_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_limited_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_standard_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#water_and_sewer_utility_allowance
+    source: manual
+    since: 2026-07-10
   - legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
     source: bulk
     since: 2026-07-08

--- a/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.test.yaml
+++ b/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.test.yaml
@@ -1,0 +1,69 @@
+- name: heating_standard_utility_allowance_applies_when_heating_or_cooling_standard_available
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 1
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_electric_utility_cost: false
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_water_and_sewer_utility_cost
+    : false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_cooking_fuel_utility_cost: false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_phone_utility_cost: false
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_garbage_and_trash_utility_cost
+    : false
+  output:
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_standard_utility_allowance_state_value: 553
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#local_snap_utility_allowance_for_shelter_costs: 553
+- name: limited_utility_allowance_applies_when_limited_utility_count_meets_minimum
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_electric_utility_cost: true
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_water_and_sewer_utility_cost
+    : false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_cooking_fuel_utility_cost: false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_phone_utility_cost: true
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_garbage_and_trash_utility_cost
+    : false
+  output:
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_limited_utility_allowance_state_value: 385
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#local_snap_utility_allowance_for_shelter_costs: 385
+- name: individual_utility_allowances_sum_when_no_heating_or_limited_allowance_applies
+  period: 2025-10
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 1
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_electric_utility_cost: true
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_water_and_sewer_utility_cost
+    : false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_cooking_fuel_utility_cost: false
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_phone_utility_cost: true
+    ? us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#input.household_has_garbage_and_trash_utility_cost
+    : true
+  output:
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_individual_utility_allowance_state_value: 31
+    us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#local_snap_utility_allowance_for_shelter_costs: 214

--- a/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml
+++ b/us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml
@@ -1,0 +1,294 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+      - us:regulations/7-cfr/273/9
+      - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: Federal SNAP regulations delegate state standard utility allowance
+        amounts and availability mechanics to state agency standards. This Wisconsin
+        FoodShare Handbook appendix is the state parameter source that sets the operative
+        Wisconsin monthly utility allowance amounts effective October 1, 2025.
+  summary: '"8.1.3 Deductions Effective October 1, 2025." Utility Allowances: HSUA
+    $553; LUA $385; EUA $155; WUA $106; FUA $48; PUA $31; TUA $28.'
+imports:
+- us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available
+- us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count
+- us:regulations/7-cfr/273/9
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, HSUA
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_limited_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, LUA
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, PUA
+- name: snap_standard_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: heating_standard_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#heating_standard_utility_allowance
+          output: heating_standard_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, HSUA
+- name: snap_limited_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: limited_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#limited_utility_allowance
+          output: limited_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, LUA
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: phone_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-wi:policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360#phone_utility_allowance
+          output: phone_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, PUA
+- name: heating_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, HSUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: HSUA (Heating Standard Utility Allowance) $553
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '553'
+- name: limited_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, LUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: LUA (Limited Utility Allowance) $385
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '385'
+- name: electric_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, EUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: EUA (Electric Utility Allowance) $155
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '155'
+- name: water_and_sewer_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, WUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: WUA (Water and Sewer Utility Allowance) $106
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '106'
+- name: cooking_fuel_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, FUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: FUA (Cooking Fuel Allowance) $48
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '48'
+- name: phone_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, PUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: PUA (Phone Utility Allowance) $31
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '31'
+- name: garbage_and_trash_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances, TUA
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: TUA (Garbage and Trash Utility Allowance) $28
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Effective October 1, 2025
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '28'
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: FoodShare Handbook Appendix 360, 8.1.3 Utility Allowances
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-wi/manual/dhs/foodshare/handbook/release-26-01/page-360
+          excerpt: Utility Allowances HSUA ... $553 ... LUA ... $385 ... EUA ... $155
+            ... WUA ... $106 ... FUA ... $48 ... PUA ... $31 ... TUA ... $28
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available
+          output: snap_standard_with_heating_or_cooling_component_available
+          hash: sha256:80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count
+          output: snap_limited_utility_allowance_meets_minimum_utility_count
+          hash: sha256:80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_standard_with_heating_or_cooling_component_available: heating_standard_utility_allowance
+      else: if snap_limited_utility_allowance_meets_minimum_utility_count: limited_utility_allowance
+      else: (if household_has_electric_utility_cost: electric_utility_allowance else:
+      0) + (if household_has_water_and_sewer_utility_cost: water_and_sewer_utility_allowance
+      else: 0) + (if household_has_cooking_fuel_utility_cost: cooking_fuel_allowance
+      else: 0) + (if household_has_phone_utility_cost: phone_utility_allowance else:
+      0) + (if household_has_garbage_and_trash_utility_cost: garbage_and_trash_utility_allowance
+      else: 0)'


### PR DESCRIPTION
## Summary
- encode Wisconsin FoodShare SNAP utility allowance amounts effective October 1, 2025
- add companion tests for HSUA, LUA, and individual utility allowance branches
- declare new Wisconsin SNAP utility outputs as oracle-coverage pending classification

## Checks
- axiom-encode validate --skip-reviewers us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml
- axiom-encode proof-validate us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-wi-snap-utility us-wi/policies/dhs/foodshare/handbook/deductions/utility-allowances/page-360.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-wi-snap-utility --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-wi-snap-utility
- axiom-encode oracle-coverage --root /tmp/wi-coverage-root --json

## Review cycle
- pending /cycle independent review
