### PR TITLE
Pin shared validate-rulespec workflow to reviewed SHA

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@main
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@55686f89c852b45b26b25ddd4157d6b37bf81926 # pinned (was @main); axiom-encode#1101
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## What

Pins the shared reusable-workflow reference in `.github/workflows/repository-checks.yml` (the `validate` job's `uses:`) from the mutable `@main` to the current reviewed commit SHA of `TheAxiomFoundation/.github`:

- from `TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@main`
- to `TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@55686f89c852b45b26b25ddd4157d6b37bf81926`

## Why

Part of the axiom-encode#1101 canonical-provenance migration. Pinning to a reviewed SHA protects this repo's CI from the pending breaking rewrite of the shared workflow in `TheAxiomFoundation/.github#24` ("Enforce strict validation waiver ratchet"), which would otherwise reach every consumer the moment it merges to `main`.

**Behavior-identical today:** `55686f89` is the current `HEAD` of `main` in `TheAxiomFoundation/.github`, so this pin changes nothing about how CI runs right now. It only freezes the reference so a future `main` change cannot silently alter validation here.

## Scope

- Single-line change: only the `@main` to `@55686f89...` substitution, plus an inline provenance comment (`# pinned (was @main); axiom-encode#1101`).
- The separate ref-authenticity hard-fail + CODEOWNERS enforcement work is tracked independently and is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
