### PR TITLE
Encode Connecticut SNAP excess shelter deduction

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/excess-shelter-deduction.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/excess-shelter-deduction.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/excess-shelter-deduction.test.yaml",
+      "sha256": "c74cab9fdac62c2ae5fa2d8eeb8cfbf4c754d5b931359828934e1141a13281a3"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml",
+      "sha256": "7457e72b8c2a71b4ce7fe58330a468a6fee2a058fe40710260e644631d291647"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/excess-shelter-deduction",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T18:42:36.794924+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62p947ez/sign-applied-files/us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62p947ez",
+  "generated_output_sha256": "7457e72b8c2a71b4ce7fe58330a468a6fee2a058fe40710260e644631d291647",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d57550eb3cd675ac3b569c4a66006439ca20280bf3657a4408c2bfa6abd60a44"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8200,6 +8200,15 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-3": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/excess-shelter-deduction.test.yaml
+++ b/us-ct/policies/dss/snap/tables/excess-shelter-deduction.test.yaml
@@ -1,0 +1,29 @@
+- name: elderly_disabled_edg_no_maximum
+  period: 2025-10
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.only_elderly_or_disabled_member_is_ineligible: false
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.uncapped_snap_excess_shelter_expense_deduction: 900
+  output:
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_deduction_all_other_edg_applies: not_holds
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_expense_deduction: 900
+- name: all_other_edg_maximum_applies
+  period: 2025-10
+  input:
+    us:statutes/7/2012/j#relation.member_of_household: []
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.only_elderly_or_disabled_member_is_ineligible: false
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.uncapped_snap_excess_shelter_expense_deduction: 900
+  output:
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_deduction_all_other_edg_applies: holds
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_expense_deduction: 744
+- name: only_elderly_disabled_member_ineligible_uses_all_other_cap
+  period: 2025-10
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.only_elderly_or_disabled_member_is_ineligible: true
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#input.uncapped_snap_excess_shelter_expense_deduction: 900
+  output:
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_deduction_all_other_edg_applies: holds
+    us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_expense_deduction: 744

--- a/us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml
+++ b/us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml
@@ -1,0 +1,99 @@
+format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/manual/dss/snap/tables/block-3
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
+        - us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_48_states_dc
+      rationale: |-
+        Federal SNAP context supplies the delegated full-excess-shelter rule and current-year federal maximum; the Connecticut DSS table is the direct local source for applying the no-maximum and $744 maximum EDG categories in this state table slice.
+  summary: |-
+    Elderly / Disabled EDG: No Maximum. All Other EDGs: $744. Exception: the All Other EDGs deduction applies if the only elderly/disabled member is ineligible.
+rules:
+  - name: snap_all_other_edg_maximum_excess_shelter_deduction
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: CT DSS SNAP excess shelter deduction table, All Other EDGs column
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-3
+              excerpt: "All Other EDGs ... $744"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          744
+
+  - name: snap_excess_shelter_deduction_all_other_edg_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: CT DSS SNAP excess shelter deduction table, exception for only elderly/disabled member ineligible
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-3
+              excerpt: "All Other EDGs applies if the only elderly/disabled member is ineligible"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/9#snap_full_excess_shelter_deduction_applies
+              output: snap_full_excess_shelter_deduction_applies
+              hash: sha256:76dd530624a00c5199f27bd4ec3ce866cd89e897fd7332b368164cf58f222b9f
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not snap_full_excess_shelter_deduction_applies
+          or only_elderly_or_disabled_member_is_ineligible
+
+  - name: snap_excess_shelter_expense_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: CT DSS SNAP excess shelter deduction table, maximum by EDG category
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-3
+              excerpt: "Elderly / Disabled EDG ... No Maximum $744"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-3
+              excerpt: "All Other EDGs applies if the only elderly/disabled member is ineligible"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_all_other_edg_maximum_excess_shelter_deduction
+              output: snap_all_other_edg_maximum_excess_shelter_deduction
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/excess-shelter-deduction#snap_excess_shelter_deduction_all_other_edg_applies
+              output: snap_excess_shelter_deduction_all_other_edg_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_excess_shelter_deduction_all_other_edg_applies: min(max(0, uncapped_snap_excess_shelter_expense_deduction), snap_all_other_edg_maximum_excess_shelter_deduction) else: max(0, uncapped_snap_excess_shelter_expense_deduction)


### PR DESCRIPTION
## Summary
- encodes Connecticut SNAP excess shelter deduction table from CT DSS SNAP Policy Manual Tables
- adds the  all-other EDG cap, no-maximum elderly/disabled branch, and exception for when the only elderly/disabled member is ineligible
- adds companion tests for full/no-cap, capped all-other, and ineligible-only exception cases

## Source
- corpus: us-ct/manual/dss/snap/tables/block-3
- source text: CT DSS SNAP Policy Manual Tables, Excess Shelter Deduction
- encoder artifact: /Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-excess-shelter-20260712/block-3

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml
- axiom-encode proof-validate us-ct/policies/dss/snap/tables/excess-shelter-deduction.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ct-snap-excess-shelter us-ct/policies/dss/snap/tables/excess-shelter-deduction.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-excess-shelter --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-excess-shelter
- axiom-encode oracle-coverage --root /tmp/ct-excess-shelter-coverage-root --json (CT excess shelter leaves classified known_not_comparable)