### PR TITLE
Encode Arizona SNAP utility expense types

### DIFF
--- a/.axiom/encoding-manifests/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.json
+++ b/.axiom/encoding-manifests/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.test.yaml",
+      "sha256": "3407b620051370d95b844061e02ec7cafdc24393853341cc652ecbb10a441867"
+    },
+    {
+      "path": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+      "sha256": "9d959ef77b166535027d15a5c3a2781a9e0c6c7e1b6338c929b781c676e3d7da"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T21:59:59.656275+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpstcg6bm5/sign-applied-files/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpstcg6bm5",
+  "generated_output_sha256": "9d959ef77b166535027d15a5c3a2781a9e0c6c7e1b6338c929b781c676e3d7da",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "57739f6637d24ed370c19f344abceee44b9a55541953a6de3315d66e68df868c"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1390,11 +1390,107 @@
         ]
       }
     ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-10": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-11": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-12": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-13": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-14": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-15": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-16": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-18": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-2": [
       {
         "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility.yaml",
         "via": [
           "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-3": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-6": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-7": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-8": [
+      {
+        "module": "us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml",
+        "via": [
           "proof_atom"
         ]
       }

--- a/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.test.yaml
+++ b/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.test.yaml
@@ -1,0 +1,107 @@
+- name: heating_source_triggers_sua_for_electricity
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_coal_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_electricity_utility_expense_used_to_produce_heating_or_cooling: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_gas_or_propane_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_oil_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_wood_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.central_air_conditioner_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.evaporative_cooler_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.room_air_conditioner_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.only_supplemental_heating_or_cooling_source_cost: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.electric_blanket_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.fan_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.heat_lamp_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.water_for_evaporative_cooler_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.heating_or_cooling_equipment_maintenance_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.chimney_maintenance_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.wood_cutting_equipment_expense: false
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_heating_or_cooling_source_expense_triggers_sua: holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_supplemental_heating_or_cooling_source_excluded_from_sua: not_holds
+
+- name: supplemental_source_does_not_trigger_sua
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_coal_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_electricity_utility_expense_used_to_produce_heating_or_cooling: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_gas_or_propane_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_oil_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.allowable_wood_utility_expense_used_to_produce_heat: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.central_air_conditioner_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.evaporative_cooler_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.room_air_conditioner_expense_used_to_cool_home: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.fan_expense: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.only_supplemental_heating_or_cooling_source_cost: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.electric_blanket_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.heat_lamp_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.water_for_evaporative_cooler_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.heating_or_cooling_equipment_maintenance_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.chimney_maintenance_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.wood_cutting_equipment_expense: false
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_heating_or_cooling_source_expense_triggers_sua: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_supplemental_heating_or_cooling_source_excluded_from_sua: holds
+
+- name: utility_installation_deposit_not_allowable
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_installation_fee_is_initial_installation: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_provider_performs_installation: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.one_time_utility_deposit: true
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_initial_utility_installation_fee_allowable: not_holds
+
+- name: initial_utility_installation_fee_is_allowable
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_installation_fee_is_initial_installation: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_provider_performs_installation: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.one_time_utility_deposit: false
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_initial_utility_installation_fee_allowable: holds
+
+- name: erap_and_water_expenses_are_allowable
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.budgetary_unit_eligible_for_emergency_rental_assistance_program: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_expense_billed_separate_or_itemized_with_rent_or_mortgage: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.water_services_expense: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.well_maintenance_chemicals_for_water_treatment_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.well_maintenance_service_or_repair_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.purchasing_water_when_onsite_water_not_available_expense: false
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_erap_utility_expense_allowable: holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_water_utility_expense_allowable: holds
+
+- name: two_non_heating_expenses_support_lua
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_expense_billed_separate_or_itemized_with_rent_or_mortgage: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.garbage_expense: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.sewer_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.trash_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.portable_toilet_rental_expense_when_no_bathroom_exists: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.septic_maintenance_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_installation_fee_is_initial_installation: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.utility_provider_performs_installation: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.one_time_utility_deposit: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.budgetary_unit_obligated_to_pay_any_portion_of_telephone_expense: true
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.budgetary_unit_participates_in_lifeline_assistance_program: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.lifeline_discount_does_not_pay_telephone_expense_in_full: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.extra_airtime_purchased_after_exhausting_free_minutes: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.water_services_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.well_maintenance_chemicals_for_water_treatment_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.well_maintenance_service_or_repair_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.purchasing_water_when_onsite_water_not_available_expense: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.budgetary_unit_eligible_for_emergency_rental_assistance_program: false
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#input.non_heating_or_cooling_utility_expense_obligations_verified: true
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_garbage_sewer_trash_utility_expense_allowable: holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_initial_utility_installation_fee_allowable: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_telephone_utility_expense_allowable: holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_water_utility_expense_allowable: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_erap_utility_expense_allowable: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_non_heating_or_cooling_utility_expense_count: 2
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types#az_snap_lua_verified_non_heating_or_cooling_expenses: holds

--- a/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml
+++ b/us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml
@@ -1,0 +1,283 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-3
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-5
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-6
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-7
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-8
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-10
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-11
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-12
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-13
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-14
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-15
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-16
+      - us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-18
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us/regulation/7/273/9/d/6/ii
+        - us/regulation/7/273/9/d/6/iii
+        - us/regulation/7/273/10/d
+      rationale: |-
+        Arizona FAA5 block 22 cites 7 CFR 273.9(d), 7 CFR 273.9(d)(6)(ii), 7 CFR 273.9(d)(iii)(A), (C), (E), and (F), and 7 CFR 273.10(d) as legal authorities for NA utility expenses. This slice encodes Arizona's operational utility-expense categories and verification conditions from FAA5 blocks 3 and 5-18 rather than altering the federal deduction framework.
+  summary: |-
+    Arizona Nutrition Assistance utility expense-type rules identify allowable utility categories and the utility obligations that can qualify a budgetary unit for SUA, LUA, or TUA. Heating/cooling utility expenses include electricity, gas or propane, coal, wood, oil, and listed cooling equipment when used to heat or cool the home. Supplemental heating/cooling costs such as electric blankets, fans, heat lamps, evaporative-cooler water, equipment maintenance, chimney maintenance, and wood-cutting equipment do not qualify for SUA. Other allowable utilities include ERAP-paid utilities, garbage, sewer, trash, initial installation fees, telephone, water, and related listed expenses.
+rules:
+  - name: az_snap_heating_or_cooling_source_expense_triggers_sua
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, blocks 3, 6, 7, 11, 12, and 16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-3
+              excerpt: "Any of the following utility expenses are considered heating sources when used to provide heat for the home: Electricity; Gas or propane; Coal, wood, or oil"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-3
+              excerpt: "Any of the following are considered cooling sources: Central air conditioners; Evaporative coolers; Room air conditioners"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-6
+              excerpt: "When coal is used to produce heat, the budgetary unit is eligible for SUA."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-7
+              excerpt: "When electricity is used to produce heating or cooling, the budgetary unit is eligible for SUA."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-11
+              excerpt: "When gas or propane is used as a fuel to produce heat, the budgetary unit is eligible for SUA."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-12
+              excerpt: "When oil is used to produce heat, the budgetary unit is eligible for SUA."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-16
+              excerpt: "The wood is used to produce heat."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (
+            allowable_coal_utility_expense_used_to_produce_heat
+            or allowable_electricity_utility_expense_used_to_produce_heating_or_cooling
+            or allowable_gas_or_propane_utility_expense_used_to_produce_heat
+            or allowable_oil_utility_expense_used_to_produce_heat
+            or allowable_wood_utility_expense_used_to_produce_heat
+            or central_air_conditioner_expense_used_to_cool_home
+            or evaporative_cooler_expense_used_to_cool_home
+            or room_air_conditioner_expense_used_to_cool_home
+          )
+          and not only_supplemental_heating_or_cooling_source_cost
+
+  - name: az_snap_supplemental_heating_or_cooling_source_excluded_from_sua
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-3
+              excerpt: "The cost for any of the following supplemental sources of heating or cooling do not qualify for the SUA"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          electric_blanket_expense
+          or fan_expense
+          or heat_lamp_expense
+          or water_for_evaporative_cooler_expense
+          or heating_or_cooling_equipment_maintenance_expense
+          or chimney_maintenance_expense
+          or wood_cutting_equipment_expense
+
+  - name: az_snap_erap_utility_expense_allowable
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 8
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-8
+              excerpt: "Budgetary units that are eligible for ERAP are eligible for a utility expense."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          budgetary_unit_eligible_for_emergency_rental_assistance_program
+
+  - name: az_snap_garbage_sewer_trash_utility_expense_allowable
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 10
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-10
+              excerpt: "Garbage; Sewer; Trash; Portable toilet rental when no bathroom exists; Septic maintenance"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          utility_expense_billed_separate_or_itemized_with_rent_or_mortgage
+          and (
+            garbage_expense
+            or sewer_expense
+            or trash_expense
+            or portable_toilet_rental_expense_when_no_bathroom_exists
+            or septic_maintenance_expense
+          )
+
+  - name: az_snap_initial_utility_installation_fee_allowable
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 13
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-13
+              excerpt: "The initial utility installation fee is an allowable NA Utility Expense in the month the expense is billed"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-13
+              excerpt: "NOTE One-time deposits are not an allowable NA Utility Expense."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          utility_installation_fee_is_initial_installation
+          and utility_provider_performs_installation
+          and not one_time_utility_deposit
+
+  - name: az_snap_telephone_utility_expense_allowable
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 14
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-14
+              excerpt: "The expense for basic service fees of landlines or cell phones are allowable when the budgetary unit is obligated to pay any portion of the telephone expense."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-14
+              excerpt: "When the budgetary unit participates in the Lifeline Assistance Program, a telephone expense is allowable"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          budgetary_unit_obligated_to_pay_any_portion_of_telephone_expense
+          or (
+            budgetary_unit_participates_in_lifeline_assistance_program
+            and (
+              lifeline_discount_does_not_pay_telephone_expense_in_full
+              or extra_airtime_purchased_after_exhausting_free_minutes
+            )
+          )
+
+  - name: az_snap_water_utility_expense_allowable
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 15
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-15
+              excerpt: "Water services expense ... Well maintenance ... The expense of purchasing water when onsite water is not available."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          utility_expense_billed_separate_or_itemized_with_rent_or_mortgage
+          and (
+            water_services_expense
+            or well_maintenance_chemicals_for_water_treatment_expense
+            or well_maintenance_service_or_repair_expense
+            or purchasing_water_when_onsite_water_not_available_expense
+          )
+
+  - name: az_snap_non_heating_or_cooling_utility_expense_count
+    kind: derived
+    entity: Household
+    dtype: Count
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, blocks 5, 10, 13, 14, 15, and 18
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-18
+              excerpt: "To be eligible for the Limited Utility Allowance (LUA), the obligation of at least two non-heating or non-cooling utility expenses are required to be verified."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (if az_snap_garbage_sewer_trash_utility_expense_allowable: 1 else: 0)
+          + (if az_snap_initial_utility_installation_fee_allowable: 1 else: 0)
+          + (if az_snap_telephone_utility_expense_allowable: 1 else: 0)
+          + (if az_snap_water_utility_expense_allowable: 1 else: 0)
+          + (if az_snap_erap_utility_expense_allowable: 1 else: 0)
+
+  - name: az_snap_lua_verified_non_heating_or_cooling_expenses
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: DES FAA5 NA Utility Expenses and Allowances, block 18
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-az/manual/des/faa5/na-utility-expenses-and-allowances/block-18
+              excerpt: "the obligation of at least two non-heating or non-cooling utility expenses are required to be verified"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          az_snap_non_heating_or_cooling_utility_expense_count >= 2
+          and non_heating_or_cooling_utility_expense_obligations_verified


### PR DESCRIPTION
## Summary
- Encodes Arizona FAA5 NA utility expense-type helpers for heating/cooling SUA triggers, supplemental-source exclusions, ERAP utility expense allowance, garbage/sewer/trash, initial installation fees, telephone, water, non-heating utility counts, and LUA verification support.
- Adds 6 companion tests and signed apply manifest.
- Regenerates reverse index.

## Checks
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml
- axiom-encode proof-validate us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.yaml
- AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-az-snap-utility-expense-types us-az/policies/des/faa5/na-utility-expenses-and-allowances/utility-expense-types.test.yaml
- axiom-encode guard-generated --repo /tmp/rulespec-us-az-snap-utility-expense-types --base-ref origin/main --head-ref HEAD
- python tests/generate_reverse_index.py
- python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-az-snap-utility-expense-types
- oracle-coverage: all new outputs known_not_comparable

## Known blocker
Full us-az validation is blocked by pre-existing non-SNAP/CMS/tax/CCAP source-grounding failures. This new SNAP file passes; a separate Arizona grounding repair PR is needed to make the jurisdiction shard green.

## Cycle
- Requested independent review with /cycle.