### PR TITLE
Encode Pennsylvania SNAP standard deduction

### DIFF
--- a/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.json
+++ b/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.test.yaml",
+      "sha256": "7f9cf0b6edcba10e723f7dfce92299ecc3c1e90266f1e3496745ea8f9cb12aa7"
+    },
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml",
+      "sha256": "7ef3442e0534bfcd5e5add32cfe0ffe20a3db11431fbc96cff7f7af9152daf03"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T21:05:18.799741+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwe9edmvg/sign-applied-files/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwe9edmvg",
+  "generated_output_sha256": "7ef3442e0534bfcd5e5add32cfe0ffe20a3db11431fbc96cff7f7af9152daf03",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4fc34c445696992204ed15a0a7a01c028b1ec7b375a055a51ce3d5c4660ea366"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18101,6 +18101,15 @@
         ]
       }
     ],
+    "us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1": [
+      {
+        "module": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ri/statute/44-30-103": [
       {
         "module": "us-ri/statutes/44-30-103.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 681
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -219,6 +219,15 @@ entries:
   - legal_id: us-ia:statutes/422/12#tuition_credit_rate
     source: bulk
     since: 2026-07-08
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction_household_size_six_or_more_key
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction_table
+    source: manual
+    since: 2026-07-10
   - legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
     source: bulk
     since: 2026-07-08

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.test.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.test.yaml
@@ -1,0 +1,18 @@
+- name: household_size_three_standard_deduction
+  period: 2025-10
+  input:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#input.household_size: 3
+  output:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction: 209
+- name: household_size_four_standard_deduction
+  period: 2025-10
+  input:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#input.household_size: 4
+  output:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction: 223
+- name: household_size_seven_uses_six_or_more_row
+  period: 2025-10
+  input:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#input.household_size: 7
+  output:
+    us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026#snap_standard_deduction: 299

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml
@@ -1,0 +1,85 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:policies/usda/snap/fy-2026-cola/deductions
+      rationale: >-
+        The Pennsylvania manual appendix supplies the FY 2026 Pennsylvania
+        SNAP deduction table values for the 48-state standard deduction
+        surface. Federal regulation context supplies the deduction framework,
+        and USDA FY 2026 COLA context supplies matching 48-state values, but
+        this state manual slice is the requested source for the local encoded
+        table.
+  summary: |-
+    Standard deduction table: households of 1-3 have $209, 4 have $223, 5 have $261, and 6+ have $299.
+rules:
+  - name: snap_standard_deduction_household_size_six_or_more_key
+    kind: parameter
+    dtype: Count
+    source: PA DHS SNAP 560 Appendix A FY 2026, standard deduction row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+              excerpt: "6+ $299"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          6
+
+  - name: snap_standard_deduction_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    source: PA DHS SNAP 560 Appendix A FY 2026, standard deduction table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+              excerpt: "1-3 $209 ... 4 $223 5 $261 6+ $299"
+              table:
+                header: Standard
+                row_key: household_size
+                column_key: standard_deduction
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 209
+          2: 209
+          3: 209
+          4: 223
+          5: 261
+          6: 299
+
+  - name: snap_standard_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: PA DHS SNAP 560 Appendix A FY 2026, standard deduction table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+              excerpt: "1-3 $209 ... 4 $223 5 $261 6+ $299"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_standard_deduction_table[min(household_size, snap_standard_deduction_household_size_six_or_more_key)]


### PR DESCRIPTION
## Summary
- encode Pennsylvania SNAP FY 2026 standard deduction table from Appendix A
- add companion tests for household sizes 3, 4, and 6+
- declare new Pennsylvania standard deduction outputs as oracle-coverage pending classification

## Checks
- axiom-encode validate --skip-reviewers us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml
- axiom-encode proof-validate us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-pa-snap-utility-standards us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-standards/fy-2026.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-pa-snap-utility-standards --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-pa-snap-utility-standards
- axiom-encode oracle-coverage --root /tmp/pa-std-coverage-root --json

## Review cycle
- pending /cycle independent review
