### PR TITLE
Encode Kansas SNAP shelter and utility allowances

### DIFF
--- a/.axiom/encoding-manifests/us-ks/policies/dcf/keesm/keesm7226/block-1.json
+++ b/.axiom/encoding-manifests/us-ks/policies/dcf/keesm/keesm7226/block-1.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ks/policies/dcf/keesm/keesm7226/block-1.test.yaml",
+      "sha256": "935ab3277ed4151b7e2bbf6196511a243bd16532e25e582897a589255cc51497"
+    },
+    {
+      "path": "us-ks/policies/dcf/keesm/keesm7226/block-1.yaml",
+      "sha256": "f64a0ea6ef9b15560663ca0946ced5970de8e2e483ab173f7d7e34a311950cc9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ks:policies/dcf/keesm/keesm7226/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T00:26:27.314730+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpncexb8iu/sign-applied-files/us-ks/policies/dcf/keesm/keesm7226/block-1.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpncexb8iu",
+  "generated_output_sha256": "f64a0ea6ef9b15560663ca0946ced5970de8e2e483ab173f7d7e34a311950cc9",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "ebcc59e082861b1c64d1bc8da88f5ede30de977a7f226c97f742a14d8e179d39"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11327,6 +11327,15 @@
         ]
       }
     ],
+    "us-ks/manual/dcf/keesm/keesm7226/block-1": [
+      {
+        "module": "us-ks/policies/dcf/keesm/keesm7226/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/manual/dcf/keesm/keesm7400/block-1": [
       {
         "module": "us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 688
+ceiling: 708
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -321,6 +321,66 @@ entries:
   - legal_id: us-ia:statutes/422/12C#refundable_excess_credit_amount
     source: bulk
     since: 2026-07-08
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_actual_single_nontelephone_utility_expense_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction_before_cap
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction_cap_non_elderly_disabled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense_monthly_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_lieap_sua_minimum_payment
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_monthly_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_minimum_expense_count
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_shelter_excess_income_share
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_monthly_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_telephone_standard_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_telephone_standard_monthly_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_utility_allowance
+    source: manual
+    since: 2026-07-12
   - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
     source: manual
     since: 2026-07-09

--- a/us-ks/policies/dcf/keesm/keesm7226/block-1.test.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7226/block-1.test.yaml
@@ -1,0 +1,209 @@
+- name: standard_utility_allowance_and_capped_excess_shelter
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : true
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 1000
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 1000
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_entitled: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_state_option: 469
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_state_option: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_utility_allowance: 469
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction_before_cap: 969
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction: 744
+
+- name: standard_utility_allowance_via_lieap_and_uncapped_excess_shelter
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: true
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : true
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 20
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 1000
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 1000
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_entitled: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_state_option: 469
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction_before_cap: 969
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_excess_shelter_deduction: 969
+
+- name: limited_utility_allowance_takes_priority_over_individual_utility_inputs
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 2
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : true
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: true
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 65
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_entitled: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_state_option: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_state_option: 345
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_telephone_standard_entitled: not_holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_actual_single_nontelephone_utility_expense_allowed: not_holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_utility_allowance: 345
+
+- name: telephone_standard_when_only_telephone_cost
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: true
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_telephone_standard_entitled: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option: 44
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_utility_allowance: 44
+
+- name: single_nontelephone_utility_uses_actual_expense
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 1
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : true
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 65
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_actual_single_nontelephone_utility_expense_allowed: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option: 65
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_utility_allowance: 65
+
+- name: homeless_shelter_expense_requires_expected_shelter_or_utility_cost
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: true
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : true
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense_entitled: holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense: 198.99
+
+- name: homeless_shelter_expense_denied_without_expected_cost
+  period: 2025-10
+  input:
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+    : false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_lieap_payment_amount: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+    : false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_only_utility_expense_is_telephone: false
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_actual_single_nontelephone_utility_expense: 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_shelter_costs: 0
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_monthly_income_after_allowable_exclusions_and_deductions
+    : 0
+    us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_all_members_are_homeless: true
+    ? us-ks:policies/dcf/keesm/keesm7226/block-1#input.snap_household_incurs_or_expects_shelter_or_utility_expense
+    : false
+  output:
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense_entitled: not_holds
+    us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_homeless_shelter_expense: 0

--- a/us-ks/policies/dcf/keesm/keesm7226/block-1.yaml
+++ b/us-ks/policies/dcf/keesm/keesm7226/block-1.yaml
@@ -1,0 +1,474 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+      rationale: |-
+        7 CFR 273.9 delegates SNAP utility allowance treatment to state standards. Kansas KEESM 7226 supplies the state-specific shelter and utility allowance amounts and conditions encoded here.
+  summary: |-
+    Kansas SNAP shelter costs include excess shelter, rent or mortgage, taxes and insurance, mandatory standard utility allowances, limited non-occupancy costs, disaster repair costs, and a homeless shelter expense. The Standard Utility Allowance is $469, the Limited Utility Allowance is $345, the Telephone Standard is $44, the non-elderly/non-disabled excess shelter cap is $744, and the homeless shelter expense is $198.99.
+imports:
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: sets_kansas_snap_standard_utility_allowance
+    kind: source_relation
+    source: Kansas KEESM 7226.3, Standard Utility Allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_standard_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_kansas_snap_limited_utility_allowance
+    kind: source_relation
+    source: Kansas KEESM 7226.3, Limited Utility Allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+      authority: state
+      value: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_limited_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_kansas_snap_individual_utility_allowance
+    kind: source_relation
+    source: Kansas KEESM 7226.3, individual utility and Telephone Standard
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      authority: state
+      value: us-ks:policies/dcf/keesm/keesm7226/block-1#kansas_snap_individual_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: kansas_snap_shelter_excess_income_share
+    kind: parameter
+    dtype: Rate
+    source: Kansas KEESM 7226, excessive shelter definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "in excess of 50% of the household's monthly income"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          0.50
+
+  - name: kansas_snap_excess_shelter_deduction_cap_non_elderly_disabled
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226, maximum excess shelter deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "Households containing no elderly or disabled members"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          744
+
+  - name: kansas_snap_standard_utility_allowance_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Standard Utility Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "A standard utility allowance (SUA) of $469"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          469
+
+  - name: kansas_snap_limited_utility_allowance_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Limited Utility Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "Limited Utility Allowance (LUA) of $345"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          345
+
+  - name: kansas_snap_limited_utility_minimum_expense_count
+    kind: parameter
+    dtype: Count
+    source: Kansas KEESM 7226.3, Limited Utility Allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "have at least two of the following utility expenses"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          2
+
+  - name: kansas_snap_telephone_standard_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Telephone Standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "standard telephone expense of $44"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          44
+
+  - name: kansas_snap_homeless_shelter_expense_monthly_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.6, Homeless Shelter Expense
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "Homeless Shelter Expense of $198.99"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          198.99
+
+  - name: kansas_snap_lieap_sua_minimum_payment
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Receipt of LIEAP and the SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "received a LIEAP payment of at least $20"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          20
+
+  - name: kansas_snap_standard_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Kansas KEESM 7226.3, Standard Utility Allowance conditions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "received a LIEAP payment of at least $20"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_incurred_heating_or_cooling_costs_separately_from_rent_or_mortgage
+          or snap_household_private_rental_housing_billed_for_heating_or_cooling_utilities_by_landlord
+          or snap_household_public_housing_charged_only_for_excess_heating_or_cooling_costs
+          or (
+            snap_household_contains_elderly_or_disabled_member
+            and snap_household_lieap_payment_received_in_current_month_or_previous_12_months
+            and snap_household_lieap_payment_amount >= kansas_snap_lieap_sua_minimum_payment
+          )
+
+  - name: kansas_snap_limited_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Kansas KEESM 7226.3, Limited Utility Allowance conditions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "not entitled to the SUA"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not kansas_snap_standard_utility_allowance_entitled
+          and snap_household_non_heating_cooling_utility_expense_count >= kansas_snap_limited_utility_minimum_expense_count
+
+  - name: kansas_snap_actual_single_nontelephone_utility_expense_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Kansas KEESM 7226.3, one non-heating/cooling non-telephone utility expense
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "incurs only one of the following expenses"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not kansas_snap_standard_utility_allowance_entitled
+          and not kansas_snap_limited_utility_allowance_entitled
+          and snap_household_incurred_one_non_heating_cooling_nontelephone_utility_expense
+
+  - name: kansas_snap_telephone_standard_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Kansas KEESM 7226.3, Telephone Standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "only incur telephone (cell phone and/or landline) costs"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not kansas_snap_standard_utility_allowance_entitled
+          and not kansas_snap_limited_utility_allowance_entitled
+          and snap_household_only_utility_expense_is_telephone
+
+  - name: kansas_snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Standard Utility Allowance state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "mandatory for use in calculating shelter costs"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if kansas_snap_standard_utility_allowance_entitled:
+            kansas_snap_standard_utility_allowance_monthly_amount
+          else:
+            0
+
+  - name: kansas_snap_limited_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Limited Utility Allowance state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "Limited Utility Allowance (LUA) of $345"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if kansas_snap_limited_utility_allowance_entitled:
+            kansas_snap_limited_utility_allowance_monthly_amount
+          else:
+            0
+
+  - name: kansas_snap_individual_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, Telephone Standard and actual one-utility expense
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if kansas_snap_telephone_standard_entitled:
+            kansas_snap_telephone_standard_monthly_amount
+          elif kansas_snap_actual_single_nontelephone_utility_expense_allowed:
+            snap_household_actual_single_nontelephone_utility_expense
+          else:
+            0
+
+  - name: kansas_snap_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.3, utility standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          kansas_snap_standard_utility_allowance_state_option
+          + kansas_snap_limited_utility_allowance_state_option
+          + kansas_snap_individual_utility_allowance_state_option
+
+  - name: kansas_snap_excess_shelter_deduction_before_cap
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226, excessive shelter definition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "in excess of 50% of the household's monthly income"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(
+            0,
+            snap_household_monthly_shelter_costs
+            + kansas_snap_utility_allowance
+            - snap_household_monthly_income_after_allowable_exclusions_and_deductions * kansas_snap_shelter_excess_income_share
+          )
+
+  - name: kansas_snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226, maximum excess shelter deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_contains_elderly_or_disabled_member:
+            kansas_snap_excess_shelter_deduction_before_cap
+          else:
+            min(kansas_snap_excess_shelter_deduction_before_cap, kansas_snap_excess_shelter_deduction_cap_non_elderly_disabled)
+
+  - name: kansas_snap_homeless_shelter_expense_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Kansas KEESM 7226.6, Homeless Shelter Expense
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "all members are homeless"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+              excerpt: "incur or reasonably expect to incur any shelter or utility expense"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_all_members_are_homeless
+          and snap_household_incurs_or_expects_shelter_or_utility_expense
+
+  - name: kansas_snap_homeless_shelter_expense
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Kansas KEESM 7226.6, Homeless Shelter Expense
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/manual/dcf/keesm/keesm7226/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if kansas_snap_homeless_shelter_expense_entitled:
+            kansas_snap_homeless_shelter_expense_monthly_amount
+          else:
+            0


### PR DESCRIPTION
## Summary
- Encodes Kansas KEESM 7226 SNAP shelter and utility allowance provisions.
- Adds state delegated hook relations for the Kansas SUA, LUA, and individual utility allowance values.
- Covers SUA $469, LUA $345, telephone standard $44, LIEAP $20 threshold for elderly/disabled SUA, excess shelter cap $744, and homeless shelter expense $198.99.

## Local checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ks/policies/dcf/keesm/keesm7226/block-1.yaml`
- `axiom-encode proof-validate us-ks/policies/dcf/keesm/keesm7226/block-1.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ks-snap-utility us-ks/policies/dcf/keesm/keesm7226/block-1.test.yaml`
- `axiom-encode oracle-coverage-pending sync/check --root /tmp/ks-coverage-root --repo rulespec-us --source manual --since 2026-07-12`
- changed-file `oracle-coverage`: 20 items, 0 failures
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ks-snap-utility` (18 passed, 1 warning)
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ks-snap-utility --base-ref origin/main --head-ref HEAD`
- `git diff --check HEAD~1 HEAD`

## Notes
- PE/oracle mapping for these Kansas-specific outputs is not present yet; outputs are declared in the oracle-coverage pending lane.
- The encoder first produced an empty module and apply was blocked by validation; this PR contains the repaired source-grounded encoding with a signed apply manifest.
