### PR TITLE
Encode Connecticut SNAP standard deduction

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/standard-deduction.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/standard-deduction.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/standard-deduction.test.yaml",
+      "sha256": "fdbc494bb94f0165c32a3999ea6ba9979d9efd8be35c8152f9407120d8bd26de"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/standard-deduction.yaml",
+      "sha256": "81043282e65a078563e170a6ec7f7bc0dd49cc4530a9166b655c6cac0a730fda"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/standard-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T18:30:04.299208+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbc0eehuj/sign-applied-files/us-ct/policies/dss/snap/tables/standard-deduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbc0eehuj",
+  "generated_output_sha256": "81043282e65a078563e170a6ec7f7bc0dd49cc4530a9166b655c6cac0a730fda",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4f503c147d1d73e2397d5c7744d3b214d40e449b4e4948d73c4bd346e107c47b"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-12T18:29:16.629674+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "1064d616b14dde2b772a0fda35461cfc8bc49c89baded351a8932696828223b4",
+    "prior_signature": "0722636418f274b684e881d8fdd06e0d9d7cabd5c303a7cd9303be4cd3752913",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8200,6 +8200,15 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-14": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/standard-deduction.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/standard-deduction.test.yaml
+++ b/us-ct/policies/dss/snap/tables/standard-deduction.test.yaml
@@ -1,0 +1,28 @@
+- name: one_person_household_standard_deduction
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/standard-deduction#input.household_size: 1
+    us-ct:policies/dss/snap/tables/standard-deduction#input.certified_group_size: 1
+  output:
+    us-ct:policies/dss/snap/tables/standard-deduction#snap_standard_deduction: 209
+- name: four_person_household_standard_deduction
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/standard-deduction#input.household_size: 4
+    us-ct:policies/dss/snap/tables/standard-deduction#input.certified_group_size: 4
+  output:
+    us-ct:policies/dss/snap/tables/standard-deduction#snap_standard_deduction: 223
+- name: five_person_household_standard_deduction
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/standard-deduction#input.household_size: 5
+    us-ct:policies/dss/snap/tables/standard-deduction#input.certified_group_size: 5
+  output:
+    us-ct:policies/dss/snap/tables/standard-deduction#snap_standard_deduction: 261
+- name: over_six_person_household_standard_deduction
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/standard-deduction#input.household_size: 7
+    us-ct:policies/dss/snap/tables/standard-deduction#input.certified_group_size: 7
+  output:
+    us-ct:policies/dss/snap/tables/standard-deduction#snap_standard_deduction: 299

--- a/us-ct/policies/dss/snap/tables/standard-deduction.yaml
+++ b/us-ct/policies/dss/snap/tables/standard-deduction.yaml
@@ -1,0 +1,83 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/manual/dss/snap/tables/block-14
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:policies/usda/snap/fy-2026-cola/deductions
+      rationale: >-
+        The copied federal regulation context identifies SNAP deduction
+        mechanics and state-administered SNAP standards, while the USDA FY 2026
+        context supplies the same standard-deduction amounts for the 48 states
+        and District of Columbia. The Connecticut DSS table is used here as the
+        requested local parameter source because it directly states the certified
+        group-size standard deduction amounts for this Connecticut source unit.
+  summary: |-
+    Certified Group Size Amount 1 $209 2 $209 3 $209 4 $223 5 $261 6 $299 Over 6 $299
+rules:
+  - name: snap_standard_deduction_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: certified_group_size
+    source: Connecticut DSS SNAP standard deduction table, certified group size amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-14
+              excerpt: Certified Group Size Amount 1 $209 2 $209 3 $209 4 $223 5 $261 6 $299 Over 6 $299
+              table:
+                header: Certified Group Size Amount
+                row_key: certified_group_size
+                column_key: amount
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 209
+          2: 209
+          3: 209
+          4: 223
+          5: 261
+          6: 299
+  - name: snap_standard_deduction_maximum_group_size_key
+    kind: parameter
+    dtype: Count
+    source: Connecticut DSS SNAP standard deduction table, Over 6 row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-14
+              excerpt: Over 6 $299
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          6
+  - name: snap_standard_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Connecticut DSS SNAP standard deduction table, certified group size amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-14
+              excerpt: Certified Group Size Amount 1 $209 2 $209 3 $209 4 $223 5 $261 6 $299 Over 6 $299
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_standard_deduction_table[min(household_size, snap_standard_deduction_maximum_group_size_key)]


### PR DESCRIPTION
## Summary
- encodes Connecticut SNAP standard deduction table from CT DSS SNAP Policy Manual Tables
- adds certified group size table for /////, with over-6 households capped at the 6-person amount
- adds companion tests for household sizes 1, 4, 5, and over 6

## Source
- corpus: us-ct/manual/dss/snap/tables/block-14
- source text: CT DSS SNAP Policy Manual Tables, Standard Deduction
- encoder artifact: /Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-standard-deduction-20260712/block-14

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/standard-deduction.yaml
- axiom-encode proof-validate us-ct/policies/dss/snap/tables/standard-deduction.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ct-snap-standard-deduction us-ct/policies/dss/snap/tables/standard-deduction.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-standard-deduction --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-standard-deduction
- axiom-encode oracle-coverage --root /tmp/ct-standard-deduction-coverage-root --json (CT standard deduction leaves classified known_not_comparable)