### PR TITLE
Encode Connecticut SNAP income limits

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml",
+      "sha256": "dbe5c8a179c60cdd0500243c831100055d9d53abee5bbb46e06be05af502521a"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.test.yaml",
+      "sha256": "fc74cda5d5899171f1a2b4b954c21e9383287a521b6b18d155aa7b13cd98a555"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "deterministic",
+  "citation": "us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:00:12.746381+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpmnoepp1f/deterministic-repair/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpmnoepp1f",
+  "generated_output_sha256": "dbe5c8a179c60cdd0500243c831100055d9d53abee5bbb46e06be05af502521a",
+  "generation_prompt_sha256": null,
+  "model": "proof-import-hash-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "9fa85ae8c6cff8ad951399c455fcda46bd23164b6ab91662cbd715d89a62698d"
+  },
+  "tool": "axiom-encode repair-proof-import-hashes",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8522,6 +8522,22 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-7": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/manual/dss/snap/tables/block-8": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.test.yaml
+++ b/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.test.yaml
@@ -1,0 +1,46 @@
+- name: one_member_income_limits_and_maximum_benefit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#input.household_size: 1
+  output:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl_table: 2609
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl: 2609
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_income_change_reporting_threshold: 2609
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_165_percent_fpl: 2152
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_130_percent_fpl: 1696
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_net_income_limit_100_percent_fpl: 1305
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_maximum_monthly_benefit: 298
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_minimum_benefit: 24
+
+- name: eight_member_income_limits_and_maximum_benefit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#input.household_size: 8
+  output:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl_table: 9025
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl: 9025
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_income_change_reporting_threshold: 9025
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_165_percent_fpl: 7446
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_130_percent_fpl: 5867
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_net_income_limit_100_percent_fpl: 4513
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_maximum_monthly_benefit: 1789
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_minimum_benefit: 0
+
+- name: additional_member_amounts_are_added
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#input.household_size: 9
+  output:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl: 9942
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_income_change_reporting_threshold: 9942
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_165_percent_fpl: 8203
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_gross_income_limit_130_percent_fpl: 6463
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_net_income_limit_100_percent_fpl: 4972
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_maximum_monthly_benefit: 2007
+
+- name: two_member_household_gets_minimum_benefit
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#input.household_size: 2
+  output:
+    us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_minimum_benefit: 24

--- a/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml
+++ b/us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml
@@ -1,0 +1,285 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ct/manual/dss/snap/tables/block-7
+      - us-ct/manual/dss/snap/tables/block-8
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:statutes/7/2014/c
+        - us:statutes/7/2017/a
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/10
+        - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
+        - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+      rationale: |-
+        The Connecticut DSS table republishes FY 2026 SNAP income eligibility
+        standards and maximum benefit values for the 48-state table. The
+        federal USDA FY 2026 COLA RuleSpec modules are the higher-authority
+        source for the 100%, 130%, 165%, and maximum-benefit columns, while the
+        Connecticut table is the direct source for the local 200% ECE column,
+        the income-change reporting threshold label, and the stated $24 minimum
+        benefit for households of 1 to 2 members.
+  summary: |-
+    Connecticut DSS SNAP income limits and maximum benefit table effective
+    October 1, 2025. The table includes the 200% FPL expanded categorical
+    eligibility and income-change reporting threshold column, the federal 165%,
+    130%, 100%, and maximum SNAP benefit columns for household sizes 1 through
+    8 plus each additional member, and a $24 minimum benefit for households of
+    1 to 2 members.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+rules:
+  - name: snap_ece_gross_income_limit_200_percent_fpl_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Gross Monthly Income Limit (200% FPL)"
+              table:
+                header: Gross Monthly Income Limit (200% FPL)
+                row_key: SNAP EDG Size
+                column_key: Gross Monthly Income Limit (200% FPL)
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-8
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 2609
+          2: 3525
+          3: 4442
+          4: 5359
+          5: 6275
+          6: 7192
+          7: 8109
+          8: 9025
+
+  - name: snap_ece_gross_income_limit_200_percent_fpl_additional_member
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Added for Each Additional Member +$917"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-8
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          917
+
+  - name: snap_ece_gross_income_limit_200_percent_fpl
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Gross Monthly Income Limit (200% FPL)"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl_table
+              output: snap_ece_gross_income_limit_200_percent_fpl_table
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl_additional_member
+              output: snap_ece_gross_income_limit_200_percent_fpl_additional_member
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_ece_gross_income_limit_200_percent_fpl_table[max(min(household_size, 8), 1)]
+          + (max(household_size - 8, 0) * snap_ece_gross_income_limit_200_percent_fpl_additional_member)
+
+  - name: snap_income_change_reporting_threshold
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Expanded Categorical Eligibility (ECE) ... Income Change Reporting Threshold"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_ece_gross_income_limit_200_percent_fpl
+              output: snap_ece_gross_income_limit_200_percent_fpl
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_ece_gross_income_limit_200_percent_fpl
+
+  - name: snap_net_income_limit_100_percent_fpl
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_net_income_limit_100_percent_fpl_48_states_dc
+              output: snap_net_income_limit_100_percent_fpl_48_states_dc
+              hash: sha256:94d8f5eaefa63fd65fc5f4d19ee1ff5c4dd07d26189e29007bc914218bd5c3a4
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_net_income_limit_100_percent_fpl_48_states_dc
+
+  - name: snap_gross_income_limit_130_percent_fpl
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_130_percent_fpl_48_states_dc
+              output: snap_gross_income_limit_130_percent_fpl_48_states_dc
+              hash: sha256:94d8f5eaefa63fd65fc5f4d19ee1ff5c4dd07d26189e29007bc914218bd5c3a4
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_gross_income_limit_130_percent_fpl_48_states_dc
+
+  - name: snap_gross_income_limit_165_percent_fpl
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_165_percent_fpl_48_states_dc
+              output: snap_gross_income_limit_165_percent_fpl_48_states_dc
+              hash: sha256:94d8f5eaefa63fd65fc5f4d19ee1ff5c4dd07d26189e29007bc914218bd5c3a4
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_gross_income_limit_165_percent_fpl_48_states_dc
+
+  - name: snap_maximum_monthly_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
+              output: snap_maximum_allotment
+              hash: sha256:2e4708b8df906b506f07d091fe93dbcc6aefe603a31500502ecc270d436e9f2e
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_maximum_allotment
+
+  - name: snap_minimum_benefit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Minimum Benefit for Households of 1 - 2 Members: $24"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-8
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          24
+
+  - name: snap_minimum_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Income Limits and Maximum Benefit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-7
+              excerpt: "Minimum Benefit for Households of 1 - 2 Members: $24"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit#snap_minimum_benefit_amount
+              output: snap_minimum_benefit_amount
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_size >= 1 and household_size <= 2: snap_minimum_benefit_amount else: 0


### PR DESCRIPTION
## Summary
- Encode Connecticut DSS SNAP income limits and maximum benefit table effective 2025-10-01.
- Add CT 200% FPL ECE/income-change reporting threshold table for household sizes 1-8 plus each additional member.
- Add CT-local surfaces for the federal 165%, 130%, 100%, and maximum monthly benefit columns by importing FY 2026 USDA SNAP COLA modules.
- Add the $24 minimum benefit for households of 1-2 members.

## Sources
- `us-ct/manual/dss/snap/tables/block-7`
- `us-ct/manual/dss/snap/tables/block-8`
- Higher authority checked against `us:statutes/7/2014/c`, `us:statutes/7/2017/a`, `us:regulations/7-cfr/273/9`, `us:regulations/7-cfr/273/10`, and FY 2026 USDA SNAP COLA RuleSpec modules.
- Generated artifact: `/Users/pavelmakarchuk/axiom-encode-artifacts/ct-snap-income-benefits-20260712/block-7`

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-ct-snap-income-benefits us-ct/policies/dss/snap/tables/income-limits-and-maximum-benefit.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-income-benefits --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-income-benefits`
- Oracle coverage for `us-ct:policies/dss/snap/tables/income-limits-and-maximum-benefit` classified as `known_not_comparable` for all leaves.

## Review cycle
- Pending `/cycle`.
