### PR TITLE
Encode Connecticut SNAP room and board compensation

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.test.yaml",
+      "sha256": "aed37ef9fc00700f7170997b1494147d3ac6cf4b0894f7da4f29ec77b8fa5f57"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml",
+      "sha256": "05ce14d4dd160f6b7e9f49506bd9209fef72c72978b504a67cbe3e901f2a8182"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:08:05.069588+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp50a4tv0f/sign-applied-files/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp50a4tv0f",
+  "generated_output_sha256": "05ce14d4dd160f6b7e9f49506bd9209fef72c72978b504a67cbe3e901f2a8182",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0037873e3b7ca122665805b082d862984a035481416a37d37994024883373ba1"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8522,6 +8522,22 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-12": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/manual/dss/snap/tables/block-13": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.test.yaml
+++ b/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.test.yaml
@@ -1,0 +1,39 @@
+- name: one_boarder_more_than_two_meals_per_day
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_group_size: 1
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_receives_more_than_two_meals_per_day: true
+  output:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day_table: 298
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day: 298
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_room_and_board_compensation: 298
+
+- name: one_boarder_two_meals_or_less_per_day
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_group_size: 1
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_receives_more_than_two_meals_per_day: false
+  output:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day_table: 200
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day: 200
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_room_and_board_compensation: 200
+
+- name: tenth_boarder_group_uses_table_values
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_group_size: 10
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_receives_more_than_two_meals_per_day: false
+  output:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day: 2225
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day: 1491
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_room_and_board_compensation: 1491
+
+- name: additional_boarder_members_add_increment
+  period: 2026-01
+  input:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_group_size: 11
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#input.boarder_receives_more_than_two_meals_per_day: true
+  output:
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day: 2443
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day: 1638
+    us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_room_and_board_compensation: 2443

--- a/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml
+++ b/us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml
@@ -1,0 +1,314 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ct/manual/dss/snap/tables/block-12
+      - us-ct/manual/dss/snap/tables/block-13
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:statutes/7/2017/a
+        - us:regulations/7-cfr/273/10
+        - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+      rationale: |-
+        Federal SNAP allotment authority and the USDA FY 2026 COLA module supply
+        the maximum allotment amounts mirrored by the "More than Two Meals per
+        Day" column. The Connecticut DSS table is the operative source for the
+        published room-and-board compensation table, including the "Two meals or
+        Less per Day" amounts and additional-member increments.
+  summary: |-
+    Connecticut DSS SNAP reasonable room and board compensation table effective
+    October 1, 2025. Boarder group sizes 1 through 10 have separate required
+    monthly compensation amounts for more than two meals per day and for two
+    meals or less per day, with additional-member increments above 10.
+rules:
+  - name: reasonable_boarder_compensation_table_min_group_size
+    kind: parameter
+    dtype: Count
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Boarder Group Size ... 1"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          1
+
+  - name: reasonable_boarder_compensation_table_max_group_size
+    kind: parameter
+    dtype: Count
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "10 $2,225 $1,491"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          10
+
+  - name: reasonable_boarder_compensation_more_than_two_meals_per_day_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: boarder_group_size
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Boarder Group Size More than Two Meals per Day"
+              table:
+                header: Reasonable Room and Board Compensation
+                row_key: Boarder Group Size
+                column_key: More than Two Meals per Day
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 298
+          2: 546
+          3: 785
+          4: 994
+          5: 1183
+          6: 1421
+          7: 1571
+          8: 1789
+          9: 2007
+          10: 2225
+
+  - name: reasonable_boarder_compensation_more_than_two_meals_per_day_additional_member
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Each Additional Member +$218"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          218
+
+  - name: reasonable_boarder_compensation_more_than_two_meals_per_day
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "More than Two Meals per Day"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day_table
+              output: reasonable_boarder_compensation_more_than_two_meals_per_day_table
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day_additional_member
+              output: reasonable_boarder_compensation_more_than_two_meals_per_day_additional_member
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_table_min_group_size
+              output: reasonable_boarder_compensation_table_min_group_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_table_max_group_size
+              output: reasonable_boarder_compensation_table_max_group_size
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          reasonable_boarder_compensation_more_than_two_meals_per_day_table[max(min(boarder_group_size, reasonable_boarder_compensation_table_max_group_size), reasonable_boarder_compensation_table_min_group_size)]
+          + (max(boarder_group_size - reasonable_boarder_compensation_table_max_group_size, 0) * reasonable_boarder_compensation_more_than_two_meals_per_day_additional_member)
+
+  - name: reasonable_boarder_compensation_two_meals_or_less_per_day_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: boarder_group_size
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Two meals or Less per Day"
+              table:
+                header: Reasonable Room and Board Compensation
+                row_key: Boarder Group Size
+                column_key: Two meals or Less per Day
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 200
+          2: 366
+          3: 526
+          4: 666
+          5: 793
+          6: 953
+          7: 1053
+          8: 1199
+          9: 1345
+          10: 1491
+
+  - name: reasonable_boarder_compensation_two_meals_or_less_per_day_additional_member
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Each Additional Member +$147"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-13
+              excerpt: "Effective Date: 10/01/2025"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          147
+
+  - name: reasonable_boarder_compensation_two_meals_or_less_per_day
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "Two meals or Less per Day"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day_table
+              output: reasonable_boarder_compensation_two_meals_or_less_per_day_table
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day_additional_member
+              output: reasonable_boarder_compensation_two_meals_or_less_per_day_additional_member
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_table_min_group_size
+              output: reasonable_boarder_compensation_table_min_group_size
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_table_max_group_size
+              output: reasonable_boarder_compensation_table_max_group_size
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          reasonable_boarder_compensation_two_meals_or_less_per_day_table[max(min(boarder_group_size, reasonable_boarder_compensation_table_max_group_size), reasonable_boarder_compensation_table_min_group_size)]
+          + (max(boarder_group_size - reasonable_boarder_compensation_table_max_group_size, 0) * reasonable_boarder_compensation_two_meals_or_less_per_day_additional_member)
+
+  - name: reasonable_room_and_board_compensation
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: DSS SNAP tables, Reasonable Room and Board Compensation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-12
+              excerpt: "More than Two Meals per Day Two meals or Less per Day"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_more_than_two_meals_per_day
+              output: reasonable_boarder_compensation_more_than_two_meals_per_day
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation#reasonable_boarder_compensation_two_meals_or_less_per_day
+              output: reasonable_boarder_compensation_two_meals_or_less_per_day
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if boarder_receives_more_than_two_meals_per_day:
+              reasonable_boarder_compensation_more_than_two_meals_per_day
+          else:
+              reasonable_boarder_compensation_two_meals_or_less_per_day


### PR DESCRIPTION
## Summary
- Encode Connecticut DSS SNAP reasonable room and board compensation table effective 2025-10-01.
- Add boarder group-size tables for more than two meals per day and two meals or less per day.
- Add additional-member increments and a selector rule for the applicable reasonable room and board compensation amount.

## Sources
- `us-ct/manual/dss/snap/tables/block-12`
- `us-ct/manual/dss/snap/tables/block-13`
- Higher authority checked against `us:statutes/7/2017/a`, `us:regulations/7-cfr/273/10`, and `us:policies/usda/snap/fy-2026-cola/maximum-allotments`.

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-ct-snap-room-board us-ct/policies/dss/snap/tables/reasonable-room-and-board-compensation.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-room-board --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-room-board`
- Oracle coverage for `us-ct:policies/dss/snap/tables/reasonable-room-and-board-compensation` classified as `known_not_comparable` for all leaves.

## Review cycle
- Pending `/cycle`.
