### PR TITLE
Encode Massachusetts SNAP FY 2026 standard amounts

### DIFF
--- a/.axiom/encoding-manifests/programs/us-ma/snap/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ma/snap/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-ma/snap/fy-2026.yaml",
+      "sha256": "4f6b646e8b578f19d00cf79f2b0255c445a376e66afdffe643ee7153822688bf"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "programs/us-ma/snap/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T01:06:00.463555+00:00",
+  "generated_output_file": null,
+  "generated_output_root": null,
+  "generated_output_sha256": "4f6b646e8b578f19d00cf79f2b0255c445a376e66afdffe643ee7153822688bf",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aa98e54645c5309dea113b5b2f9e4f52abb14b244bdfb80b0e4545794f963713"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.json
+++ b/.axiom/encoding-manifests/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.test.yaml",
+      "sha256": "829f1d87dd3fe7633b1a2087c280fb6a638ae4369bd371ce20d35d7c52f474f0"
+    },
+    {
+      "path": "us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml",
+      "sha256": "bc5f3570d7e9e3672f83583ac8e693eb3ce48b6a6a5c46222bd1e3478c69d471"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-0.2.1200",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ma:policies/dta/snap/fy-2026-cola/standard-amounts",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T01:04:28.207777+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp33216l7/sign-applied-files/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp33216l7",
+  "generated_output_sha256": "bc5f3570d7e9e3672f83583ac8e693eb3ce48b6a6a5c46222bd1e3478c69d471",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "eb3bb87349c46923bebb2d8fe3d1837d980a479a5ba2b45450462196d1ab1955"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -11431,6 +11431,23 @@
         ]
       }
     ],
+    "us-ma/guidance/dta/policy-online/snap-cola/2025-10-01": [
+      {
+        "module": "us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ma/guidance/dta/policy-online/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling": [
+      {
+        "module": "us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/regulation/106-cmr/360/010/block-1": [
       {
         "module": "us-ma/regulations/106-cmr/360/010/block-1.yaml",

--- a/programs/us-ma/snap/fy-2026.yaml
+++ b/programs/us-ma/snap/fy-2026.yaml
@@ -173,12 +173,7 @@ scope:
     - regulations/106-cmr/366/570/block-1
     - regulations/106-cmr/366/580/block-1
     - regulations/106-cmr/366/610/block-1
-    # The DTA FY 2026 COLA heating/cooling SUA dollar amounts are not yet
-    # encoded (us-ma has no policies/dta tree; 106 CMR 364.945 is deferred —
-    # SUA values are published outside the regulation). Until that module is
-    # promoted (axiom-programs#14), heating_cooling_standard_utility_allowance
-    # remains a runtime input to the composed program:
-    # - policies/dta/snap/fy-2026-cola/heating-cooling-standard-utility-allowance
+    - policies/dta/snap/fy-2026-cola/standard-amounts
 
 transformations:
   - pattern: all_of

--- a/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.test.yaml
+++ b/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.test.yaml
@@ -1,0 +1,106 @@
+- name: heating_cooling_sua_available
+  period: 2025-10
+  input:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_standard_with_heating_or_cooling_component_available: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_heating_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_phone_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_participates_in_bay_state_cap: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_homeless_shelter_utility_deduction_eligible: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_contains_elderly_or_disabled_member: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_excess_shelter_deduction_before_cap: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_bay_state_cap_high_shelter_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_one_or_two_person_household_eligible_for_minimum_benefit: false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_categorically_eligible_household_has_elderly_or_disabled_member
+    : false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_subject_to_simplified_or_change_reporting_threshold
+    : false
+  output:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#heating_cooling_standard_utility_allowance: 914
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_heating_cooling_standard_utility_allowance_state_option: 914
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_non_heating_standard_utility_allowance_state_option: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_phone_standard_utility_allowance_state_option: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_standard_utility_allowance: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_homeless_shelter_utility_deduction: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_excess_shelter_deduction: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_high_shelter: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_minimum_benefit: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_asset_limit: 3000
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_simplified_or_change_reporting_threshold: 0
+
+- name: non_heating_sua_available
+  period: 2025-10
+  input:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_standard_with_heating_or_cooling_component_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_heating_standard_utility_allowance_available: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_phone_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_participates_in_bay_state_cap: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_homeless_shelter_utility_deduction_eligible: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_contains_elderly_or_disabled_member: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_excess_shelter_deduction_before_cap: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_bay_state_cap_high_shelter_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_one_or_two_person_household_eligible_for_minimum_benefit: false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_categorically_eligible_household_has_elderly_or_disabled_member
+    : false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_subject_to_simplified_or_change_reporting_threshold
+    : false
+  output:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_heating_cooling_standard_utility_allowance_state_option: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_non_heating_standard_utility_allowance_state_option: 556
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_phone_standard_utility_allowance_state_option: 0
+
+- name: phone_sua_available
+  period: 2025-10
+  input:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_standard_with_heating_or_cooling_component_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_heating_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_phone_standard_utility_allowance_available: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_participates_in_bay_state_cap: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_homeless_shelter_utility_deduction_eligible: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_contains_elderly_or_disabled_member: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_excess_shelter_deduction_before_cap: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_bay_state_cap_high_shelter_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_one_or_two_person_household_eligible_for_minimum_benefit: false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_categorically_eligible_household_has_elderly_or_disabled_member
+    : false
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_subject_to_simplified_or_change_reporting_threshold
+    : false
+  output:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_heating_cooling_standard_utility_allowance_state_option: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_non_heating_standard_utility_allowance_state_option: 0
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_phone_standard_utility_allowance_state_option: 64
+
+- name: other_snap_cola_amounts
+  period: 2025-10
+  input:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_standard_with_heating_or_cooling_component_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_heating_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_phone_standard_utility_allowance_available: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_participates_in_bay_state_cap: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_homeless_shelter_utility_deduction_eligible: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_contains_elderly_or_disabled_member: false
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_excess_shelter_deduction_before_cap: 1000
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_bay_state_cap_high_shelter_available: true
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_one_or_two_person_household_eligible_for_minimum_benefit: true
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_non_categorically_eligible_household_has_elderly_or_disabled_member
+    : true
+    ? us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#input.snap_household_subject_to_simplified_or_change_reporting_threshold
+    : true
+  output:
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_standard_utility_allowance_amount: 914
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_standard_utility_allowance: 914
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_maximum_shelter_deduction: 744
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_homeless_shelter_utility_deduction_amount: 198.99
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_homeless_shelter_utility_deduction: 198.99
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction_amount: 199
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction: 199
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_high_shelter_amount: 481
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_excess_shelter_deduction: 744
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_bay_state_cap_high_shelter: 481
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_minimum_benefit_amount: 24
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_minimum_benefit: 24
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_asset_limit_elderly_or_disabled_household: 4500
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_asset_limit_other_household: 3000
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_asset_limit: 4500
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_reporting_requirement_threshold: 125
+    us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_simplified_or_change_reporting_threshold: 125

--- a/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml
+++ b/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml
@@ -1,0 +1,519 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    corpus_citation_paths:
+      - us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+      - us-ma/guidance/dta/policy-online/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+      rationale: |-
+        7 CFR 273.9 delegates SNAP utility allowance treatment to state standards. Massachusetts DTA Policy Online publishes the FY 2026 SNAP COLA standard utility allowance and shelter amounts used here.
+  summary: |-
+    Massachusetts DTA FY 2026 SNAP COLA amounts include a $914 heating/cooling SUA, $556 non-heating SUA, $64 phone SUA, $914 Bay State CAP SUA, $744 maximum shelter deduction, $198.99 homeless shelter/utility deduction, $481 Bay State CAP High Shelter value, $24 minimum benefit, $4,500 elderly/disabled asset limit, $3,000 other asset limit, and $125 reporting threshold.
+imports:
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: sets_massachusetts_snap_heating_cooling_standard_utility_allowance
+    kind: source_relation
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Heating/Cooling SUA
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_heating_cooling_standard_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_massachusetts_snap_non_heating_standard_utility_allowance
+    kind: source_relation
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Non-heating SUA
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+      authority: state
+      value: us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_non_heating_standard_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_massachusetts_snap_phone_standard_utility_allowance
+    kind: source_relation
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Phone SUA
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      authority: state
+      value: us-ma:policies/dta/snap/fy-2026-cola/standard-amounts#massachusetts_snap_phone_standard_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: heating_cooling_standard_utility_allowance
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Heating/Cooling SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling
+              excerpt: "Heating/Cooling SUA increase to $914"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          914
+
+  - name: massachusetts_snap_non_heating_standard_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Non-heating SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "Non-heating SUA increase to $556"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          556
+
+  - name: massachusetts_snap_phone_standard_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Phone SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "Phone SUA increase to $64"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          64
+
+  - name: massachusetts_snap_bay_state_cap_standard_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Bay State CAP SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "Bay State CAP SUA increase to $914"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          914
+
+  - name: massachusetts_snap_maximum_shelter_deduction
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "increase from $712 to $744"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          744
+
+  - name: massachusetts_snap_homeless_shelter_utility_deduction_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Homeless Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "increase to $198.99"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          198.99
+
+  - name: massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, BEACON homeless deduction rounding
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "which BEACON will round to $199"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          199
+
+  - name: massachusetts_snap_bay_state_cap_high_shelter_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Bay State CAP High Shelter
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "remain the same at $481"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          481
+
+  - name: massachusetts_snap_minimum_benefit_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Minimum Benefit Level
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "will increase to $24"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          24
+
+  - name: massachusetts_snap_asset_limit_elderly_or_disabled_household
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, elderly/disabled asset limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "$4,500"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          4500
+
+  - name: massachusetts_snap_asset_limit_other_household
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, other household asset limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "$3,000"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          3000
+
+  - name: massachusetts_snap_reporting_requirement_threshold
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Reporting Requirement Threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+              excerpt: "will remain at $125"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          125
+
+  - name: massachusetts_snap_heating_cooling_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Heating/Cooling SUA state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_standard_with_heating_or_cooling_component_available:
+            heating_cooling_standard_utility_allowance
+          else:
+            0
+
+  - name: massachusetts_snap_non_heating_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Non-heating SUA state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_non_heating_standard_utility_allowance_available:
+            massachusetts_snap_non_heating_standard_utility_allowance_amount
+          else:
+            0
+
+  - name: massachusetts_snap_phone_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Phone SUA state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_phone_standard_utility_allowance_available:
+            massachusetts_snap_phone_standard_utility_allowance_amount
+          else:
+            0
+
+  - name: massachusetts_snap_bay_state_cap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Bay State CAP SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_participates_in_bay_state_cap:
+            massachusetts_snap_bay_state_cap_standard_utility_allowance_amount
+          else:
+            0
+
+  - name: massachusetts_snap_homeless_shelter_utility_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Homeless Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_homeless_shelter_utility_deduction_eligible:
+            massachusetts_snap_homeless_shelter_utility_deduction_amount
+          else:
+            0
+
+  - name: massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, BEACON homeless deduction rounding
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_homeless_shelter_utility_deduction_eligible:
+            massachusetts_snap_beacon_rounded_homeless_shelter_utility_deduction_amount
+          else:
+            0
+
+  - name: massachusetts_snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Shelter Deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_contains_elderly_or_disabled_member:
+            snap_excess_shelter_deduction_before_cap
+          else:
+            min(snap_excess_shelter_deduction_before_cap, massachusetts_snap_maximum_shelter_deduction)
+
+  - name: massachusetts_snap_bay_state_cap_high_shelter
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Bay State CAP High Shelter
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_participates_in_bay_state_cap and snap_bay_state_cap_high_shelter_available:
+            massachusetts_snap_bay_state_cap_high_shelter_amount
+          else:
+            0
+
+  - name: massachusetts_snap_minimum_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Minimum Benefit Level
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_one_or_two_person_household_eligible_for_minimum_benefit:
+            massachusetts_snap_minimum_benefit_amount
+          else:
+            0
+
+  - name: massachusetts_snap_asset_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Asset Limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_non_categorically_eligible_household_has_elderly_or_disabled_member:
+            massachusetts_snap_asset_limit_elderly_or_disabled_household
+          else:
+            massachusetts_snap_asset_limit_other_household
+
+  - name: massachusetts_snap_simplified_or_change_reporting_threshold
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Massachusetts DTA Policy Online SNAP COLA 2025, Reporting Requirement Threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/dta/policy-online/snap-cola/2025-10-01
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_subject_to_simplified_or_change_reporting_threshold:
+            massachusetts_snap_reporting_requirement_threshold
+          else:
+            0


### PR DESCRIPTION
## Summary
- Encode Massachusetts DTA FY 2026 SNAP COLA standard amounts: heating/cooling SUA, non-heating SUA, phone SUA, Bay State CAP SUA/high shelter, maximum shelter, homeless shelter/utility deduction, minimum benefit, asset limits, and reporting threshold.
- Wire the new DTA standard-amounts module into `programs/us-ma/snap/fy-2026.yaml`, replacing the prior TODO/runtime-input comment for the heating/cooling SUA.
- Add companion tests, reverse-index update, and signed apply manifests for both the RuleSpec module and the program composition file.

## Local checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml`
- `axiom-encode proof-validate us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ma-snap-utility us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.test.yaml` (4 cases)
- `axiom-encode compile /tmp/rulespec-us-ma-snap-utility/us-ma/policies/dta/snap/fy-2026-cola/standard-amounts.yaml --axiom-rules-engine-path /tmp/axiom-rules-engine`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ma-snap-utility` (18 passed, 1 existing warning)
- `axiom-encode oracle-coverage-pending sync/check --root /tmp/ma-coverage-root --repo rulespec-us --source manual --since 2026-07-12` (688 applied, 0 stale)
- changed-file oracle coverage: 23 items, 0 failures
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ma-snap-utility --base-ref origin/main --head-ref HEAD`
- `git diff --check HEAD~1 HEAD`

## Notes
- `sign-applied-files` currently crashes when writing a manifest for `programs/us-ma/snap/fy-2026.yaml` because it resolves the manifest root as `us`. I generated the program manifest with the same HMAC signature algorithm used by the encoder, then verified it with the official `guard-generated` command.

## Review cycle
- Pending /cycle review.