### PR TITLE
Encode Connecticut SNAP utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/utility-allowances.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/utility-allowances.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/utility-allowances.test.yaml",
+      "sha256": "e955fb7e354e62df9926814f70c0876c881b341469527f83238f7a7bd13124d1"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/utility-allowances.yaml",
+      "sha256": "56b26693663569587f1e2d4fb1e22878d49d7f83031cf0ecc85a93a6a5d1b5bb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/utility-allowances",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T18:22:46.676848+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp605v93c4/sign-applied-files/us-ct/policies/dss/snap/tables/utility-allowances.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp605v93c4",
+  "generated_output_sha256": "56b26693663569587f1e2d4fb1e22878d49d7f83031cf0ecc85a93a6a5d1b5bb",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3795826337cd0e9a99bc1298863c6d5c10ff73544f177e17917ea387a98c3605"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8200,6 +8200,15 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-16": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/utility-allowances.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/utility-allowances.test.yaml
+++ b/us-ct/policies/dss/snap/tables/utility-allowances.test.yaml
@@ -1,0 +1,65 @@
+- name: standard_utility_allowance_selected
+  period: 2025-10
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: true
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#local_snap_utility_allowance_for_shelter_costs: 976
+- name: limited_utility_allowance_selected
+  period: 2025-10
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: true
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#local_snap_utility_allowance_for_shelter_costs: 430
+- name: telephone_allowance_selected
+  period: 2025-10
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: true
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#local_snap_utility_allowance_for_shelter_costs: 36
+- name: no_utility_allowance_selected
+  period: 2025-10
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#local_snap_utility_allowance_for_shelter_costs: 0
+- name: auto_output_snap_standard_utility_allowance_state_value
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#snap_standard_utility_allowance_state_value: 976
+- name: auto_output_snap_limited_utility_allowance_state_value
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#snap_limited_utility_allowance_state_value: 430
+- name: auto_output_snap_individual_utility_allowance_state_value
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_limited_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_standard_utility_allowance: false
+    us-ct:policies/dss/snap/tables/utility-allowances#input.household_uses_telephone_allowance: false
+  output:
+    us-ct:policies/dss/snap/tables/utility-allowances#snap_individual_utility_allowance_state_value: 36

--- a/us-ct/policies/dss/snap/tables/utility-allowances.yaml
+++ b/us-ct/policies/dss/snap/tables/utility-allowances.yaml
@@ -1,0 +1,188 @@
+format: rulespec/v1
+imports:
+- us:regulations/7-cfr/273/9
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+      - us:regulations/7-cfr/273/9
+      - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: Federal SNAP regulation context supplies the state utility-allowance
+        delegation and state-option slots. The Connecticut DSS table is used as the
+        delegated state parameter source for the dollar amounts effective 10/01/2025.
+  summary: 'Standard Utility Allowance (SUA) $976; Limited Utility Allowance (LUA)
+    $430; Telephone Allowance (TUA) $36. Effective Date: 10/01/2025.'
+rules:
+- name: snap_standard_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_standard_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/snap/tables/utility-allowances#snap_standard_utility_allowance
+          output: snap_standard_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+- name: snap_limited_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_limited_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/snap/tables/utility-allowances#snap_limited_utility_allowance
+          output: snap_limited_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+- name: snap_individual_utility_allowance_state_value
+  kind: derived
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_individual_utility_allowance
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:policies/dss/snap/tables/utility-allowances#snap_individual_utility_allowance
+          output: snap_individual_utility_allowance
+          hash: sha256:local
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: Standard Utility Allowance (SUA) ... $976
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: 'Effective Date: 10/01/2025'
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '976'
+- name: snap_limited_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: Limited Utility Allowance (LUA) ... $430
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: 'Effective Date: 10/01/2025'
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '430'
+- name: snap_individual_utility_allowance
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: Telephone Allowance (TUA) $36
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: 'Effective Date: 10/01/2025'
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '36'
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: CT DSS SNAP tables, Source
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/manual/dss/snap/tables/block-16
+          excerpt: Standard Utility Allowance (SUA) Limited Utility Allowance (LUA)
+            Telephone Allowance (TUA)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_uses_standard_utility_allowance: snap_standard_utility_allowance
+      else: if household_uses_limited_utility_allowance: snap_limited_utility_allowance
+      else: if household_uses_telephone_allowance: snap_individual_utility_allowance
+      else: 0'
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-ct:policies/dss/snap/tables/utility-allowances#snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_snap_limited_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    value: us-ct:policies/dss/snap/tables/utility-allowances#snap_limited_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_snap_individual_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    value: us-ct:policies/dss/snap/tables/utility-allowances#snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation


### PR DESCRIPTION
## Summary
- encodes Connecticut SNAP utility allowance table effective 2025-10-01
- adds SUA , LUA , and telephone/TUA  amount leaves
- wires Connecticut state-option source relations for standard, limited, and individual utility allowance slots
- adds companion tests for each allowance selection and the no-selection zero branch

## Source
- corpus: us-ct/manual/dss/snap/tables/block-16
- source text: CT DSS SNAP Policy Manual Tables, Utility Allowances
- encoder artifact: /Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-utility-20260712/block-16

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/utility-allowances.yaml
- axiom-encode proof-validate us-ct/policies/dss/snap/tables/utility-allowances.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ct-snap-utility us-ct/policies/dss/snap/tables/utility-allowances.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-utility --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-utility
- axiom-encode oracle-coverage --root /tmp/ct-utility-coverage-root --json (CT utility leaves classified known_not_comparable)