### PR TITLE
Encode Connecticut SNAP asset limits

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/asset-limits.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/asset-limits.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/asset-limits.test.yaml",
+      "sha256": "915ad12951c81023b4f43e47f2992892d38d889bb12fb62b9f261553b4c7fb15"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/asset-limits.yaml",
+      "sha256": "0161616767ecd699435a4be0cbf9e139f1e518ffcecedde69a081ec604e167a1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/asset-limits",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T20:51:39.716642+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpsstkwl14/sign-applied-files/us-ct/policies/dss/snap/tables/asset-limits.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpsstkwl14",
+  "generated_output_sha256": "0161616767ecd699435a4be0cbf9e139f1e518ffcecedde69a081ec604e167a1",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e0c8be317f8829dca8bd00f10cdbbb947ae9c5a17bc8a711144ff175f6f812e2"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8522,6 +8522,22 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-1": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/asset-limits.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/manual/dss/snap/tables/block-2": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/asset-limits.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/asset-limits.test.yaml
+++ b/us-ct/policies/dss/snap/tables/asset-limits.test.yaml
@@ -1,0 +1,27 @@
+- name: elderly_or_disabled_edg_over_200_percent_has_4500_asset_limit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/asset-limits#input.edg_gross_income_over_200_percent: true
+    us-ct:policies/dss/snap/tables/asset-limits#input.snap_household_has_elderly_or_disabled_member: true
+    us-ct:policies/dss/snap/tables/asset-limits#input.only_elderly_or_disabled_member_is_disqualified_or_ineligible: false
+  output:
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit_applies: holds
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit: 4500
+- name: only_elderly_or_disabled_member_disqualified_over_200_percent_has_4500_asset_limit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/asset-limits#input.edg_gross_income_over_200_percent: true
+    us-ct:policies/dss/snap/tables/asset-limits#input.snap_household_has_elderly_or_disabled_member: false
+    us-ct:policies/dss/snap/tables/asset-limits#input.only_elderly_or_disabled_member_is_disqualified_or_ineligible: true
+  output:
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit_applies: holds
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit: 4500
+- name: all_other_edg_has_no_applicable_asset_limit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/asset-limits#input.edg_gross_income_over_200_percent: false
+    us-ct:policies/dss/snap/tables/asset-limits#input.snap_household_has_elderly_or_disabled_member: true
+    us-ct:policies/dss/snap/tables/asset-limits#input.only_elderly_or_disabled_member_is_disqualified_or_ineligible: false
+  output:
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit_applies: not_holds
+    us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit: 0

--- a/us-ct/policies/dss/snap/tables/asset-limits.yaml
+++ b/us-ct/policies/dss/snap/tables/asset-limits.yaml
@@ -1,0 +1,104 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ct/manual/dss/snap/tables/block-1
+      - us-ct/manual/dss/snap/tables/block-2
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:statutes/7/2014/g
+      rationale: |-
+        Federal SNAP resource-limit authority provides generally applicable household resource limits and adjustment mechanics, but the Connecticut DSS table is the operative source for the state EDG asset-limit rows and the $4,500 current table amount encoded here.
+  summary: |-
+    "Elderly/Disabled EDG with Gross Income Over 200%" and "EDG's with Gross Income Over 200% and the only Elderly/Disabled Member is Disqualified or Ineligible" have asset limits of "$4,500"; "All Other EDGs" are "N/A."
+rules:
+  - name: snap_asset_limit_amount_for_gross_income_over_200_percent_elderly_or_disabled_edg
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Asset Limits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-1
+              excerpt: '$4,500'
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-2
+              excerpt: 'Effective Date: 10/01/2025'
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          4500
+
+  - name: snap_asset_limit_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DSS SNAP tables, Asset Limits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-1
+              excerpt: 'Elderly/Disabled EDG with Gross Income Over 200%'
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-1
+              excerpt: "EDG's with Gross Income Over 200% and the only Elderly/Disabled Member is Disqualified or Ineligible"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-1
+              excerpt: 'All Other EDGs ... N/A'
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          edg_gross_income_over_200_percent
+          and (
+            snap_household_has_elderly_or_disabled_member
+            or only_elderly_or_disabled_member_is_disqualified_or_ineligible
+          )
+
+  - name: snap_asset_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Asset Limits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-1
+              excerpt: 'All Other EDGs $4,500 $4,500 N/A'
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit_amount_for_gross_income_over_200_percent_elderly_or_disabled_edg
+              output: snap_asset_limit_amount_for_gross_income_over_200_percent_elderly_or_disabled_edg
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/asset-limits#snap_asset_limit_applies
+              output: snap_asset_limit_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_asset_limit_applies: snap_asset_limit_amount_for_gross_income_over_200_percent_elderly_or_disabled_edg else: 0


### PR DESCRIPTION
## Summary
- Encode Connecticut DSS SNAP asset-limit table effective 2025-10-01.
- Represent the $4,500 limit for elderly/disabled EDGs over 200% gross income and EDGs over 200% where the only elderly/disabled member is disqualified or ineligible.
- Represent all other EDGs as no applicable table asset limit via `snap_asset_limit_applies: not_holds` and `snap_asset_limit: 0`.

## Sources
- `us-ct/manual/dss/snap/tables/block-1`
- `us-ct/manual/dss/snap/tables/block-2`
- Generated artifact: `/Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-asset-limits-20260712/block-1`

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/asset-limits.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-ct/policies/dss/snap/tables/asset-limits.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-ct-snap-asset-limits us-ct/policies/dss/snap/tables/asset-limits.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-asset-limits --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-asset-limits`
- Oracle coverage for `us-ct:policies/dss/snap/tables/asset-limits` classified as `known_not_comparable` for all leaves.

## Review cycle
- Pending `/cycle`.
