### PR TITLE
Encode Connecticut SNAP homeless shelter deduction

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/homeless-shelter-deduction.test.yaml",
+      "sha256": "ff4083eccb3c1eefef2f43c3308b1e4753421bb1ff4306eba5bc997be5400898"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml",
+      "sha256": "7000903d9ce1733c69698930fd729dc2682c6999fb9cbe1d15ab644666cb242a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/homeless-shelter-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T18:34:14.866975+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpokgfevo7/sign-applied-files/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpokgfevo7",
+  "generated_output_sha256": "7000903d9ce1733c69698930fd729dc2682c6999fb9cbe1d15ab644666cb242a",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "81747be95c70e0e441d3b7e2bc605650c91ca9e6eab8afa5e0f6c3d9375a85fb"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8200,6 +8200,15 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-5": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.test.yaml
+++ b/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.test.yaml
@@ -1,0 +1,5 @@
+- name: homeless_edg_standard_amount
+  period: 2025-10
+  input: {}
+  output:
+    us-ct:policies/dss/snap/tables/homeless-shelter-deduction#snap_homeless_shelter_deduction: 198.99

--- a/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml
+++ b/us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml
@@ -1,0 +1,55 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/manual/dss/snap/tables/block-5
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+      rationale: >-
+        7 CFR 273.9 supplies the federal SNAP shelter-deduction framework and
+        copied federal context includes related shelter-deduction concepts, but
+        this Connecticut DSS manual table is the requested official local table
+        row for the Homeless EDG amount.
+  summary: |-
+    Homeless EDG $198.99
+rules:
+  - name: homeless_edg_standard_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Connecticut DSS SNAP table, Homeless EDG row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-5
+              excerpt: Homeless EDG $198.99
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          198.99
+  - name: snap_homeless_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Connecticut DSS SNAP table, Homeless EDG row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/homeless-shelter-deduction#homeless_edg_standard_amount
+              output: homeless_edg_standard_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          homeless_edg_standard_amount


### PR DESCRIPTION
## Summary
- encodes Connecticut SNAP Homeless EDG shelter deduction amount from CT DSS SNAP Policy Manual Tables
- adds the .99 homeless shelter deduction amount and executable output
- adds a companion test for the stated amount

## Source
- corpus: us-ct/manual/dss/snap/tables/block-5
- source text: CT DSS SNAP Policy Manual Tables, Homeless Shelter Deduction
- encoder artifact: /Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-homeless-shelter-20260712/block-5

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml
- axiom-encode proof-validate us-ct/policies/dss/snap/tables/homeless-shelter-deduction.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ct-snap-homeless-shelter us-ct/policies/dss/snap/tables/homeless-shelter-deduction.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-homeless-shelter --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-homeless-shelter
- axiom-encode oracle-coverage --root /tmp/ct-homeless-shelter-coverage-root --json (CT homeless shelter leaves classified known_not_comparable)