### PR TITLE
Bump the pinned axiom-corpus ref for the C.R.S. title 39 article 22 ingest

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "7661f3c9a3655e93fc9b2420048d70d231e7d44b"
+axiom_corpus_ref = "f5a491849befe1abfcc23af6d3561c8cfed884bf"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
One-line toolchain bump: `axiom_corpus_ref` → `f5a49184` (axiom-corpus#314, Sol-reviewed SHIP), picking up the new `us-co/statute` bundle for C.R.S. 2025 title 39 article 22 — 245 substantive sections grounding Colorado income tax encodings. Toolchain changes trigger full-repository revalidation by design; that run is the gate.

First consumer: a wave-1 encode of 39-22-130 (family affordability credit), 39-22-627 (TABOR income tax rate adjustment), 39-22-2003 (state sales tax refund), 39-22-123, 39-22-544, 39-22-547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)