### PR TITLE
Fix NY SNAP utility fixture validation

### DIFF
--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/a.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/a.json
@@ -1,41 +1,47 @@
 {
   "applied_files": [
     {
-      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml",
-      "sha256": "53ca3d912c6c46c6311fb990e6a96aaf8c1796c44caa83d30ec71435738bfe52"
-    },
-    {
       "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml",
-      "sha256": "99c8ec84077b9e78ffc5350c948b8670b5f53b12538d0e3f49dd0cd8ee883dc8"
+      "sha256": "f7c3f73029f654536bb50aaa14ee84b0ec8f10183a0c727ce2862ff6cbec3d3e"
     }
   ],
   "axiom_encode_git": {
-    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.655",
-    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.655",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
   "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/a",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-14T22:15:14.393991+00:00",
-  "generated_output_file": null,
-  "generated_output_root": "/tmp/rulespec-us",
-  "generated_output_sha256": null,
+  "generated_at": "2026-07-12T18:14:35.140171+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5ngfablo/sign-applied-files/us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5ngfablo",
+  "generated_output_sha256": "53ca3d912c6c46c6311fb990e6a96aaf8c1796c44caa83d30ec71435738bfe52",
   "generation_prompt_sha256": null,
-  "model": "gpt-5",
-  "run_id": "snap-utility-hooks-derived-sets-20260614",
-  "runner": "manual",
+  "manual_exception": "fixtures",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "5ac27a8da0e96a2e655f82593d657257aa768ef7daac8dce854366209af1644f"
+    "value": "962b24ca0f50ec626d9aca473de2b8d8d99fbd11097375e023f77d7e3dda359d"
   },
-  "tool": "axiom-encode manual-apply-manifest",
+  "supersedes": {
+    "backend": "codex",
+    "generated_at": "2026-06-14T22:15:14.393991+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "83e7ae77413ae6bdc9a1875760260f2629e35275601355b4282bf32d32380430",
+    "prior_signature": "5ac27a8da0e96a2e655f82593d657257aa768ef7daac8dce854366209af1644f",
+    "run_id": "snap-utility-hooks-derived-sets-20260614",
+    "tool": "axiom-encode manual-apply-manifest"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/b.json
+++ b/.axiom/encoding-manifests/us-ny/regulations/18-nycrr/387/12/f/3/v/b.json
@@ -1,41 +1,47 @@
 {
   "applied_files": [
     {
-      "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml",
-      "sha256": "d850e89a2484a4e3283add1af7390b581abe03219531a2513df081c66cf30a0f"
-    },
-    {
       "path": "us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml",
-      "sha256": "238095d242a7269ff087c2d67d5b457449f8d02e481a97c0b584e09311313218"
+      "sha256": "32e1343a93b94b32088025feaeed5897c925c0756fadcb399904a2ef6ca079d6"
     }
   ],
   "axiom_encode_git": {
-    "commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.655",
-    "version_commit": "26ebd455cf8c51f3f79917070e30a630cda3ce9c"
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.655",
-  "backend": "codex",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
   "citation": "us-ny:regulations/18-nycrr/387/12/f/3/v/b",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-14T22:15:14.393991+00:00",
-  "generated_output_file": null,
-  "generated_output_root": "/tmp/rulespec-us",
-  "generated_output_sha256": null,
+  "generated_at": "2026-07-12T18:14:35.142079+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5ngfablo/sign-applied-files/us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5ngfablo",
+  "generated_output_sha256": "d850e89a2484a4e3283add1af7390b581abe03219531a2513df081c66cf30a0f",
   "generation_prompt_sha256": null,
-  "model": "gpt-5",
-  "run_id": "snap-utility-hooks-derived-sets-20260614",
-  "runner": "manual",
+  "manual_exception": "fixtures",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3979786dea7dee84632ff19f28102953b81a4ff7a3fbbf824c065e7136d974a1"
+    "value": "f776046812f341509c4642265d0ca3613eb05e2d655ab585737194210d791799"
   },
-  "tool": "axiom-encode manual-apply-manifest",
+  "supersedes": {
+    "backend": "codex",
+    "generated_at": "2026-06-14T22:15:14.393991+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "fca76435569782a2059cb6838b76a0f9523d98ba8865484f6595c6c9b4b9848d",
+    "prior_signature": "3979786dea7dee84632ff19f28102953b81a4ff7a3fbbf824c065e7136d974a1",
+    "run_id": "snap-utility-hooks-derived-sets-20260614",
+    "tool": "axiom-encode manual-apply-manifest"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml
@@ -1,13 +1,13 @@
 - name: heating_cooling_allowance_applies_in_new_york_city
   period: 2026-01
-  input: &base_heating_cooling
+  input:
     us:statutes/7/2012/j#relation.member_of_household: []
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
-  oracle_inputs: &oracle_new_york_city
+  oracle_inputs:
     policyengine:
       snap_utility_region_str: NY_NYC
   output:
@@ -19,7 +19,10 @@
 - name: heating_cooling_allowance_applies_in_nassau_or_suffolk
   period: 2026-01
   input:
-    <<: *base_heating_cooling
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: true
   oracle_inputs:
@@ -32,7 +35,10 @@
 - name: heating_cooling_allowance_applies_in_rest_of_state
   period: 2026-01
   input:
-    <<: *base_heating_cooling
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
   oracle_inputs:
@@ -45,21 +51,31 @@
 - name: central_meter_excess_cost_only_household_needs_heap_or_liheaa
   period: 2026-01
   input:
-    <<: *base_heating_cooling
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: true
-  oracle_inputs: *oracle_new_york_city
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
+  oracle_inputs:
+    policyengine:
+      snap_utility_region_str: NY_NYC
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_heating_cooling_standard_allowance_eligible: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 0
 
 - name: elderly_or_disabled_household_with_heap_or_liheaa_qualifies
   period: 2026-01
   input:
-    <<: *base_heating_cooling
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: true
-  oracle_inputs: *oracle_new_york_city
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
+  oracle_inputs:
+    policyengine:
+      snap_utility_region_str: NY_NYC
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_heating_cooling_standard_allowance_eligible: holds

--- a/us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml
+++ b/us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml
@@ -1,6 +1,6 @@
 - name: utilities_allowance_applies_in_new_york_city
   period: 2026-01
-  input: &base_utilities
+  input:
     us:statutes/7/2012/j#relation.member_of_household: []
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
@@ -8,7 +8,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: false
-  oracle_inputs: &oracle_new_york_city
+  oracle_inputs:
     policyengine:
       snap_utility_region_str: NY_NYC
   output:
@@ -20,7 +20,11 @@
 - name: utilities_allowance_applies_in_nassau_or_suffolk
   period: 2026-01
   input:
-    <<: *base_utilities
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: true
   oracle_inputs:
@@ -33,7 +37,11 @@
 - name: utilities_allowance_applies_in_rest_of_state
   period: 2026-01
   input:
-    <<: *base_utilities
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: false
   oracle_inputs:
@@ -46,17 +54,33 @@
 - name: heating_cooling_eligibility_prevents_utilities_allowance
   period: 2026-01
   input:
-    <<: *base_utilities
+    us:statutes/7/2012/j#relation.member_of_household: []
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: true
-  oracle_inputs: *oracle_new_york_city
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: false
+  oracle_inputs:
+    policyengine:
+      snap_utility_region_str: NY_NYC
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_utilities_standard_allowance_eligible: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_limited_utility_allowance: 0
 
 - name: telephone_only_cost_does_not_create_utilities_allowance
   period: 2026-01
   input:
-    <<: *base_utilities
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling: false
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_entitled_to_heap_or_liheaa_payment: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-  oracle_inputs: *oracle_new_york_city
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_new_york_city: true
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_resides_in_nassau_or_suffolk_county: false
+  oracle_inputs:
+    policyengine:
+      snap_utility_region_str: NY_NYC
   output:
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_utilities_standard_allowance_eligible: not_holds
+    us-ny:regulations/18-nycrr/387/12/f/3/v/b#snap_limited_utility_allowance: 0


### PR DESCRIPTION
## Summary
- rewrites NY SNAP heating/cooling and utilities companion tests without YAML merge anchors so strict duplicate-key parsing passes
- adds explicit zero-branch assertions for the heating/cooling and limited utility allowance outputs
- re-signs the affected applied-file manifests with manual_exception: fixtures

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml
- axiom-encode proof-validate us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ny-snap-heating-sua us-ny/regulations/18-nycrr/387/12/f/3/v/a.test.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/b.test.yaml us-ny/regulations/18-nycrr/387/12/f/3/v/c.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ny-snap-heating-sua --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ny-snap-heating-sua
- axiom-encode oracle-coverage --root /tmp/ny-utility-coverage-root --json (NY utility outputs comparable for a/b/c)