### PR TITLE
Add CODEOWNERS for provenance-critical paths

### DIFF
--- a/.axiom/repository-structure.yaml
+++ b/.axiom/repository-structure.yaml
@@ -89,6 +89,8 @@ path_rules:
     allow_extensions:
       - ".yml"
       - ".yaml"
+    allow_filenames:
+      - "CODEOWNERS"
   - patterns:
       - "bulk/**"
     allow_extensions:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Provenance-critical paths. Review by the code owner is enforced once
+# `require_code_owner_reviews` is enabled on the protected branch; until
+# then GitHub still auto-requests the owner on PRs touching these paths.
+/.axiom/toolchain.toml @MaxGhenis
+/.github/ @MaxGhenis
+/known-validation-gaps.yaml @MaxGhenis


### PR DESCRIPTION
Part of the canonical-provenance hardening (axiom-encode #1101 backlog): `.axiom/toolchain.toml`, `.github/`, and `known-validation-gaps.yaml` get a code owner. **Inert until `require_code_owner_reviews` is enabled on main's branch protection** — that toggle is left to Max:

```bash
gh api -X PATCH repos/TheAxiomFoundation/rulespec-us/branches/main/protection/required_pull_request_reviews -F require_code_owner_reviews=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)