### PR TITLE
Encode Oregon SNAP categorical eligibility

### DIFF
--- a/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/categorical-eligibility.json
+++ b/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/categorical-eligibility.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-or/policies/odhs/open/snap/categorical-eligibility.test.yaml",
+      "sha256": "277d95db03a1457df65f3edefd29869cc86c5549690a01db0d7ac4926cd6ab93"
+    },
+    {
+      "path": "us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+      "sha256": "3d8f082b7b8cc0abd397229099654182b12bfee7a3c492fa2c406c05d86e3c43"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-or:policies/odhs/open/snap/categorical-eligibility",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:23:11.124850+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa0sz87nz/sign-applied-files/us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa0sz87nz",
+  "generated_output_sha256": "3d8f082b7b8cc0abd397229099654182b12bfee7a3c492fa2c406c05d86e3c43",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "56535b4dd1789a5b5f39ebabd5ce61e48dbd791e64b7b3fc19852973767c5b32"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18521,6 +18521,38 @@
         ]
       }
     ],
+    "us-or/manual/odhs/open/page-210": [
+      {
+        "module": "us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-or/manual/odhs/open/page-211": [
+      {
+        "module": "us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-or/manual/odhs/open/page-212": [
+      {
+        "module": "us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-or/manual/odhs/open/page-215": [
+      {
+        "module": "us-or/policies/odhs/open/snap/categorical-eligibility.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-or/statute/315.264": [
       {
         "module": "us-or/statutes/315/264.yaml",

--- a/us-or/policies/odhs/open/snap/categorical-eligibility.test.yaml
+++ b/us-or/policies/odhs/open/snap/categorical-eligibility.test.yaml
@@ -1,0 +1,122 @@
+- name: individual_regular_ce_from_tanf
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_tanf: true
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_supplemental_security_income: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_general_assistance: false
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_individual_regular_categorically_eligible: holds
+
+- name: individual_ece_from_erdc
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_erdc: true
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_housing_stabilization_program: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_ta_dvs: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_tanf_jobs: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_receives_employment_payments: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.individual_has_ssi_1619a_or_1619b_status: false
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_individual_expanded_categorically_eligible: holds
+
+- name: all_members_regular_ce_group
+  period: 2026-04
+  input:
+    <<: &base_group_defaults
+      us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_filing_group_size: 2
+      us-or:policies/odhs/open/snap/categorical-eligibility#input.same_filing_group_previously_discontinued_due_to_lottery_or_gambling_winnings: false
+      us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_has_member_currently_disqualified_due_to_snap_ipv: false
+      us-or:policies/odhs/open/snap/categorical-eligibility#input.head_of_household_disqualified_for_snap_work_registration_or_abawd: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 2
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 0
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_regular_categorically_eligible: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_categorical_eligibility_assumed_factor_applies: holds
+
+- name: mixed_regular_and_expanded_ce_group
+  period: 2026-04
+  input:
+    <<: *base_group_defaults
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 1
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 1
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 0
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_regular_categorically_eligible: not_holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_expanded_categorically_eligible: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: holds
+
+- name: bbce_group_meets_oregon_conditions
+  period: 2026-04
+  input:
+    <<: *base_group_defaults
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: true
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 3999
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 4000
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 1000
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 4500
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_broad_based_categorically_eligible: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: holds
+
+- name: bbce_requires_income_below_200_percent_threshold
+  period: 2026-04
+  input:
+    <<: *base_group_defaults
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: true
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 4000
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 4000
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 1000
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 4500
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_broad_based_categorically_eligible: not_holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: not_holds
+
+- name: lottery_discontinuance_excludes_categorical_eligibility
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_filing_group_size: 2
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 2
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.same_filing_group_previously_discontinued_due_to_lottery_or_gambling_winnings: true
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_has_member_currently_disqualified_due_to_snap_ipv: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.head_of_household_disqualified_for_snap_work_registration_or_abawd: false
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_categorical_eligibility_exclusion_applies: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: not_holds
+
+- name: head_work_disqualification_excludes_categorical_eligibility
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_filing_group_size: 2
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_regular_ce_member_count: 2
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_expanded_ce_member_count: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_received_or_will_receive_information_and_referral_pamphlet: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_countable_income: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.snap_bbce_200_percent_fpl_threshold: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.liquid_assets_from_lottery_or_gambling_winnings: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.lottery_or_gambling_winnings_resource_limit: 0
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.same_filing_group_previously_discontinued_due_to_lottery_or_gambling_winnings: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.filing_group_has_member_currently_disqualified_due_to_snap_ipv: false
+    us-or:policies/odhs/open/snap/categorical-eligibility#input.head_of_household_disqualified_for_snap_work_registration_or_abawd: true
+  output:
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_categorical_eligibility_exclusion_applies: holds
+    us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible: not_holds

--- a/us-or/policies/odhs/open/snap/categorical-eligibility.yaml
+++ b/us-or/policies/odhs/open/snap/categorical-eligibility.yaml
@@ -1,0 +1,264 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-or/manual/odhs/open/page-210
+      - us-or/manual/odhs/open/page-211
+      - us-or/manual/odhs/open/page-212
+      - us-or/manual/odhs/open/page-213
+      - us-or/manual/odhs/open/page-214
+      - us-or/manual/odhs/open/page-215
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/2/j
+        - us:regulations/7-cfr/273/8
+        - us:regulations/7-cfr/273/9
+      rationale: |-
+        Federal SNAP categorical eligibility, resource, and income eligibility
+        rules define the higher-authority structure. Oregon OPEN pages 210-215
+        are the operative state manual source for Oregon's CE, ECE, and BBCE
+        categories, the factors assumed met, and the Oregon exclusions that
+        require regular SNAP rules.
+  summary: |-
+    Oregon SNAP categorical eligibility rules. A filing group may be
+    categorically eligible through regular CE, expanded categorical eligibility
+    (ECE), or broad-based categorical eligibility (BBCE), unless an Oregon OPEN
+    exclusion applies such as prior lottery/gambling discontinuance for the
+    same filing group, a current SNAP IPV disqualification, or head-of-household
+    work-registration/ABAWD disqualification.
+rules:
+  - name: snap_individual_regular_categorically_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "An individual is CE if receiving one of the following: Temporary Assistance for Needy Families (TANF) ... Supplemental Security Income (SSI) ... General Assistance (GA)"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          individual_receives_tanf
+          or individual_receives_supplemental_security_income
+          or individual_receives_general_assistance
+
+  - name: snap_individual_expanded_categorically_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Expanded Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "An individual is ECE if receiving one of the following: ERDC ... Housing Stabilization Program ... TA-DVS ... TANF JOBS ... Employment Payments ... 1619(a) or 1619(b)"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          individual_receives_erdc
+          or individual_receives_housing_stabilization_program
+          or individual_receives_ta_dvs
+          or individual_receives_tanf_jobs
+          or individual_receives_employment_payments
+          or individual_has_ssi_1619a_or_1619b_status
+
+  - name: snap_filing_group_regular_categorically_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "The group is CE if every member is receiving one of the benefits listed above."
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_filing_group_size > 0
+          and snap_regular_ce_member_count == snap_filing_group_size
+
+  - name: snap_filing_group_expanded_categorically_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Expanded Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "The group is ECE if at least one member of the filing group is not CE and the remaining members of the group are either CE or ECE."
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_filing_group_size > 0
+          and snap_expanded_ce_member_count > 0
+          and snap_regular_ce_member_count + snap_expanded_ce_member_count == snap_filing_group_size
+
+  - name: snap_filing_group_broad_based_categorically_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Broad Based Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "The filing group is BBCE if at least one member of the filing group is neither 'CE' nor 'ECE' and the filing group meets all of the following"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "Received, or will receive upon approval, the Information and Referral Services pamphlet"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "Countable income less than 200% FPL"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-212
+              excerpt: "If there are liquid assets from lottery/gambling winnings, they must be less than the resource limit"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_filing_group_size > 0
+          and snap_regular_ce_member_count + snap_expanded_ce_member_count < snap_filing_group_size
+          and filing_group_received_or_will_receive_information_and_referral_pamphlet
+          and snap_countable_income < snap_bbce_200_percent_fpl_threshold
+          and liquid_assets_from_lottery_or_gambling_winnings < lottery_or_gambling_winnings_resource_limit
+
+  - name: snap_categorical_eligibility_exclusion_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Who is not categorically eligible for SNAP benefits?
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-215
+              excerpt: "SNAP was previously discontinued due to receipt of lottery/gambling winnings"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-215
+              excerpt: "Those currently disqualified due to a SNAP Intentional Program Violation (IPV)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-215
+              excerpt: "The head of household is disqualified for failure to comply with a SNAP Work Registration or ABAWD work requirement."
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          same_filing_group_previously_discontinued_due_to_lottery_or_gambling_winnings
+          or filing_group_has_member_currently_disqualified_due_to_snap_ipv
+          or head_of_household_disqualified_for_snap_work_registration_or_abawd
+
+  - name: snap_filing_group_categorically_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, Categorical Eligibility for SNAP
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-211
+              excerpt: "In Oregon there are three categories of Categorical Eligibility"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_regular_categorically_eligible
+              output: snap_filing_group_regular_categorically_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_expanded_categorically_eligible
+              output: snap_filing_group_expanded_categorically_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_broad_based_categorically_eligible
+              output: snap_filing_group_broad_based_categorically_eligible
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/categorical-eligibility#snap_categorical_eligibility_exclusion_applies
+              output: snap_categorical_eligibility_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          (
+              snap_filing_group_regular_categorically_eligible
+              or snap_filing_group_expanded_categorically_eligible
+              or snap_filing_group_broad_based_categorically_eligible
+          )
+          and not snap_categorical_eligibility_exclusion_applies
+
+  - name: snap_categorical_eligibility_assumed_factor_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, What it means to be categorically eligible
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-210
+              excerpt: "If the following eligibility factors are verified for the program which granted Categorical Eligibility for SNAP, they are assumed to be met for SNAP as well"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-211
+              excerpt: "ODHS|OHA will determine SNAP eligibility and benefits for all categorically eligible households, automatically assuming they already meet SSN, Oregon residency, countable income limit, adjusted income limit and resources."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/categorical-eligibility#snap_filing_group_categorically_eligible
+              output: snap_filing_group_categorically_eligible
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_filing_group_categorically_eligible


### PR DESCRIPTION
## Summary
- Encode Oregon OPEN SNAP categorical eligibility categories: regular CE, ECE, and BBCE.
- Encode Oregon exclusions for prior same-filing-group lottery/gambling discontinuance, current SNAP IPV disqualification, and head-of-household work-registration/ABAWD disqualification.
- Add assumed-factor bridge for categorically eligible groups.

## Sources
- `us-or/manual/odhs/open/page-210`
- `us-or/manual/odhs/open/page-211`
- `us-or/manual/odhs/open/page-212`
- `us-or/manual/odhs/open/page-213`
- `us-or/manual/odhs/open/page-214`
- `us-or/manual/odhs/open/page-215`
- Higher authority checked against `us:regulations/7-cfr/273/2/j`, `us:regulations/7-cfr/273/8`, and `us:regulations/7-cfr/273/9`.

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-or/policies/odhs/open/snap/categorical-eligibility.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-or/policies/odhs/open/snap/categorical-eligibility.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-or-snap-categorical-eligibility us-or/policies/odhs/open/snap/categorical-eligibility.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-or-snap-categorical-eligibility --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-or-snap-categorical-eligibility`
- Oracle coverage ran; Oregon categorical eligibility leaves currently report `unmapped` because no PolicyEngine oracle mapping exists for this state-specific surface.

## Review cycle
- Pending `/cycle`.
