### PR TITLE
Encode Alaska SNAP shelter utility rules

### DIFF
--- a/.axiom/encoding-manifests/us-ak/policies/dpa/snap/602-604-2-e/block-1.json
+++ b/.axiom/encoding-manifests/us-ak/policies/dpa/snap/602-604-2-e/block-1.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ak/policies/dpa/snap/602-604-2-e/block-1.test.yaml",
+      "sha256": "8073e9bbdeccff9ca1227e7c2a846d469450b994b6d2aa6e535bdfe62ba764a1"
+    },
+    {
+      "path": "us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml",
+      "sha256": "96f9faaa2f1c8aaf1328a9e8d3151480d8292f94af676992d391fd916311a99a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ak:policies/dpa/snap/602-604-2-e/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T23:26:16.624234+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpkyp7wwtm/sign-applied-files/us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpkyp7wwtm",
+  "generated_output_sha256": "96f9faaa2f1c8aaf1328a9e8d3151480d8292f94af676992d391fd916311a99a",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "58de7d163bb89ce9cfa0db84fbb6e12a78a5685aa3fb65a0724c0fceec966150"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -34,6 +34,15 @@
         ]
       }
     ],
+    "us-ak/manual/dpa/snap/602-604-2-e/block-1": [
+      {
+        "module": "us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ak/regulation/aac/title-7/chapter-45/7 AAC 45.280": [
       {
         "module": "us-ak/regulations/aac/title-7/chapter-45/45-280-resource-limit.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,35 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 688
+ceiling: 697
 entries:
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#heating_assistance_minimum_payment_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#homeless_shelter_standard_deduction_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_cost_change_verification_threshold
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_cost_verification_required_for_reported_change
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_excess_threshold_rate
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_excess_shelter_expenses
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_heating_utility_standard_applies
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_non_heating_utility_standard_applies
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_shelter_deduction
+    source: manual
+    since: 2026-07-12
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
     since: 2026-07-08

--- a/us-ak/policies/dpa/snap/602-604-2-e/block-1.test.yaml
+++ b/us-ak/policies/dpa/snap/602-604-2-e/block-1.test.yaml
@@ -1,0 +1,104 @@
+- name: regular_household_shelter_deduction_capped_by_addendum_maximum
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_total_allowable_shelter_expenses: 900
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_net_income: 1000
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_maximum_shelter_deduction_from_addendum_4: 300
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_household_has_elderly_or_disabled_member: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_all_members_are_homeless: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_incurs_some_shelter_expense: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_chooses_homeless_shelter_standard_deduction: false
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_excess_shelter_expenses: 400
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_shelter_deduction: 300
+
+- name: specat_household_receives_uncapped_excess_shelter_amount
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_total_allowable_shelter_expenses: 900
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_net_income: 1000
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_maximum_shelter_deduction_from_addendum_4: 300
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_household_has_elderly_or_disabled_member: true
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_all_members_are_homeless: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_incurs_some_shelter_expense: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_chooses_homeless_shelter_standard_deduction: false
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_excess_shelter_expenses: 400
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_shelter_deduction: 400
+
+- name: homeless_household_chooses_standard_homeless_shelter_deduction
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_total_allowable_shelter_expenses: 50
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_net_income: 200
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_maximum_shelter_deduction_from_addendum_4: 300
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_household_has_elderly_or_disabled_member: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_all_members_are_homeless: true
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_incurs_some_shelter_expense: true
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_chooses_homeless_shelter_standard_deduction: true
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_shelter_deduction: 199
+
+- name: elderly_disabled_energy_assistance_triggers_heating_standard
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_household_has_elderly_or_disabled_member: true
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_primary_heating_costs_separate_from_rent_or_mortgage
+    : false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_heating_fuel_costs_to_vendor_or_utility: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_heating_fuel_costs_to_landlord_separate_from_rent
+    : false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_in_subsidized_housing_is_charged_for_heating_costs: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_verifies_payment_of_heating_expense_billed_in_another_name: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_condominium_or_association_fee_includes_heat: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_received_qualifying_weatherization_program_payment_in_application_month_or_preceding_12_months
+    : false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_received_heating_or_native_energy_assistance_in_application_month_or_preceding_12_months
+    : 21
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_non_heating_utility_costs_to_vendor_or_utility: true
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_in_subsidized_housing_is_charged_for_non_heating_utility_costs: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_non_heating_utility_costs_to_landlord_separate_from_rent
+    : false
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_heating_utility_standard_applies: holds
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_non_heating_utility_standard_applies: not_holds
+
+- name: non_heating_utility_standard_applies_without_heating_standard
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.snap_household_has_elderly_or_disabled_member: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_primary_heating_costs_separate_from_rent_or_mortgage
+    : false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_heating_fuel_costs_to_vendor_or_utility: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_heating_fuel_costs_to_landlord_separate_from_rent
+    : false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_in_subsidized_housing_is_charged_for_heating_costs: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_verifies_payment_of_heating_expense_billed_in_another_name: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_condominium_or_association_fee_includes_heat: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_received_qualifying_weatherization_program_payment_in_application_month_or_preceding_12_months
+    : false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_received_heating_or_native_energy_assistance_in_application_month_or_preceding_12_months
+    : 0
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_non_heating_utility_costs_to_vendor_or_utility: true
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_in_subsidized_housing_is_charged_for_non_heating_utility_costs: false
+    ? us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_responsible_for_non_heating_utility_costs_to_landlord_separate_from_rent
+    : false
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_heating_utility_standard_applies: not_holds
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#snap_non_heating_utility_standard_applies: holds
+
+- name: shelter_cost_change_over_threshold_requires_verification
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_reports_new_shelter_costs: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_reported_shelter_cost_change_amount: 26
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_cost_verification_required_for_reported_change: holds
+
+- name: shelter_cost_change_at_threshold_does_not_require_verification_by_change_amount
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_reports_new_shelter_costs: false
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#input.household_reported_shelter_cost_change_amount: 25
+  output:
+    us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_cost_verification_required_for_reported_change: not_holds

--- a/us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml
+++ b/us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml
@@ -1,0 +1,233 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+      rationale: |-
+        Federal SNAP regulations provide the higher-authority shelter-deduction and utility-allowance framework. Alaska DPA Manual MS 602-4E is the direct source for the state shelter-cost, homeless shelter deduction, heating/non-heating utility standard eligibility, and shelter-cost verification rules encoded here.
+  summary: |-
+    Alaska SNAP households receive a shelter deduction when total shelter costs exceed 50% of net income. Regular households receive the excess shelter amount up to the maximum shelter deduction, while SPECAT households with an elderly or disabled member receive the uncapped excess amount. All-homeless households that incur some shelter expense may use a $199 homeless shelter deduction instead of other shelter and utility deductions. Heating utility standard eligibility includes households responsible for primary heating costs and elderly or disabled households receiving qualifying weatherization, Heating Assistance, or Native organization energy assistance. Shelter-cost verification is required at application, for new shelter costs, and when reported shelter costs change by more than $25.
+rules:
+  - name: shelter_excess_threshold_rate
+    kind: parameter
+    dtype: Rate
+    source: MS 602-4E, Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "more than 50% of their net income"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          0.50
+
+  - name: homeless_shelter_standard_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: MS 602-4E(6), Homeless Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "standard deduction of $199"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          199
+
+  - name: shelter_cost_change_verification_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: MS 602-4E(7), Verification of Shelter Costs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "changed by more than $25"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          25
+
+  - name: heating_assistance_minimum_payment_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: MS 602-4E(2)(a), Heating Utility Standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "$21 or more in the month of application or the preceding 12 months"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          21
+
+  - name: snap_excess_shelter_expenses
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: MS 602-4E, Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "excess shelter amount that exceeds 50% of their countable net income"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ak:policies/dpa/snap/602-604-2-e/block-1#shelter_excess_threshold_rate
+              output: shelter_excess_threshold_rate
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, snap_total_allowable_shelter_expenses - (shelter_excess_threshold_rate * snap_net_income))
+
+  - name: snap_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: MS 602-4E and MS 602-4E(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "Regular households are allowed the excess shelter amount that exceeds 50% of their countable net income, up to the maximum shelter deduction"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "Special Category ( SPECAT ) households with a disabled or elderly household member are allowed the excess shelter amount that exceeds 50% of their countable net income. These households have no maximum shelter deduction"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "If the household is allowed the homeless standard deduction, they are not allowed other shelter or utility deductions"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_all_members_are_homeless and household_incurs_some_shelter_expense and household_chooses_homeless_shelter_standard_deduction:
+            homeless_shelter_standard_deduction_amount
+          else:
+            if snap_household_has_elderly_or_disabled_member:
+              snap_excess_shelter_expenses
+            else:
+              min(snap_excess_shelter_expenses, snap_maximum_shelter_deduction_from_addendum_4)
+
+  - name: snap_heating_utility_standard_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: MS 602-4E(2)(a), Heating Utility Standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "Households that are responsible for paying primary heating costs separate from their rent or mortgage are allowed the heating utility standard"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "Households including an aged or disabled individual, living in a multi-unit dwelling or an individual unit, and received a qualifying weatherization program payment"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "received Heating Assistance or energy assistance administered by a Native organization in the amount of $21 or more"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          household_responsible_for_primary_heating_costs_separate_from_rent_or_mortgage
+          or household_responsible_for_heating_fuel_costs_to_vendor_or_utility
+          or household_responsible_for_heating_fuel_costs_to_landlord_separate_from_rent
+          or household_in_subsidized_housing_is_charged_for_heating_costs
+          or household_verifies_payment_of_heating_expense_billed_in_another_name
+          or household_condominium_or_association_fee_includes_heat
+          or (
+            snap_household_has_elderly_or_disabled_member
+            and household_received_qualifying_weatherization_program_payment_in_application_month_or_preceding_12_months
+          )
+          or (
+            snap_household_has_elderly_or_disabled_member
+            and household_received_heating_or_native_energy_assistance_in_application_month_or_preceding_12_months >= heating_assistance_minimum_payment_amount
+          )
+
+  - name: snap_non_heating_utility_standard_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: MS 602-4E(2)(b), Non-Heating Utility Standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "Non-heating utility standards are given to households that are responsible for electricity, water, sewer, and/or phone costs, yet are not responsible for paying heating costs"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not snap_heating_utility_standard_applies
+          and (
+            household_responsible_for_non_heating_utility_costs_to_vendor_or_utility
+            or household_in_subsidized_housing_is_charged_for_non_heating_utility_costs
+            or household_responsible_for_non_heating_utility_costs_to_landlord_separate_from_rent
+          )
+
+  - name: shelter_cost_verification_required_for_reported_change
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: MS 602-4E(7), Verification of Shelter Costs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/manual/dpa/snap/602-604-2-e/block-1
+              excerpt: "During the certification period, when the household reports new shelter costs or reports that their shelter costs have changed by more than $25"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          household_reports_new_shelter_costs
+          or household_reported_shelter_cost_change_amount > shelter_cost_change_verification_threshold


### PR DESCRIPTION
## Summary
- Encodes Alaska DPA SNAP Manual MS 602-4E shelter deduction and utility-standard eligibility rules.
- Adds focused tests for regular capped shelter deduction, SPECAT uncapped shelter deduction, homeless shelter deduction, heating/non-heating utility standards, and shelter-cost verification threshold.
- Updates reverse index, signed apply manifest, and oracle-coverage pending declarations for 9 new Alaska outputs.

## Local checks
- `axiom-encode validate --skip-reviewers us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml` passed
- `axiom-encode proof-validate us-ak/policies/dpa/snap/602-604-2-e/block-1.yaml` passed
- `axiom-encode test --root /tmp/rulespec-us-ak-snap-reporting us-ak/policies/dpa/snap/602-604-2-e/block-1.test.yaml` passed: 7 cases
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ak-snap-reporting --base-ref origin/main --head-ref HEAD` passed
- `axiom-encode oracle-coverage-pending check --root /tmp/ak-coverage-root --repo rulespec-us` passed: 697 declared, 697 applied, 0 stale
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ak-snap-reporting` passed: 18 passed, 1 existing warning
- `git diff --check` passed

## Cycle
- /cycle requested after PR creation.