### PR TITLE
Declare us-me/us-ut TANF outputs in the oracle-coverage pending lane

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 678
+ceiling: 688
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -429,6 +429,18 @@ entries:
   - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income
     source: bulk
     since: 2026-07-09
+  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_maximum_grant
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_standard_of_need
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_maximum_grant
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_standard_of_need
+    source: bulk
+    since: 2026-07-12
   - legal_id: us-me:statutes/36/5111#head_of_household_band_0_upper
     source: bulk
     since: 2026-07-08
@@ -1266,6 +1278,24 @@ entries:
   - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income
     source: bulk
     since: 2026-07-08
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_204_component_eligible
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_eligible
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_gross_income_eligible
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_payment_standard_amount
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_resources_eligible_output
+    source: bulk
+    since: 2026-07-12
+  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_work_expense_allowance
+    source: bulk
+    since: 2026-07-12
   - legal_id: us-ut:statutes/59-10-1018#applicable_income_threshold
     source: bulk
     since: 2026-07-08


### PR DESCRIPTION
Bookkeeping only: declares 10 pre-existing unmapped program outputs (`us-me:programs/tanf/fy-2026#me_tanf_*`, `us-ut:programs/tanf/fy-2026#ut_fep_*`) that merged without pending-lane entries, so the weekly bulk-encode sync doesn't sweep them into an unrelated PR's diff. Generated by `axiom-encode oracle-coverage-pending sync` at the toolchain-pinned encoder (0.2.1200); ceiling 678→688. No rule values change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)