### PR TITLE
Encode New York SNAP telephone standard allowance

### DIFF
--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.test.yaml",
+      "sha256": "8086e21b38bfbfa581fb3398154a3935716163b47dc2821fe98e21c9a903ef24"
+    },
+    {
+      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml",
+      "sha256": "4f7482d79c0ada186977596309ed6cd63d8488fed9c1ec0e5a31c4d5bdb13948"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-11T14:09:47.978262+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpn_3ordm6/sign-applied-files/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpn_3ordm6",
+  "generated_output_sha256": "4f7482d79c0ada186977596309ed6cd63d8488fed9c1ec0e5a31c4d5bdb13948",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a1895494605ccda0467537b55977efde41c5a67dd8bb6a893de7844fd61d949e"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17816,6 +17816,13 @@
         "via": [
           "module"
         ]
+      },
+      {
+        "module": "us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
       }
     ],
     "us-ny/regulation/18-nycrr/387/12/f/3/vi": [

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.test.yaml
@@ -1,0 +1,45 @@
+- name: telephone_standard_allowance_applies
+  period: 2025-10
+  input:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_has_basic_telephone_service_cost: true
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_heating_or_cooling
+    : false
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_utilities
+    : false
+  output:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_individual_utility_allowance_state_value: 32
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance_available: holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#local_snap_utility_allowance_for_shelter_costs: 32
+- name: no_allowance_without_basic_telephone_service_cost
+  period: 2025-10
+  input:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_has_basic_telephone_service_cost: false
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_heating_or_cooling
+    : false
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_utilities
+    : false
+  output:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance_available: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#local_snap_utility_allowance_for_shelter_costs: 0
+- name: heating_or_cooling_standard_blocks_telephone_allowance
+  period: 2025-10
+  input:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_has_basic_telephone_service_cost: true
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_heating_or_cooling
+    : true
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_utilities
+    : false
+  output:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance_available: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#local_snap_utility_allowance_for_shelter_costs: 0
+- name: utilities_standard_blocks_telephone_allowance
+  period: 2025-10
+  input:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_has_basic_telephone_service_cost: true
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_heating_or_cooling
+    : false
+    ? us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#input.household_qualifies_for_standard_allowance_for_utilities
+    : true
+  output:
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance_available: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#local_snap_utility_allowance_for_shelter_costs: 0

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml
@@ -1,0 +1,113 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/regulation/18-nycrr/387/12/f/3/v/c
+  summary: The telephone standard allowance consists of the cost for basic service
+    for one telephone, is available only to households that do not qualify for the
+    heating/cooling or utilities standard allowances, and is $32 as of October 1,
+    2025.
+imports:
+- us:regulations/7-cfr/273/9
+rules:
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  source: 18 NYCRR 387.12(f)(3)(v)(c)
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_telephone_standard_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance
+          output: snap_telephone_standard_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 18 NYCRR 387.12(f)(3)(v)(c)
+- name: snap_telephone_standard_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 18 NYCRR 387.12(f)(3)(v)(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-ny/regulation/18-nycrr/387/12/f/3/v/c
+          excerpt: As of October 1, [2024] 2025
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ny/regulation/18-nycrr/387/12/f/3/v/c
+          excerpt: the standard allowance for telephone ... is [$31] $32
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '32'
+- name: snap_telephone_standard_allowance_available
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 18 NYCRR 387.12(f)(3)(v)(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-ny/regulation/18-nycrr/387/12/f/3/v/c
+          excerpt: consists of the cost for basic service for one telephone
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-ny/regulation/18-nycrr/387/12/f/3/v/c
+          excerpt: available to households which do not qualify for the standard allowance
+            for heating/cooling or the standard allowance for utilities
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'household_has_basic_telephone_service_cost
+
+      and not household_qualifies_for_standard_allowance_for_heating_or_cooling
+
+      and not household_qualifies_for_standard_allowance_for_utilities'
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 18 NYCRR 387.12(f)(3)(v)(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ny:regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance#snap_telephone_standard_allowance
+          output: snap_telephone_standard_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_qualifies_for_standard_allowance_for_heating_or_cooling:
+      0 else: if household_qualifies_for_standard_allowance_for_utilities: 0 else:
+      if household_has_basic_telephone_service_cost: snap_telephone_standard_allowance
+      else: 0'


### PR DESCRIPTION
## Summary
- encode New York SNAP telephone standard allowance under 18 NYCRR 387.12(f)(3)(v)(c)
- add availability rule for households not qualifying for heating/cooling or utilities standard allowances
- add companion tests for positive and blocked/zero branches

## Checks
- axiom-encode validate --skip-reviewers us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml
- axiom-encode proof-validate us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ny-snap-telephone-sua us-ny/regulations/18-nycrr/387/12/f/3/v/c/telephone-standard-allowance.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ny-snap-telephone-sua --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ny-snap-telephone-sua
- axiom-encode oracle-coverage --root /tmp/ny-phone-coverage-root --json

## Review cycle
- pending /cycle independent review
