### PR TITLE
Encode Oregon SNAP countable income

### DIFF
--- a/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/countable-income.json
+++ b/.axiom/encoding-manifests/us-or/policies/odhs/open/snap/countable-income.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-or/policies/odhs/open/snap/countable-income.test.yaml",
+      "sha256": "d77b2183e7271c1c8f6ffe16d90dc066200e62bc56353ff6bb6550ce6f9e8bc2"
+    },
+    {
+      "path": "us-or/policies/odhs/open/snap/countable-income.yaml",
+      "sha256": "17e9af4d3622743f957a53d5965811e1dd7f6f3e78d83e4044ef5ee2ded79d42"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-or:policies/odhs/open/snap/countable-income",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:29:39.152672+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjlpfeqs7/sign-applied-files/us-or/policies/odhs/open/snap/countable-income.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjlpfeqs7",
+  "generated_output_sha256": "17e9af4d3622743f957a53d5965811e1dd7f6f3e78d83e4044ef5ee2ded79d42",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5f60d15611370d7c3355ef853e3742170ebc0cb6a0aad68b35ea523709c67f9a"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18602,6 +18602,15 @@
         ]
       }
     ],
+    "us-or/manual/odhs/open/page-272": [
+      {
+        "module": "us-or/policies/odhs/open/snap/countable-income.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-or/statute/315.264": [
       {
         "module": "us-or/statutes/315/264.yaml",

--- a/us-or/policies/odhs/open/snap/countable-income.test.yaml
+++ b/us-or/policies/odhs/open/snap/countable-income.test.yaml
@@ -1,0 +1,96 @@
+- name: self_employment_with_costs_gets_50_percent_exclusion
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: true
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 1000
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 1200
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: true
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 300
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_self_employment_cost_exclusion_rate: 0.5
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_self_employment_income: 500
+    us-or:policies/odhs/open/snap/countable-income#snap_verified_court_ordered_child_support_exclusion: 300
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income: 1400
+
+- name: self_employment_without_costs_has_no_50_percent_exclusion
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 1000
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 1200
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: true
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 300
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_self_employment_income: 1000
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income: 1900
+
+- name: unverified_child_support_is_not_excluded
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 1800
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: false
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 300
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_verified_court_ordered_child_support_exclusion: 0
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income: 1800
+
+- name: non_categorical_non_elderly_group_must_be_below_countable_income_limit
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 1695
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: false
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_categorically_eligible: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_contains_elderly_or_disabled_member: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_countable_income_limit_130_percent_fpl: 1696
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_exemption_applies: not_holds
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_test_passed: holds
+
+- name: equal_to_countable_income_limit_fails_when_test_applies
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 1696
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: false
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_categorically_eligible: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_contains_elderly_or_disabled_member: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_countable_income_limit_130_percent_fpl: 1696
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_test_passed: not_holds
+
+- name: categorical_group_bypasses_countable_income_limit
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 5000
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: false
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_categorically_eligible: true
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_contains_elderly_or_disabled_member: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_countable_income_limit_130_percent_fpl: 1696
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_exemption_applies: holds
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_test_passed: holds
+
+- name: elderly_or_disabled_group_bypasses_countable_income_limit
+  period: 2026-04
+  input:
+    us-or:policies/odhs/open/snap/countable-income#input.self_employment_with_allowable_costs_selected: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_self_employment_income: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_gross_non_self_employment_income: 5000
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_verified_for_child_outside_filing_group: false
+    us-or:policies/odhs/open/snap/countable-income#input.court_ordered_child_support_expense_paid_by_filing_group_member: 0
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_categorically_eligible: false
+    us-or:policies/odhs/open/snap/countable-income#input.snap_filing_group_contains_elderly_or_disabled_member: true
+    us-or:policies/odhs/open/snap/countable-income#input.snap_countable_income_limit_130_percent_fpl: 1696
+  output:
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_exemption_applies: holds
+    us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_test_passed: holds

--- a/us-or/policies/odhs/open/snap/countable-income.yaml
+++ b/us-or/policies/odhs/open/snap/countable-income.yaml
@@ -1,0 +1,197 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-or/manual/odhs/open/page-272
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/10
+      rationale: |-
+        Federal SNAP income and benefit-calculation regulations provide the
+        higher-authority income framework. Oregon OPEN page 272 is the operative
+        state manual source for the ONE-system countable-income steps encoded
+        here, including the 50 percent self-employment cost exclusion and the
+        verified court-ordered child-support exclusion.
+  summary: |-
+    Oregon OPEN SNAP countable-income calculation step. The system adds income,
+    applies a 50 percent exclusion for self-employment with allowable costs when
+    selected, subtracts verified court-ordered child-support expense payments
+    for children outside the filing group, and compares countable income to the
+    130 percent FPL countable-income limit unless the group is categorically
+    eligible or contains an elderly person or an individual with disabilities.
+rules:
+  - name: snap_self_employment_cost_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "the system will allow 50 percent exclusion for the costs"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          0.5
+
+  - name: snap_countable_self_employment_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "If income includes self-employment with allowable costs of doing business, the system will allow 50 percent exclusion for the costs"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/countable-income#snap_self_employment_cost_exclusion_rate
+              output: snap_self_employment_cost_exclusion_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          if self_employment_with_allowable_costs_selected:
+              max(0, snap_gross_self_employment_income - (snap_gross_self_employment_income * snap_self_employment_cost_exclusion_rate))
+          else:
+              max(0, snap_gross_self_employment_income)
+
+  - name: snap_verified_court_ordered_child_support_exclusion
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "When Court Ordered Support (COS) expense payments are being made by a member of the filing group for a child who is not in the filing group and have been verified"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "the amount of the allowable expense is subtracted from the countable income"
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          if court_ordered_child_support_expense_verified_for_child_outside_filing_group:
+              max(0, court_ordered_child_support_expense_paid_by_filing_group_member)
+          else:
+              0
+
+  - name: snap_countable_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "Add all types of income"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "The subtotal is the applicant’s SNAP countable income."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/countable-income#snap_countable_self_employment_income
+              output: snap_countable_self_employment_income
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/countable-income#snap_verified_court_ordered_child_support_exclusion
+              output: snap_verified_court_ordered_child_support_exclusion
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          max(
+              0,
+              snap_gross_non_self_employment_income
+              + snap_countable_self_employment_income
+              - snap_verified_court_ordered_child_support_exclusion
+          )
+
+  - name: snap_countable_income_limit_exemption_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "Filing groups that are categorically eligible or contain an elderly person or an individual with disabilities do not need to meet the SNAP countable income limit."
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_filing_group_categorically_eligible
+          or snap_filing_group_contains_elderly_or_disabled_member
+
+  - name: snap_countable_income_limit_test_passed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Oregon OPEN, SNAP benefit allotment calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "This amount is compared to the SNAP countable income limit – 130 percent FPL."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-or/manual/odhs/open/page-272
+              excerpt: "if the household is not categorically eligible or does not contain an elderly person or an individual with disabilities, and income is equal to or exceeds the countable income limit, the household is not eligible"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/countable-income#snap_countable_income
+              output: snap_countable_income
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-or:policies/odhs/open/snap/countable-income#snap_countable_income_limit_exemption_applies
+              output: snap_countable_income_limit_exemption_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          snap_countable_income_limit_exemption_applies
+          or snap_countable_income < snap_countable_income_limit_130_percent_fpl


### PR DESCRIPTION
## Summary
- Encode Oregon OPEN SNAP countable-income calculation step from benefit allotment calculation.
- Add 50% self-employment cost exclusion when self-employment with costs is selected.
- Add verified court-ordered child-support exclusion for a child outside the filing group.
- Add countable-income limit pass rule with categorical and elderly/disabled exemptions.

## Sources
- `us-or/manual/odhs/open/page-272`
- Higher authority checked against `us:regulations/7-cfr/273/9` and `us:regulations/7-cfr/273/10`.

## Checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode validate --skip-reviewers us-or/policies/odhs/open/snap/countable-income.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode proof-validate us-or/policies/odhs/open/snap/countable-income.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine /tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode test --root /tmp/rulespec-us-or-snap-countable-income us-or/policies/odhs/open/snap/countable-income.test.yaml`
- `/tmp/axiom-encode-0.2.1200/.venv/bin/axiom-encode guard-generated --repo /tmp/rulespec-us-or-snap-countable-income --base-ref origin/main --head-ref HEAD`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-or-snap-countable-income`
- Oracle coverage ran; Oregon countable-income leaves currently report `unmapped` because no PolicyEngine oracle mapping exists for this state-specific surface.

## Review cycle
- Pending `/cycle`.
