### PR TITLE
Encode Alaska SNAP FY2026 standards

### DIFF
--- a/.axiom/encoding-manifests/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.json
+++ b/.axiom/encoding-manifests/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ak/policies/dpa/snap/addenda-addendum-4/block-1.test.yaml",
+      "sha256": "bbdceed74d51d78ab7ebc06de0da32d8d2971e9b01ddd9c98c61f8b9a7eade76"
+    },
+    {
+      "path": "us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml",
+      "sha256": "31af43d7045f4d16174269d6a2f35f6b0b831a21f0689828e38758edd8d647d0"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ak:policies/dpa/snap/addenda-addendum-4/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-12T23:34:12.592987+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp9whvw9p6/sign-applied-files/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp9whvw9p6",
+  "generated_output_sha256": "31af43d7045f4d16174269d6a2f35f6b0b831a21f0689828e38758edd8d647d0",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "6de971837642e6ff882fcf8437ce84f805f62e0e919a28278817eb66e09f0474"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -34,6 +34,15 @@
         ]
       }
     ],
+    "us-ak/manual/dpa/snap/addenda-addendum-4/block-1": [
+      {
+        "module": "us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ak/regulation/aac/title-7/chapter-45/7 AAC 45.280": [
       {
         "module": "us-ak/regulations/aac/title-7/chapter-45/45-280-resource-limit.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,92 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 688
+ceiling: 716
 entries:
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_central_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_earned_income_deduction_rate
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_excess_shelter_deduction_cap
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_gross_income_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_income_gross_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_income_gross_limit_additional_member
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_income_net_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_income_net_limit_additional_member
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_maximum_urban_allotment
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_maximum_urban_allotment_additional_member
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_maximum_urban_allotment_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_medical_expense_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_medical_expense_threshold
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_minimum_urban_allotment_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_minimum_urban_allotment_amount_scalar_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_net_income_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_northern_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_northwest_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit_scalar_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit_scalar_limit_2
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_south_central_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_southeast_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_southwest_heating_sud
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit_2
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit_3
+    source: manual
+    since: 2026-07-12
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
     since: 2026-07-08

--- a/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.test.yaml
+++ b/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.test.yaml
@@ -1,0 +1,32 @@
+- name: elderly_or_disabled_household_resource_limit
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.snap_household_has_elderly_or_disabled_member: true
+  output:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit: 4500
+- name: household_size_nine_income_and_allotment
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.household_size: 9
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.snap_household_has_elderly_or_disabled_member: false
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.snap_total_medical_expenses: 100
+  output:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit: 3000
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_gross_income_limit: 8082
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_net_income_limit: 6217
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction: 738
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_medical_expense_deduction: 65
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_maximum_urban_allotment_amount: 2596
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_minimum_urban_allotment_amount: 0
+- name: two_person_urban_minimum_and_zero_medical_excess
+  period: 2025-10
+  input:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.household_size: 2
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#input.snap_total_medical_expenses: 35
+  output:
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_gross_income_limit: 2864
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_net_income_limit: 2203
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction: 358
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_medical_expense_deduction: 0
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_maximum_urban_allotment_amount: 707
+    us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_minimum_urban_allotment_amount: 31

--- a/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml
+++ b/us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml
@@ -1,0 +1,614 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+      - us:regulations/7-cfr/273/9
+      - us:regulations/7-cfr/273/10
+      rationale: Federal SNAP regulations delegate state administration of utility
+        allowances, deductions, income standards, and allotment computation. This
+        Alaska DPA SNAP Addendum is the official state parameter source for the Alaska
+        FY 2026 standards and maximum allotments encoded here.
+  summary: ADDENDUM 4 ALASKA SNAP STANDARDS AND MAXIMUM ALLOTMENTS, effective October
+    1, 2025 through September 30, 2026. Resource limits are $3,000 per household,
+    or $4,500 with at least one member disabled or age 60 or older. Tables state income
+    limits, standard deductions, other deductions, maximum/minimum allotments, and
+    regional utility standards.
+rules:
+- name: snap_resource_limit_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Resource Limits
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: $3,000 per household; or $4,500 per household with at least one
+            member disabled or age 60 years or older.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '3000'
+- name: snap_resource_limit_scalar_limit_2
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Resource Limits
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: $3,000 per household; or $4,500 per household with at least one
+            member disabled or age 60 years or older.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '4500'
+- name: snap_resource_limit
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Resource Limits
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: $3,000 per household; or $4,500 per household with at least one
+            member disabled or age 60 years or older.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit_scalar_limit
+          output: snap_resource_limit_scalar_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_resource_limit_scalar_limit_2
+          output: snap_resource_limit_scalar_limit_2
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if snap_household_has_elderly_or_disabled_member: snap_resource_limit_scalar_limit_2
+      else: snap_resource_limit_scalar_limit'
+- name: snap_income_gross_limit
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  indexed_by: household_size
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          table:
+            header: INCOME LIMITS AND STANDARD DEDUCTIONS
+            row_key: household size
+            column_key: gross limit (130% FPL)
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 2118
+      2: 2864
+      3: 3609
+      4: 4354
+      5: 5100
+      6: 5845
+      7: 6590
+      8: 7336
+- name: snap_income_gross_limit_additional_member
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Additional Member + $746
+          table:
+            header: INCOME LIMITS AND STANDARD DEDUCTIONS
+            row: Additional Member
+            column: gross limit (130% FPL)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '746'
+- name: snap_gross_income_limit
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: HOUSEHOLD SIZE GROSS LIMIT ... 8 $7,336 ... Additional Member +
+            $746
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_size <= 8: snap_income_gross_limit[household_size] else:
+      snap_income_gross_limit[8] + ((household_size - 8) * snap_income_gross_limit_additional_member)'
+- name: snap_income_net_limit
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  indexed_by: household_size
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          table:
+            header: INCOME LIMITS AND STANDARD DEDUCTIONS
+            row_key: household size
+            column_key: net limit (100% FPL)
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 1630
+      2: 2203
+      3: 2776
+      4: 3350
+      5: 3923
+      6: 4496
+      7: 5070
+      8: 5643
+- name: snap_income_net_limit_additional_member
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Additional Member ... + $574
+          table:
+            header: INCOME LIMITS AND STANDARD DEDUCTIONS
+            row: Additional Member
+            column: net limit (100% FPL)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '574'
+- name: snap_net_income_limit
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: HOUSEHOLD SIZE ... NET LIMIT (100% FPL) ... Additional Member +
+            $574
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_size <= 8: snap_income_net_limit[household_size] else:
+      snap_income_net_limit[8] + ((household_size - 8) * snap_income_net_limit_additional_member)'
+- name: snap_standard_deduction_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: STANDARD DEDUCTION ... 1 $358 ... 6 $374 ... Additional Member
+            + $364
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '358'
+- name: snap_standard_deduction_scalar_limit_2
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: STANDARD DEDUCTION ... 1 $358 ... 6 $374 ... Additional Member
+            + $364
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '364'
+- name: snap_standard_deduction_scalar_limit_3
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: STANDARD DEDUCTION ... 1 $358 ... 6 $374 ... Additional Member
+            + $364
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '374'
+- name: snap_standard_deduction
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Income Limits and Standard Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: STANDARD DEDUCTION ... 1 $358 ... 6 $374 ... Additional Member
+            + $364
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit
+          output: snap_standard_deduction_scalar_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit_2
+          output: snap_standard_deduction_scalar_limit_2
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_standard_deduction_scalar_limit_3
+          output: snap_standard_deduction_scalar_limit_3
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_size <= 5: snap_standard_deduction_scalar_limit else: if
+      household_size <= 8: snap_standard_deduction_scalar_limit_3 else: snap_standard_deduction_scalar_limit_3
+      + ((household_size - 8) * snap_standard_deduction_scalar_limit_2)'
+- name: snap_earned_income_deduction_rate
+  kind: parameter
+  dtype: Rate
+  source: Addendum 4, Other Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: EARNED INCOME ... 20% of Gross Income
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0.20'
+- name: snap_excess_shelter_deduction_cap
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Other Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: EXCESS SHELTER $1,189
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1189'
+- name: snap_medical_expense_threshold
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Other Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: MEDICAL ... Amount in excess of $35
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '35'
+- name: snap_medical_expense_deduction
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Other Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: MEDICAL ... Amount in excess of $35
+  versions:
+  - effective_from: '2025-10-01'
+    formula: max(0, snap_total_medical_expenses - snap_medical_expense_threshold)
+- name: snap_maximum_urban_allotment
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  indexed_by: household_size
+  source: Addendum 4, Maximum and Minimum SNAP Allotments
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          table:
+            header: MAXIMUM and MINIMUM SNAP ALLOTMENTS
+            row_key: household size
+            column_key: urban
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 385
+      2: 707
+      3: 1015
+      4: 1285
+      5: 1529
+      6: 1838
+      7: 2031
+      8: 2314
+- name: snap_maximum_urban_allotment_additional_member
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Maximum and Minimum SNAP Allotments
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Additional Member $282
+          table:
+            header: MAXIMUM and MINIMUM SNAP ALLOTMENTS
+            row: Additional Member
+            column: urban
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '282'
+- name: snap_maximum_urban_allotment_amount
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Maximum and Minimum SNAP Allotments
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: URBAN ... 8 $2,314 ... Additional Member $282
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_size <= 8: snap_maximum_urban_allotment[household_size]
+      else: snap_maximum_urban_allotment[8] + ((household_size - 8) * snap_maximum_urban_allotment_additional_member)'
+- name: snap_minimum_urban_allotment_amount_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: Addendum 4, Maximum and Minimum SNAP Allotments
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: URBAN Minimum ... 1 $31 ... 2 $31 ... 3 N/A
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '31'
+- name: snap_minimum_urban_allotment_amount
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Maximum and Minimum SNAP Allotments
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: URBAN Minimum ... 1 $31 ... 2 $31 ... 3 N/A
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ak:policies/dpa/snap/addenda-addendum-4/block-1#snap_minimum_urban_allotment_amount_scalar_limit
+          output: snap_minimum_urban_allotment_amount_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if household_size <= 2: snap_minimum_urban_allotment_amount_scalar_limit
+      else: 0'
+- name: snap_central_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Central (CE) $625
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: Central (CE)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '625'
+- name: snap_northern_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Northern (NO) $825
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: Northern (NO)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '825'
+- name: snap_northwest_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Northwest (NW) $1,107
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: Northwest (NW)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1107'
+- name: snap_south_central_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: South Central (SC) $591
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: South Central (SC)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '591'
+- name: snap_southeast_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Southeast (SE) $517
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: Southeast (SE)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '517'
+- name: snap_southwest_heating_sud
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Addendum 4, Regional Heating SUD and Nonheating Utility Standards
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-ak/manual/dpa/snap/addenda-addendum-4/block-1
+          excerpt: Southwest (SW) $1,064
+          table:
+            header: REGIONAL HEATING SUD AND NONHEATING UTILITY STANDARDS
+            row: Southwest (SW)
+            column: SUD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1064'


### PR DESCRIPTION
## Summary
- Encodes Alaska DPA SNAP Addendum 4 FY2026 standards from the official manual capture.
- Covers resource limits, gross and net income limits, standard deduction, earned-income deduction rate, excess shelter cap, medical expense threshold/deduction, urban maximum/minimum allotments, and six regional heating SUD amounts.
- Adds focused tests for elderly/disabled resource limit, household-size-nine income/allotment calculations, and medical threshold behavior.
- Updates reverse index, signed apply manifest, and oracle-coverage pending declarations for 28 new Alaska outputs.

## Known follow-up
- The same Addendum 4 source still has Rural I/Rural II allotment columns and non-heating utility columns (electricity, phone, sewer, water) to encode in follow-up slices.

## Local checks
- `axiom-encode validate --skip-reviewers us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml` passed
- `axiom-encode proof-validate us-ak/policies/dpa/snap/addenda-addendum-4/block-1.yaml` passed
- `axiom-encode test --root /tmp/rulespec-us-ak-snap-standards us-ak/policies/dpa/snap/addenda-addendum-4/block-1.test.yaml` passed: 3 cases
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ak-snap-standards --base-ref origin/main --head-ref HEAD` passed
- `axiom-encode oracle-coverage-pending check --root /tmp/ak-standards-coverage-root --repo rulespec-us` passed: 716 declared, 716 applied, 0 stale
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ak-snap-standards` passed: 18 passed, 1 existing warning
- `git diff --check` passed

## Cycle
- /cycle requested after PR creation.