### PR TITLE
Encode Connecticut SNAP qualifying work quarters

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/qualifying-work-quarters.json
+++ b/.axiom/encoding-manifests/us-ct/policies/dss/snap/tables/qualifying-work-quarters.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ct/policies/dss/snap/tables/qualifying-work-quarters.test.yaml",
+      "sha256": "7ef58f60a8294eab6d7ee4dbbdf6c13bcbb55a67317a867f5b998b6bd3a16bbe"
+    },
+    {
+      "path": "us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml",
+      "sha256": "62a8540d01b5eb06161444c71bd71f4b2a6c491578169420c28d300053bda143"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ct:policies/dss/snap/tables/qualifying-work-quarters",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:14:10.514092+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpezg4ibvj/sign-applied-files/us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpezg4ibvj",
+  "generated_output_sha256": "62a8540d01b5eb06161444c71bd71f4b2a6c491578169420c28d300053bda143",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a5f2596d50427ca655916e38a9392991369fbb5b7b51c9ad28f02919df774504"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -8522,6 +8522,30 @@
         ]
       }
     ],
+    "us-ct/manual/dss/snap/tables/block-10": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/manual/dss/snap/tables/block-11": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/manual/dss/snap/tables/block-9": [
+      {
+        "module": "us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/policy/dss/program-standards/2026-01-01/page-1": [
       {
         "module": "us-ct/policies/dss/program-standards/2026-01-01/personal-needs.yaml",

--- a/us-ct/policies/dss/snap/tables/qualifying-work-quarters.test.yaml
+++ b/us-ct/policies/dss/snap/tables/qualifying-work-quarters.test.yaml
@@ -1,0 +1,78 @@
+- name: pre_1978_wage_quarter_requires_50_dollars
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_calendar_quarter_wages: 50
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_calendar_quarters_with_wages_at_least_threshold: 3
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_quarter_earnings_threshold: 50
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_quarter_qualifies: holds
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_qualifying_work_quarters: 3
+
+- name: pre_1978_wage_quarters_are_capped_at_four
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_calendar_quarter_wages: 49
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_calendar_quarters_with_wages_at_least_threshold: 5
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_quarter_qualifies: not_holds
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_qualifying_work_quarters: 4
+
+- name: pre_1978_self_employment_400_dollars_earns_four_quarters
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_self_employment_earnings: 400
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_self_employment_four_quarters_earnings_threshold: 400
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_self_employment_qualifying_work_quarters: 4
+
+- name: pre_1978_self_employment_below_400_earns_zero_quarters
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_self_employment_earnings: 399
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_self_employment_qualifying_work_quarters: 0
+
+- name: pre_1978_migrant_seasonal_farmworker_wages_use_100_dollar_increment_and_cap
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.pre_1978_migrant_seasonal_farmworker_wages: 550
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_migrant_seasonal_farmworker_wage_quarter_increment: 100
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_migrant_seasonal_farmworker_qualifying_work_quarters: 4
+
+- name: post_1977_earned_income_divided_by_increment_and_capped
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.post_1977_total_yearly_earned_income: 7250
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.post_1977_quarter_increment_amount_for_year: 1810
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#post_1977_qualifying_work_quarters: 4
+
+- name: post_1977_partial_increment_rounds_down
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.post_1977_total_yearly_earned_income: 3000
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#input.post_1977_quarter_increment_amount_for_year: 1810
+  output:
+    us-ct:policies/dss/snap/tables/qualifying-work-quarters#post_1977_qualifying_work_quarters: 1

--- a/us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml
+++ b/us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml
@@ -1,0 +1,258 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ct/manual/dss/snap/tables/block-9
+      - us-ct/manual/dss/snap/tables/block-10
+      - us-ct/manual/dss/snap/tables/block-11
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/4
+      rationale: |-
+        Federal SNAP alien-status eligibility rules use 40 qualifying quarters
+        as an immediate-eligibility condition for qualified aliens. The
+        Connecticut DSS table supplies the operative local calculation
+        instructions for determining pre-1978 and post-1977 qualifying work
+        quarters in this table slice.
+  summary: |-
+    Connecticut DSS SNAP qualifying work-quarter table. Before 1978, a quarter
+    may be earned from calendar-quarter wages of $50 or more, four quarters may
+    be earned from taxable-year self-employment earnings of $400 or more, and
+    migrant or seasonal farmworker wages from 1955 through 1977 earn one
+    quarter per $100, limited to four. For 1978 or later, qualifying quarters
+    are based on total yearly earnings divided by the SSA increment amount for
+    the year, with no more than four quarters in each year.
+rules:
+  - name: pre_1978_wage_quarter_earnings_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "$50 or more in wages"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-11
+              excerpt: "Effective Date: 1/1/18"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          50
+
+  - name: pre_1978_self_employment_four_quarters_earnings_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "self-employment earnings were $400 or more"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-11
+              excerpt: "Effective Date: 1/1/18"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          400
+
+  - name: pre_1978_migrant_seasonal_farmworker_wage_quarter_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "each $100 (limited to 4) of migrant or seasonal farmworker wages"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-11
+              excerpt: "Effective Date: 1/1/18"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          100
+
+  - name: qualifying_work_quarters_per_year_cap
+    kind: parameter
+    dtype: Count
+    source: DSS SNAP tables, Qualifying Work Quarters
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-10
+              excerpt: "No more than 4 quarters can be earned in each year."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-11
+              excerpt: "Effective Date: 1/1/18"
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          4
+
+  - name: pre_1978_wage_qualifying_work_quarters
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "A qualifying work quarter was earned for each calendar quarter an individual was paid $50 or more in wages"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#qualifying_work_quarters_per_year_cap
+              output: qualifying_work_quarters_per_year_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          min(pre_1978_calendar_quarters_with_wages_at_least_threshold, qualifying_work_quarters_per_year_cap)
+
+  - name: pre_1978_wage_quarter_qualifies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "paid $50 or more in wages"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_wage_quarter_earnings_threshold
+              output: pre_1978_wage_quarter_earnings_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          pre_1978_calendar_quarter_wages >= pre_1978_wage_quarter_earnings_threshold
+
+  - name: pre_1978_self_employment_qualifying_work_quarters
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "Four quarters were earned for each taxable year in which self-employment earnings were $400 or more."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_self_employment_four_quarters_earnings_threshold
+              output: pre_1978_self_employment_four_quarters_earnings_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#qualifying_work_quarters_per_year_cap
+              output: qualifying_work_quarters_per_year_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          if pre_1978_self_employment_earnings >= pre_1978_self_employment_four_quarters_earnings_threshold:
+              qualifying_work_quarters_per_year_cap
+          else:
+              0
+
+  - name: pre_1978_migrant_seasonal_farmworker_qualifying_work_quarters
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: DSS SNAP tables, Qualifying Work Quarters Prior to 1978
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-9
+              excerpt: "A quarter was earned for each $100 (limited to 4) of migrant or seasonal farmworker wages for years 1955-1977."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#pre_1978_migrant_seasonal_farmworker_wage_quarter_increment
+              output: pre_1978_migrant_seasonal_farmworker_wage_quarter_increment
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#qualifying_work_quarters_per_year_cap
+              output: qualifying_work_quarters_per_year_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          min(floor(pre_1978_migrant_seasonal_farmworker_wages / pre_1978_migrant_seasonal_farmworker_wage_quarter_increment), qualifying_work_quarters_per_year_cap)
+
+  - name: post_1977_qualifying_work_quarters
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Year
+    source: DSS SNAP tables, Qualifying Work Quarters for 1978 or Later
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ct/manual/dss/snap/tables/block-10
+              excerpt: "Divide the individual’s total earned income by the increment amount for the year."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ct:policies/dss/snap/tables/qualifying-work-quarters#qualifying_work_quarters_per_year_cap
+              output: qualifying_work_quarters_per_year_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2018-01-01'
+        formula: |-
+          min(floor(post_1977_total_yearly_earned_income / post_1977_quarter_increment_amount_for_year), qualifying_work_quarters_per_year_cap)


### PR DESCRIPTION
## Summary
- Encode Connecticut DSS SNAP qualifying work-quarter methods effective 2018-01-01.
- Add pre-1978 wage, self-employment, and migrant/seasonal farmworker quarter calculations.
- Add post-1977 yearly earned-income divided by SSA increment method, capped at four quarters per year.

## Sources
- `us-ct/manual/dss/snap/tables/block-9`
- `us-ct/manual/dss/snap/tables/block-10`
- `us-ct/manual/dss/snap/tables/block-11`
- Higher authority checked against `us:regulations/7-cfr/273/4`.

## Note
- The CT table points to SSA for yearly post-1977 quarter increment amounts. This PR encodes the CT calculation method using `post_1977_quarter_increment_amount_for_year` as an input; a follow-up corpus/rules slice should ingest and encode the SSA annual increment table before hard-coding those year values.

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-ct/policies/dss/snap/tables/qualifying-work-quarters.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-ct-snap-work-quarters us-ct/policies/dss/snap/tables/qualifying-work-quarters.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-ct-snap-work-quarters --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ct-snap-work-quarters`
- Oracle coverage for `us-ct:policies/dss/snap/tables/qualifying-work-quarters` classified as `known_not_comparable` for all leaves.

## Review cycle
- Pending `/cycle`.
