### PR TITLE
Encode the whole-dollar rounding the FNS SNAP computation applies

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/10.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/10.json
@@ -2,31 +2,31 @@
   "applied_files": [
     {
       "path": "us/regulations/7-cfr/273/10.test.yaml",
-      "sha256": "e3ccd29b58cfe7567c26488e8e31eaab648d9aa28f0a16d16e8ed80e4d624d69"
+      "sha256": "f8a7bf1d017a590fa1e2fb9ace86470d90f9c4dd5bff8b0a5135681621519420"
     },
     {
       "path": "us/regulations/7-cfr/273/10.yaml",
-      "sha256": "c0fea2e5d8677777fdf6356f65d31e93f7722eb83335e2dc01214e6b46dc3b27"
+      "sha256": "f9b9f00101218d1d335aa9fff400f0578ae2dc314334693bae7e0dde51202dff"
     }
   ],
   "axiom_encode_git": {
-    "commit": "9759dd348474c15f9fca71253431db76b9273fc7",
+    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
     "dirty_tracked": false,
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1192",
-    "version_commit": "9759dd348474c15f9fca71253431db76b9273fc7"
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
   },
-  "axiom_encode_version": "0.2.1192",
+  "axiom_encode_version": "0.2.1201",
   "backend": "manual",
   "citation": "us:regulations/7-cfr/273/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-08T21:15:18.870263+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzuezj7vr/sign-applied-files/us/regulations/7-cfr/273/10.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzuezj7vr",
-  "generated_output_sha256": "c0fea2e5d8677777fdf6356f65d31e93f7722eb83335e2dc01214e6b46dc3b27",
+  "generated_at": "2026-07-11T19:27:32.512054+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbb7ld8vh/sign-applied-files/us/regulations/7-cfr/273/10.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbb7ld8vh",
+  "generated_output_sha256": "f9b9f00101218d1d335aa9fff400f0578ae2dc314334693bae7e0dde51202dff",
   "generation_prompt_sha256": null,
-  "manual_exception": "TheAxiomFoundation/rulespec-us#761",
+  "manual_exception": "TheAxiomFoundation/rulespec-us#762",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8208b51bc2fb6107eb0ca4ac6ab21bf5e2762f81710dadb89288cc298bd275c9"
+    "value": "064bd68b7f3e42bf2c883950057f1f4905c7d5a4d05951e473454b018325e77d"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-08T21:15:18.870263+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "f460469cf646771def7082d5ee9687bf116d4ba336060ccad8aed84df7dacea4",
+    "prior_signature": "8208b51bc2fb6107eb0ca4ac6ab21bf5e2762f81710dadb89288cc298bd275c9",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/us/regulations/7-cfr/273/10.test.yaml
+++ b/us/regulations/7-cfr/273/10.test.yaml
@@ -28,9 +28,9 @@
     us:regulations/7-cfr/273/10#snap_excess_medical_deduction_for_net_income: 0
     us:regulations/7-cfr/273/10#snap_homeless_shelter_deduction_for_net_income: 0
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 591
-    us:regulations/7-cfr/273/10#snap_excess_shelter_cost: 204.5
-    us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 204.5
-    us:regulations/7-cfr/273/10#snap_net_monthly_income: 386.5
+    us:regulations/7-cfr/273/10#snap_excess_shelter_cost: 205
+    us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 205
+    us:regulations/7-cfr/273/10#snap_net_monthly_income: 386
     us:regulations/7-cfr/273/10#snap_minimum_benefit: 24
     us:regulations/7-cfr/273/10#snap_calculated_monthly_allotment_before_minimums: 182
     us:regulations/7-cfr/273/10#snap_monthly_allotment: 182
@@ -52,11 +52,11 @@
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
   output:
-    us:regulations/7-cfr/273/10#snap_homeless_shelter_deduction_for_net_income: 198.99
-    us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 92.01
+    us:regulations/7-cfr/273/10#snap_homeless_shelter_deduction_for_net_income: 199
+    us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 92
     us:regulations/7-cfr/273/10#snap_excess_shelter_cost: 0
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 0
-    us:regulations/7-cfr/273/10#snap_net_monthly_income: 92.01
+    us:regulations/7-cfr/273/10#snap_net_monthly_income: 92
     us:regulations/7-cfr/273/10#snap_monthly_allotment: 270
 - name: initial_month_under_ten_dollars_not_issued
   period: 2026-01

--- a/us/regulations/7-cfr/273/10.yaml
+++ b/us/regulations/7-cfr/273/10.yaml
@@ -9,13 +9,23 @@ module:
       checked_paths:
         - us/statute/7/2014
         - us/guidance/usda/fns/snap-fy2026-cola/page-2
-      rationale: The homeless shelter deduction maximum printed in 273.10(e)
+        - us/guidance/usda/fns/snap-qc-fy2024-technical-documentation/page-84
+      rationale: >-
+        The homeless shelter deduction maximum printed in 273.10(e)
         ($143) is the fiscal year 2019 base value from the Agriculture
         Improvement Act of 2018; 7 USC 2014(e)(6)(D)(ii) adjusts it annually
         and USDA publishes the controlling amount in each fiscal year's
         cost-of-living adjustment memorandum. The deduction cap therefore
         binds the COLA policy module's snap_homeless_shelter_deduction
-        rather than the superseded printed figure.
+        rather than the superseded printed figure. Rounding follows the
+        273.10(e)(1)(ii) election as FNS applies it in the SNAP quality
+        control computation (the authoritative recomputation this encoding
+        is validated against): the excess shelter calculation and the
+        applied homeless deduction round to the nearest whole dollar per
+        the (e)(1)(ii)(A) text, and the earned income deduction drops
+        cents, matching the constructed FSERNDED values throughout the
+        QC file (for example, earned income of 432 and 424 yield
+        deductions of 86 and 84).
   deferred_outputs:
     - output: us:regulations/7-cfr/273/10/a#month_of_application_eligibility_and_benefit_level_determination
       blocked_by:
@@ -63,7 +73,7 @@ module:
         calculation rules; household notice generation and timing are deferred
         until the surrounding certification notice workflow is encoded.
   summary: |-
-    7 CFR 273.10(e)(1) provides that, to determine a household's net monthly income, the State agency shall add gross earned income and unearned income minus exclusions; subtract 20 percent of earned income; subtract the standard deduction; subtract excess medical expenses over $35; subtract allowable dependent care and, if applicable, child support; subtract the homeless shelter deduction up to the annually adjusted maximum (the regulation's printed $143 is the fiscal year 2019 base value; 7 USC 2014(e)(6)(D)(ii) indexes it each October 1 and the USDA cost-of-living adjustment memoranda publish the controlling amount, bound here from the fiscal-year COLA policy module); compute excess shelter costs as shelter costs exceeding 50 percent of income after the above deductions; and subtract excess shelter costs up to the applicable maximum unless the household is entitled to the full amount. 7 CFR 273.10(e)(2)(ii) provides that, except as otherwise specified, the monthly allotment equals the maximum SNAP allotment for household size reduced by 30 percent of net monthly income, with specified rounding options; initial-month benefits under $10 are not issued; and, except during an initial month, eligible one- and two-person households receive at least the minimum benefit, equal to 8 percent of the maximum allotment for a household of one, rounded to the nearest whole dollar.
+    7 CFR 273.10(e)(1) provides that, to determine a household's net monthly income, the State agency shall add gross earned income and unearned income minus exclusions; subtract 20 percent of earned income; subtract the standard deduction; subtract excess medical expenses over $35; subtract allowable dependent care and, if applicable, child support; subtract the homeless shelter deduction up to the annually adjusted maximum (the regulation's printed $143 is the fiscal year 2019 base value; 7 USC 2014(e)(6)(D)(ii) indexes it each October 1 and the USDA cost-of-living adjustment memoranda publish the controlling amount, bound here from the fiscal-year COLA policy module); compute excess shelter costs as shelter costs exceeding 50 percent of income after the above deductions, rounded to the nearest whole dollar under the 273.10(e)(1)(ii)(A) election; and subtract excess shelter costs up to the applicable maximum unless the household is entitled to the full amount. The earned income deduction is computed in whole dollars with cents dropped, and the homeless shelter deduction is applied at its nearest-dollar value, matching the computation FNS applies in the SNAP quality control database (the constructed FSERNDED, FSSLTDED, and HOMELESS_DED values). 7 CFR 273.10(e)(2)(ii) provides that, except as otherwise specified, the monthly allotment equals the maximum SNAP allotment for household size reduced by 30 percent of net monthly income, with specified rounding options; initial-month benefits under $10 are not issued; and, except during an initial month, eligible one- and two-person households receive at least the minimum benefit, equal to 8 percent of the maximum allotment for a household of one, rounded to the nearest whole dollar.
 imports:
   - us:policies/usda/snap/fy-2026-cola/deductions
   - us:policies/usda/snap/fy-2026-cola/maximum-allotments
@@ -216,7 +226,7 @@ rules:
     dtype: Money
     period: Month
     unit: USD
-    source: 7 CFR 273.10(e)(1)(i)(B)
+    source: 7 CFR 273.10(e)(1)(i)(B) with the (e)(1)(ii) rounding election
     metadata:
       proof:
         atoms:
@@ -234,7 +244,7 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          snap_gross_monthly_earned_income * snap_earned_income_deduction_rate_for_net_income
+          floor(snap_gross_monthly_earned_income * snap_earned_income_deduction_rate_for_net_income)
 
   - name: snap_excess_medical_deduction_for_net_income
     kind: derived
@@ -280,7 +290,7 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          min(snap_claimed_homeless_shelter_deduction, snap_homeless_shelter_deduction)
+          floor(min(snap_claimed_homeless_shelter_deduction, snap_homeless_shelter_deduction) + 0.5)
 
   - name: snap_net_income_before_shelter
     kind: derived
@@ -332,10 +342,15 @@ rules:
             source:
               corpus_citation_path: us/regulation/7/273/10
               excerpt: Subtract from total shelter costs 50 percent of the household's monthly income after all the above deductions have been subtracted. The remaining amount, if any, is the excess shelter cost.
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/10
+              excerpt: Round down each income and allotment calculation that ends in 1 through 49 cents and round up each calculation that ends in 50 through 99 cents
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          if snap_homeless_shelter_deduction_for_net_income > 0: 0 else: max(0, snap_total_allowable_shelter_expenses - (snap_net_income_before_shelter * snap_excess_shelter_income_share))
+          if snap_homeless_shelter_deduction_for_net_income > 0: 0 else: max(0, floor(snap_total_allowable_shelter_expenses - (snap_net_income_before_shelter * snap_excess_shelter_income_share) + 0.5))
 
   - name: snap_excess_shelter_deduction_for_net_income
     kind: derived


### PR DESCRIPTION
Fixes #762 — the last residual class in the SNAP QC administrative-data oracle (TheAxiomFoundation/axiom-oracles#244): 33 of 856 Colorado FY 2024 replays differed by exactly $1 because the encoded chain carried cents where FNS computes in whole dollars.

The convention was derived twice, independently, and reconciled: an exhaustive grid search over a Decimal-exact reference chain (cross-model: GPT-5.6 built and ran it — 114 of 3,456 toggle combinations reproduce all 856 benefits; ablation isolates the earned-income-deduction floor and the whole-dollar excess-shelter step as load-bearing), and the regulation text (273.10(e)(1)(ii)(A): round down 1–49 cents, up 50–99 — which fixes the shelter direction the data alone cannot distinguish).

Three formulas change: the earned income deduction drops cents (FSERNDED is empirically floor, not nearest — 432→86, 424→84), the excess shelter calculation rounds half-up per the election text, and the applied homeless deduction takes its nearest-dollar value (179.66→180, matching HOMELESS_DED). The 30-percent reduction rounding was already encoded. Companion tests recomputed for 273/10 + CO/CA/NY compositions; the two NY failures are pre-existing on main (missing `household_entitled_to_excess_medical_deduction` input) and unrelated.

With this and #765, the oracle's expected Colorado result is 856/856 exact; the verification rerun lands on axiom-oracles#244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)