### PR TITLE
Encode South Carolina SNAP homeless shelter deduction

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.test.yaml",
+      "sha256": "048bda2be443e19a5874f917787edf47c78c61b5dba8dbf98d0958af1521ace8"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml",
+      "sha256": "34fc8ba869de22dd755c89393e656adc9adc7210d3fbf88aefc475a5672a3f10"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-11T13:58:04.317629+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmptovi5bom/sign-applied-files/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmptovi5bom",
+  "generated_output_sha256": "34fc8ba869de22dd755c89393e656adc9adc7210d3fbf88aefc475a5672a3f10",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "68070267b97a6033312ba84734f41541d429f55aeeff7352d197e864ea59ff1b"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18553,6 +18553,15 @@
         ]
       }
     ],
+    "us-sc/manual/dss/snap-policy-manual/page-159": [
+      {
+        "module": "us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-16": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-16.yaml",

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.test.yaml
@@ -1,0 +1,32 @@
+- name: homeless household claimed deduction capped
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_all_members_are_homeless: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_incurs_shelter_expenses: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.snap_claimed_homeless_shelter_deduction: 250
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#homeless_shelter_deduction: 198.99
+- name: homeless household claimed deduction below maximum
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_all_members_are_homeless: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_incurs_shelter_expenses: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.snap_claimed_homeless_shelter_deduction: 150
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#homeless_shelter_deduction: 150
+- name: household not all members homeless
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_all_members_are_homeless: false
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_incurs_shelter_expenses: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.snap_claimed_homeless_shelter_deduction: 150
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#homeless_shelter_deduction: 0
+- name: homeless household without shelter expenses
+  period: 2026-01
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_all_members_are_homeless: true
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.household_incurs_shelter_expenses: false
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#input.snap_claimed_homeless_shelter_deduction: 150
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#homeless_shelter_deduction: 0

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml
@@ -1,0 +1,68 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+      rationale: The copied federal SNAP regulation context was checked for shelter-deduction authority, but the South Carolina manual page supplies the state-specific homeless standard shelter deduction amount and operative conditions encoded here.
+  summary: |-
+    NOTE: Households where all members are homeless may be given a homeless standard shelter deduction up to the maximum of $198.99, if they incur shelter expenses.
+rules:
+  - name: homeless_standard_shelter_deduction_maximum
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: SNAP Manual Chapter 12, page 159, Section 12.1(C) note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "homeless standard shelter deduction up to the maximum of $198.99"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          198.99
+
+  - name: homeless_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: SNAP Manual Chapter 12, page 159, Section 12.1(C) note
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "Households where all members are homeless"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "if they incur shelter expenses"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "up to the maximum of $198.99"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/chapter-12/shelter-deductions#homeless_standard_shelter_deduction_maximum
+              output: homeless_standard_shelter_deduction_maximum
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_all_members_are_homeless and household_incurs_shelter_expenses: min(snap_claimed_homeless_shelter_deduction, homeless_standard_shelter_deduction_maximum) else: 0


### PR DESCRIPTION
## Summary
- encode South Carolina SNAP homeless standard shelter deduction maximum from SNAP Manual Chapter 12
- add executable capped homeless shelter deduction with positive, capped, and zero branch tests

## Checks
- axiom-encode validate --skip-reviewers us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml
- axiom-encode proof-validate us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-sc-snap-shelter-deductions us-sc/policies/dss/snap-policy-manual/chapter-12/shelter-deductions.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-sc-snap-shelter-deductions --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-sc-snap-shelter-deductions
- axiom-encode oracle-coverage --root /tmp/sc-shelter-coverage-root --json

## Review cycle
- pending /cycle independent review
