### PR TITLE
Encode South Carolina SNAP excess shelter cap

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.test.yaml",
+      "sha256": "b77dc9eae38ff4677929d340f65b67c716207216367912f8203930e4638d550f"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml",
+      "sha256": "25745be7b681735e0e847919ce045a62f4b00b97d536a2d8e33da64302e9d4e2"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-11T14:03:09.477596+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpup26o0fs/sign-applied-files/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpup26o0fs",
+  "generated_output_sha256": "25745be7b681735e0e847919ce045a62f4b00b97d536a2d8e33da64302e9d4e2",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bffede0e0098a44f87f9f9b97a2bb2d64bec5bc4d666f8ee1e62cf1dd0e64baf"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18553,6 +18553,15 @@
         ]
       }
     ],
+    "us-sc/manual/dss/snap-policy-manual/page-159": [
+      {
+        "module": "us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-16": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-16.yaml",

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.test.yaml
@@ -1,0 +1,13 @@
+- name: excess_shelter_below_cap
+  period: 2025-10
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction#input.snap_excess_shelter_expenses_before_cap: 600
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction#snap_excess_shelter_expense_deduction: 600
+- name: excess_shelter_capped
+  period: 2025-10
+  input:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction#input.snap_excess_shelter_expenses_before_cap: 900
+  output:
+    us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction#snap_maximum_excess_shelter_expense_deduction: 744
+    us-sc:policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction#snap_excess_shelter_expense_deduction: 744

--- a/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+      rationale: |-
+        The copied federal regulation context includes SNAP excess-shelter deduction rules and the federal full excess-shelter deduction applicability slot. This South Carolina manual page is used for the state/manual current-dollar excess shelter cap stated in the source text.
+  summary: |-
+    "After determining the gross income of each household member, the following deductions, provided the household is eligible for them, may be given: ... (C) $744 Maximum excess shelter deduction (See Section 12.4 Shelter Deduction)."
+rules:
+  - name: snap_maximum_excess_shelter_expense_deduction
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: SNAP Manual Chapter 12, page 159, Section 12.1(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$744 Maximum excess shelter deduction"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          744
+
+  - name: snap_excess_shelter_expense_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: SNAP Manual Chapter 12, page 159, Section 12.1(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$744 Maximum excess shelter deduction"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "Maximum excess shelter deduction"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          min(max(0, snap_excess_shelter_expenses_before_cap), snap_maximum_excess_shelter_expense_deduction)


### PR DESCRIPTION
## Summary
- encode South Carolina SNAP maximum excess shelter deduction from SNAP Manual Chapter 12
- add companion tests for below-cap and capped amounts

## Checks
- axiom-encode validate --skip-reviewers us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml
- axiom-encode proof-validate us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-sc-snap-excess-shelter us-sc/policies/dss/snap-policy-manual/chapter-12/excess-shelter-deduction.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-sc-snap-excess-shelter --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-sc-snap-excess-shelter
- axiom-encode oracle-coverage --root /tmp/sc-excess-coverage-root --json

## Review cycle
- pending /cycle independent review
