### PR TITLE
Encode Pennsylvania SNAP excess shelter cap

### DIFF
--- a/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.json
+++ b/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.test.yaml",
+      "sha256": "a708b5710a965b999b135b2d34007a87dd6a13fb2494206f7a2759b4cc8b8e22"
+    },
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml",
+      "sha256": "de920c1aafadcc7399857bc860e9370f7e5586e72ea50b8b752b1ea32d246de5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T20:58:41.210218+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpz_lavmtt/sign-applied-files/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpz_lavmtt",
+  "generated_output_sha256": "de920c1aafadcc7399857bc860e9370f7e5586e72ea50b8b752b1ea32d246de5",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "574f7dda548b80a8c1f8663e61206e679881f7563e7cf50639be6db0cb0a8707"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18101,6 +18101,15 @@
         ]
       }
     ],
+    "us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1": [
+      {
+        "module": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ri/statute/44-30-103": [
       {
         "module": "us-ri/statutes/44-30-103.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 680
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -219,6 +219,12 @@ entries:
   - legal_id: us-ia:statutes/422/12#tuition_credit_rate
     source: bulk
     since: 2026-07-08
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_excess_shelter_expense_deduction
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_maximum_excess_shelter_expense_deduction
+    source: manual
+    since: 2026-07-10
   - legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
     source: bulk
     since: 2026-07-08

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.test.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.test.yaml
@@ -1,0 +1,16 @@
+- name: capped_excess_shelter_deduction
+  period: 2026-01
+  input:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#input.snap_excess_shelter_expenses_before_cap: 900
+  output:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_maximum_excess_shelter_expense_deduction: 744
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_excess_shelter_expense_deduction: 744
+- name: full_excess_shelter_deduction_for_elderly_or_disabled_household
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#input.snap_excess_shelter_expenses_before_cap: 900
+  output:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_maximum_excess_shelter_expense_deduction: 744
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/fy-2026#snap_excess_shelter_expense_deduction: 900

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml
@@ -1,0 +1,60 @@
+format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+      rationale: The Pennsylvania appendix states the FY 2026 excess shelter amount while citing 7 CFR 273.9(d)(3); the local manual table is used for the Pennsylvania source slice and the federal regulation context supplies the unlimited-excess-shelter applicability condition.
+  summary: |-
+    Excess Shelter 7 CFR 273.9(d)(3) ... $744.
+rules:
+  - name: snap_maximum_excess_shelter_expense_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Appendix A FY 2026 SNAP income deductions table, Excess Shelter column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+              excerpt: "Excess Shelter ... $744"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          744
+
+  - name: snap_excess_shelter_expense_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: Appendix A FY 2026 SNAP income deductions table, Excess Shelter column; 7 CFR 273.9(d)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+              excerpt: "Excess Shelter ... $744"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
+              output: snap_full_excess_shelter_deduction_applies
+              hash: sha256:76dd530624a00c5199f27bd4ec3ce866cd89e897fd7332b368164cf58f222b9f
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_full_excess_shelter_deduction_applies: max(0, snap_excess_shelter_expenses_before_cap) else: min(max(0, snap_excess_shelter_expenses_before_cap), snap_maximum_excess_shelter_expense_deduction)


### PR DESCRIPTION
## Summary
- encode Pennsylvania SNAP FY 2026 maximum excess shelter expense deduction from Appendix A
- add companion tests for capped and full elderly/disabled excess shelter branches
- declare new Pennsylvania outputs as oracle-coverage pending classification

## Checks
- axiom-encode validate --skip-reviewers us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml
- axiom-encode proof-validate us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-pa-snap-appendix-a us-pa/policies/dhs/snap/560-income-deductions/appendix-a/fy-2026.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-pa-snap-appendix-a --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-pa-snap-appendix-a
- axiom-encode oracle-coverage --root /tmp/pa-coverage-root --json

## Review cycle
- pending /cycle independent review
