### PR TITLE
Encode Mississippi SNAP shelter and utility rules

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -13798,6 +13798,39 @@
         ]
       }
     ],
+    "us-ms/manual/mdhs/snap-policy-manual/part-14/page-102": [
+      {
+        "module": "us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ms/manual/mdhs/snap-policy-manual/part-14/page-103": [
+      {
+        "module": "us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ms/manual/mdhs/snap-policy-manual/part-14/page-130": [
+      {
+        "module": "us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ms/manual/mdhs/snap-policy-manual/part-14/page-141": [
+      {
+        "module": "us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 688
+ceiling: 701
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -885,6 +885,45 @@ entries:
   - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
     source: bulk
     since: 2026-07-08
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_actual_utility_expenses_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_basic_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_child_support_deduction_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_claimed_homeless_shelter_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_cost
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_income_share
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_homeless_shelter_deduction_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_liheap_sua_threshold
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_shared_heating_cooling_sua_not_prorated
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_telephone_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_verified_actual_homeless_shelter_costs_allowed
+    source: manual
+    since: 2026-07-12
   - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
     source: bulk
     since: 2026-07-08

--- a/us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.test.yaml
+++ b/us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.test.yaml
@@ -1,0 +1,116 @@
+- name: standard_utility_allowance_shared_heat_and_capped_shelter
+  period: 2025-12
+  input:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.household_member_pays_legally_obligated_child_support_to_non_household_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.payment_is_alimony: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_all_members_are_homeless: true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_free_shelter_throughout_month: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs_verified: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_total_allowable_shelter_expenses: 1400
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_income_after_prior_deductions: 1000
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_contains_disabled_or_elderly_individual: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+    : true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_includes_elderly_or_disabled_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_liheap_amount: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_telephone_bill_only_separately_billed_utility_expense
+    : false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_actual_utility_expenses_verified: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_lives_and_shares_heating_or_cooling_expenses_with_others
+    : true
+  output:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_homeless_shelter_deduction_entitled: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_claimed_homeless_shelter_deduction: 198.99
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_cost: 900
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_deduction: 744
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_utility_allowance_entitled: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_basic_utility_allowance_entitled: not_holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_telephone_allowance_entitled: not_holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_actual_utility_expenses_allowed: not_holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_shared_heating_cooling_sua_not_prorated: holds
+
+- name: basic_utility_allowance_and_uncapped_shelter
+  period: 2025-12
+  input:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.household_member_pays_legally_obligated_child_support_to_non_household_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.payment_is_alimony: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_all_members_are_homeless: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_free_shelter_throughout_month: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs_verified: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_total_allowable_shelter_expenses: 1400
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_income_after_prior_deductions: 1000
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_contains_disabled_or_elderly_individual: true
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+    : false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_includes_elderly_or_disabled_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_liheap_amount: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_non_heating_cooling_utility_expense_count: 2
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_telephone_bill_only_separately_billed_utility_expense
+    : true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_actual_utility_expenses_verified: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_lives_and_shares_heating_or_cooling_expenses_with_others
+    : false
+  output:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_claimed_homeless_shelter_deduction: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_excess_shelter_deduction: 900
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_utility_allowance_entitled: not_holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_basic_utility_allowance_entitled: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_telephone_allowance_entitled: not_holds
+
+- name: telephone_allowance_only
+  period: 2025-12
+  input:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.household_member_pays_legally_obligated_child_support_to_non_household_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.payment_is_alimony: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_all_members_are_homeless: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_free_shelter_throughout_month: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs_verified: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_total_allowable_shelter_expenses: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_income_after_prior_deductions: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_contains_disabled_or_elderly_individual: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+    : false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_includes_elderly_or_disabled_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_liheap_amount: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_telephone_bill_only_separately_billed_utility_expense
+    : true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_actual_utility_expenses_verified: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_lives_and_shares_heating_or_cooling_expenses_with_others
+    : false
+  output:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_standard_telephone_allowance_entitled: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_actual_utility_expenses_allowed: not_holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_shared_heating_cooling_sua_not_prorated: not_holds
+
+- name: child_support_actual_homeless_costs_and_actual_utilities
+  period: 2025-12
+  input:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.household_member_pays_legally_obligated_child_support_to_non_household_member: true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.payment_is_alimony: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_all_members_are_homeless: true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_free_shelter_throughout_month: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs_verified: true
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_homeless_actual_shelter_costs: 250
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_total_allowable_shelter_expenses: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_income_after_prior_deductions: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_contains_disabled_or_elderly_individual: false
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+    : false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_includes_elderly_or_disabled_member: false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_receives_liheap_amount: 0
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_non_heating_cooling_utility_expense_count: 0
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_telephone_bill_only_separately_billed_utility_expense
+    : false
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_actual_utility_expenses_verified: true
+    ? us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#input.snap_household_lives_and_shares_heating_or_cooling_expenses_with_others
+    : false
+  output:
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_child_support_deduction_allowed: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_verified_actual_homeless_shelter_costs_allowed: holds
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_claimed_homeless_shelter_deduction: 250
+    us-ms:manual/mdhs/snap-policy-manual/part-14/page-102#mississippi_snap_actual_utility_expenses_allowed: holds

--- a/us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml
+++ b/us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml
@@ -1,0 +1,292 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+    corpus_citation_paths:
+      - us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+      - us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+      - us-ms/manual/mdhs/snap-policy-manual/part-14/page-129
+      - us-ms/manual/mdhs/snap-policy-manual/part-14/page-130
+      - us-ms/manual/mdhs/snap-policy-manual/part-14/page-141
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+        - us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_48_states_dc
+      rationale: |-
+        Mississippi SNAP Manual Rule 18.8 applies the maximum shelter deduction provided by FNS and the elderly/disabled exception; the FY 2026 dollar cap is imported from USDA's FY 2026 COLA deduction module.
+  summary: |-
+    Mississippi SNAP allows an optional deduction for legally obligated child support paid to non-household members, offers the standard homeless shelter deduction to all-homeless households not receiving free shelter throughout the month, permits verified higher actual homeless costs, calculates excess shelter costs above 50% of income after prior deductions, caps non-elderly/non-disabled excess shelter deductions at the FNS maximum, and applies the SUA, BUA, telephone allowance, or verified actual utilities according to Rule 18.9.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/deductions
+rules:
+  - name: mississippi_snap_child_support_deduction_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.6
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+              excerpt: "legally obligated child support payments"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          household_member_pays_legally_obligated_child_support_to_non_household_member
+          and not payment_is_alimony
+
+  - name: mississippi_snap_homeless_shelter_deduction_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rules 18.7 and 26.5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+              excerpt: "all members are homeless and not receiving free shelter throughout the month"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          snap_household_all_members_are_homeless
+          and not snap_household_receives_free_shelter_throughout_month
+
+  - name: mississippi_snap_verified_actual_homeless_shelter_costs_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rules 18.7 and 26.5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-130
+              excerpt: "actual costs are higher and verified"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          mississippi_snap_homeless_shelter_deduction_entitled
+          and snap_homeless_actual_shelter_costs_verified
+          and snap_homeless_actual_shelter_costs > snap_homeless_shelter_deduction
+
+  - name: mississippi_snap_claimed_homeless_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Mississippi SNAP Policy Manual Rules 18.7 and 26.5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          if mississippi_snap_verified_actual_homeless_shelter_costs_allowed:
+            snap_homeless_actual_shelter_costs
+          else:
+            if mississippi_snap_homeless_shelter_deduction_entitled:
+              snap_homeless_shelter_deduction
+            else:
+              0
+
+  - name: mississippi_snap_excess_shelter_income_share
+    kind: parameter
+    dtype: Rate
+    source: Mississippi SNAP Policy Manual Rule 18.8
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+              excerpt: "in excess of 50 percent of the household's income"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          0.50
+
+  - name: mississippi_snap_liheap_sua_threshold
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Mississippi SNAP Policy Manual Rule 18.9, LIHEAP threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+              excerpt: "receive more than $20 under the LIHEAP program"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          20
+
+  - name: mississippi_snap_excess_shelter_cost
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Mississippi SNAP Policy Manual Rules 18.8 and 30.13
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-141
+              excerpt: "Subtract from total shelter costs 50 percent of the household's monthly income"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          max(0, snap_total_allowable_shelter_expenses - snap_household_income_after_prior_deductions * mississippi_snap_excess_shelter_income_share)
+
+  - name: mississippi_snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Mississippi SNAP Policy Manual Rule 18.8
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-102
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          if snap_household_contains_disabled_or_elderly_individual:
+            mississippi_snap_excess_shelter_cost
+          else:
+            min(mississippi_snap_excess_shelter_cost, snap_maximum_excess_shelter_deduction_48_states_dc)
+
+  - name: mississippi_snap_standard_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.9, SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          snap_household_incurs_heating_or_cooling_expenses_separately_from_rent_or_mortgage
+          or (
+            snap_household_includes_elderly_or_disabled_member
+            and snap_household_receives_liheap_amount > mississippi_snap_liheap_sua_threshold
+          )
+
+  - name: mississippi_snap_basic_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.9, BUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+              excerpt: "at least two electricity and fuel utilities other than heating or cooling"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          not mississippi_snap_standard_utility_allowance_entitled
+          and snap_household_non_heating_cooling_utility_expense_count >= 2
+
+  - name: mississippi_snap_standard_telephone_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.9, telephone allowance
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+              excerpt: "telephone bill is their only separately billed utility expense"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          not mississippi_snap_standard_utility_allowance_entitled
+          and not mississippi_snap_basic_utility_allowance_entitled
+          and snap_household_telephone_bill_only_separately_billed_utility_expense
+
+  - name: mississippi_snap_actual_utility_expenses_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.9, actual utility expenses
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+              excerpt: "may claim actual utility expenses, which must be verified"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          not mississippi_snap_standard_utility_allowance_entitled
+          and not mississippi_snap_basic_utility_allowance_entitled
+          and not mississippi_snap_standard_telephone_allowance_entitled
+          and snap_actual_utility_expenses_verified
+
+  - name: mississippi_snap_shared_heating_cooling_sua_not_prorated
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Mississippi SNAP Policy Manual Rule 18.9, shared heating/cooling SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/manual/mdhs/snap-policy-manual/part-14/page-103
+              excerpt: "will not prorate a SUA that includes heating or cooling costs"
+    versions:
+      - effective_from: '2025-12-01'
+        formula: |-
+          mississippi_snap_standard_utility_allowance_entitled
+          and snap_household_lives_and_shares_heating_or_cooling_expenses_with_others


### PR DESCRIPTION
## Summary
- Encode Mississippi SNAP Manual Rules 18.6-18.9 and related homeless/net-income sections for child support deduction, homeless shelter deduction, excess shelter deduction, and utility allowance hierarchy.
- Add companion tests for SUA/shared non-proration, BUA, telephone allowance, verified actual utilities, verified actual homeless costs, capped shelter, and elderly/disabled uncapped shelter.
- Update reverse index and oracle pending coverage.

## Local checks
- `AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus axiom-encode validate --skip-reviewers us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml`
- `axiom-encode proof-validate us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml`
- `AXIOM_RULES_ENGINE_BIN=/tmp/axiom-rules-engine/target/release/axiom-rules-engine axiom-encode test --root /tmp/rulespec-us-ms-snap-utility us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.test.yaml` (4 cases)
- `axiom-encode compile /tmp/rulespec-us-ms-snap-utility/us-ms/manual/mdhs/snap-policy-manual/part-14/page-102.yaml --axiom-rules-engine-path /tmp/axiom-rules-engine`
- `python tests/generate_reverse_index.py`
- `python -m pytest -q tests/test_reverse_index.py tests/test_encoding_manifests.py tests/test_repository_layout.py --rootdir=/tmp/rulespec-us-ms-snap-utility` (18 passed, 1 existing warning)
- `axiom-encode oracle-coverage-pending sync/check --root /tmp/ms-coverage-root --repo rulespec-us --source manual --since 2026-07-12` (701 applied, 0 stale)
- changed-file oracle coverage: 13 items, 0 failures
- `axiom-encode sign-applied-files --repo /tmp/rulespec-us-ms-snap-utility --base-ref origin/main --head-ref HEAD --manual-exception repair` (no protected RuleSpec files to attest for this root)
- `axiom-encode guard-generated --repo /tmp/rulespec-us-ms-snap-utility --base-ref origin/main --head-ref HEAD`
- `git diff --check HEAD~1 HEAD`

## Review cycle
- Pending /cycle review.