### PR TITLE
Encode Colorado Adult Financial grant determinations (9 CCR 2503-5)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -7623,6 +7623,33 @@
         ]
       }
     ],
+    "us-co/regulation/9-ccr-2503-5/3.540": [
+      {
+        "module": "us-co/regulations/9-ccr-2503-5/3.540.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-co/regulation/9-ccr-2503-5/3.543": [
+      {
+        "module": "us-co/regulations/9-ccr-2503-5/3.543.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-co/regulation/9-ccr-2503-5/3.544": [
+      {
+        "module": "us-co/regulations/9-ccr-2503-5/3.544.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-co/regulation/9-ccr-2503-5/3.546": [
       {
         "module": "us-co/regulations/9-ccr-2503-5/3.546.yaml",
@@ -7644,6 +7671,15 @@
     "us-co/regulation/9-ccr-2503-5/3.548": [
       {
         "module": "us-co/regulations/9-ccr-2503-5/3.548.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-co/regulation/9-ccr-2503-5/3.549": [
+      {
+        "module": "us-co/regulations/9-ccr-2503-5/3.549.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.540.json
+++ b/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.540.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/9-ccr-2503-5/3.540.yaml",
+      "sha256": "22a4c785b0aaabf40d5fa6e8de6f855da1916cf4042145a0355f076386fa98ac"
+    },
+    {
+      "path": "regulations/9-ccr-2503-5/3.540.test.yaml",
+      "sha256": "8bc598182764948b0fade7f26d4aff4161f2a287257511cee903af525d741bec"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us-co/regulation/9-ccr-2503-5/3.540",
+  "context_manifest_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.540/_eval_workspaces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.540/workspace/context-manifest.json",
+  "context_manifest_sha256": "8cb6ae88c76b4b82541335351042361ca34696663f365d76835b4eb58fb8a76a",
+  "generated_at": "2026-07-12T12:50:53.576179+00:00",
+  "generated_output_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.540/codex-gpt-5.6-terra/regulations/9-ccr-2503-5/3.540.yaml",
+  "generated_output_root": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.540",
+  "generated_output_sha256": "22a4c785b0aaabf40d5fa6e8de6f855da1916cf4042145a0355f076386fa98ac",
+  "generation_prompt_sha256": "7b11c9200968b25747b71057daa6ee59f889498390cd003804f36da7d4670b95",
+  "model": "gpt-5.6-terra",
+  "run_id": "f8f9c23c",
+  "runner": "codex-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bf1bf5d87e9aae98a57dacf224c5c54f9aa08e14f8b3500bd69756960d2d1c3d"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.540/traces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.540.json",
+  "trace_sha256": "6ae347bec77acdcb3fec098cddf41f3336a7414f221b696e1d817a41a81aa23c"
+}

--- a/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.543.json
+++ b/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.543.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/9-ccr-2503-5/3.543.yaml",
+      "sha256": "817f6b5d9dd6924d7e21261d3342e737269748cfa39c2ae68451d125ff5e25aa"
+    },
+    {
+      "path": "regulations/9-ccr-2503-5/3.543.test.yaml",
+      "sha256": "d7ec58a506b0866874ef23ffdb35035df4c807f96dd590fb9625ec963a59521b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us-co/regulation/9-ccr-2503-5/3.543",
+  "context_manifest_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.543/_eval_workspaces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.543/workspace/context-manifest.json",
+  "context_manifest_sha256": "ff9115e663cf6b03078f4c5b5d419614b4f28424202288cb32de9d458b6d4cb9",
+  "generated_at": "2026-07-12T13:00:49.064836+00:00",
+  "generated_output_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.543/codex-gpt-5.6-terra/regulations/9-ccr-2503-5/3.543.yaml",
+  "generated_output_root": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.543",
+  "generated_output_sha256": "817f6b5d9dd6924d7e21261d3342e737269748cfa39c2ae68451d125ff5e25aa",
+  "generation_prompt_sha256": "cea3080231a76c310d6a9ccc1ffef54892bad4d9de437aba37642907fe27a21b",
+  "model": "gpt-5.6-terra",
+  "run_id": "752df34e",
+  "runner": "codex-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bb47dc0ad8920740406e1d83aaf799f48ad193b53f3cdb0245f81befedb02be8"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.543/traces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.543.json",
+  "trace_sha256": "e0527295ec7d488a0a53a76e6efdfb9f84f0a523672d140c62c43b5625c198a9"
+}

--- a/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.544.json
+++ b/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.544.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/9-ccr-2503-5/3.544.yaml",
+      "sha256": "8dc689f042acf23482d00c13e1119ae1b6644b5859678640ec2895da65329251"
+    },
+    {
+      "path": "regulations/9-ccr-2503-5/3.544.test.yaml",
+      "sha256": "672a652ac64405bf092877dbaf0258fc376ff18b18bca37898b7b2f213463adb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us-co/regulation/9-ccr-2503-5/3.544",
+  "context_manifest_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.544/_eval_workspaces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.544/workspace/context-manifest.json",
+  "context_manifest_sha256": "8f02d93ebf6dcd1610206c8ba1e1e91c3490d8cfd443eda0b07ecc604caf0f3f",
+  "generated_at": "2026-07-12T12:57:02.012888+00:00",
+  "generated_output_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.544/codex-gpt-5.6-terra/regulations/9-ccr-2503-5/3.544.yaml",
+  "generated_output_root": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.544",
+  "generated_output_sha256": "8dc689f042acf23482d00c13e1119ae1b6644b5859678640ec2895da65329251",
+  "generation_prompt_sha256": "4be986b2fe25c78db18153fbea8bd88f4bed910145b7cddb7fb68442759925b7",
+  "model": "gpt-5.6-terra",
+  "run_id": "92c55a5a",
+  "runner": "codex-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "12050441691ebbde24cd67bcee6002eec744ec24a31779028bcc553230ff6b68"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.544/traces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.544.json",
+  "trace_sha256": "e8e9d594aad5efee285b041d128376a1be3bc5f00d0dd74a90d65bcf96125471"
+}

--- a/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.549.json
+++ b/us-co/.axiom/encoding-manifests/regulations/9-ccr-2503-5/3.549.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/9-ccr-2503-5/3.549.yaml",
+      "sha256": "f41fbf028af99a72190dbf772ba8977e829dcfb10f12005c11018cda7667c887"
+    },
+    {
+      "path": "regulations/9-ccr-2503-5/3.549.test.yaml",
+      "sha256": "85d1b48efa62b699922f17a866c28d353c9e1db2b3c10945c665fef8278c6a28"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us-co/regulation/9-ccr-2503-5/3.549",
+  "context_manifest_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.549/_eval_workspaces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.549/workspace/context-manifest.json",
+  "context_manifest_sha256": "239543f0757a70cc0cf6d359600dd3cd9d8222c24e4b7a0aa248e1a1bac7037a",
+  "generated_at": "2026-07-12T13:09:01.094313+00:00",
+  "generated_output_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.549/codex-gpt-5.6-terra/regulations/9-ccr-2503-5/3.549.yaml",
+  "generated_output_root": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.549",
+  "generated_output_sha256": "f41fbf028af99a72190dbf772ba8977e829dcfb10f12005c11018cda7667c887",
+  "generation_prompt_sha256": "ba2100a12c06e9bbe2b5c5fff53f2cbf1fcd1b0fcfd61b65d260e3d7fc3111c3",
+  "model": "gpt-5.6-terra",
+  "run_id": "dfb96c6c",
+  "runner": "codex-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d80b3ff16832200d9cee2c00ab2b0ac87640397ac2dcd8a757f1b0017d665d3c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/claude-501/-Users-maxghenis/c668e803-0f93-4440-b037-0e4eb19b2a4f/scratchpad/encode-out-3.549/traces/codex-gpt-5.6-terra/us-co-regulation-9-ccr-2503-5-3.549.json",
+  "trace_sha256": "68e2c494ccf6761dcd2bec5805d18f7a6f6ee63de07b0402954319d76241c633"
+}

--- a/us-co/regulations/9-ccr-2503-5/3.540.test.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.540.test.yaml
@@ -1,0 +1,52 @@
+- name: qualifying_nonblind_person_requirements
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_age_in_years: 18
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_diagnosed_with_blindness: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_total_disability: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_is_partially_disabled: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_short_term_disability: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssi: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssdi: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_age_requirement_met: holds
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_total_disability_requirement_met: holds
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_ssi_ssdi_approval_requirement_met: holds
+- name: blind_child_meets_age_requirement
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_age_in_years: 0
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_diagnosed_with_blindness: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_total_disability: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_is_partially_disabled: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_short_term_disability: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssi: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssdi: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_age_requirement_met: holds
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_total_disability_requirement_met: holds
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_ssi_ssdi_approval_requirement_met: holds
+- name: partially_disabled_person_is_not_total_disabled
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_age_in_years: 18
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_diagnosed_with_blindness: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_total_disability: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_is_partially_disabled: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_short_term_disability: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssi: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssdi: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_total_disability_requirement_met: not_holds
+- name: ssi_approval_blocks_ssi_ssdi_requirement
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_age_in_years: 18
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_diagnosed_with_blindness: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_total_disability: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_is_partially_disabled: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_has_short_term_disability: false
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssi: true
+    us-co:regulations/9-ccr-2503-5/3.540#input.client_approved_for_ssdi: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.540#and_so_ssi_ssdi_approval_requirement_met: not_holds

--- a/us-co/regulations/9-ccr-2503-5/3.540.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.540.yaml
@@ -1,0 +1,158 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+  summary: AND-SO serves clients age 18 through 59, or age 0 through 59 if diagnosed
+    with blindness, who are disabled or blind and not approved for SSI or SSDI. Partially
+    disabled or short-term disabled individuals are ineligible. The total grant standard
+    is $248.00 effective April 1, 2022.
+  deferred_outputs:
+  - output: us-co:regulations/9-ccr-2503-5/3.540#and_so_client_eligible
+    reason: Full AND-SO eligibility also requires non-financial and financial eligibility
+      requirements in section 3.520.71, which is not available as copied RuleSpec
+      context.
+rules:
+- name: and_so_standard_minimum_age_years
+  kind: parameter
+  dtype: Integer
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: age eighteen (18) through fifty-nine (59) years of age
+  versions:
+  - effective_from: '2022-04-01'
+    formula: '18'
+- name: and_so_blindness_minimum_age_years
+  kind: parameter
+  dtype: Integer
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: unless diagnosed with blindness, then age zero (0) through 59 years
+  versions:
+  - effective_from: '2022-04-01'
+    formula: '0'
+- name: and_so_maximum_age_years
+  kind: parameter
+  dtype: Integer
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: through fifty-nine (59) years of age
+  versions:
+  - effective_from: '2022-04-01'
+    formula: '59'
+- name: and_so_total_grant_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "9 CCR 2503-5, \xA7 3.540(A)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: The total AND-SO grant standard is $248.00, effective April 1,
+            2022.
+  versions:
+  - effective_from: '2022-04-01'
+    formula: '248'
+- name: and_so_age_requirement_met
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: age eighteen (18) through fifty-nine (59) years of age (unless
+            diagnosed with blindness, then age zero (0) through 59 years of age)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/9-ccr-2503-5/3.540#and_so_standard_minimum_age_years
+          output: and_so_standard_minimum_age_years
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/9-ccr-2503-5/3.540#and_so_blindness_minimum_age_years
+          output: and_so_blindness_minimum_age_years
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/9-ccr-2503-5/3.540#and_so_maximum_age_years
+          output: and_so_maximum_age_years
+          hash: sha256:local
+  versions:
+  - effective_from: '2022-04-01'
+    formula: "((((client_diagnosed_with_blindness) and client_age_in_years >= and_so_blindness_minimum_age_years)\n\
+      \  or (not (client_diagnosed_with_blindness) and client_age_in_years >= and_so_standard_minimum_age_years)))\
+      \ and client_age_in_years <= and_so_maximum_age_years"
+- name: and_so_total_disability_requirement_met
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: Individuals who are partially disabled or have a short-term disability
+            are not eligible.
+  versions:
+  - effective_from: '2022-04-01'
+    formula: 'client_has_total_disability
+
+      and not client_is_partially_disabled
+
+      and not client_has_short_term_disability'
+- name: and_so_ssi_ssdi_approval_requirement_met
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.540"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.540
+          excerpt: have not been approved for Supplemental Security Income (SSI) or
+            Social Security Disability Insurance (SSDI)
+  versions:
+  - effective_from: '2022-04-01'
+    formula: 'not client_approved_for_ssi
+
+      and not client_approved_for_ssdi'

--- a/us-co/regulations/9-ccr-2503-5/3.543.test.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.543.test.yaml
@@ -1,0 +1,164 @@
+- name: qualifying_client_receives_monthly_pna_maximum
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#client_resides_in_pna_qualifying_facility: holds
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 79
+- name: inmate_is_ineligible_for_grant_and_pna
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_found_eligible_for_and_so: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_total_countable_income: 0
+    us-co:regulations/9-ccr-2503-5/3.543#input.month_is_initial_and_so_eligibility_month: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_eligibility_determined_on_first_day_of_month: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.days_remaining_in_month: 15
+    us-co:regulations/9-ccr-2503-5/3.543#input.days_in_month: 30
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_grant_payment_eligibility: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_authorized_grant_payment_after_countable_income: 0
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_grant_payment_for_month: 0
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: unlicensed_or_uncertified_facility_blocks_payments
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_found_eligible_for_and_so: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_total_countable_income: 0
+    us-co:regulations/9-ccr-2503-5/3.543#input.month_is_initial_and_so_eligibility_month: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_eligibility_determined_on_first_day_of_month: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.days_remaining_in_month: 30
+    us-co:regulations/9-ccr-2503-5/3.543#input.days_in_month: 30
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_grant_payment_eligibility: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_authorized_grant_payment_after_countable_income: 0
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_grant_payment_for_month: 0
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: pna_requires_program_requirements
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: pna_requires_thirty_consecutive_days_of_residence
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: pna_requires_a_listed_facility
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#client_resides_in_pna_qualifying_facility: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: not_holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: pna_maximum_requires_full_calendar_month
+  period: 2016-10
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_meets_and_so_program_requirements: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_resident_for_at_least_30_consecutive_days_in_facility: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_general_medical_and_surgical_hospital: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_nursing_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_assisted_living_residence: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_intermediate_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_group_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_host_home: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_other_long_term_care_facility: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_adult_financial_approved_setting: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_resident_for_full_calendar_month_in_approved_facility: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#client_eligible_for_monthly_pna: holds
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_pna_payment_maximum_for_month: 0
+- name: auto_positive_and_so_grant_payment_eligibility
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_has_been_found_eligible_for_and_so: true
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_is_inmate_in_penal_institution: false
+    us-co:regulations/9-ccr-2503-5/3.543#input.client_resides_in_unlicensed_private_or_uncertified_public_facility: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.543#and_so_grant_payment_eligibility: holds

--- a/us-co/regulations/9-ccr-2503-5/3.543.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.543.yaml
@@ -1,0 +1,170 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  summary: "\u201CThe client's authorized AND-SO grant payment shall be determined\
+    \ by deducting the client's total countable income from the AND-SO grant standard.\u201D\
+    \ Initial-month payments are full when eligibility is determined on the first\
+    \ day and otherwise prorated for days remaining. A monthly PNA requires program\
+    \ requirements, 30 consecutive facility-residence days, and a listed facility;\
+    \ inmates and residents of unlicensed private or uncertified public facilities\
+    \ are ineligible. The PNA maximum is $79 for every full calendar month in an approved\
+    \ facility, effective October 1, 2016."
+imports:
+- us-co:regulations/9-ccr-2503-5/3.540#and_so_total_grant_standard
+rules:
+- name: and_so_grant_payment_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(B), (E)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  versions:
+  - effective_from: '2016-10-01'
+    formula: 'client_has_been_found_eligible_for_and_so
+
+      and not client_is_inmate_in_penal_institution
+
+      and not client_resides_in_unlicensed_private_or_uncertified_public_facility'
+- name: and_so_authorized_grant_payment_after_countable_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(B)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-co:regulations/9-ccr-2503-5/3.540#and_so_total_grant_standard
+          output: and_so_total_grant_standard
+          hash: sha256:22a4c785b0aaabf40d5fa6e8de6f855da1916cf4042145a0355f076386fa98ac
+  versions:
+  - effective_from: '2016-10-01'
+    formula: 'if and_so_grant_payment_eligibility: max(0, and_so_total_grant_standard
+      - client_total_countable_income) else: 0'
+- name: and_so_grant_payment_for_month
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(B)(1)-(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  versions:
+  - effective_from: '2016-10-01'
+    formula: "if not and_so_grant_payment_eligibility:\n  0\nelse:\n  if not month_is_initial_and_so_eligibility_month:\n\
+      \    and_so_authorized_grant_payment_after_countable_income\n  else:\n    if\
+      \ client_eligibility_determined_on_first_day_of_month:\n      and_so_authorized_grant_payment_after_countable_income\n\
+      \    else:\n      and_so_authorized_grant_payment_after_countable_income * days_remaining_in_month\
+      \ / days_in_month"
+- name: client_resides_in_pna_qualifying_facility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(D)(1)-(2)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  versions:
+  - effective_from: '2016-10-01'
+    formula: 'client_resides_in_general_medical_and_surgical_hospital
+
+      or client_resides_in_nursing_home
+
+      or client_resides_in_assisted_living_residence
+
+      or client_resides_in_intermediate_care_facility
+
+      or client_resides_in_group_home
+
+      or client_resides_in_host_home
+
+      or client_resides_in_other_long_term_care_facility
+
+      or client_resides_in_adult_financial_approved_setting'
+- name: client_eligible_for_monthly_pna
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(D)-(E)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  versions:
+  - effective_from: '2016-10-01'
+    formula: 'client_meets_and_so_program_requirements
+
+      and client_has_been_resident_for_at_least_30_consecutive_days_in_facility
+
+      and client_resides_in_pna_qualifying_facility
+
+      and not client_is_inmate_in_penal_institution
+
+      and not client_resides_in_unlicensed_private_or_uncertified_public_facility'
+- name: and_so_personal_needs_allowance_maximum
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: "9 CCR 2503-5, \xA7 3.543(F)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+          excerpt: shall be seventy nine dollars ($79) effective October 1, 2016
+  versions:
+  - effective_from: '2016-10-01'
+    formula: '79'
+- name: and_so_pna_payment_maximum_for_month
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: "9 CCR 2503-5, \xA7 3.543(D), (F)"
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.543
+  versions:
+  - effective_from: '2016-10-01'
+    formula: 'if client_eligible_for_monthly_pna and client_is_resident_for_full_calendar_month_in_approved_facility:
+      and_so_personal_needs_allowance_maximum else: 0'

--- a/us-co/regulations/9-ccr-2503-5/3.544.test.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.544.test.yaml
@@ -1,0 +1,70 @@
+- name: client_and_spouse_income_with_split_unearned_disregard
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_earned_income: 165
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_unearned_income: 120
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_earned_income: 265
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_unearned_income: 120
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_income_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_has_retained_mmmna: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.institutionalized_spouse_mmmna: 0
+  output:
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_countable_earned_income: 50
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_countable_unearned_income: 110
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_spouse_income_available_for_deeming: holds
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_earned_income: 100
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_unearned_income: 110
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_income_after_mmmna: 210
+- name: spouse_income_unavailable_when_receiving_ssi_within_limit
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_earned_income: 165
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_unearned_income: 120
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_earned_income: 265
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_unearned_income: 120
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_ssi_benefits: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_income_no_greater_than_ssi_limit: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_has_retained_mmmna: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.institutionalized_spouse_mmmna: 0
+  output:
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_spouse_income_available_for_deeming: not_holds
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_income_after_mmmna: 0
+- name: institutionalized_spouse_mmmna_reduces_deemed_income
+  period: 2022-04
+  input:
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_earned_income: 165
+    us-co:regulations/9-ccr-2503-5/3.544#input.gross_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_earned_income: 265
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_gross_unearned_income: 120
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_share_of_unearned_income_disregard: 10
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_income_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.544#input.spouse_is_institutionalized: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.client_has_retained_mmmna: true
+    us-co:regulations/9-ccr-2503-5/3.544#input.institutionalized_spouse_mmmna: 50
+  output:
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_countable_earned_income: 50
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_countable_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_spouse_income_available_for_deeming: holds
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_earned_income: 100
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_unearned_income: 100
+    us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_income_after_mmmna: 150

--- a/us-co/regulations/9-ccr-2503-5/3.544.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.544.yaml
@@ -1,0 +1,233 @@
+format: rulespec/v1
+imports:
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+  summary: |-
+    Deduct $65 from gross earned income and divide the remainder by two; deduct $20 from gross unearned income, subject to the married-client allocation rule. Spousal earned and unearned income is deemed under the same disregards, except specified spouse income is unavailable and MMMNA is deducted from an institutionalized spouse's total income.
+  deferred_outputs:
+    - output: us-co:regulations/9-ccr-2503-5/3.544#sponsor_income_deemed_to_non_citizen_client
+      reason: Sponsor deeming requires the current SSI benefit standard for an individual defined in section 3.510, which is not available as copied RuleSpec context.
+      source_values:
+        - us-co:regulations/9-ccr-2503-5/3.544#and_so_sponsor_spouse_deduction_fraction
+    - output: us-co:regulations/9-ccr-2503-5/3.544#and_so_grant_payment_amount
+      reason: The final grant payment must include sponsor-deemed income, whose calculation depends on the unavailable section 3.510 SSI benefit standard.
+rules:
+  - name: and_so_earned_income_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(A)(1), (D)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: Deduct $65 from the gross earned income.
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          65
+  - name: and_so_unearned_income_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(B)(2), (E)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: Deduct $20.00.
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          20
+  - name: and_so_sponsor_spouse_deduction_fraction
+    kind: parameter
+    dtype: Decimal
+    source: 9 CCR 2503-5, § 3.544(G)(2)(b)-(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: equal to one-half the current SSI benefit standard for an individual
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          1 / 2
+  - name: and_so_countable_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: Deduct $65 from the gross earned income; and, divide the remainder by two (2).
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_earned_income_disregard_amount
+              output: and_so_earned_income_disregard_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          max(0, (gross_earned_income - and_so_earned_income_disregard_amount) / 2)
+  - name: and_so_countable_unearned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: If the client is married, the $20.00 disregard shall be split between the client and the spouse so that no more than a $20.00 disregard is applied.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_unearned_income_disregard_amount
+              output: and_so_unearned_income_disregard_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          max(0, gross_unearned_income - (if client_is_married: client_share_of_unearned_income_disregard else: and_so_unearned_income_disregard_amount))
+  - name: and_so_spouse_income_available_for_deeming
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 9 CCR 2503-5, § 3.544(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: their income shall not be considered as available to the client and shall not be deemed
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          not (
+            (spouse_receives_adult_financial_grant_payments
+            or spouse_receives_ssi_benefits
+            or spouse_receives_medicaid_assistance)
+            and spouse_income_no_greater_than_ssi_limit
+          )
+  - name: and_so_deemed_spouse_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(D), (F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: The result is the amount of earned income deemed to the client.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_earned_income_disregard_amount
+              output: and_so_earned_income_disregard_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_spouse_income_available_for_deeming
+              output: and_so_spouse_income_available_for_deeming
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          if and_so_spouse_income_available_for_deeming: max(0, (spouse_gross_earned_income - and_so_earned_income_disregard_amount) / 2) else: 0
+  - name: and_so_deemed_spouse_unearned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(E), (F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: Deduct $20.00 unless the client also has unearned income.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_unearned_income_disregard_amount
+              output: and_so_unearned_income_disregard_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_spouse_income_available_for_deeming
+              output: and_so_spouse_income_available_for_deeming
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          if and_so_spouse_income_available_for_deeming: max(0, spouse_gross_unearned_income - (if gross_unearned_income > 0: spouse_share_of_unearned_income_disregard else: and_so_unearned_income_disregard_amount)) else: 0
+  - name: and_so_deemed_spouse_income_after_mmmna
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5, § 3.544(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.544
+              excerpt: the MMMNA shall be deducted from the institutionalized spouse’s total income.
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_earned_income
+              output: and_so_deemed_spouse_earned_income
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.544#and_so_deemed_spouse_unearned_income
+              output: and_so_deemed_spouse_unearned_income
+              hash: sha256:local
+    versions:
+      - effective_from: '2022-04-01'
+        formula: |-
+          if spouse_is_institutionalized and client_has_retained_mmmna: max(0, and_so_deemed_spouse_earned_income + and_so_deemed_spouse_unearned_income - institutionalized_spouse_mmmna) else: and_so_deemed_spouse_earned_income + and_so_deemed_spouse_unearned_income

--- a/us-co/regulations/9-ccr-2503-5/3.549.test.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.549.test.yaml
@@ -1,0 +1,123 @@
+- name: client_income_disregards_and_grant
+  period: 2026-01
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 200
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_client_unearned_income_disregard_used: 10
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_unearned_income_disregard_available_for_client_earned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_countable_client_earned_income: 62.5
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_countable_client_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_total_countable_client_income: 62.5
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_standard_spouse_deeming_method_applies: not_holds
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_earned_income_under_standard_method: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_unearned_income_under_standard_method: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_authorized_grant_payment_before_deemed_income: 931.5
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_state_supplementary_payment_before_deemed_income: 0
+- name: ssi_only_client_has_no_unearned_disregard
+  period: 2026-01
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 200
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_client_unearned_income_disregard_used: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_unearned_income_disregard_available_for_client_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_countable_client_earned_income: 67.5
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_countable_client_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_total_countable_client_income: 77.5
+- name: married_client_standard_spouse_deeming
+  period: 2026-01
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 200
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 50
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_client_unearned_income_disregard_used: 10
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_standard_spouse_deeming_method_applies: holds
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_earned_income_under_standard_method: 67.5
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_unearned_income_under_standard_method: 40
+- name: spouse_assistance_exception_blocks_standard_deeming
+  period: 2026-01
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 200
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 50
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: false
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_standard_spouse_deeming_method_applies: not_holds
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_earned_income_under_standard_method: 0
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_spouse_unearned_income_under_standard_method: 0
+- name: institutionalized_spouse_requires_mmmna_method
+  period: 2026-01
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 10
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 200
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 50
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: true
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: true
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_standard_spouse_deeming_method_applies: not_holds
+- name: auto_zero_and_cs_countable_client_earned_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_has_retained_mmmna: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.client_is_married: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.gross_unearned_income: 1
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_earned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_gross_unearned_income: 0
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_income_is_no_greater_than_ssi_limit: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_is_institutionalized: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_adult_financial_grant_payments: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_medicaid_assistance: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.spouse_receives_ssi_benefits: false
+    us-co:regulations/9-ccr-2503-5/3.549#input.ssi_income_amount: 0
+  output:
+    us-co:regulations/9-ccr-2503-5/3.549#and_cs_countable_client_earned_income: 0

--- a/us-co/regulations/9-ccr-2503-5/3.549.yaml
+++ b/us-co/regulations/9-ccr-2503-5/3.549.yaml
@@ -1,0 +1,310 @@
+format: rulespec/v1
+imports:
+  - us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard
+  - us-co:regulations/9-ccr-2503-5/3.546#and_cs_payment_floor_standard
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+  summary: |-
+    “Deduct $65 from the monthly gross income; and, divide the remainder by two (2).”
+    For unearned income, subtract SSI, apply the $20 disregard subject to the married-couple
+    split and SSI-only exception, then add SSI back. A spouse's income is deemed under the
+    stated earned and unearned calculations, except for specified assistance recipients; an
+    institutionalized spouse's MMMNA adjustment, parental deeming, and sponsor deeming apply
+    under separate provisions.
+  deferred_outputs:
+    - output: us-co:regulations/9-ccr-2503-5/3.549#and_cs_grant_payment_after_all_deemed_income
+      reason: The final calculation requires parental deeming, sponsor deeming using the current SSI benefit standard under section 3.510, and the institutionalized-spouse MMMNA allocation across earned and unearned income; the required section 3.510 amount and relationship structures are not supplied as executable context.
+    - output: us-co:regulations/9-ccr-2503-5/3.549#and_cs_deemed_income_from_institutionalized_spouse_after_mmmna
+      reason: The source requires deduction of the MMMNA from an institutionalized spouse's total income, but does not specify how that total-income deduction is allocated between the separate earned and unearned deeming calculations.
+rules:
+  - name: and_cs_client_earned_income_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.1.a
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Deduct $65 from the monthly gross income.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          65
+
+  - name: and_cs_spouse_earned_income_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 9 CCR 2503-5 3.549 C.2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Deduct $65.00 from the monthly gross income.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          65
+
+  - name: and_cs_unearned_income_general_disregard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.2.c
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Deduct $20 from the remainder.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          20
+
+  - name: and_cs_income_disregard_divisor
+    kind: parameter
+    dtype: Integer
+    source: 9 CCR 2503-5 3.549 A.1.b, C.3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Divide the remainder by two (2).
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          2
+
+  - name: and_cs_client_unearned_income_disregard_used
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.2.c.1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: The $20 disregard shall be split between the client and the spouse so that no more than a $20.00 disregard is applied for the married couple. A client who receives SSI only ... does not receive an unearned income disregard.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          if gross_unearned_income <= 0: 0 else: if gross_unearned_income == ssi_income_amount and gross_unearned_income > 0: 0 else: min(and_cs_unearned_income_general_disregard_amount / (if client_is_married: and_cs_income_disregard_divisor else: 1), max(0, gross_unearned_income - ssi_income_amount))
+
+  - name: and_cs_unearned_income_disregard_available_for_client_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.2.f
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: If the client's unearned income is less than $20.00, the difference between the gross unearned income and the $20.00 deduction shall be applied to the earned income calculation.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          if gross_unearned_income <= 0: 0 else: if gross_unearned_income == ssi_income_amount and gross_unearned_income > 0: 0 else: max(0, and_cs_unearned_income_general_disregard_amount - gross_unearned_income)
+
+  - name: and_cs_countable_client_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.1, A.2.f
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Deduct $65 from the monthly gross income; and, divide the remainder by two (2). ... the difference ... shall be applied to the earned income calculation.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          if gross_earned_income <= 0: 0 else: max(0, (gross_earned_income - and_cs_client_earned_income_disregard_amount - and_cs_unearned_income_disregard_available_for_client_earned_income) / and_cs_income_disregard_divisor)
+
+  - name: and_cs_countable_client_unearned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Subtract any amount received from SSI. Deduct $20 from the remainder. Add the full SSI income back to the remainder.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          max(0, gross_unearned_income - ssi_income_amount - and_cs_client_unearned_income_disregard_used) + ssi_income_amount
+
+  - name: and_cs_total_countable_client_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 A.1.c, A.2.e
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: The result is the countable earned income. The result is the countable unearned income.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          and_cs_countable_client_earned_income + and_cs_countable_client_unearned_income
+
+  - name: and_cs_standard_spouse_deeming_method_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 9 CCR 2503-5 3.549 C-F
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: If a spouse ... is receiving Adult Financial grant payments, SSI benefits, or Medicaid assistance and has income no greater than the SSI limit, their income shall not be considered as available ... and shall not be deemed.
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: If a spouse is institutionalized and the client has retained the MMMNA, the MMMNA shall be deducted from the institutionalized spouse’s total income.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          client_is_married
+          and not ((spouse_receives_adult_financial_grant_payments or spouse_receives_ssi_benefits or spouse_receives_medicaid_assistance) and spouse_income_is_no_greater_than_ssi_limit)
+          and not (spouse_is_institutionalized and client_has_retained_mmmna)
+
+  - name: and_cs_deemed_spouse_earned_income_under_standard_method
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 C
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Determine the spouse's monthly gross income. Deduct $65.00 from the monthly gross income; and, divide the remainder by two (2). The result is the amount deemed to the client.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          if and_cs_standard_spouse_deeming_method_applies: max(0, (spouse_gross_earned_income - and_cs_spouse_earned_income_disregard_amount) / and_cs_income_disregard_divisor) else: 0
+
+  - name: and_cs_deemed_spouse_unearned_income_under_standard_method
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 D
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Deduct any remaining unearned income disregard remaining from the client or $20.00, whichever is less. A couple shall be allowed a combined $20.00 disregard.
+    versions:
+      - effective_from: '2016-10-01'
+        formula: |-
+          if and_cs_standard_spouse_deeming_method_applies: max(0, spouse_gross_unearned_income - max(0, and_cs_unearned_income_general_disregard_amount - and_cs_client_unearned_income_disregard_used)) else: 0
+
+  - name: and_cs_authorized_grant_payment_before_deemed_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard
+              output: and_cs_total_grant_standard
+              hash: sha256:a3785d093a214f42b55cfaa9d4bd0e0129a5ccf131d32196a74d6c21deb7c462
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: Subtract the countable earned and countable unearned income from the AND-CS grant standard to determine the grant payment amount.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, and_cs_total_grant_standard - and_cs_total_countable_client_income)
+
+  - name: and_cs_state_supplementary_payment_before_deemed_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 9 CCR 2503-5 3.549 B
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:regulations/9-ccr-2503-5/3.546#and_cs_payment_floor_standard
+              output: and_cs_payment_floor_standard
+              hash: sha256:a3785d093a214f42b55cfaa9d4bd0e0129a5ccf131d32196a74d6c21deb7c462
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/regulation/9-ccr-2503-5/3.549
+              excerpt: If the grant payment is less than the AND-CS payment floor standard ... a state supplementary payment will be issued to raise the grant payment to meet the payment floor standard.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if and_cs_authorized_grant_payment_before_deemed_income < and_cs_payment_floor_standard: and_cs_payment_floor_standard - and_cs_authorized_grant_payment_before_deemed_income else: 0


### PR DESCRIPTION
## Encode Colorado Adult Financial grant determinations (AND-SO + AND-CS disregards)

Four `us-co` provisions from the already-ingested 9 CCR 2503-5 corpus bundle
(`2026-06-19-co-oap-9-ccr-2503-5.jsonl` @ pinned corpus `7661f3c9`), completing the
grant-determination chain for Colorado's three Adult Financial cash programs. OAP
(3.530/3.532/3.533) and AND-CS (3.546–3.548) were already encoded; this adds:

| Citation | Heading | Role |
|---|---|---|
| `us-co/regulation/9-ccr-2503-5/3.540` | AND-SO program | Program scope, age bounds, **$248 grant standard (eff. 2022-04-01)** |
| `us-co/regulation/9-ccr-2503-5/3.544` | AND-SO income disregards and deemed income | $65 + ½ earned / $20 unearned disregards, spousal + sponsor deeming |
| `us-co/regulation/9-ccr-2503-5/3.543` | AND-SO grant payment determination | standard − countable income, first-month proration, $79 PNA cap |
| `us-co/regulation/9-ccr-2503-5/3.549` | AND-CS income disregards and deemed income | SSI add-back sequence, spousal/parental/sponsor deeming; closes the AND-CS set |

After this PR, OAP, AND-SO, and AND-CS each have program standard + grant
determination + income disregards encoded.

- Encoder: `codex:gpt-5.6-terra`, toolchain-pinned axiom-encode **0.2.1200**
  (`3869d66d`, per `.axiom/toolchain.toml`); engine `e19f1b75`; corpus `7661f3c9`.
- Produced by `axiom-encode encode <citation> --apply --no-sync` (fail-closed overlay
  validation; signed apply manifests under `us-co/.axiom/encoding-manifests/`).
- Local gate battery run in PR-CI order from a clean `origin/main` worktree:
  guard-generated, `validate --skip-reviewers`, `proof-validate`, companion tests.

### Manifest summaries
| Citation | Model | Run | Encoder |
|---|---|---|---|
| `us-co/regulation/9-ccr-2503-5/3.540` | gpt-5.6-terra | `f8f9c23c` | 0.2.1200 |
| `us-co/regulation/9-ccr-2503-5/3.543` | gpt-5.6-terra | `752df34e` | 0.2.1200 |
| `us-co/regulation/9-ccr-2503-5/3.544` | gpt-5.6-terra | `92c55a5a` | 0.2.1200 |
| `us-co/regulation/9-ccr-2503-5/3.549` | gpt-5.6-terra | `dfb96c6c` | 0.2.1200 |

Notes: 3.540 and 3.543 were installed after the encoder's own deterministic repair passes
(`auto_repaired_judgment_conditionals`, `auto_repaired_judgment_positive_tests`); 3.549's first
generation was blocked fail-closed on a fixture-arithmetic mismatch and was re-generated clean.
3.544 declares `deferred_outputs` for the sponsor-deeming chain pending a §3.510 (SSI benefit
standard) encoding — the encoder's fail-closed handling, not an omission.

### Local gate battery output
```
=== 1. guard-generated ===
All changed RuleSpec files have encoder apply manifests.
=== 2. validate 3.540 ===
CI: ✓
Result: ✓ PASSED
=== 3. proof-validate 3.540 ===
Atoms checked: 10
Result: ✓ PASSED
=== 2. validate 3.543 ===
CI: ✓
Result: ✓ PASSED
=== 3. proof-validate 3.543 ===
Atoms checked: 8
Result: ✓ PASSED
=== 2. validate 3.544 ===
CI: ✓
Result: ✓ PASSED
=== 3. proof-validate 3.544 ===
Atoms checked: 17
Result: ✓ PASSED
=== 2. validate 3.549 ===
CI: ✓
Result: ✓ PASSED
=== 3. proof-validate 3.549 ===
Atoms checked: 17
Result: ✓ PASSED
=== 4. companion tests (all four) ===
RuleSpec companion tests passed: 4 file(s), 21 case(s)
=== GATE BATTERY EXIT: 0 ===
```

The authoritative gate is the required `validate / validate` check on this PR.
Do not merge without Max's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
