### PR TITLE
Encode South Carolina SNAP standard deduction

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.test.yaml",
+      "sha256": "f529afd20d67d9762164ce312235aac3a11c3fdd9b0d458f41c41ffe34fc4b0a"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml",
+      "sha256": "50de45ef4726c019136df915379d9774f31a1a147da732f1a2e5893fc0854480"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-11T13:52:53.396554+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwzzymecm/sign-applied-files/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwzzymecm",
+  "generated_output_sha256": "50de45ef4726c019136df915379d9774f31a1a147da732f1a2e5893fc0854480",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ff64be101294cd07796258bdb18dd28ea4e6fa26d6b63c22a3737f32f5a01820"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18553,6 +18553,15 @@
         ]
       }
     ],
+    "us-sc/manual/dss/snap-policy-manual/page-159": [
+      {
+        "module": "us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-16": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-16.yaml",

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.test.yaml
@@ -1,0 +1,24 @@
+- name: household_size_three_gets_209
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#input.household_size: 3
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction: 209
+- name: household_size_four_gets_223
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#input.household_size: 4
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction: 223
+- name: household_size_five_gets_261
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#input.household_size: 5
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction: 261
+- name: household_size_seven_uses_six_or_more_row
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#input.household_size: 7
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction: 299

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml
@@ -1,0 +1,97 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:policies/usda/snap/fy-2026-cola/deductions
+      rationale: >-
+        The South Carolina SNAP manual states the operative household-size
+        standard deduction amounts for this state manual source unit. Federal
+        regulation context supplies the SNAP deduction framework, and USDA FY
+        2026 COLA context supplies matching 48-state standard deduction values;
+        this manual slice remains the requested local source for the encoded
+        state standard deduction table.
+  summary: |-
+    Section 12.2 Standard Deduction: each household is allowed a standard deduction that varies according to household size. Total income is reduced by the amount of the standard deduction. The standard deduction is $209 for household size 1-3, $223 for household size 4, $261 for household size 5, and $299 for household size 6 or more.
+rules:
+  - name: snap_standard_deduction_household_size_six_or_more_key
+    kind: parameter
+    dtype: Count
+    source: SNAP Manual section 12.2, standard deduction row label
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$299 for household size of 6 or more"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          6
+
+  - name: snap_standard_deduction_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    source: SNAP Manual section 12.2, standard deduction by household size
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$209 for household size of 1- 3 ... $299 for household size of 6 or more"
+              table:
+                header: standard deduction by household size
+                row_key: household_size
+                column_key: standard_deduction
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 209
+          2: 209
+          3: 209
+          4: 223
+          5: 261
+          6: 299
+
+  - name: snap_standard_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: SNAP Manual section 12.2, total income reduced by standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "Total income is reduced by the amount of the standard deduction."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction_table
+              output: snap_standard_deduction_table
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/chapter-12/standard-deduction#snap_standard_deduction_household_size_six_or_more_key
+              output: snap_standard_deduction_household_size_six_or_more_key
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_standard_deduction_table[min(household_size, snap_standard_deduction_household_size_six_or_more_key)]


### PR DESCRIPTION
## Summary
- encode South Carolina SNAP standard deduction table from SNAP Manual Chapter 12
- add companion tests for household sizes 3, 4, 5, and 6+

## Checks
- axiom-encode validate --skip-reviewers us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml
- axiom-encode proof-validate us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-sc-snap-standard-deduction us-sc/policies/dss/snap-policy-manual/chapter-12/standard-deduction.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-sc-snap-standard-deduction --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-sc-snap-standard-deduction
- axiom-encode oracle-coverage --root /tmp/sc-std-coverage-root --json

## Review cycle
- pending /cycle independent review
