### PR TITLE
Encode Pennsylvania SNAP utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.json
+++ b/.axiom/encoding-manifests/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.test.yaml",
+      "sha256": "c7cf44facde8fd4770af345ff62f6034e0a9ce0d06d705d96364d8092e79caba"
+    },
+    {
+      "path": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml",
+      "sha256": "8100fbfb33e18168ca72a407514d2f57adfaade5a48605683b8813d1bf93ea0d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-10T21:14:14.256763+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpaf0hqh7_/sign-applied-files/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpaf0hqh7_",
+  "generated_output_sha256": "8100fbfb33e18168ca72a407514d2f57adfaade5a48605683b8813d1bf93ea0d",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "733bf569794813d936b8bc805ddc16f246be181a9401ed669f5ba341a1a7d84d"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-10T21:13:39.332497+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "1dca524884e1fd2cf5c8f534b8f38286dfcfc61194b5160458b2bbb45d32b266",
+    "prior_signature": "b3529fc29e0d9e9cb504e809eefaeb9b3b51f4041649e999f4f946ea3e8f3d7d",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18101,6 +18101,15 @@
         ]
       }
     ],
+    "us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1": [
+      {
+        "module": "us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ri/statute/44-30-103": [
       {
         "module": "us-ri/statutes/44-30-103.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 686
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -219,6 +219,30 @@ entries:
   - legal_id: us-ia:statutes/422/12#tuition_credit_rate
     source: bulk
     since: 2026-07-08
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_heating_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_limited_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_non_heating_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_phone_utility_allowance
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_individual_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_limited_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
+  - legal_id: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_standard_utility_allowance_state_value
+    source: manual
+    since: 2026-07-10
   - legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
     source: bulk
     since: 2026-07-08

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.test.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.test.yaml
@@ -1,0 +1,106 @@
+- name: heating_utility_allowance_applies
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: true
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 0
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_non_heating_utility_costs
+    : false
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_basic_telephone_service_cost
+    : false
+  output:
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_standard_utility_allowance_state_value
+    : 857
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    : 857
+- name: non_heating_utility_allowance_applies_without_heating
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 0
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_non_heating_utility_costs
+    : true
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_basic_telephone_service_cost
+    : false
+  output:
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    : 488
+- name: limited_utility_allowance_applies_without_standard_or_non_heating
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 2
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_non_heating_utility_costs
+    : false
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_basic_telephone_service_cost
+    : false
+  output:
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_limited_utility_allowance_state_value
+    : 128
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    : 128
+- name: phone_utility_allowance_applies_when_no_higher_allowance
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 0
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_non_heating_utility_costs
+    : false
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_basic_telephone_service_cost
+    : true
+  output:
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_individual_utility_allowance_state_value
+    : 107
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    : 107
+- name: no_utility_allowance_when_no_qualifying_utility_costs
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/9/d/6/iii#input.household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_rental_housing_billed_by_landlord_based_on_individual_usage_or_flat_rate_separately_from_rent
+    : false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.household_in_public_housing_unit_with_central_utility_meters_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.state_agency_mandates_use_of_standard_utility_allowances_under_paragraph_g: false
+    ? us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_payment_received_or_made_on_household_behalf_in_current_month_or_immediately_preceding_twelve_months
+    : false
+    us:regulations/7-cfr/273/9/d/6/iii#input.liheaa_or_similar_energy_assistance_annual_payment_amount: 0
+    us:regulations/7-cfr/273/9/d/6/iii#input.limited_utility_allowance_utility_count: 0
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_non_heating_utility_costs
+    : false
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#input.household_has_basic_telephone_service_cost
+    : false
+  output:
+    ? us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#local_snap_utility_allowance_for_shelter_costs
+    : 0

--- a/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml
+++ b/us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml
@@ -1,0 +1,212 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+      - us/regulation/7/273/9
+      - us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+      - us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available
+      rationale: 7 CFR 273.9(d)(6)(iii) delegates state standard utility allowance
+        implementation. The Pennsylvania DHS appendix is the delegated FY 2026 parameter
+        source for the state utility allowance dollar amounts.
+  summary: 'Appendix A lists FY 2026 SNAP utility allowance figures under "Phone Heating
+    Non-heating Limited Homeless": Heating $857, Non-heating $488, Limited $128, and
+    Phone $107.'
+imports:
+- us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available
+- us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count
+- us:regulations/7-cfr/273/9
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Appendix A FY 2026 utility allowances, Heating
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_limited_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Appendix A FY 2026 utility allowances, Limited
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: Appendix A FY 2026 utility allowances, Phone
+- name: snap_standard_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: pa_snap_heating_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_heating_utility_allowance
+          output: pa_snap_heating_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Heating
+- name: snap_limited_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: pa_snap_limited_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_limited_utility_allowance
+          output: pa_snap_limited_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Limited
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: pa_snap_phone_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-pa:policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026#pa_snap_phone_utility_allowance
+          output: pa_snap_phone_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Phone
+- name: pa_snap_heating_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Heating
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+          excerpt: Heating ... $857
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '857'
+- name: pa_snap_non_heating_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Non-heating
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+          excerpt: Non-heating ... $488
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '488'
+- name: pa_snap_limited_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Limited
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+          excerpt: Limited ... $128
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '128'
+- name: pa_snap_phone_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances, Phone
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+          excerpt: Phone ... $107
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '107'
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Appendix A FY 2026 utility allowances; 7 CFR 273.9(d)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-pa/manual/dhs/snap/560-income-deductions-560-appendix-a/block-1
+          excerpt: Phone Heating Non-heating Limited
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/9/d/6/iii#snap_standard_with_heating_or_cooling_component_available
+          output: snap_standard_with_heating_or_cooling_component_available
+          hash: sha256:80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/9/d/6/iii#snap_limited_utility_allowance_meets_minimum_utility_count
+          output: snap_limited_utility_allowance_meets_minimum_utility_count
+          hash: sha256:80e41b5400958b9133f1702fd5250c6982264a1680997eddd469264d36e3cf62
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_standard_with_heating_or_cooling_component_available: pa_snap_heating_utility_allowance
+      else: if household_has_non_heating_utility_costs: pa_snap_non_heating_utility_allowance
+      else: if snap_limited_utility_allowance_meets_minimum_utility_count: pa_snap_limited_utility_allowance
+      else: if household_has_basic_telephone_service_cost: pa_snap_phone_utility_allowance
+      else: 0'


### PR DESCRIPTION
## Summary
- encode Pennsylvania SNAP FY 2026 utility allowance amounts from Appendix A
- add state-value hooks and local aggregate for heating, non-heating, limited, and phone utility allowance branches
- add companion tests for heating, non-heating, limited, phone, and zero branches
- declare new Pennsylvania utility outputs as oracle-coverage pending classification

## Checks
- axiom-encode validate --skip-reviewers us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml
- axiom-encode proof-validate us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-pa-snap-utility-only us-pa/policies/dhs/snap/560-income-deductions/appendix-a/utility-allowances/fy-2026.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-pa-snap-utility-only --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-pa-snap-utility-only
- axiom-encode oracle-coverage --root /tmp/pa-util-coverage-root --json

## Review cycle
- pending /cycle independent review
